### PR TITLE
perf(edge): route lookup via host-partitioned radix trie (removes O(n) upstream scan)

### DIFF
--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -15,6 +15,7 @@ use spooky_lb::UpstreamPool;
 use spooky_transport::h2_pool::H2Pool;
 
 pub mod quic_listener;
+mod route_index;
 
 pub struct QUICListener {
     pub socket: UdpSocket,
@@ -23,6 +24,7 @@ pub struct QUICListener {
     pub h3_config: Arc<quiche::h3::Config>,
     pub h2_pool: Arc<H2Pool>,
     pub upstream_pools: HashMap<String, Arc<Mutex<UpstreamPool>>>,
+    pub(crate) routing_index: route_index::RouteIndex,
     pub metrics: Metrics,
     pub draining: bool,
     pub drain_start: Option<Instant>,
@@ -59,17 +61,20 @@ pub struct RequestEnvelope {
 
 #[derive(Debug)]
 pub enum HealthClassification {
-    Success,           // 2xx, 3xx responses
-    Failure,           // 5xx responses, Transport/Pool/Timeout errors
-    Neutral,           // 4xx responses, Bridge/TLS errors
+    Success, // 2xx, 3xx responses
+    Failure, // 5xx responses, Transport/Pool/Timeout errors
+    Neutral, // 4xx responses, Bridge/TLS errors
 }
 
 pub fn outcome_from_status(status: http::StatusCode) -> HealthClassification {
-    if status.is_server_error() { // 5xx
+    if status.is_server_error() {
+        // 5xx
         HealthClassification::Failure
-    } else if status.is_client_error() { // 4xx
+    } else if status.is_client_error() {
+        // 4xx
         HealthClassification::Neutral
-    } else {    // 2xx, 3xx
+    } else {
+        // 2xx, 3xx
         HealthClassification::Success
     }
 }

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -14,14 +14,17 @@ use quiche::Config;
 use quiche::h3::NameValue;
 use rand::RngCore;
 use spooky_bridge::h3_to_h2::build_h2_request;
+use spooky_errors::ProxyError;
 use spooky_lb::{HealthTransition, UpstreamPool};
 use spooky_transport::h2_pool::H2Pool;
-use spooky_errors::ProxyError;
 use tokio::runtime::Handle;
 
 use spooky_config::config::Config as SpookyConfig;
 
-use crate::{Metrics, QUICListener, QuicConnection, RequestEnvelope, outcome_from_status};
+use crate::{
+    Metrics, QUICListener, QuicConnection, RequestEnvelope, outcome_from_status,
+    route_index::RouteIndex,
+};
 
 fn is_hop_header(name: &str) -> bool {
     matches!(
@@ -40,39 +43,6 @@ fn request_hash_key(req: &RequestEnvelope) -> &str {
     }
 
     &req.method
-}
-
-fn find_upstream_for_request<'a>(
-    upstreams: &'a std::collections::HashMap<String, spooky_config::config::Upstream>,
-    path: &str,
-    host: Option<&str>,
-) -> Option<&'a str> {
-    // Find the most specific route that matches the path and/or host
-    // We need to find the longest matching path prefix
-    let mut best_match: Option<(&str, usize)> = None;
-
-    for (upstream_name, upstream) in upstreams {
-        let has_host_match = match (&upstream.route.host, host) {
-            (Some(route_host), Some(request_host)) => route_host == request_host,
-            (None, _) => true,        // No host constraint
-            (Some(_), None) => false, // Host constraint but no host in request
-        };
-
-        let path_match_len = match &upstream.route.path_prefix {
-            Some(path_prefix) if path.starts_with(path_prefix) => path_prefix.len(),
-            None => 0,     // No path constraint, matches but with lowest priority
-            _ => continue, // No match
-        };
-
-        if has_host_match {
-            // Keep the match with the longest path prefix
-            if best_match.is_none() || path_match_len > best_match.unwrap().1 {
-                best_match = Some((upstream_name.as_str(), path_match_len));
-            }
-        }
-    }
-
-    best_match.map(|(name, _)| name)
 }
 
 const BACKEND_TIMEOUT: Duration = Duration::from_secs(2);
@@ -152,6 +122,7 @@ impl QUICListener {
                 UpstreamPool::from_upstream(upstream).expect("Failed to create upstream pool");
             upstream_pools.insert(name.clone(), Arc::new(Mutex::new(upstream_pool)));
         }
+        let routing_index = RouteIndex::from_upstreams(&config.upstream);
 
         let metrics = Metrics::default();
 
@@ -164,6 +135,7 @@ impl QUICListener {
             h3_config,
             h2_pool,
             upstream_pools,
+            routing_index,
             metrics,
             draining: false,
             drain_start: None,
@@ -613,7 +585,7 @@ impl QUICListener {
                 &mut connection,
                 &h2_pool,
                 &self.upstream_pools,
-                &self.config.upstream,
+                &self.routing_index,
                 &self.metrics,
             )
         {
@@ -703,7 +675,7 @@ impl QUICListener {
         connection: &mut QuicConnection,
         h2_pool: &H2Pool,
         upstream_pools: &HashMap<String, Arc<Mutex<UpstreamPool>>>,
-        upstreams: &std::collections::HashMap<String, spooky_config::config::Upstream>,
+        routing_index: &RouteIndex,
         metrics: &Metrics,
     ) -> Result<(), quiche::h3::Error> {
         let mut body_buf = [0u8; 65_535];
@@ -779,7 +751,7 @@ impl QUICListener {
                             req,
                             h2_pool,
                             upstream_pools,
-                            upstreams,
+                            routing_index,
                             metrics,
                         )?;
                     }
@@ -805,7 +777,7 @@ impl QUICListener {
         req: RequestEnvelope,
         h2_pool: &H2Pool,
         upstream_pools: &HashMap<String, Arc<Mutex<UpstreamPool>>>,
-        upstreams: &std::collections::HashMap<String, spooky_config::config::Upstream>,
+        routing_index: &RouteIndex,
         metrics: &Metrics,
     ) -> Result<(), quiche::h3::Error> {
         let start = req.start;
@@ -820,16 +792,15 @@ impl QUICListener {
         }
 
         // Find the upstream for this request
-        let upstream_name =
-            find_upstream_for_request(upstreams, &req.path, req.authority.as_deref()).ok_or_else(
-                || {
-                    error!(
-                        "No route found for path: {} (host: {:?})",
-                        req.path, req.authority
-                    );
-                    quiche::h3::Error::InternalError
-                },
-            )?;
+        let upstream_name = routing_index
+            .lookup(&req.path, req.authority.as_deref())
+            .ok_or_else(|| {
+                error!(
+                    "No route found for path: {} (host: {:?})",
+                    req.path, req.authority
+                );
+                quiche::h3::Error::InternalError
+            })?;
 
         let upstream_pool = upstream_pools.get(upstream_name).ok_or_else(|| {
             error!("Upstream pool not found for: {}", upstream_name);
@@ -895,9 +866,13 @@ impl QUICListener {
             Ok((status, headers, body)) => {
                 let transition = upstream_pool.lock().ok().and_then(|mut pool| {
                     match outcome_from_status(status) {
-                        crate::HealthClassification::Success => pool.pool.mark_success(backend_index),
-                        crate::HealthClassification::Failure => pool.pool.mark_failure(backend_index),
-                        crate::HealthClassification::Neutral => None
+                        crate::HealthClassification::Success => {
+                            pool.pool.mark_success(backend_index)
+                        }
+                        crate::HealthClassification::Failure => {
+                            pool.pool.mark_failure(backend_index)
+                        }
+                        crate::HealthClassification::Neutral => None,
                     }
                 });
                 if let Some(transition) = transition {

--- a/crates/edge/src/route_index.rs
+++ b/crates/edge/src/route_index.rs
@@ -1,0 +1,310 @@
+use std::collections::HashMap;
+
+use spooky_config::config::Upstream;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct IndexedRoute {
+    upstream_idx: usize,
+    path_len: usize,
+    order: usize,
+}
+
+#[derive(Default)]
+struct TrieNode {
+    route: Option<IndexedRoute>,
+    children: HashMap<u8, TrieNode>,
+}
+
+impl TrieNode {
+    fn update_route(&mut self, candidate: IndexedRoute) {
+        if let Some(current) = self.route {
+            if candidate.path_len > current.path_len
+                || (candidate.path_len == current.path_len && candidate.order < current.order)
+            {
+                self.route = Some(candidate);
+            }
+            return;
+        }
+        self.route = Some(candidate);
+    }
+}
+
+#[derive(Default)]
+struct RouteTrie {
+    root: TrieNode,
+}
+
+impl RouteTrie {
+    fn insert(&mut self, prefix: Option<&str>, route: IndexedRoute) {
+        let prefix = prefix.unwrap_or("");
+        let mut node = &mut self.root;
+
+        if prefix.is_empty() {
+            node.update_route(route);
+            return;
+        }
+
+        for byte in prefix.as_bytes() {
+            node = node.children.entry(*byte).or_default();
+        }
+
+        node.update_route(route);
+    }
+
+    fn longest_prefix(&self, path: &str) -> Option<IndexedRoute> {
+        let mut node = &self.root;
+        let mut best = node.route;
+
+        for byte in path.as_bytes() {
+            let Some(next) = node.children.get(byte) else {
+                break;
+            };
+            node = next;
+            best = prefer_route(best, node.route);
+        }
+
+        best
+    }
+}
+
+pub(crate) struct RouteIndex {
+    host_tries: HashMap<String, RouteTrie>,
+    default_trie: RouteTrie,
+    upstream_names: Vec<String>,
+}
+
+impl RouteIndex {
+    pub(crate) fn from_upstreams(upstreams: &HashMap<String, Upstream>) -> Self {
+        let mut host_tries = HashMap::new();
+        let mut default_trie = RouteTrie::default();
+        let mut upstream_names = Vec::with_capacity(upstreams.len());
+
+        for (order, (name, upstream)) in upstreams.iter().enumerate() {
+            let upstream_idx = upstream_names.len();
+            upstream_names.push(name.clone());
+
+            let route = IndexedRoute {
+                upstream_idx,
+                path_len: upstream
+                    .route
+                    .path_prefix
+                    .as_ref()
+                    .map(|prefix| prefix.len())
+                    .unwrap_or(0),
+                order,
+            };
+
+            match upstream.route.host.as_deref() {
+                Some(host) => host_tries
+                    .entry(host.to_string())
+                    .or_insert_with(RouteTrie::default)
+                    .insert(upstream.route.path_prefix.as_deref(), route),
+                None => default_trie.insert(upstream.route.path_prefix.as_deref(), route),
+            }
+        }
+
+        Self {
+            host_tries,
+            default_trie,
+            upstream_names,
+        }
+    }
+
+    pub(crate) fn lookup<'a>(&'a self, path: &str, host: Option<&str>) -> Option<&'a str> {
+        let mut best = self.default_trie.longest_prefix(path);
+
+        if let Some(host) = host
+            && let Some(host_trie) = self.host_tries.get(host)
+        {
+            best = prefer_route(best, host_trie.longest_prefix(path));
+        }
+
+        best.map(|route| self.upstream_names[route.upstream_idx].as_str())
+    }
+}
+
+fn prefer_route(
+    current: Option<IndexedRoute>,
+    candidate: Option<IndexedRoute>,
+) -> Option<IndexedRoute> {
+    match (current, candidate) {
+        (None, None) => None,
+        (Some(route), None) | (None, Some(route)) => Some(route),
+        (Some(current), Some(candidate)) => {
+            if candidate.path_len > current.path_len
+                || (candidate.path_len == current.path_len && candidate.order < current.order)
+            {
+                Some(candidate)
+            } else {
+                Some(current)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn scan_lookup<'a>(
+    upstreams: &'a HashMap<String, Upstream>,
+    path: &str,
+    host: Option<&str>,
+) -> Option<&'a str> {
+    let mut best_match: Option<(&str, usize)> = None;
+
+    for (upstream_name, upstream) in upstreams {
+        let has_host_match = match (&upstream.route.host, host) {
+            (Some(route_host), Some(request_host)) => route_host == request_host,
+            (None, _) => true,
+            (Some(_), None) => false,
+        };
+
+        let path_match_len = match &upstream.route.path_prefix {
+            Some(path_prefix) if path.starts_with(path_prefix) => path_prefix.len(),
+            None => 0,
+            _ => continue,
+        };
+
+        if has_host_match
+            && (best_match.is_none() || path_match_len > best_match.expect("checked").1)
+        {
+            best_match = Some((upstream_name.as_str(), path_match_len));
+        }
+    }
+
+    best_match.map(|(name, _)| name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use spooky_config::config::{LoadBalancing, RouteMatch};
+    use std::time::Instant;
+
+    fn test_upstream(host: Option<&str>, path_prefix: Option<&str>) -> Upstream {
+        Upstream {
+            load_balancing: LoadBalancing {
+                lb_type: "random".to_string(),
+                key: None,
+            },
+            route: RouteMatch {
+                host: host.map(str::to_string),
+                path_prefix: path_prefix.map(str::to_string),
+                method: None,
+            },
+            backends: vec![],
+        }
+    }
+
+    #[test]
+    fn longest_prefix_lookup_works() {
+        let mut upstreams = HashMap::new();
+        upstreams.insert("root".to_string(), test_upstream(None, Some("/")));
+        upstreams.insert("api".to_string(), test_upstream(None, Some("/api")));
+        upstreams.insert("api-v1".to_string(), test_upstream(None, Some("/api/v1")));
+
+        let index = RouteIndex::from_upstreams(&upstreams);
+        let selected = index.lookup("/api/v1/users", None);
+        assert_eq!(selected, Some("api-v1"));
+    }
+
+    #[test]
+    fn indexed_lookup_matches_scan_lookup() {
+        let mut upstreams = HashMap::new();
+        upstreams.insert("default-root".to_string(), test_upstream(None, Some("/")));
+        upstreams.insert("default-api".to_string(), test_upstream(None, Some("/api")));
+        upstreams.insert(
+            "api-host-only".to_string(),
+            test_upstream(Some("api.example.com"), None),
+        );
+        upstreams.insert(
+            "api-host-route".to_string(),
+            test_upstream(Some("api.example.com"), Some("/api")),
+        );
+        upstreams.insert(
+            "admin-host-route".to_string(),
+            test_upstream(Some("admin.example.com"), Some("/admin")),
+        );
+
+        let index = RouteIndex::from_upstreams(&upstreams);
+        let queries = vec![
+            ("/", None),
+            ("/api/users", None),
+            ("/api/users", Some("api.example.com")),
+            ("/admin/users", Some("admin.example.com")),
+            ("/unknown", Some("api.example.com")),
+            ("/unknown", Some("missing.example.com")),
+        ];
+
+        for (path, host) in queries {
+            assert_eq!(
+                index.lookup(path, host),
+                scan_lookup(&upstreams, path, host)
+            );
+        }
+    }
+
+    fn build_route_table(route_count: usize) -> HashMap<String, Upstream> {
+        let mut upstreams = HashMap::with_capacity(route_count);
+        for i in 0..route_count {
+            let name = format!("upstream-{i:05}");
+            let path = format!("/svc/{i:05}");
+            let host = (i % 2 == 1).then_some("bench.example.com");
+            upstreams.insert(name, test_upstream(host, Some(&path)));
+        }
+        upstreams
+    }
+
+    fn measure_lookup<F>(iterations: usize, mut lookup: F) -> std::time::Duration
+    where
+        F: FnMut() -> Option<String>,
+    {
+        let start = Instant::now();
+        let mut sink = 0usize;
+        for _ in 0..iterations {
+            if let Some(value) = lookup() {
+                sink ^= value.len();
+            }
+        }
+        std::hint::black_box(sink);
+        start.elapsed()
+    }
+
+    #[test]
+    #[ignore = "microbenchmark"]
+    fn route_lookup_microbenchmarks() {
+        for route_count in [100usize, 1_000, 10_000] {
+            let upstreams = build_route_table(route_count);
+            let index = RouteIndex::from_upstreams(&upstreams);
+            let query_path = format!("/svc/{:05}/resource", route_count - 1);
+            let host = Some("bench.example.com");
+            let iterations = match route_count {
+                100 => 200_000,
+                1_000 => 100_000,
+                _ => 20_000,
+            };
+
+            assert_eq!(
+                index.lookup(&query_path, host),
+                scan_lookup(&upstreams, &query_path, host)
+            );
+
+            let scan_time = measure_lookup(iterations, || {
+                scan_lookup(&upstreams, &query_path, host).map(str::to_string)
+            });
+            let indexed_time = measure_lookup(iterations, || {
+                index.lookup(&query_path, host).map(str::to_string)
+            });
+            let speedup = scan_time.as_secs_f64() / indexed_time.as_secs_f64();
+
+            eprintln!(
+                "routes={route_count:>5} scan={scan_time:?} indexed={indexed_time:?} speedup={speedup:.2}x"
+            );
+
+            if route_count >= 1_000 {
+                assert!(
+                    indexed_time < scan_time,
+                    "expected indexed lookup to be faster for {route_count} routes"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
Ref: #32 
## Summary
This PR replaces per-request linear upstream route scanning with an immutable routing index built at startup.

## Problem
Route selection previously iterated all upstreams on every request and used repeated `starts_with()` checks, making lookup cost grow linearly with route count.

## What changed
- Added `RouteIndex` in `crates/edge/src/route_index.rs`.
- Implemented path-prefix trie (radix-style) longest-prefix matching.
- Partitioned routing by host:
  - `HashMap<host, trie>` for host-constrained routes.
  - Default trie for hostless routes.
- Built index once during `QUICListener::new`.
- Switched request-time route lookup to indexed lookup.
- Kept upstream pool selection/forwarding flow unchanged.
- Added route-lookup microbenchmarks for 100, 1k, and 10k routes.
- Added parity tests to ensure indexed lookup matches prior scan behavior.

## Behavior/compatibility
- Longest-prefix semantics preserved.
- Host + path semantics preserved.
- No changes to upstream pool/LB/health-check flow.

## Benchmarks
`cargo test -p spooky-edge route_lookup_microbenchmarks -- --ignored --nocapture`

- 100 routes: `1.403s -> 1.060s` (`1.32x`)
- 1,000 routes: `7.551s -> 0.600s` (`12.58x`)
- 10,000 routes: `22.363s -> 0.106s` (`210.70x`)

## Validation
- `cargo test --workspace` passes.
- Microbenchmark test passes (ignored by default).