### PR TITLE
Refactor: centralize runtime/tuning constants and remove magic numbers

### DIFF
--- a/crates/edge/src/benchmark.rs
+++ b/crates/edge/src/benchmark.rs
@@ -3,6 +3,11 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use spooky_config::config::{Backend, HealthCheck, LoadBalancing, RouteMatch, Upstream};
 
+use crate::constants::{
+    BENCH_CONN_ALIAS_SUFFIX, BENCH_CONN_MISS_ID_FILL, BENCH_CONN_MISS_ID_LEN_BYTES,
+    BENCH_CONN_MISS_PORT, BENCH_CONN_PEER_BASE_PORT, BENCH_CONN_PEER_PORT_SPAN,
+    BENCH_CONN_PRIMARY_ID_LEN_BYTES, BENCH_CONN_PRIMARY_ID_PREFIX_BYTES,
+};
 use crate::route_index::{RouteIndex, scan_lookup};
 
 fn default_health_check() -> HealthCheck {
@@ -108,8 +113,9 @@ impl ConnectionLookupBench {
         let mut peer_routes = HashMap::with_capacity(size);
 
         for i in 0..size {
-            let mut primary = vec![0_u8; 16];
-            primary[..8].copy_from_slice(&(i as u64).to_be_bytes());
+            let mut primary = vec![0_u8; BENCH_CONN_PRIMARY_ID_LEN_BYTES];
+            primary[..BENCH_CONN_PRIMARY_ID_PREFIX_BYTES]
+                .copy_from_slice(&(i as u64).to_be_bytes());
             let peer = SocketAddr::new(
                 IpAddr::V4(Ipv4Addr::new(
                     172,
@@ -117,14 +123,14 @@ impl ConnectionLookupBench {
                     ((i >> 8) & 0xff) as u8,
                     (i & 0xff) as u8,
                 )),
-                20_000 + (i % 20_000) as u16,
+                BENCH_CONN_PEER_BASE_PORT + (i % BENCH_CONN_PEER_PORT_SPAN) as u16,
             );
 
             exact_routes.insert(primary.clone(), peer);
             peer_routes.insert(peer, primary.clone());
 
             let mut alias = primary.clone();
-            alias.extend_from_slice(&[0xaa, 0xbb, 0xcc, 0xdd]);
+            alias.extend_from_slice(&BENCH_CONN_ALIAS_SUFFIX);
             alias_routes.insert(alias, primary);
         }
 
@@ -132,12 +138,15 @@ impl ConnectionLookupBench {
             .to_be_bytes()
             .iter()
             .copied()
-            .chain([0_u8; 8])
+            .chain([0_u8; BENCH_CONN_PRIMARY_ID_PREFIX_BYTES])
             .collect();
         let mut hit_alias = hit_exact.clone();
-        hit_alias.extend_from_slice(&[0xaa, 0xbb, 0xcc, 0xdd]);
-        let prefix_miss = vec![0xff; 24];
-        let miss_peer = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 255, 255, 255)), 65535);
+        hit_alias.extend_from_slice(&BENCH_CONN_ALIAS_SUFFIX);
+        let prefix_miss = vec![BENCH_CONN_MISS_ID_FILL; BENCH_CONN_MISS_ID_LEN_BYTES];
+        let miss_peer = SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(10, 255, 255, 255)),
+            BENCH_CONN_MISS_PORT,
+        );
 
         Self {
             exact_routes,

--- a/crates/edge/src/constants.rs
+++ b/crates/edge/src/constants.rs
@@ -1,0 +1,48 @@
+use std::time::Duration;
+
+pub const MAX_DATAGRAM_SIZE_BYTES: usize = 65_535;
+pub const MAX_UDP_PAYLOAD_BYTES: usize = 1_350;
+
+pub const UDP_READ_TIMEOUT_MS: u64 = 50;
+pub const BACKEND_TIMEOUT_SECS: u64 = 2;
+pub const DRAIN_TIMEOUT_SECS: u64 = 5;
+pub const REQUEST_TIMEOUT_SECS: u64 = 5;
+
+pub const QUIC_IDLE_TIMEOUT_MS: u64 = 5_000;
+pub const QUIC_INITIAL_MAX_DATA: u64 = 10_000_000;
+pub const QUIC_INITIAL_STREAM_DATA: u64 = 1_000_000;
+pub const QUIC_INITIAL_MAX_STREAMS_BIDI: u64 = 100;
+pub const QUIC_INITIAL_MAX_STREAMS_UNI: u64 = 100;
+
+pub const MAX_INFLIGHT_PER_BACKEND: usize = 64;
+pub const DEFAULT_SCID_LEN_BYTES: usize = 16;
+pub const RESET_TOKEN_LEN_BYTES: usize = 16;
+pub const MIN_SCID_LEN_BYTES: usize = 8;
+
+pub const SCID_ROTATION_INTERVAL_SECS: u64 = 60;
+pub const SCID_ROTATION_PACKET_THRESHOLD: u64 = 8;
+
+pub const BENCH_CONN_PRIMARY_ID_LEN_BYTES: usize = 16;
+pub const BENCH_CONN_PRIMARY_ID_PREFIX_BYTES: usize = 8;
+pub const BENCH_CONN_ALIAS_SUFFIX: [u8; 4] = [0xaa, 0xbb, 0xcc, 0xdd];
+pub const BENCH_CONN_MISS_ID_LEN_BYTES: usize = 24;
+pub const BENCH_CONN_MISS_ID_FILL: u8 = 0xff;
+pub const BENCH_CONN_PEER_BASE_PORT: u16 = 20_000;
+pub const BENCH_CONN_PEER_PORT_SPAN: usize = 20_000;
+pub const BENCH_CONN_MISS_PORT: u16 = u16::MAX;
+
+pub fn backend_timeout() -> Duration {
+    Duration::from_secs(BACKEND_TIMEOUT_SECS)
+}
+
+pub fn drain_timeout() -> Duration {
+    Duration::from_secs(DRAIN_TIMEOUT_SECS)
+}
+
+pub fn request_timeout() -> Duration {
+    Duration::from_secs(REQUEST_TIMEOUT_SECS)
+}
+
+pub fn scid_rotation_interval() -> Duration {
+    Duration::from_secs(SCID_ROTATION_INTERVAL_SECS)
+}

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -15,9 +15,11 @@ use spooky_lb::UpstreamPool;
 use spooky_transport::h2_pool::H2Pool;
 
 use crate::cid_radix::CidRadix;
+use crate::constants::MAX_DATAGRAM_SIZE_BYTES;
 
 pub mod benchmark;
 pub mod cid_radix;
+pub mod constants;
 pub mod quic_listener;
 mod route_index;
 
@@ -33,8 +35,8 @@ pub struct QUICListener {
     pub draining: bool,
     pub drain_start: Option<Instant>,
 
-    pub recv_buf: [u8; 65535], // array initialization, let arr [<data type>, <no of elements>] = [<value of all>, <no of elements>]
-    pub send_buf: [u8; 65535],
+    pub recv_buf: [u8; MAX_DATAGRAM_SIZE_BYTES],
+    pub send_buf: [u8; MAX_DATAGRAM_SIZE_BYTES],
 
     pub connections: HashMap<Arc<[u8]>, QuicConnection>, // KEY: SCID(server connection id)
     pub cid_routes: HashMap<Vec<u8>, Vec<u8>>,           // KEY: alias SCID, VALUE: primary SCID

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -22,7 +22,17 @@ use tokio::runtime::Handle;
 use spooky_config::config::Config as SpookyConfig;
 
 use crate::{
-    Metrics, QUICListener, QuicConnection, RequestEnvelope, cid_radix::CidRadix, outcome_from_status, route_index::RouteIndex
+    Metrics, QUICListener, QuicConnection, RequestEnvelope,
+    cid_radix::CidRadix,
+    constants::{
+        DEFAULT_SCID_LEN_BYTES, MAX_DATAGRAM_SIZE_BYTES, MAX_INFLIGHT_PER_BACKEND,
+        MAX_UDP_PAYLOAD_BYTES, MIN_SCID_LEN_BYTES, QUIC_IDLE_TIMEOUT_MS, QUIC_INITIAL_MAX_DATA,
+        QUIC_INITIAL_MAX_STREAMS_BIDI, QUIC_INITIAL_MAX_STREAMS_UNI, QUIC_INITIAL_STREAM_DATA,
+        RESET_TOKEN_LEN_BYTES, SCID_ROTATION_PACKET_THRESHOLD, UDP_READ_TIMEOUT_MS,
+        backend_timeout, drain_timeout, scid_rotation_interval,
+    },
+    outcome_from_status,
+    route_index::RouteIndex,
 };
 
 fn is_hop_header(name: &str) -> bool {
@@ -44,19 +54,13 @@ fn request_hash_key(req: &RequestEnvelope) -> &str {
     &req.method
 }
 
-const BACKEND_TIMEOUT: Duration = Duration::from_secs(2);
-const MAX_INFLIGHT_PER_BACKEND: usize = 64;
-const DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
-const SCID_ROTATION_INTERVAL: Duration = Duration::from_secs(60);
-const SCID_ROTATION_PACKET_THRESHOLD: u64 = 8;
-
 impl QUICListener {
     pub fn new(config: SpookyConfig) -> Result<Self, ProxyError> {
         let socket_address = format!("{}:{}", &config.listen.address, &config.listen.port);
 
         let socket = UdpSocket::bind(socket_address.as_str()).expect("Failed to bind UDP socker");
         socket
-            .set_read_timeout(Some(Duration::from_millis(50)))
+            .set_read_timeout(Some(Duration::from_millis(UDP_READ_TIMEOUT_MS)))
             .expect("Failed to set UDP read timeout");
 
         let mut quic_config = Config::new(quiche::PROTOCOL_VERSION).expect("REASON");
@@ -84,15 +88,15 @@ impl QUICListener {
         quic_config
             .set_application_protos(quiche::h3::APPLICATION_PROTOCOL)
             .unwrap();
-        quic_config.set_max_idle_timeout(5000);
-        quic_config.set_max_recv_udp_payload_size(1350);
-        quic_config.set_max_send_udp_payload_size(1350);
-        quic_config.set_initial_max_data(10_000_000);
-        quic_config.set_initial_max_stream_data_bidi_local(1_000_000);
-        quic_config.set_initial_max_stream_data_bidi_remote(1_000_000);
-        quic_config.set_initial_max_stream_data_uni(1_000_000);
-        quic_config.set_initial_max_streams_bidi(100);
-        quic_config.set_initial_max_streams_uni(100);
+        quic_config.set_max_idle_timeout(QUIC_IDLE_TIMEOUT_MS);
+        quic_config.set_max_recv_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+        quic_config.set_max_send_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+        quic_config.set_initial_max_data(QUIC_INITIAL_MAX_DATA);
+        quic_config.set_initial_max_stream_data_bidi_local(QUIC_INITIAL_STREAM_DATA);
+        quic_config.set_initial_max_stream_data_bidi_remote(QUIC_INITIAL_STREAM_DATA);
+        quic_config.set_initial_max_stream_data_uni(QUIC_INITIAL_STREAM_DATA);
+        quic_config.set_initial_max_streams_bidi(QUIC_INITIAL_MAX_STREAMS_BIDI);
+        quic_config.set_initial_max_streams_uni(QUIC_INITIAL_MAX_STREAMS_UNI);
         quic_config.set_disable_active_migration(true);
         quic_config.verify_peer(false);
 
@@ -138,12 +142,12 @@ impl QUICListener {
             metrics,
             draining: false,
             drain_start: None,
-            recv_buf: [0; 65535],
-            send_buf: [0; 65535],
+            recv_buf: [0; MAX_DATAGRAM_SIZE_BYTES],
+            send_buf: [0; MAX_DATAGRAM_SIZE_BYTES],
             connections: HashMap::new(),
             cid_routes: HashMap::new(),
             peer_routes: HashMap::new(),
-            cid_radix: CidRadix::new()
+            cid_radix: CidRadix::new(),
         })
     }
 
@@ -166,7 +170,7 @@ impl QUICListener {
         }
 
         if let Some(start) = self.drain_start
-            && start.elapsed() >= DRAIN_TIMEOUT
+            && start.elapsed() >= drain_timeout()
         {
             self.close_all();
             return true;
@@ -184,7 +188,7 @@ impl QUICListener {
             }
         };
 
-        let mut send_buf = [0u8; 65_535];
+        let mut send_buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
         for connection in self.connections.values_mut() {
             let _ = connection.quic.close(true, 0x0, b"draining");
             Self::flush_send(&socket, &mut send_buf, connection);
@@ -230,7 +234,7 @@ impl QUICListener {
 
         // For Short packets, try prefix match (client may append bytes to our SCID)
         // This handles cases where client uses longer DCIDs based on server's SCID
-        if header.ty == quiche::Type::Short && dcid_bytes.len() > 8 {
+        if header.ty == quiche::Type::Short && dcid_bytes.len() > MIN_SCID_LEN_BYTES {
             if let Some(matched_cid) = self.cid_radix.longest_prefix_match(&dcid_bytes) {
                 debug!(
                     "Found connection via prefix match. Stored CID: {:02x?}, Packet DCID: {:02x?}",
@@ -261,7 +265,7 @@ impl QUICListener {
             // return None;
         }
 
-        let mut scid_bytes = [0u8; 16]; // scid must be >= 8 bytes, 16 is perfect
+        let mut scid_bytes = [0u8; DEFAULT_SCID_LEN_BYTES];
         rand::thread_rng().fill_bytes(&mut scid_bytes);
 
         let scid = quiche::ConnectionId::from_ref(&scid_bytes);
@@ -292,7 +296,7 @@ impl QUICListener {
     }
 
     fn random_reset_token() -> u128 {
-        let mut token = [0u8; 16];
+        let mut token = [0u8; RESET_TOKEN_LEN_BYTES];
         rand::thread_rng().fill_bytes(&mut token);
         u128::from_be_bytes(token)
     }
@@ -305,7 +309,7 @@ impl QUICListener {
         let now = Instant::now();
         let elapsed = now.saturating_duration_since(connection.last_scid_rotation);
         if connection.packets_since_rotation < SCID_ROTATION_PACKET_THRESHOLD
-            && elapsed < SCID_ROTATION_INTERVAL
+            && elapsed < scid_rotation_interval()
         {
             return;
         }
@@ -314,7 +318,12 @@ impl QUICListener {
             return;
         }
 
-        let cid_len = connection.quic.source_id().as_ref().len().max(8);
+        let cid_len = connection
+            .quic
+            .source_id()
+            .as_ref()
+            .len()
+            .max(MIN_SCID_LEN_BYTES);
         let mut cid_bytes = vec![0u8; cid_len];
         rand::thread_rng().fill_bytes(&mut cid_bytes);
 
@@ -388,8 +397,12 @@ impl QUICListener {
         // Add new SCIDs to radix trie
         for cid in &active_scids {
             // Get Arc<[u8]> reference from connections HashMap
-            if let Some(arc_cid) = self.connections.keys().find(|k| k.as_ref() == cid.as_slice()) {
-                self.cid_radix.insert(Arc::clone(arc_cid));  // NEW
+            if let Some(arc_cid) = self
+                .connections
+                .keys()
+                .find(|k| k.as_ref() == cid.as_slice())
+            {
+                self.cid_radix.insert(Arc::clone(arc_cid)); // NEW
             }
         }
 
@@ -587,7 +600,7 @@ impl QUICListener {
 
         Self::maybe_rotate_scid(&mut connection, &self.metrics);
 
-        let mut send_buf = [0u8; 65_535];
+        let mut send_buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
 
         Self::flush_send(&socket, &mut send_buf, &mut connection);
         Self::handle_timeout(&socket, &mut send_buf, &mut connection);
@@ -621,7 +634,7 @@ impl QUICListener {
             }
         };
 
-        let mut send_buf = [0u8; 65_535];
+        let mut send_buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
         let mut to_remove = Vec::new();
 
         for (scid, connection) in self.connections.iter_mut() {
@@ -673,7 +686,7 @@ impl QUICListener {
         routing_index: &RouteIndex,
         metrics: &Metrics,
     ) -> Result<(), quiche::h3::Error> {
-        let mut body_buf = [0u8; 65_535];
+        let mut body_buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
 
         if connection.h3.is_none() {
             connection.h3 = Some(quiche::h3::Connection::with_transport(
@@ -978,7 +991,7 @@ impl QUICListener {
         .map_err(ProxyError::Bridge)?;
 
         let response = run_blocking(|| async {
-            tokio::time::timeout(BACKEND_TIMEOUT, h2_pool.send(backend_addr, request)).await
+            tokio::time::timeout(backend_timeout(), h2_pool.send(backend_addr, request)).await
         })
         .map_err(|e| ProxyError::Transport(format!("send: {e}")))?;
 
@@ -989,9 +1002,10 @@ impl QUICListener {
 
         let (parts, body) = response.into_parts();
 
-        let body_bytes =
-            run_blocking(|| async { tokio::time::timeout(BACKEND_TIMEOUT, body.collect()).await })
-                .map_err(|e| ProxyError::Transport(format!("body: {e}")))?;
+        let body_bytes = run_blocking(|| async {
+            tokio::time::timeout(backend_timeout(), body.collect()).await
+        })
+        .map_err(|e| ProxyError::Transport(format!("body: {e}")))?;
 
         let body_bytes = match body_bytes {
             Ok(inner) => inner

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -18,6 +18,11 @@ use tokio::net::TcpListener;
 
 use spooky_config::config::{Backend, Config, HealthCheck, Listen, LoadBalancing, Log, Tls};
 use spooky_edge::QUICListener;
+use spooky_edge::constants::{
+    MAX_DATAGRAM_SIZE_BYTES, MAX_UDP_PAYLOAD_BYTES, QUIC_IDLE_TIMEOUT_MS, QUIC_INITIAL_MAX_DATA,
+    QUIC_INITIAL_MAX_STREAMS_BIDI, QUIC_INITIAL_MAX_STREAMS_UNI, QUIC_INITIAL_STREAM_DATA,
+    REQUEST_TIMEOUT_SECS, UDP_READ_TIMEOUT_MS,
+};
 
 fn write_test_certs(dir: &TempDir) -> (String, String) {
     let mut params = CertificateParams::new(vec!["localhost".into()]);
@@ -120,15 +125,15 @@ fn run_h3_client(addr: SocketAddr) -> Result<String, String> {
     config
         .set_application_protos(quiche::h3::APPLICATION_PROTOCOL)
         .map_err(|e| format!("alpn: {e:?}"))?;
-    config.set_max_idle_timeout(5_000);
-    config.set_max_recv_udp_payload_size(1350);
-    config.set_max_send_udp_payload_size(1350);
-    config.set_initial_max_data(10_000_000);
-    config.set_initial_max_stream_data_bidi_local(1_000_000);
-    config.set_initial_max_stream_data_bidi_remote(1_000_000);
-    config.set_initial_max_stream_data_uni(1_000_000);
-    config.set_initial_max_streams_bidi(100);
-    config.set_initial_max_streams_uni(100);
+    config.set_max_idle_timeout(QUIC_IDLE_TIMEOUT_MS);
+    config.set_max_recv_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    config.set_max_send_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    config.set_initial_max_data(QUIC_INITIAL_MAX_DATA);
+    config.set_initial_max_stream_data_bidi_local(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_stream_data_bidi_remote(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_stream_data_uni(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_streams_bidi(QUIC_INITIAL_MAX_STREAMS_BIDI);
+    config.set_initial_max_streams_uni(QUIC_INITIAL_MAX_STREAMS_UNI);
     config.set_disable_active_migration(true);
 
     let mut scid_bytes = [0u8; quiche::MAX_CONN_ID_LEN];
@@ -141,8 +146,8 @@ fn run_h3_client(addr: SocketAddr) -> Result<String, String> {
     let h3_config = quiche::h3::Config::new().map_err(|e| format!("h3: {e:?}"))?;
     let mut h3_conn: Option<quiche::h3::Connection> = None;
 
-    let mut out = [0u8; 1350];
-    let mut buf = [0u8; 65_535];
+    let mut out = [0u8; MAX_UDP_PAYLOAD_BYTES];
+    let mut buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
 
     let (write, send_info) = conn.send(&mut out).map_err(|e| format!("send: {e:?}"))?;
     socket
@@ -164,7 +169,9 @@ fn run_h3_client(addr: SocketAddr) -> Result<String, String> {
             }
         }
 
-        let timeout = conn.timeout().unwrap_or(Duration::from_millis(50));
+        let timeout = conn
+            .timeout()
+            .unwrap_or(Duration::from_millis(UDP_READ_TIMEOUT_MS));
         socket
             .set_read_timeout(Some(timeout))
             .map_err(|e| format!("timeout: {e:?}"))?;
@@ -233,7 +240,7 @@ fn run_h3_client(addr: SocketAddr) -> Result<String, String> {
             }
         }
 
-        if start.elapsed() > Duration::from_secs(5) {
+        if start.elapsed() > Duration::from_secs(REQUEST_TIMEOUT_SECS) {
             return Err("timeout waiting for response".to_string());
         }
     }

--- a/crates/edge/tests/h3_edge.rs
+++ b/crates/edge/tests/h3_edge.rs
@@ -19,6 +19,11 @@ use tokio::net::TcpListener;
 
 use spooky_config::config::{Backend, Config, HealthCheck, Listen, LoadBalancing, Log, Tls};
 use spooky_edge::QUICListener;
+use spooky_edge::constants::{
+    MAX_DATAGRAM_SIZE_BYTES, MAX_UDP_PAYLOAD_BYTES, QUIC_IDLE_TIMEOUT_MS, QUIC_INITIAL_MAX_DATA,
+    QUIC_INITIAL_MAX_STREAMS_BIDI, QUIC_INITIAL_MAX_STREAMS_UNI, QUIC_INITIAL_STREAM_DATA,
+    REQUEST_TIMEOUT_SECS, UDP_READ_TIMEOUT_MS,
+};
 
 fn write_test_certs(dir: &TempDir) -> (String, String) {
     let mut params = CertificateParams::new(vec!["localhost".into()]);
@@ -127,15 +132,15 @@ fn run_h3_client(addr: std::net::SocketAddr) -> Result<String, String> {
     config
         .set_application_protos(quiche::h3::APPLICATION_PROTOCOL)
         .map_err(|e| format!("alpn: {e:?}"))?;
-    config.set_max_idle_timeout(5_000);
-    config.set_max_recv_udp_payload_size(1350);
-    config.set_max_send_udp_payload_size(1350);
-    config.set_initial_max_data(10_000_000);
-    config.set_initial_max_stream_data_bidi_local(1_000_000);
-    config.set_initial_max_stream_data_bidi_remote(1_000_000);
-    config.set_initial_max_stream_data_uni(1_000_000);
-    config.set_initial_max_streams_bidi(100);
-    config.set_initial_max_streams_uni(100);
+    config.set_max_idle_timeout(QUIC_IDLE_TIMEOUT_MS);
+    config.set_max_recv_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    config.set_max_send_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    config.set_initial_max_data(QUIC_INITIAL_MAX_DATA);
+    config.set_initial_max_stream_data_bidi_local(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_stream_data_bidi_remote(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_stream_data_uni(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_streams_bidi(QUIC_INITIAL_MAX_STREAMS_BIDI);
+    config.set_initial_max_streams_uni(QUIC_INITIAL_MAX_STREAMS_UNI);
     config.set_disable_active_migration(true);
 
     let mut scid_bytes = [0u8; quiche::MAX_CONN_ID_LEN];
@@ -148,8 +153,8 @@ fn run_h3_client(addr: std::net::SocketAddr) -> Result<String, String> {
     let h3_config = quiche::h3::Config::new().map_err(|e| format!("h3: {e:?}"))?;
     let mut h3_conn: Option<quiche::h3::Connection> = None;
 
-    let mut out = [0u8; 1350];
-    let mut buf = [0u8; 65_535];
+    let mut out = [0u8; MAX_UDP_PAYLOAD_BYTES];
+    let mut buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
 
     let (write, send_info) = conn.send(&mut out).map_err(|e| format!("send: {e:?}"))?;
     socket
@@ -171,7 +176,9 @@ fn run_h3_client(addr: std::net::SocketAddr) -> Result<String, String> {
             }
         }
 
-        let timeout = conn.timeout().unwrap_or(Duration::from_millis(50));
+        let timeout = conn
+            .timeout()
+            .unwrap_or(Duration::from_millis(UDP_READ_TIMEOUT_MS));
         socket
             .set_read_timeout(Some(timeout))
             .map_err(|e| format!("timeout: {e:?}"))?;
@@ -240,7 +247,7 @@ fn run_h3_client(addr: std::net::SocketAddr) -> Result<String, String> {
             }
         }
 
-        if start.elapsed() > Duration::from_secs(5) {
+        if start.elapsed() > Duration::from_secs(REQUEST_TIMEOUT_SECS) {
             return Err("timeout waiting for response".to_string());
         }
     }
@@ -260,15 +267,15 @@ fn run_h3_client_multiple_requests(
         .set_application_protos(quiche::h3::APPLICATION_PROTOCOL)
         .map_err(|e| format!("alpn: {e:?}"))?;
     config.set_active_connection_id_limit(8);
-    config.set_max_idle_timeout(5_000);
-    config.set_max_recv_udp_payload_size(1350);
-    config.set_max_send_udp_payload_size(1350);
-    config.set_initial_max_data(10_000_000);
-    config.set_initial_max_stream_data_bidi_local(1_000_000);
-    config.set_initial_max_stream_data_bidi_remote(1_000_000);
-    config.set_initial_max_stream_data_uni(1_000_000);
-    config.set_initial_max_streams_bidi(100);
-    config.set_initial_max_streams_uni(100);
+    config.set_max_idle_timeout(QUIC_IDLE_TIMEOUT_MS);
+    config.set_max_recv_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    config.set_max_send_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    config.set_initial_max_data(QUIC_INITIAL_MAX_DATA);
+    config.set_initial_max_stream_data_bidi_local(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_stream_data_bidi_remote(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_stream_data_uni(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_streams_bidi(QUIC_INITIAL_MAX_STREAMS_BIDI);
+    config.set_initial_max_streams_uni(QUIC_INITIAL_MAX_STREAMS_UNI);
     config.set_disable_active_migration(true);
 
     let mut scid_bytes = [0u8; quiche::MAX_CONN_ID_LEN];
@@ -280,8 +287,8 @@ fn run_h3_client_multiple_requests(
     let h3_config = quiche::h3::Config::new().map_err(|e| format!("h3: {e:?}"))?;
     let mut h3_conn: Option<quiche::h3::Connection> = None;
 
-    let mut out = [0u8; 1350];
-    let mut buf = [0u8; 65_535];
+    let mut out = [0u8; MAX_UDP_PAYLOAD_BYTES];
+    let mut buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
     let mut requests_sent = 0usize;
     let mut requests_done = 0usize;
     let mut in_flight = false;
@@ -305,7 +312,9 @@ fn run_h3_client_multiple_requests(
             }
         }
 
-        let timeout = conn.timeout().unwrap_or(Duration::from_millis(50));
+        let timeout = conn
+            .timeout()
+            .unwrap_or(Duration::from_millis(UDP_READ_TIMEOUT_MS));
         socket
             .set_read_timeout(Some(timeout))
             .map_err(|e| format!("timeout: {e:?}"))?;

--- a/crates/edge/tests/lb_integration.rs
+++ b/crates/edge/tests/lb_integration.rs
@@ -20,6 +20,11 @@ use spooky_config::config::{
     Backend, Config, HealthCheck, Listen, LoadBalancing, Log, RouteMatch, Tls, Upstream,
 };
 use spooky_edge::QUICListener;
+use spooky_edge::constants::{
+    MAX_DATAGRAM_SIZE_BYTES, MAX_UDP_PAYLOAD_BYTES, QUIC_IDLE_TIMEOUT_MS, QUIC_INITIAL_MAX_DATA,
+    QUIC_INITIAL_MAX_STREAMS_BIDI, QUIC_INITIAL_MAX_STREAMS_UNI, QUIC_INITIAL_STREAM_DATA,
+    REQUEST_TIMEOUT_SECS, UDP_READ_TIMEOUT_MS,
+};
 
 fn write_test_certs(dir: &TempDir) -> (String, String) {
     let mut params = CertificateParams::new(vec!["localhost".into()]);
@@ -121,15 +126,15 @@ fn run_h3_client(addr: SocketAddr, authority: &str) -> Result<String, String> {
     config
         .set_application_protos(quiche::h3::APPLICATION_PROTOCOL)
         .map_err(|e| format!("alpn: {e:?}"))?;
-    config.set_max_idle_timeout(5_000);
-    config.set_max_recv_udp_payload_size(1350);
-    config.set_max_send_udp_payload_size(1350);
-    config.set_initial_max_data(10_000_000);
-    config.set_initial_max_stream_data_bidi_local(1_000_000);
-    config.set_initial_max_stream_data_bidi_remote(1_000_000);
-    config.set_initial_max_stream_data_uni(1_000_000);
-    config.set_initial_max_streams_bidi(100);
-    config.set_initial_max_streams_uni(100);
+    config.set_max_idle_timeout(QUIC_IDLE_TIMEOUT_MS);
+    config.set_max_recv_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    config.set_max_send_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    config.set_initial_max_data(QUIC_INITIAL_MAX_DATA);
+    config.set_initial_max_stream_data_bidi_local(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_stream_data_bidi_remote(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_stream_data_uni(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_streams_bidi(QUIC_INITIAL_MAX_STREAMS_BIDI);
+    config.set_initial_max_streams_uni(QUIC_INITIAL_MAX_STREAMS_UNI);
     config.set_disable_active_migration(true);
 
     let mut scid_bytes = [0u8; quiche::MAX_CONN_ID_LEN];
@@ -142,8 +147,8 @@ fn run_h3_client(addr: SocketAddr, authority: &str) -> Result<String, String> {
     let h3_config = quiche::h3::Config::new().map_err(|e| format!("h3: {e:?}"))?;
     let mut h3_conn: Option<quiche::h3::Connection> = None;
 
-    let mut out = [0u8; 1350];
-    let mut buf = [0u8; 65_535];
+    let mut out = [0u8; MAX_UDP_PAYLOAD_BYTES];
+    let mut buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
 
     let (write, send_info) = conn.send(&mut out).map_err(|e| format!("send: {e:?}"))?;
     socket
@@ -165,7 +170,9 @@ fn run_h3_client(addr: SocketAddr, authority: &str) -> Result<String, String> {
             }
         }
 
-        let timeout = conn.timeout().unwrap_or(Duration::from_millis(50));
+        let timeout = conn
+            .timeout()
+            .unwrap_or(Duration::from_millis(UDP_READ_TIMEOUT_MS));
         socket
             .set_read_timeout(Some(timeout))
             .map_err(|e| format!("timeout: {e:?}"))?;
@@ -234,7 +241,7 @@ fn run_h3_client(addr: SocketAddr, authority: &str) -> Result<String, String> {
             }
         }
 
-        if start.elapsed() > Duration::from_secs(5) {
+        if start.elapsed() > Duration::from_secs(REQUEST_TIMEOUT_SECS) {
             return Err("timeout waiting for response".to_string());
         }
     }

--- a/spooky/src/bin/h3_client.rs
+++ b/spooky/src/bin/h3_client.rs
@@ -6,6 +6,11 @@ use std::{
 use clap::Parser;
 use quiche::h3::NameValue;
 use rand::RngCore;
+use spooky_edge::constants::{
+    MAX_DATAGRAM_SIZE_BYTES, MAX_UDP_PAYLOAD_BYTES, QUIC_IDLE_TIMEOUT_MS, QUIC_INITIAL_MAX_DATA,
+    QUIC_INITIAL_MAX_STREAMS_BIDI, QUIC_INITIAL_MAX_STREAMS_UNI, QUIC_INITIAL_STREAM_DATA,
+    REQUEST_TIMEOUT_SECS, UDP_READ_TIMEOUT_MS,
+};
 
 #[derive(Parser)]
 #[command(version, about = "Minimal HTTP/3 client using quiche")]
@@ -34,15 +39,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION)?;
     config.set_application_protos(quiche::h3::APPLICATION_PROTOCOL)?;
-    config.set_max_idle_timeout(5_000);
-    config.set_max_recv_udp_payload_size(65_527);
-    config.set_max_send_udp_payload_size(65_527);
-    config.set_initial_max_data(10_000_000);
-    config.set_initial_max_stream_data_bidi_local(1_000_000);
-    config.set_initial_max_stream_data_bidi_remote(1_000_000);
-    config.set_initial_max_stream_data_uni(1_000_000);
-    config.set_initial_max_streams_bidi(100);
-    config.set_initial_max_streams_uni(100);
+    config.set_max_idle_timeout(QUIC_IDLE_TIMEOUT_MS);
+    config.set_max_recv_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    config.set_max_send_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    config.set_initial_max_data(QUIC_INITIAL_MAX_DATA);
+    config.set_initial_max_stream_data_bidi_local(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_stream_data_bidi_remote(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_stream_data_uni(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_streams_bidi(QUIC_INITIAL_MAX_STREAMS_BIDI);
+    config.set_initial_max_streams_uni(QUIC_INITIAL_MAX_STREAMS_UNI);
     config.enable_early_data();
     config.verify_peer(!cli.insecure);
 
@@ -56,8 +61,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut response_done = false;
     let mut response_body = Vec::new();
 
-    let mut out = [0u8; 65_535];
-    let mut buf = [0u8; 65_535];
+    let mut out = [0u8; MAX_DATAGRAM_SIZE_BYTES];
+    let mut buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
     let start = Instant::now();
     let mut last_timeout = Instant::now();
 
@@ -75,7 +80,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
 
-        let timeout = conn.timeout().unwrap_or(Duration::from_millis(50));
+        let timeout = conn
+            .timeout()
+            .unwrap_or(Duration::from_millis(UDP_READ_TIMEOUT_MS));
         socket.set_read_timeout(Some(timeout))?;
 
         match socket.recv_from(&mut buf) {
@@ -154,7 +161,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
 
-        if start.elapsed() > Duration::from_secs(5) && !response_done {
+        if start.elapsed() > Duration::from_secs(REQUEST_TIMEOUT_SECS) && !response_done {
             return Err("timeout waiting for response".into());
         }
     }


### PR DESCRIPTION
Ref: #20 
## Summary
This PR removes hardcoded operational literals (UDP payload sizes, buffer sizes, SCID/token lengths, timeouts, and QUIC transport tuning values) and replaces them with centralized named constants for better readability, consistency, and future tuning.

## What changed
- Added shared constants module:
  - [constants.rs](/Users/apple/Desktop/spooky/crates/edge/src/constants.rs)
- Replaced runtime literals in edge data plane/control paths:
  - [lib.rs](/Users/apple/Desktop/spooky/crates/edge/src/lib.rs)
  - [quic_listener.rs](/Users/apple/Desktop/spooky/crates/edge/src/quic_listener.rs)
  - [benchmark.rs](/Users/apple/Desktop/spooky/crates/edge/src/benchmark.rs)
- Replaced duplicated quiche setup literals in client + integration tests:
  - [h3_client.rs](/Users/apple/Desktop/spooky/spooky/src/bin/h3_client.rs)
  - [h3_bridge.rs](/Users/apple/Desktop/spooky/crates/edge/tests/h3_bridge.rs)
  - [h3_edge.rs](/Users/apple/Desktop/spooky/crates/edge/tests/h3_edge.rs)
  - [lb_integration.rs](/Users/apple/Desktop/spooky/crates/edge/tests/lb_integration.rs)

## Behavior
- No functional behavior change intended.
- Values are unchanged, now named and reused from one place.

## Validation
- `cargo test --workspace` ✅
- `cargo test -p spooky-edge --tests` ✅
- `cargo test -p spooky --bin h3_client` ✅
- `cargo clippy --workspace --all-targets` ✅ (existing unrelated warnings remain)
- Manual smoke: `cargo run -p spooky --bin h3_client -- --help` ✅