### PR TITLE
bench: add CPU + memory regression benchmarks with baseline gating 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/transport",
     "crates/lb",
     "crates/errors",
+    "crates/bench",
 ]
 resolver = "2"
 
@@ -24,6 +25,7 @@ quiche = "0.24.6"
 rand = "0.8"
 rustls-pki-types = "1.12.0"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 serde_yaml = "0.9.34"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }

--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,0 +1,3 @@
+latest.json
+latest.md
+baseline.md

--- a/bench/baseline.json
+++ b/bench/baseline.json
@@ -1,0 +1,368 @@
+{
+  "suite": "spooky-cpu-memory-regression",
+  "generated_unix_secs": 1773680186,
+  "cpu_threshold": 0.4,
+  "mem_threshold": 0.2,
+  "cases": [
+    {
+      "name": "connection_alias_lookup",
+      "scale": 100,
+      "iterations": 300000,
+      "duration_ns": 18574915,
+      "latency_ns_per_op": 61.916383333333336,
+      "alloc_calls": 0,
+      "alloc_bytes": 0,
+      "rss_delta_kb": 0
+    },
+    {
+      "name": "connection_alias_lookup",
+      "scale": 1000,
+      "iterations": 200000,
+      "duration_ns": 13205132,
+      "latency_ns_per_op": 66.02566,
+      "alloc_calls": 0,
+      "alloc_bytes": 0,
+      "rss_delta_kb": 0
+    },
+    {
+      "name": "connection_alias_lookup",
+      "scale": 10000,
+      "iterations": 80000,
+      "duration_ns": 4661544,
+      "latency_ns_per_op": 58.2693,
+      "alloc_calls": 0,
+      "alloc_bytes": 0,
+      "rss_delta_kb": 0
+    },
+    {
+      "name": "connection_exact_lookup",
+      "scale": 100,
+      "iterations": 300000,
+      "duration_ns": 9288880,
+      "latency_ns_per_op": 30.962933333333332,
+      "alloc_calls": 0,
+      "alloc_bytes": 0,
+      "rss_delta_kb": 0
+    },
+    {
+      "name": "connection_exact_lookup",
+      "scale": 1000,
+      "iterations": 200000,
+      "duration_ns": 6069480,
+      "latency_ns_per_op": 30.3474,
+      "alloc_calls": 0,
+      "alloc_bytes": 0,
+      "rss_delta_kb": 0
+    },
+    {
+      "name": "connection_exact_lookup",
+      "scale": 10000,
+      "iterations": 80000,
+      "duration_ns": 2299956,
+      "latency_ns_per_op": 28.74945,
+      "alloc_calls": 0,
+      "alloc_bytes": 0,
+      "rss_delta_kb": 0
+    },
+    {
+      "name": "connection_peer_map_hit",
+      "scale": 100,
+      "iterations": 300000,
+      "duration_ns": 15632200,
+      "latency_ns_per_op": 52.10733333333333,
+      "alloc_calls": 0,
+      "alloc_bytes": 0,
+      "rss_delta_kb": 0
+    },
+    {
+      "name": "connection_peer_map_hit",
+      "scale": 1000,
+      "iterations": 200000,
+      "duration_ns": 11299725,
+      "latency_ns_per_op": 56.498625,
+      "alloc_calls": 0,
+      "alloc_bytes": 0,
+      "rss_delta_kb": 0
+    },
+    {
+      "name": "connection_peer_map_hit",
+      "scale": 10000,
+      "iterations": 80000,
+      "duration_ns": 4103316,
+      "latency_ns_per_op": 51.29145,
+      "alloc_calls": 0,
+      "alloc_bytes": 0,
+      "rss_delta_kb": 0
+    },
+    {
+      "name": "connection_peer_map_miss",
+      "scale": 100,
+      "iterations": 300000,
+      "duration_ns": 6489182,
+      "latency_ns_per_op": 21.630606666666665,
+      "alloc_calls": 0,
+      "alloc_bytes": 0,
+      "rss_delta_kb": 0
+    },
+    {
+      "name": "connection_peer_map_miss",
+      "scale": 1000,
+      "iterations": 200000,
+      "duration_ns": 4433083,
+      "latency_ns_per_op": 22.165415,
+      "alloc_calls": 0,
+      "alloc_bytes": 0,
+      "rss_delta_kb": 0
+    },
+    {
+      "name": "connection_peer_map_miss",
+      "scale": 10000,
+      "iterations": 80000,
+      "duration_ns": 1766355,
+      "latency_ns_per_op": 22.0794375,
+      "alloc_calls": 0,
+      "alloc_bytes": 0,
+      "rss_delta_kb": 0
+    },
+    {
+      "name": "connection_peer_scan_miss",
+      "scale": 100,
+      "iterations": 150000,
+      "duration_ns": 20262870,
+      "latency_ns_per_op": 135.0858,
+      "alloc_calls": 0,
+      "alloc_bytes": 0,
+      "rss_delta_kb": 0
+    },
+    {
+      "name": "connection_peer_scan_miss",
+      "scale": 1000,
+      "iterations": 30000,
+      "duration_ns": 47662942,
+      "latency_ns_per_op": 1588.7647333333334,
+      "alloc_calls": 0,
+      "alloc_bytes": 0,
+      "rss_delta_kb": 0
+    },
+    {
+      "name": "connection_peer_scan_miss",
+      "scale": 10000,
+      "iterations": 3000,
+      "duration_ns": 63456350,
+      "latency_ns_per_op": 21152.116666666665,
+      "alloc_calls": 0,
+      "alloc_bytes": 0,
+      "rss_delta_kb": 0
+    },
+    {
+      "name": "connection_prefix_scan_miss_lookup",
+      "scale": 100,
+      "iterations": 150000,
+      "duration_ns": 74509627,
+      "latency_ns_per_op": 496.73084666666665,
+      "alloc_calls": 0,
+      "alloc_bytes": 0,
+      "rss_delta_kb": 0
+    },
+    {
+      "name": "connection_prefix_scan_miss_lookup",
+      "scale": 1000,
+      "iterations": 30000,
+      "duration_ns": 162400112,
+      "latency_ns_per_op": 5413.337066666667,
+      "alloc_calls": 0,
+      "alloc_bytes": 0,
+      "rss_delta_kb": 0
+    },
+    {
+      "name": "connection_prefix_scan_miss_lookup",
+      "scale": 10000,
+      "iterations": 3000,
+      "duration_ns": 161400236,
+      "latency_ns_per_op": 53800.07866666667,
+      "alloc_calls": 0,
+      "alloc_bytes": 0,
+      "rss_delta_kb": 0
+    },
+    {
+      "name": "lb_consistent_hash_pick",
+      "scale": 100,
+      "iterations": 3000,
+      "duration_ns": 7886683915,
+      "latency_ns_per_op": 2628894.638333333,
+      "alloc_calls": 60357000,
+      "alloc_bytes": 1464744000,
+      "rss_delta_kb": 48
+    },
+    {
+      "name": "lb_consistent_hash_pick",
+      "scale": 1000,
+      "iterations": 500,
+      "duration_ns": 13813735388,
+      "latency_ns_per_op": 27627470.776,
+      "alloc_calls": 100605000,
+      "alloc_bytes": 2445480000,
+      "rss_delta_kb": 380
+    },
+    {
+      "name": "lb_consistent_hash_pick",
+      "scale": 10000,
+      "iterations": 40,
+      "duration_ns": 12338600315,
+      "latency_ns_per_op": 308465007.875,
+      "alloc_calls": 80465840,
+      "alloc_bytes": 1954932480,
+      "rss_delta_kb": 536
+    },
+    {
+      "name": "lb_random_pick",
+      "scale": 100,
+      "iterations": 300000,
+      "duration_ns": 239262397,
+      "latency_ns_per_op": 797.5413233333334,
+      "alloc_calls": 1800000,
+      "alloc_bytes": 604800000,
+      "rss_delta_kb": 0
+    },
+    {
+      "name": "lb_random_pick",
+      "scale": 1000,
+      "iterations": 200000,
+      "duration_ns": 630031567,
+      "latency_ns_per_op": 3150.157835,
+      "alloc_calls": 1800000,
+      "alloc_bytes": 3270400000,
+      "rss_delta_kb": 0
+    },
+    {
+      "name": "lb_random_pick",
+      "scale": 10000,
+      "iterations": 80000,
+      "duration_ns": 2045873371,
+      "latency_ns_per_op": 25573.4171375,
+      "alloc_calls": 1040000,
+      "alloc_bytes": 20968960000,
+      "rss_delta_kb": 0
+    },
+    {
+      "name": "lb_round_robin_pick",
+      "scale": 100,
+      "iterations": 300000,
+      "duration_ns": 225765015,
+      "latency_ns_per_op": 752.55005,
+      "alloc_calls": 1800000,
+      "alloc_bytes": 604800000,
+      "rss_delta_kb": 100
+    },
+    {
+      "name": "lb_round_robin_pick",
+      "scale": 1000,
+      "iterations": 200000,
+      "duration_ns": 479591480,
+      "latency_ns_per_op": 2397.9574,
+      "alloc_calls": 1800000,
+      "alloc_bytes": 3270400000,
+      "rss_delta_kb": 48
+    },
+    {
+      "name": "lb_round_robin_pick",
+      "scale": 10000,
+      "iterations": 80000,
+      "duration_ns": 2032046732,
+      "latency_ns_per_op": 25400.58415,
+      "alloc_calls": 1040000,
+      "alloc_bytes": 20968960000,
+      "rss_delta_kb": 72
+    },
+    {
+      "name": "route_lookup_indexed_hit",
+      "scale": 100,
+      "iterations": 300000,
+      "duration_ns": 122955739,
+      "latency_ns_per_op": 409.85246333333333,
+      "alloc_calls": 0,
+      "alloc_bytes": 0,
+      "rss_delta_kb": 8
+    },
+    {
+      "name": "route_lookup_indexed_hit",
+      "scale": 1000,
+      "iterations": 200000,
+      "duration_ns": 78767415,
+      "latency_ns_per_op": 393.837075,
+      "alloc_calls": 0,
+      "alloc_bytes": 0,
+      "rss_delta_kb": 0
+    },
+    {
+      "name": "route_lookup_indexed_hit",
+      "scale": 10000,
+      "iterations": 100000,
+      "duration_ns": 39559684,
+      "latency_ns_per_op": 395.59684,
+      "alloc_calls": 0,
+      "alloc_bytes": 0,
+      "rss_delta_kb": 0
+    },
+    {
+      "name": "route_lookup_indexed_miss",
+      "scale": 100,
+      "iterations": 300000,
+      "duration_ns": 17433333,
+      "latency_ns_per_op": 58.11111,
+      "alloc_calls": 0,
+      "alloc_bytes": 0,
+      "rss_delta_kb": 0
+    },
+    {
+      "name": "route_lookup_indexed_miss",
+      "scale": 1000,
+      "iterations": 200000,
+      "duration_ns": 10815443,
+      "latency_ns_per_op": 54.077215,
+      "alloc_calls": 0,
+      "alloc_bytes": 0,
+      "rss_delta_kb": 0
+    },
+    {
+      "name": "route_lookup_indexed_miss",
+      "scale": 10000,
+      "iterations": 100000,
+      "duration_ns": 5392717,
+      "latency_ns_per_op": 53.92717,
+      "alloc_calls": 0,
+      "alloc_bytes": 0,
+      "rss_delta_kb": 0
+    },
+    {
+      "name": "route_lookup_linear_hit",
+      "scale": 100,
+      "iterations": 200000,
+      "duration_ns": 319469191,
+      "latency_ns_per_op": 1597.345955,
+      "alloc_calls": 0,
+      "alloc_bytes": 0,
+      "rss_delta_kb": 0
+    },
+    {
+      "name": "route_lookup_linear_hit",
+      "scale": 1000,
+      "iterations": 40000,
+      "duration_ns": 901745909,
+      "latency_ns_per_op": 22543.647725,
+      "alloc_calls": 0,
+      "alloc_bytes": 0,
+      "rss_delta_kb": 0
+    },
+    {
+      "name": "route_lookup_linear_hit",
+      "scale": 10000,
+      "iterations": 4000,
+      "duration_ns": 1039993713,
+      "latency_ns_per_op": 259998.42825000003,
+      "alloc_calls": 0,
+      "alloc_bytes": 0,
+      "rss_delta_kb": 0
+    }
+  ]
+}

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "spooky-bench"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+clap.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+libc.workspace = true
+
+spooky-config = { path = "../config" }
+spooky-edge = { path = "../edge" }
+spooky-lb = { path = "../lb" }

--- a/crates/bench/src/main.rs
+++ b/crates/bench/src/main.rs
@@ -1,0 +1,555 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::collections::HashMap;
+use std::fs;
+use std::hint::black_box;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+use clap::Parser;
+use serde::{Deserialize, Serialize};
+use spooky_config::config::{Backend, HealthCheck, LoadBalancing, RouteMatch, Upstream};
+use spooky_edge::benchmark::{ConnectionLookupBench, RouteLookupBench};
+use spooky_lb::UpstreamPool;
+
+struct CountingAllocator;
+
+static ALLOC_CALLS: AtomicU64 = AtomicU64::new(0);
+static ALLOC_BYTES: AtomicU64 = AtomicU64::new(0);
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOC_CALLS.fetch_add(1, Ordering::Relaxed);
+        ALLOC_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        ALLOC_CALLS.fetch_add(1, Ordering::Relaxed);
+        ALLOC_BYTES.fetch_add(new_size as u64, Ordering::Relaxed);
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: CountingAllocator = CountingAllocator;
+
+#[derive(Parser, Debug)]
+#[command(
+    version,
+    about = "Spooky benchmark suite (CPU + memory regression checks)"
+)]
+struct Args {
+    #[arg(long, default_value = "bench/latest.json")]
+    output: PathBuf,
+
+    #[arg(long)]
+    markdown_out: Option<PathBuf>,
+
+    #[arg(long)]
+    baseline: Option<PathBuf>,
+
+    #[arg(long, default_value_t = false)]
+    check_baseline: bool,
+
+    #[arg(long, default_value_t = 0.40)]
+    cpu_threshold: f64,
+
+    #[arg(long, default_value_t = 0.20)]
+    mem_threshold: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct BenchCase {
+    name: String,
+    scale: usize,
+    iterations: u64,
+    duration_ns: u128,
+    latency_ns_per_op: f64,
+    alloc_calls: u64,
+    alloc_bytes: u64,
+    rss_delta_kb: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct BenchReport {
+    suite: String,
+    generated_unix_secs: u64,
+    cpu_threshold: f64,
+    mem_threshold: f64,
+    cases: Vec<BenchCase>,
+}
+
+fn reset_alloc_counters() {
+    ALLOC_CALLS.store(0, Ordering::Relaxed);
+    ALLOC_BYTES.store(0, Ordering::Relaxed);
+}
+
+fn alloc_snapshot() -> (u64, u64) {
+    (
+        ALLOC_CALLS.load(Ordering::Relaxed),
+        ALLOC_BYTES.load(Ordering::Relaxed),
+    )
+}
+
+fn current_rss_kb() -> Option<u64> {
+    #[cfg(target_os = "linux")]
+    {
+        let statm = fs::read_to_string("/proc/self/statm").ok()?;
+        let resident_pages = statm.split_whitespace().nth(1)?.parse::<u64>().ok()?;
+        let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+        if page_size <= 0 {
+            return None;
+        }
+        return Some(resident_pages * (page_size as u64) / 1024);
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let mut usage = unsafe { std::mem::zeroed::<libc::rusage>() };
+        let rc = unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut usage) };
+        if rc != 0 {
+            return None;
+        }
+        #[cfg(target_os = "macos")]
+        {
+            Some((usage.ru_maxrss as u64) / 1024)
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            Some(usage.ru_maxrss as u64)
+        }
+    }
+}
+
+fn run_case(name: &str, scale: usize, iterations: u64, mut op: impl FnMut() -> usize) -> BenchCase {
+    let warmup_iters = (iterations / 10).clamp(100, 10_000);
+    for _ in 0..warmup_iters {
+        black_box(op());
+    }
+
+    reset_alloc_counters();
+    let rss_before = current_rss_kb().unwrap_or(0);
+    let start = Instant::now();
+    let mut sink = 0usize;
+    for _ in 0..iterations {
+        sink ^= op();
+    }
+    black_box(sink);
+    let elapsed = start.elapsed();
+    let rss_after = current_rss_kb().unwrap_or(rss_before);
+    let (alloc_calls, alloc_bytes) = alloc_snapshot();
+
+    BenchCase {
+        name: name.to_string(),
+        scale,
+        iterations,
+        duration_ns: elapsed.as_nanos(),
+        latency_ns_per_op: elapsed.as_secs_f64() * 1e9 / iterations as f64,
+        alloc_calls,
+        alloc_bytes,
+        rss_delta_kb: rss_after.saturating_sub(rss_before),
+    }
+}
+
+fn route_iterations(scale: usize, linear: bool) -> u64 {
+    match (scale, linear) {
+        (100, false) => 300_000,
+        (1_000, false) => 200_000,
+        (10_000, false) => 100_000,
+        (100, true) => 200_000,
+        (1_000, true) => 40_000,
+        (10_000, true) => 4_000,
+        _ => 20_000,
+    }
+}
+
+fn fast_iterations(scale: usize) -> u64 {
+    match scale {
+        100 => 300_000,
+        1_000 => 200_000,
+        10_000 => 80_000,
+        _ => 50_000,
+    }
+}
+
+fn scan_iterations(scale: usize) -> u64 {
+    match scale {
+        100 => 150_000,
+        1_000 => 30_000,
+        10_000 => 3_000,
+        _ => 10_000,
+    }
+}
+
+fn lb_ch_iterations(scale: usize) -> u64 {
+    match scale {
+        100 => 3_000,
+        1_000 => 500,
+        10_000 => 40,
+        _ => 100,
+    }
+}
+
+fn benchmark_route_lookup(scale: usize) -> Vec<BenchCase> {
+    let bench = RouteLookupBench::new(scale);
+    assert_eq!(bench.indexed_hit() > 0, bench.linear_hit() > 0);
+
+    vec![
+        run_case(
+            "route_lookup_indexed_hit",
+            scale,
+            route_iterations(scale, false),
+            || bench.indexed_hit(),
+        ),
+        run_case(
+            "route_lookup_linear_hit",
+            scale,
+            route_iterations(scale, true),
+            || bench.linear_hit(),
+        ),
+        run_case(
+            "route_lookup_indexed_miss",
+            scale,
+            route_iterations(scale, false),
+            || bench.indexed_miss(),
+        ),
+    ]
+}
+
+fn build_lb_upstream(scale: usize, lb_type: &str) -> Upstream {
+    let backends = (0..scale.max(1))
+        .map(|idx| Backend {
+            id: format!("backend-{idx:05}"),
+            address: format!("127.0.0.1:{}", 10_000 + (idx % 50_000)),
+            weight: 1,
+            health_check: HealthCheck {
+                path: "/health".to_string(),
+                interval: 5_000,
+                timeout_ms: 1_000,
+                failure_threshold: 3,
+                success_threshold: 2,
+                cooldown_ms: 5_000,
+            },
+        })
+        .collect();
+
+    Upstream {
+        load_balancing: LoadBalancing {
+            lb_type: lb_type.to_string(),
+            key: None,
+        },
+        route: RouteMatch {
+            host: None,
+            path_prefix: Some("/".to_string()),
+            method: None,
+        },
+        backends,
+    }
+}
+
+fn benchmark_lb(scale: usize) -> Vec<BenchCase> {
+    let mut rr_pool =
+        UpstreamPool::from_upstream(&build_lb_upstream(scale, "round-robin")).expect("rr pool");
+    let mut random_pool =
+        UpstreamPool::from_upstream(&build_lb_upstream(scale, "random")).expect("random pool");
+    let mut ch_pool =
+        UpstreamPool::from_upstream(&build_lb_upstream(scale, "consistent-hash")).expect("ch pool");
+
+    let keys = [
+        "user:1", "user:2", "user:3", "user:4", "user:5", "user:6", "user:7", "user:8",
+    ];
+    let mut ch_key_idx = 0usize;
+
+    vec![
+        run_case("lb_round_robin_pick", scale, fast_iterations(scale), || {
+            rr_pool.pick("ignored").unwrap_or(usize::MAX)
+        }),
+        run_case("lb_random_pick", scale, fast_iterations(scale), || {
+            random_pool.pick("ignored").unwrap_or(usize::MAX)
+        }),
+        run_case(
+            "lb_consistent_hash_pick",
+            scale,
+            lb_ch_iterations(scale),
+            || {
+                let key = keys[ch_key_idx & 7];
+                ch_key_idx = ch_key_idx.wrapping_add(1);
+                ch_pool.pick(key).unwrap_or(usize::MAX)
+            },
+        ),
+    ]
+}
+
+fn benchmark_connection_lookup(scale: usize) -> Vec<BenchCase> {
+    let bench = ConnectionLookupBench::new(scale);
+    assert!(bench.peer_map_hit() > 0);
+
+    vec![
+        run_case(
+            "connection_exact_lookup",
+            scale,
+            fast_iterations(scale),
+            || bench.exact_lookup(),
+        ),
+        run_case(
+            "connection_alias_lookup",
+            scale,
+            fast_iterations(scale),
+            || bench.alias_lookup(),
+        ),
+        run_case(
+            "connection_prefix_scan_miss_lookup",
+            scale,
+            scan_iterations(scale),
+            || bench.prefix_scan_miss_lookup(),
+        ),
+        run_case(
+            "connection_peer_scan_miss",
+            scale,
+            scan_iterations(scale),
+            || bench.peer_scan_miss(),
+        ),
+        run_case(
+            "connection_peer_map_hit",
+            scale,
+            fast_iterations(scale),
+            || bench.peer_map_hit(),
+        ),
+        run_case(
+            "connection_peer_map_miss",
+            scale,
+            fast_iterations(scale),
+            || bench.peer_map_miss(),
+        ),
+    ]
+}
+
+fn compare_reports(
+    current: &BenchReport,
+    baseline: &BenchReport,
+    cpu_threshold: f64,
+    mem_threshold: f64,
+) -> Vec<String> {
+    let baseline_map: HashMap<(String, usize), &BenchCase> = baseline
+        .cases
+        .iter()
+        .map(|case| ((case.name.clone(), case.scale), case))
+        .collect();
+
+    let mut regressions = Vec::new();
+    for case in &current.cases {
+        let Some(base) = baseline_map.get(&(case.name.clone(), case.scale)) else {
+            continue;
+        };
+
+        let cpu_limit = base.latency_ns_per_op * (1.0 + cpu_threshold);
+        if case.latency_ns_per_op > cpu_limit {
+            regressions.push(format!(
+                "CPU regression in {}[{}]: {:.2}ns/op > {:.2}ns/op (baseline {:.2}ns/op, threshold {:.0}%)",
+                case.name,
+                case.scale,
+                case.latency_ns_per_op,
+                cpu_limit,
+                base.latency_ns_per_op,
+                cpu_threshold * 100.0
+            ));
+        }
+
+        let alloc_calls_limit = if base.alloc_calls == 0 {
+            32
+        } else {
+            ((base.alloc_calls as f64) * (1.0 + mem_threshold)).ceil() as u64
+        };
+        if case.alloc_calls > alloc_calls_limit {
+            regressions.push(format!(
+                "alloc_calls regression in {}[{}]: {} > {} (baseline {}, threshold {:.0}%)",
+                case.name,
+                case.scale,
+                case.alloc_calls,
+                alloc_calls_limit,
+                base.alloc_calls,
+                mem_threshold * 100.0
+            ));
+        }
+
+        let alloc_bytes_limit = if base.alloc_bytes == 0 {
+            16 * 1024
+        } else {
+            ((base.alloc_bytes as f64) * (1.0 + mem_threshold)).ceil() as u64
+        };
+        if case.alloc_bytes > alloc_bytes_limit {
+            regressions.push(format!(
+                "alloc_bytes regression in {}[{}]: {} > {} (baseline {}, threshold {:.0}%)",
+                case.name,
+                case.scale,
+                case.alloc_bytes,
+                alloc_bytes_limit,
+                base.alloc_bytes,
+                mem_threshold * 100.0
+            ));
+        }
+
+        // RSS can be noisy for heavy-allocation cases. Enforce strict RSS guardrails
+        // only for low-allocation paths and rely on alloc counters elsewhere.
+        if base.alloc_bytes == 0 && case.alloc_bytes == 0 {
+            let rss_limit = if base.rss_delta_kb == 0 {
+                128
+            } else {
+                ((base.rss_delta_kb as f64) * (1.0 + mem_threshold)).ceil() as u64
+            };
+            if case.rss_delta_kb > rss_limit {
+                regressions.push(format!(
+                    "rss_delta regression in {}[{}]: {}KB > {}KB (baseline {}KB, threshold {:.0}%)",
+                    case.name,
+                    case.scale,
+                    case.rss_delta_kb,
+                    rss_limit,
+                    base.rss_delta_kb,
+                    mem_threshold * 100.0
+                ));
+            }
+        }
+    }
+
+    regressions
+}
+
+fn print_summary(report: &BenchReport) {
+    println!(
+        "{:<34} {:>7} {:>12} {:>12} {:>12}",
+        "case", "scale", "ns/op", "alloc_calls", "rss_kb"
+    );
+    for case in &report.cases {
+        println!(
+            "{:<34} {:>7} {:>12.2} {:>12} {:>12}",
+            case.name, case.scale, case.latency_ns_per_op, case.alloc_calls, case.rss_delta_kb
+        );
+    }
+}
+
+fn write_markdown(path: &Path, report: &BenchReport, regressions: &[String]) -> Result<(), String> {
+    let mut lines = vec![
+        "# Spooky Benchmark Report".to_string(),
+        "".to_string(),
+        format!("- CPU threshold: {:.0}%", report.cpu_threshold * 100.0),
+        format!("- Memory threshold: {:.0}%", report.mem_threshold * 100.0),
+        "".to_string(),
+        "| case | scale | ns/op | alloc_calls | alloc_bytes | rss_delta_kb |".to_string(),
+        "| --- | ---: | ---: | ---: | ---: | ---: |".to_string(),
+    ];
+
+    for case in &report.cases {
+        lines.push(format!(
+            "| {} | {} | {:.2} | {} | {} | {} |",
+            case.name,
+            case.scale,
+            case.latency_ns_per_op,
+            case.alloc_calls,
+            case.alloc_bytes,
+            case.rss_delta_kb
+        ));
+    }
+
+    if regressions.is_empty() {
+        lines.push("".to_string());
+        lines.push("No regressions detected against baseline.".to_string());
+    } else {
+        lines.push("".to_string());
+        lines.push("## Regressions".to_string());
+        for regression in regressions {
+            lines.push(format!("- {regression}"));
+        }
+    }
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|err| {
+            format!(
+                "failed to create markdown dir '{}': {err}",
+                parent.display()
+            )
+        })?;
+    }
+    fs::write(path, lines.join("\n"))
+        .map_err(|err| format!("failed to write markdown '{}': {err}", path.display()))
+}
+
+fn load_report(path: &Path) -> Result<BenchReport, String> {
+    let text = fs::read_to_string(path)
+        .map_err(|err| format!("failed to read baseline '{}': {err}", path.display()))?;
+    serde_json::from_str(&text)
+        .map_err(|err| format!("failed to parse baseline '{}': {err}", path.display()))
+}
+
+fn write_report(path: &Path, report: &BenchReport) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|err| format!("failed to create output dir '{}': {err}", parent.display()))?;
+    }
+    let json =
+        serde_json::to_string_pretty(report).map_err(|err| format!("serialize report: {err}"))?;
+    fs::write(path, json)
+        .map_err(|err| format!("failed to write report '{}': {err}", path.display()))
+}
+
+fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn main() -> Result<(), String> {
+    let args = Args::parse();
+
+    let scales = [100usize, 1_000, 10_000];
+    let mut cases = Vec::new();
+    for scale in scales {
+        cases.extend(benchmark_route_lookup(scale));
+        cases.extend(benchmark_lb(scale));
+        cases.extend(benchmark_connection_lookup(scale));
+    }
+
+    cases.sort_by(|a, b| (&a.name, a.scale).cmp(&(&b.name, b.scale)));
+
+    let report = BenchReport {
+        suite: "spooky-cpu-memory-regression".to_string(),
+        generated_unix_secs: unix_now(),
+        cpu_threshold: args.cpu_threshold,
+        mem_threshold: args.mem_threshold,
+        cases,
+    };
+
+    print_summary(&report);
+    write_report(&args.output, &report)?;
+
+    let mut regressions = Vec::new();
+    if args.check_baseline {
+        let baseline_path = args
+            .baseline
+            .as_ref()
+            .ok_or_else(|| "--check-baseline requires --baseline <path>".to_string())?;
+        let baseline = load_report(baseline_path)?;
+        regressions = compare_reports(&report, &baseline, args.cpu_threshold, args.mem_threshold);
+    }
+
+    if let Some(markdown) = &args.markdown_out {
+        write_markdown(markdown, &report, &regressions)?;
+    }
+
+    if !regressions.is_empty() {
+        for regression in &regressions {
+            eprintln!("{regression}");
+        }
+        return Err(format!(
+            "benchmark regression check failed ({} cases)",
+            regressions.len()
+        ));
+    }
+
+    Ok(())
+}

--- a/crates/edge/src/benchmark.rs
+++ b/crates/edge/src/benchmark.rs
@@ -1,0 +1,191 @@
+use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use spooky_config::config::{Backend, HealthCheck, LoadBalancing, RouteMatch, Upstream};
+
+use crate::route_index::{RouteIndex, scan_lookup};
+
+fn default_health_check() -> HealthCheck {
+    HealthCheck {
+        path: "/health".to_string(),
+        interval: 1_000,
+        timeout_ms: 1_000,
+        failure_threshold: 3,
+        success_threshold: 2,
+        cooldown_ms: 5_000,
+    }
+}
+
+fn build_benchmark_upstream(host: Option<String>, path_prefix: String) -> Upstream {
+    Upstream {
+        load_balancing: LoadBalancing {
+            lb_type: "round-robin".to_string(),
+            key: None,
+        },
+        route: RouteMatch {
+            host,
+            path_prefix: Some(path_prefix),
+            method: None,
+        },
+        // Routing benchmark does not touch backend connectivity.
+        backends: vec![Backend {
+            id: "placeholder".to_string(),
+            address: "127.0.0.1:1".to_string(),
+            weight: 1,
+            health_check: default_health_check(),
+        }],
+    }
+}
+
+pub struct RouteLookupBench {
+    upstreams: HashMap<String, Upstream>,
+    index: RouteIndex,
+    hit_path: String,
+    hit_host: Option<String>,
+    miss_path: String,
+    miss_host: Option<String>,
+}
+
+impl RouteLookupBench {
+    pub fn new(scale: usize) -> Self {
+        let mut upstreams = HashMap::with_capacity(scale.max(1));
+        for i in 0..scale.max(1) {
+            let name = format!("upstream-{i:05}");
+            let path_prefix = format!("/svc/{i:05}");
+            let host = (i % 2 == 1).then_some("bench.example.com".to_string());
+            upstreams.insert(name, build_benchmark_upstream(host, path_prefix));
+        }
+
+        let index = RouteIndex::from_upstreams(&upstreams);
+        let target = scale.max(1) - 1;
+        let hit_path = format!("/svc/{target:05}/resource");
+        let hit_host = (target % 2 == 1).then_some("bench.example.com".to_string());
+        let miss_path = "/not-found/path".to_string();
+        let miss_host = Some("missing.example.com".to_string());
+
+        Self {
+            upstreams,
+            index,
+            hit_path,
+            hit_host,
+            miss_path,
+            miss_host,
+        }
+    }
+
+    pub fn indexed_hit(&self) -> usize {
+        self.index
+            .lookup(&self.hit_path, self.hit_host.as_deref())
+            .map_or(0, str::len)
+    }
+
+    pub fn linear_hit(&self) -> usize {
+        scan_lookup(&self.upstreams, &self.hit_path, self.hit_host.as_deref()).map_or(0, str::len)
+    }
+
+    pub fn indexed_miss(&self) -> usize {
+        self.index
+            .lookup(&self.miss_path, self.miss_host.as_deref())
+            .map_or(0, str::len)
+    }
+}
+
+pub struct ConnectionLookupBench {
+    exact_routes: HashMap<Vec<u8>, SocketAddr>,
+    alias_routes: HashMap<Vec<u8>, Vec<u8>>,
+    peer_routes: HashMap<SocketAddr, Vec<u8>>,
+    hit_exact: Vec<u8>,
+    hit_alias: Vec<u8>,
+    prefix_miss: Vec<u8>,
+    miss_peer: SocketAddr,
+}
+
+impl ConnectionLookupBench {
+    pub fn new(scale: usize) -> Self {
+        let size = scale.max(1);
+        let mut exact_routes = HashMap::with_capacity(size);
+        let mut alias_routes = HashMap::with_capacity(size);
+        let mut peer_routes = HashMap::with_capacity(size);
+
+        for i in 0..size {
+            let mut primary = vec![0_u8; 16];
+            primary[..8].copy_from_slice(&(i as u64).to_be_bytes());
+            let peer = SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::new(
+                    172,
+                    16,
+                    ((i >> 8) & 0xff) as u8,
+                    (i & 0xff) as u8,
+                )),
+                20_000 + (i % 20_000) as u16,
+            );
+
+            exact_routes.insert(primary.clone(), peer);
+            peer_routes.insert(peer, primary.clone());
+
+            let mut alias = primary.clone();
+            alias.extend_from_slice(&[0xaa, 0xbb, 0xcc, 0xdd]);
+            alias_routes.insert(alias, primary);
+        }
+
+        let hit_exact: Vec<u8> = (0_u64)
+            .to_be_bytes()
+            .iter()
+            .copied()
+            .chain([0_u8; 8])
+            .collect();
+        let mut hit_alias = hit_exact.clone();
+        hit_alias.extend_from_slice(&[0xaa, 0xbb, 0xcc, 0xdd]);
+        let prefix_miss = vec![0xff; 24];
+        let miss_peer = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 255, 255, 255)), 65535);
+
+        Self {
+            exact_routes,
+            alias_routes,
+            peer_routes,
+            hit_exact,
+            hit_alias,
+            prefix_miss,
+            miss_peer,
+        }
+    }
+
+    pub fn exact_lookup(&self) -> usize {
+        self.exact_routes.get(&self.hit_exact).map_or(0, |_| 1)
+    }
+
+    pub fn alias_lookup(&self) -> usize {
+        self.alias_routes
+            .get(&self.hit_alias)
+            .and_then(|primary| self.exact_routes.get(primary))
+            .map_or(0, |_| 1)
+    }
+
+    pub fn prefix_scan_miss_lookup(&self) -> usize {
+        self.exact_routes
+            .keys()
+            .find(|cid| self.prefix_miss.starts_with(cid.as_slice()))
+            .map_or(0, |_| 1)
+    }
+
+    pub fn peer_scan_miss(&self) -> usize {
+        self.exact_routes
+            .iter()
+            .find_map(|(_cid, peer)| (*peer == self.miss_peer).then_some(1))
+            .unwrap_or(0)
+    }
+
+    pub fn peer_map_hit(&self) -> usize {
+        self.peer_routes
+            .get(
+                self.exact_routes
+                    .get(&self.hit_exact)
+                    .expect("seed peer exists"),
+            )
+            .map_or(0, |_| 1)
+    }
+
+    pub fn peer_map_miss(&self) -> usize {
+        self.peer_routes.get(&self.miss_peer).map_or(0, |_| 1)
+    }
+}

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -14,6 +14,7 @@ use spooky_config::config::Config;
 use spooky_lb::UpstreamPool;
 use spooky_transport::h2_pool::H2Pool;
 
+pub mod benchmark;
 pub mod quic_listener;
 mod route_index;
 

--- a/crates/edge/src/route_index.rs
+++ b/crates/edge/src/route_index.rs
@@ -142,7 +142,6 @@ fn prefer_route(
     }
 }
 
-#[cfg(test)]
 pub(crate) fn scan_lookup<'a>(
     upstreams: &'a HashMap<String, Upstream>,
     path: &str,

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,79 @@
+# Benchmarks
+
+Spooky includes a dedicated benchmark harness for CPU and memory regression tracking.
+
+## Scope
+
+The suite measures:
+
+- Route lookup (indexed and linear reference)
+- Load balancer selection (round-robin, random, consistent-hash)
+- Connection lookup primitives (exact, alias, CID prefix scan, peer scan/map fallback)
+
+Each benchmark runs at scales:
+
+- 100
+- 1,000
+- 10,000
+
+## Metrics
+
+For every benchmark case, the harness reports:
+
+- `latency_ns_per_op` (CPU)
+- `alloc_calls` (allocation count)
+- `alloc_bytes` (total allocated bytes)
+- `rss_delta_kb` (resident memory delta)
+
+Outputs are written to JSON and optional Markdown summary.
+
+## Run Locally
+
+Generate a fresh benchmark report:
+
+```bash
+cargo run -p spooky-bench --release -- \
+  --output bench/latest.json \
+  --markdown-out bench/latest.md
+```
+
+Run regression checks against baseline:
+
+```bash
+cargo run -p spooky-bench --release -- \
+  --output bench/latest.json \
+  --baseline bench/baseline.json \
+  --check-baseline \
+  --cpu-threshold 0.40 \
+  --mem-threshold 0.20 \
+  --markdown-out bench/latest.md
+```
+
+## Baseline and Thresholds
+
+Baseline file:
+
+- `bench/baseline.json`
+
+Current thresholds:
+
+- CPU regression threshold: `40%`
+- Memory regression threshold: `20%`
+
+Regression checks fail if benchmark metrics exceed thresholds versus baseline.
+
+## Memory Guardrail Policy
+
+All performance-related changes must include memory deltas in reports.
+
+- Regressions with significant memory inflation should be rejected.
+- If memory growth is intentional, it must be justified in PR notes with benchmark evidence.
+
+## Artifacts
+
+Benchmark runs can emit:
+
+- JSON report
+- Markdown summary
+
+Use these artifacts to track trend lines and justify threshold updates when needed.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
     - Troubleshooting: troubleshooting/common-issues.md
   - Development:
     - Contributing: development/contributing.md
+    - Benchmarks: benchmarks.md
     - Changelog: changelog.md
   - Protocols:
     - HTTP/3: protocols/http3.md


### PR DESCRIPTION
Ref: #38 
## Summary
Adds a dedicated benchmark suite to track CPU and memory regressions for hot lookup/selection paths at realistic scales (100, 1k, 10k), with baseline comparison and threshold-based pass/fail checks.  
Nightly benchmark workflow is intentionally removed; this is local/manual only.

## What changed
- Added new benchmark crate: `crates/bench` (`spooky-bench` binary).
- Added benchmark coverage for:
  - route lookup (indexed hit/miss + linear reference hit),
  - LB selection (round-robin, random, consistent-hash),
  - connection lookup paths (exact, alias, prefix-scan miss, peer-scan miss, peer-map hit/miss).
- Added metrics output per case:
  - `latency_ns_per_op`,
  - `alloc_calls`,
  - `alloc_bytes`,
  - `rss_delta_kb`.
- Added baseline/report artifacts support:
  - `bench/baseline.json`,
  - optional markdown output (`--markdown-out`).
- Added threshold gating:
  - CPU threshold default `40%`,
  - memory threshold default `20%`.
- Added benchmark docs and usage guidance.
- Removed benchmark GitHub Actions workflow (`.github/workflows/bench-nightly.yml`).

## How to run
- Generate report:
  - `cargo run -p spooky-bench --release -- --output bench/latest.json --markdown-out bench/latest.md`
- Check against baseline:
  - `cargo run -p spooky-bench --release -- --output bench/latest.json --baseline bench/baseline.json --check-baseline --cpu-threshold 0.40 --mem-threshold 0.20`

## Acceptance criteria mapping
- Bench suite covers routing/LB/connection lookup at 100/1k/10k scales.
- Outputs latency + allocation + RSS metrics.
- Includes documented pass/fail thresholds and baseline comparison.
- Memory deltas are reported to enforce RAM guardrails.