### PR TITLE
refactor: centralize error handling using spooky-errors crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/bridge",
     "crates/transport",
     "crates/lb",
+    "crates/errors",
 ]
 resolver = "2"
 
@@ -24,6 +25,7 @@ rand = "0.8"
 rustls-pki-types = "1.12.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9.34"
+thiserror = "1"
 tokio = { version = "1", features = ["full"] }
 libc = "0.2"
 

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -9,3 +9,4 @@ http.workspace = true
 quiche.workspace = true
 bytes.workspace = true
 http-body-util.workspace = true
+spooky-errors = { path = "../errors" }

--- a/crates/bridge/src/h3_to_h2.rs
+++ b/crates/bridge/src/h3_to_h2.rs
@@ -2,26 +2,7 @@ use bytes::Bytes;
 use http::{HeaderName, HeaderValue, Method, Request, Uri};
 use http_body_util::Full;
 
-#[derive(Debug)]
-pub enum BridgeError {
-    InvalidMethod,
-    InvalidUri,
-    InvalidHeader,
-    Build(http::Error),
-}
-
-impl std::fmt::Display for BridgeError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            BridgeError::InvalidMethod => write!(f, "invalid method"),
-            BridgeError::InvalidUri => write!(f, "invalid uri"),
-            BridgeError::InvalidHeader => write!(f, "invalid header"),
-            BridgeError::Build(e) => write!(f, "request build error: {e}"),
-        }
-    }
-}
-
-impl std::error::Error for BridgeError {}
+pub use spooky_errors::BridgeError;
 
 pub fn build_h2_request(
     backend: &str,

--- a/crates/edge/Cargo.toml
+++ b/crates/edge/Cargo.toml
@@ -11,6 +11,7 @@ spooky-config = { path = "../config" }
 spooky-lb = { path = "../lb" }
 spooky-bridge = { path = "../bridge" }
 spooky-transport = { path = "../transport" }
+spooky-errors = { path = "../errors" }
 bytes.workspace = true
 http.workspace = true
 http-body-util.workspace = true

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -13,33 +13,15 @@ use log::{debug, error, info};
 use quiche::Config;
 use quiche::h3::NameValue;
 use rand::RngCore;
-use spooky_bridge::h3_to_h2::{BridgeError, build_h2_request};
+use spooky_bridge::h3_to_h2::build_h2_request;
 use spooky_lb::{HealthTransition, UpstreamPool};
-use spooky_transport::h2_pool::{H2Pool, PoolError};
+use spooky_transport::h2_pool::H2Pool;
+use spooky_errors::ProxyError;
 use tokio::runtime::Handle;
 
 use spooky_config::config::Config as SpookyConfig;
 
 use crate::{Metrics, QUICListener, QuicConnection, RequestEnvelope};
-
-#[derive(Debug)]
-pub enum ProxyError {
-    Bridge(BridgeError),
-    Transport(String),
-    Timeout,
-    Tls(String), // For TLS cred loading failure
-}
-
-impl std::fmt::Display for ProxyError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ProxyError::Bridge(err) => write!(f, "Bridge error: {}", err),
-            ProxyError::Transport(msg) => write!(f, "Transport error: {}", msg),
-            ProxyError::Timeout => write!(f, "Backend timeout"),
-            ProxyError::Tls(msg) => write!(f, "TLS error: {}", msg),
-        }
-    }
-}
 
 fn is_hop_header(name: &str) -> bool {
     matches!(
@@ -952,8 +934,8 @@ impl QUICListener {
                     b"invalid request\n",
                 )
             }
-            Err(ProxyError::Transport(err)) => {
-                error!("Transport error: {}", err);
+            Err(ProxyError::Transport(_)) | Err(ProxyError::Pool(_)) => {
+                error!("Transport error");
                 let transition = upstream_pool
                     .lock()
                     .ok()
@@ -1038,12 +1020,7 @@ impl QUICListener {
         .map_err(|e| ProxyError::Transport(format!("send: {e}")))?;
 
         let response = match response {
-            Ok(inner) => inner.map_err(|e| match e {
-                PoolError::UnknownBackend(name) => {
-                    ProxyError::Transport(format!("unknown backend: {name}"))
-                }
-                PoolError::Send(err) => ProxyError::Transport(format!("send: {err:?}")),
-            })?,
+            Ok(inner) => inner?,
             Err(_) => return Err(ProxyError::Timeout),
         };
 

--- a/crates/errors/Cargo.toml
+++ b/crates/errors/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "spooky-errors"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+thiserror = { workspace = true }
+http = { workspace = true }
+hyper-util = { workspace = true }
+quiche = { workspace = true }

--- a/crates/errors/src/lib.rs
+++ b/crates/errors/src/lib.rs
@@ -35,6 +35,9 @@ pub enum ProxyError {
     #[error("transport error: {0}")]
     Pool(#[from] PoolError),
 
+    #[error("transport error: {0}")]
+    Transport(String),
+
     #[error("backend timeout")]
     Timeout,
 

--- a/crates/errors/src/lib.rs
+++ b/crates/errors/src/lib.rs
@@ -1,0 +1,43 @@
+use thiserror::Error;
+
+/// HTTP/3 to HTTP/2 bridge error types
+#[derive(Debug, Error)]
+pub enum BridgeError {
+    #[error("invalid HTTP method")]
+    InvalidMethod,
+
+    #[error("invalid URI")]
+    InvalidUri,
+
+    #[error("invalid header")]
+    InvalidHeader,
+
+    #[error("failed to build request: {0}")]
+    Build(#[from] http::Error),
+}
+
+/// HTTP/2 pool and transport error types
+#[derive(Debug, Error)]
+pub enum PoolError {
+    #[error("unknown backend: {0}")]
+    UnknownBackend(String),
+
+    #[error("send failed: {0}")]
+    Send(#[source] hyper_util::client::legacy::Error),
+}
+
+/// Top-level proxy error type unifying bridge and transport errors
+#[derive(Debug, Error)]
+pub enum ProxyError {
+    #[error("bridge error: {0}")]
+    Bridge(#[from] BridgeError),
+
+    #[error("transport error: {0}")]
+    Pool(#[from] PoolError),
+
+    #[error("backend timeout")]
+    Timeout,
+
+    #[error("TLS error: {0}")]
+    Tls(String),
+}

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -10,3 +10,4 @@ http-body-util.workspace = true
 hyper.workspace = true
 hyper-util.workspace = true
 tokio.workspace = true
+spooky-errors = { path = "../errors" }

--- a/crates/transport/src/h2_pool.rs
+++ b/crates/transport/src/h2_pool.rs
@@ -6,25 +6,7 @@ use hyper::body::{Bytes, Incoming};
 use tokio::sync::Semaphore;
 
 use crate::h2_client::H2Client;
-
-#[derive(Debug)]
-pub enum PoolError {
-    UnknownBackend(String),
-    Send(hyper_util::client::legacy::Error),
-}
-
-impl std::fmt::Display for PoolError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            PoolError::UnknownBackend(backend) => {
-                write!(f, "unknown backend: {backend}")
-            }
-            PoolError::Send(err) => write!(f, "send failed: {err}"),
-        }
-    }
-}
-
-impl std::error::Error for PoolError {}
+pub use spooky_errors::PoolError;
 
 struct BackendHandle {
     client: H2Client,


### PR DESCRIPTION
Closes #21 

This PR centralizes error handling across the project by introducing a new
`spooky-errors` crate and migrating existing error types to it.

Changes:
- Added `spooky-errors` crate to the workspace
- Introduced `BridgeError`, `PoolError`, and `ProxyError` using `thiserror`
- Removed local error enums from bridge, transport, and edge crates
- Re-exported errors where necessary to preserve public APIs
- Replaced manual error conversions with `From` + `?` operator
- Simplified error propagation and restored proper source chains