### PR TITLE
Added active + passive health checks with cooldown and recovery

### DIFF
--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -13,6 +13,10 @@ backends:
         health_check:
             path: "/health"
             interval: 5000
+            timeout_ms: 1000
+            failure_threshold: 3
+            success_threshold: 2
+            cooldown_ms: 5000
 
 load_balancing:
     type: random  # random, round-robin, consistent-hash

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -1,9 +1,10 @@
 use serde::Deserialize;
 
 use crate::default::{
-    get_default_address, get_default_interval, get_default_load_balancing, get_default_log,
-    get_default_log_level, get_default_path, get_default_port, get_default_protocol,
-    get_default_weight,
+    get_default_address, get_default_cooldown_ms, get_default_failure_threshold,
+    get_default_health_timeout, get_default_interval, get_default_load_balancing,
+    get_default_log, get_default_log_level, get_default_path, get_default_port,
+    get_default_protocol, get_default_success_threshold, get_default_weight,
 };
 
 #[derive(Debug, Deserialize, Clone)]
@@ -54,6 +55,18 @@ pub struct HealthCheck {
 
     #[serde(default = "get_default_interval")]
     pub interval: u64, // "5000" (write in number of milli seconds)
+
+    #[serde(default = "get_default_health_timeout")]
+    pub timeout_ms: u64,
+
+    #[serde(default = "get_default_failure_threshold")]
+    pub failure_threshold: u32,
+
+    #[serde(default = "get_default_success_threshold")]
+    pub success_threshold: u32,
+
+    #[serde(default = "get_default_cooldown_ms")]
+    pub cooldown_ms: u64,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/crates/config/src/default.rs
+++ b/crates/config/src/default.rs
@@ -25,6 +25,22 @@ pub fn get_default_interval() -> u64 {
     5000
 }
 
+pub fn get_default_health_timeout() -> u64 {
+    1000
+}
+
+pub fn get_default_failure_threshold() -> u32 {
+    3
+}
+
+pub fn get_default_success_threshold() -> u32 {
+    2
+}
+
+pub fn get_default_cooldown_ms() -> u64 {
+    5_000
+}
+
 pub fn get_default_log_level() -> String {
     String::from("info")
 }

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -100,6 +100,46 @@ pub fn validate(config: &Config) -> bool {
             );
             return false;
         }
+
+        if backend.health_check.interval == 0 {
+            error!(
+                "Health check interval is invalid (0) for backend id '{}'",
+                backend.id
+            );
+            return false;
+        }
+
+        if backend.health_check.timeout_ms == 0 {
+            error!(
+                "Health check timeout is invalid (0) for backend id '{}'",
+                backend.id
+            );
+            return false;
+        }
+
+        if backend.health_check.failure_threshold == 0 {
+            error!(
+                "Health check failure threshold is invalid (0) for backend id '{}'",
+                backend.id
+            );
+            return false;
+        }
+
+        if backend.health_check.success_threshold == 0 {
+            error!(
+                "Health check success threshold is invalid (0) for backend id '{}'",
+                backend.id
+            );
+            return false;
+        }
+
+        if backend.health_check.cooldown_ms == 0 {
+            error!(
+                "Health check cooldown is invalid (0) for backend id '{}'",
+                backend.id
+            );
+            return false;
+        }
     }
 
     info!("Configuration validation passed successfully\n");

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -3,7 +3,7 @@ use std::{
     net::UdpSocket,
     sync::{
         atomic::{AtomicU64, Ordering},
-        Arc,
+        Arc, Mutex,
     },
     time::Instant,
 };
@@ -22,7 +22,7 @@ pub struct QUICListener {
     pub quic_config: quiche::Config,
     pub h3_config: Arc<quiche::h3::Config>,
     pub h2_pool: Arc<H2Pool>,
-    pub backend_pool: BackendPool,
+    pub backend_pool: Arc<Mutex<BackendPool>>,
     pub load_balancer: LoadBalancing,
     pub metrics: Metrics,
     pub draining: bool,

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -53,6 +53,10 @@ fn make_config(port: u32, backend_addr: String, cert: String, key: String) -> Co
             health_check: HealthCheck {
                 path: "/health".to_string(),
                 interval: 1000,
+                timeout_ms: 1000,
+                failure_threshold: 3,
+                success_threshold: 1,
+                cooldown_ms: 0,
             },
         }],
         load_balancing: LoadBalancing {

--- a/crates/edge/tests/h3_edge.rs
+++ b/crates/edge/tests/h3_edge.rs
@@ -48,6 +48,10 @@ fn make_config(port: u32, cert: String, key: String) -> Config {
             health_check: HealthCheck {
                 path: "/health".to_string(),
                 interval: 1000,
+                timeout_ms: 1000,
+                failure_threshold: 3,
+                success_threshold: 1,
+                cooldown_ms: 0,
             },
         }],
         load_balancing: LoadBalancing {

--- a/crates/edge/tests/lb_integration.rs
+++ b/crates/edge/tests/lb_integration.rs
@@ -225,6 +225,10 @@ fn round_robin_across_backends() {
             health_check: HealthCheck {
                 path: "/health".to_string(),
                 interval: 1000,
+                timeout_ms: 1000,
+                failure_threshold: 3,
+                success_threshold: 1,
+                cooldown_ms: 0,
             },
         },
         Backend {
@@ -234,6 +238,10 @@ fn round_robin_across_backends() {
             health_check: HealthCheck {
                 path: "/health".to_string(),
                 interval: 1000,
+                timeout_ms: 1000,
+                failure_threshold: 3,
+                success_threshold: 1,
+                cooldown_ms: 0,
             },
         },
     ];
@@ -284,6 +292,10 @@ fn consistent_hash_is_stable_per_authority() {
             health_check: HealthCheck {
                 path: "/health".to_string(),
                 interval: 1000,
+                timeout_ms: 1000,
+                failure_threshold: 3,
+                success_threshold: 1,
+                cooldown_ms: 0,
             },
         },
         Backend {
@@ -293,6 +305,10 @@ fn consistent_hash_is_stable_per_authority() {
             health_check: HealthCheck {
                 path: "/health".to_string(),
                 interval: 1000,
+                timeout_ms: 1000,
+                failure_threshold: 3,
+                success_threshold: 1,
+                cooldown_ms: 0,
             },
         },
     ];


### PR DESCRIPTION
## Summary
- Adds health check configuration fields (interval, timeout, thresholds, cooldown).
- Implements backend health state machine with cooldown + recovery thresholds.
- Adds active health probes per backend and passive failure reporting.
- Logs health transitions and skips unhealthy backends in LB selection.
- Updates configs and tests accordingly.

## Tests

```bash
curl --http3-only -k --resolve proxy.spooky.local:9889:127.0.0.1 https://proxy.spooky.local:9889
```