### PR TITLE
Added HTTP/2 connection pool with inflight limits and tests

### DIFF
--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -11,7 +11,7 @@ use std::{
 use core::net::SocketAddr;
 
 use spooky_config::config::Config;
-use spooky_transport::h2_client::H2Client;
+use spooky_transport::h2_pool::H2Pool;
 use spooky_lb::{BackendPool, LoadBalancing};
 
 pub mod quic_listener;
@@ -21,7 +21,7 @@ pub struct QUICListener {
     pub config: Config,
     pub quic_config: quiche::Config,
     pub h3_config: Arc<quiche::h3::Config>,
-    pub h2_client: Arc<H2Client>,
+    pub h2_pool: Arc<H2Pool>,
     pub backend_pool: BackendPool,
     pub load_balancer: LoadBalancing,
     pub metrics: Metrics,

--- a/crates/transport/src/h2_pool.rs
+++ b/crates/transport/src/h2_pool.rs
@@ -1,0 +1,74 @@
+use std::{collections::HashMap, sync::Arc};
+
+use http_body_util::Full;
+use hyper::body::{Bytes, Incoming};
+use hyper::Request;
+use tokio::sync::Semaphore;
+
+use crate::h2_client::H2Client;
+
+#[derive(Debug)]
+pub enum PoolError {
+    UnknownBackend(String),
+    Send(hyper_util::client::legacy::Error),
+}
+
+impl std::fmt::Display for PoolError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PoolError::UnknownBackend(backend) => {
+                write!(f, "unknown backend: {backend}")
+            }
+            PoolError::Send(err) => write!(f, "send failed: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for PoolError {}
+
+struct BackendHandle {
+    client: H2Client,
+    inflight: Arc<Semaphore>,
+}
+
+pub struct H2Pool {
+    backends: HashMap<String, BackendHandle>,
+}
+
+impl H2Pool {
+    pub fn new<I>(backends: I, max_inflight: usize) -> Self
+    where
+        I: IntoIterator<Item = String>,
+    {
+        let inflight = max_inflight.max(1);
+        let mut map = HashMap::new();
+        for backend in backends {
+            map.insert(
+                backend,
+                BackendHandle {
+                    client: H2Client::new(),
+                    inflight: Arc::new(Semaphore::new(inflight)),
+                },
+            );
+        }
+        Self { backends: map }
+    }
+
+    pub fn has_backend(&self, backend: &str) -> bool {
+        self.backends.contains_key(backend)
+    }
+
+    pub async fn send(
+        &self,
+        backend: &str,
+        req: Request<Full<Bytes>>,
+    ) -> Result<hyper::Response<Incoming>, PoolError> {
+        let handle = self
+            .backends
+            .get(backend)
+            .ok_or_else(|| PoolError::UnknownBackend(backend.to_string()))?;
+
+        let _permit = handle.inflight.acquire().await.expect("semaphore closed");
+        handle.client.send(req).await.map_err(PoolError::Send)
+    }
+}

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod h2_client;
+pub mod h2_pool;

--- a/crates/transport/tests/h2_pool.rs
+++ b/crates/transport/tests/h2_pool.rs
@@ -1,0 +1,129 @@
+use std::{
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use bytes::Bytes;
+use http_body_util::Full;
+use hyper::{body::Incoming, service::service_fn, Request, Response};
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use tokio::net::TcpListener;
+
+use spooky_transport::h2_pool::{H2Pool, PoolError};
+
+struct ConcurrencyTracker {
+    current: AtomicUsize,
+    max: AtomicUsize,
+}
+
+impl ConcurrencyTracker {
+    fn new() -> Self {
+        Self {
+            current: AtomicUsize::new(0),
+            max: AtomicUsize::new(0),
+        }
+    }
+
+    fn enter(&self) {
+        let now = self.current.fetch_add(1, Ordering::SeqCst) + 1;
+        let mut prev = self.max.load(Ordering::SeqCst);
+        while now > prev {
+            match self
+                .max
+                .compare_exchange(prev, now, Ordering::SeqCst, Ordering::SeqCst)
+            {
+                Ok(_) => break,
+                Err(next) => prev = next,
+            }
+        }
+    }
+
+    fn exit(&self) {
+        self.current.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+async fn start_h2_server(tracker: Arc<ConcurrencyTracker>) -> std::io::Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let port = listener.local_addr()?.port();
+
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = match listener.accept().await {
+                Ok(v) => v,
+                Err(_) => break,
+            };
+            let tracker = tracker.clone();
+            let service = service_fn(move |_req: Request<Incoming>| {
+                let tracker = tracker.clone();
+                async move {
+                    tracker.enter();
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    tracker.exit();
+                    Ok::<_, std::convert::Infallible>(Response::new(Full::new(Bytes::from("ok"))))
+                }
+            });
+
+            tokio::spawn(async move {
+                let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
+                    .serve_connection(TokioIo::new(stream), service)
+                    .await;
+            });
+        }
+    });
+
+    Ok(port)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pool_limits_inflight_per_backend() {
+    let tracker = Arc::new(ConcurrencyTracker::new());
+    let port = start_h2_server(tracker.clone()).await.unwrap();
+    let backend = format!("127.0.0.1:{port}");
+
+    let pool = Arc::new(H2Pool::new(vec![backend.clone()], 1));
+    let req1 = Request::builder()
+        .method("GET")
+        .uri(format!("http://{backend}/"))
+        .body(Full::new(Bytes::new()))
+        .unwrap();
+    let req2 = Request::builder()
+        .method("GET")
+        .uri(format!("http://{backend}/"))
+        .body(Full::new(Bytes::new()))
+        .unwrap();
+
+    let pool1 = pool.clone();
+    let backend1 = backend.clone();
+    let r1 = tokio::spawn(async move { pool1.send(&backend1, req1).await });
+
+    let pool2 = pool.clone();
+    let backend2 = backend.clone();
+    let r2 = tokio::spawn(async move { pool2.send(&backend2, req2).await });
+
+    let (r1, r2) = tokio::join!(r1, r2);
+    assert!(r1.unwrap().is_ok());
+    assert!(r2.unwrap().is_ok());
+
+    let max = tracker.max.load(Ordering::SeqCst);
+    assert_eq!(max, 1);
+}
+
+#[tokio::test]
+async fn pool_rejects_unknown_backend() {
+    let pool = H2Pool::new(vec!["127.0.0.1:12345".to_string()], 1);
+    let req = Request::builder()
+        .method("GET")
+        .uri("http://127.0.0.1:12345/")
+        .body(Full::new(Bytes::new()))
+        .unwrap();
+
+    let err = pool.send("127.0.0.1:9999", req).await.unwrap_err();
+    match err {
+        PoolError::UnknownBackend(name) => assert_eq!(name, "127.0.0.1:9999"),
+        _ => panic!("unexpected error"),
+    }
+}


### PR DESCRIPTION
## Summary 
- Introduces H2Pool with per‑backend inflight caps to queue requests.
- Wires pool into spooky_edge forwarding path.
- Adds unit tests for inflight limiting and unknown backend handling.

## Test

### Unit Test
```bash
cargo test
```

### Manual Test
```bash
# Build
cargo build -p spooky

# Start backends (in separate terminals)
target/debug/h2_backend --port 8081
target/debug/h2_backend --port 8082
target/debug/h2_backend --port 8083

# Start spooky
RUST_LOG=info target/debug/spooky --config /tmp/spooky-multi.yaml

# Curl HTTP/3 (run 3 times to observe RR)
curl --http3-only -k --resolve proxy.spooky.local:9889:127.0.0.1 https://proxy.spooky.local:9889
```

File: spooky-multi.yaml
```yaml
listen:
    protocol: http3
    port: 9889
    address: "127.0.0.1"
    tls:
        cert: "certs/proxy-cert.pem"
        key: "certs/proxy-key-pkcs8.pem"

backends:
    - id: "backend1"
      address: "127.0.0.1:8081"
      weight: 1
      health_check:
        path: "/health"
        interval: 5000
    - id: "backend2"
      address: "127.0.0.1:8082"
      weight: 1
      health_check:
        path: "/health"
        interval: 5000
    - id: "backend3"
      address: "127.0.0.1:8083"
      weight: 1
      health_check:
        path: "/health"
        interval: 5000

load_balancing:
    type: round-robin

log:
  level: info

```