### PR TITLE
perf(edge): replace request header Vec with SmallVec to reduce per-request allocations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ serde_yaml = "0.9.34"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }
 libc = "0.2"
+smallvec = "1"
 
 [workspace.package]
 version = "0.1.0"

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -9,6 +9,7 @@ clap.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 libc.workspace = true
+smallvec.workspace = true
 
 spooky-config = { path = "../config" }
 spooky-edge = { path = "../edge" }

--- a/crates/bench/src/main.rs
+++ b/crates/bench/src/main.rs
@@ -8,6 +8,7 @@ use std::time::Instant;
 
 use clap::Parser;
 use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
 use spooky_config::config::{Backend, HealthCheck, LoadBalancing, RouteMatch, Upstream};
 use spooky_edge::benchmark::{ConnectionLookupBench, RouteLookupBench};
 use spooky_lb::UpstreamPool;
@@ -193,6 +194,100 @@ fn lb_ch_iterations(scale: usize) -> u64 {
         10_000 => 80_000,
         _ => 50_000,
     }
+}
+
+fn header_collect_iterations(scale: usize, is_large_header_set: bool) -> u64 {
+    match (scale, is_large_header_set) {
+        (100, false) => 200_000,
+        (1_000, false) => 120_000,
+        (10_000, false) => 60_000,
+        (100, true) => 120_000,
+        (1_000, true) => 80_000,
+        (10_000, true) => 40_000,
+        _ => 50_000,
+    }
+}
+
+fn synth_h3_headers(count: usize) -> Vec<(Vec<u8>, Vec<u8>)> {
+    let mut out = Vec::with_capacity(count);
+    for i in 0..count {
+        let name = match i {
+            0 => b":method".to_vec(),
+            1 => b":path".to_vec(),
+            2 => b":authority".to_vec(),
+            3 => b"user-agent".to_vec(),
+            _ => format!("x-bench-{i}").into_bytes(),
+        };
+        let value = match i {
+            0 => b"GET".to_vec(),
+            1 => b"/bench".to_vec(),
+            2 => b"example.test".to_vec(),
+            _ => format!("value-{i}").into_bytes(),
+        };
+        out.push((name, value));
+    }
+    out
+}
+
+fn benchmark_h3_header_collection(scale: usize) -> Vec<BenchCase> {
+    const INLINE_HEADERS: usize = 16;
+    let small_headers = synth_h3_headers(8);
+    let large_headers = synth_h3_headers(24);
+
+    vec![
+        run_case(
+            "h3_headers_collect_vec_small",
+            scale,
+            header_collect_iterations(scale, false),
+            || {
+                let mut headers = Vec::with_capacity(small_headers.len());
+                for (name, value) in &small_headers {
+                    headers.push((name.as_slice().to_vec(), value.as_slice().to_vec()));
+                }
+                headers.len()
+            },
+        ),
+        run_case(
+            "h3_headers_collect_smallvec_small",
+            scale,
+            header_collect_iterations(scale, false),
+            || {
+                let mut headers = SmallVec::<[(Vec<u8>, Vec<u8>); INLINE_HEADERS]>::with_capacity(
+                    small_headers.len(),
+                );
+                for (name, value) in &small_headers {
+                    headers.push((name.as_slice().to_vec(), value.as_slice().to_vec()));
+                }
+                headers.len()
+            },
+        ),
+        run_case(
+            "h3_headers_collect_vec_large",
+            scale,
+            header_collect_iterations(scale, true),
+            || {
+                let mut headers = Vec::with_capacity(large_headers.len());
+                for (name, value) in &large_headers {
+                    headers.push((name.as_slice().to_vec(), value.as_slice().to_vec()));
+                }
+                headers.len()
+            },
+        ),
+        run_case(
+            "h3_headers_collect_smallvec_large",
+            scale,
+            header_collect_iterations(scale, true),
+            || {
+                let mut headers = SmallVec::<[(Vec<u8>, Vec<u8>); INLINE_HEADERS]>::with_capacity(
+                    large_headers.len(),
+                );
+                for (name, value) in &large_headers {
+                    headers.push((name.as_slice().to_vec(), value.as_slice().to_vec()));
+                }
+                headers.len()
+            },
+        ),
+    ]
 }
 
 fn benchmark_route_lookup(scale: usize) -> Vec<BenchCase> {
@@ -512,6 +607,7 @@ fn main() -> Result<(), String> {
         cases.extend(benchmark_route_lookup(scale));
         cases.extend(benchmark_lb(scale));
         cases.extend(benchmark_connection_lookup(scale));
+        cases.extend(benchmark_h3_header_collection(scale));
     }
 
     cases.sort_by(|a, b| (&a.name, a.scale).cmp(&(&b.name, b.scale)));

--- a/crates/edge/Cargo.toml
+++ b/crates/edge/Cargo.toml
@@ -18,6 +18,7 @@ http-body-util.workspace = true
 hyper.workspace = true
 tokio.workspace = true
 rand.workspace = true
+smallvec.workspace = true
 hmac = "0.12"
 sha2 = "0.10"
 hex = "0.4"

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -1,3 +1,4 @@
+use smallvec::SmallVec;
 use std::{
     collections::{HashMap, HashSet},
     net::UdpSocket,
@@ -62,7 +63,7 @@ pub struct RequestEnvelope {
     pub method: String,
     pub path: String,
     pub authority: Option<String>,
-    pub headers: Vec<(Vec<u8>, Vec<u8>)>,
+    pub headers: SmallVec<[(Vec<u8>, Vec<u8>); 16]>,
     pub body: Vec<u8>,
     pub start: Instant,
 }

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -13,6 +13,7 @@ use log::{debug, error, info};
 use quiche::Config;
 use quiche::h3::NameValue;
 use rand::RngCore;
+use smallvec::SmallVec;
 use spooky_bridge::h3_to_h2::build_h2_request;
 use spooky_errors::ProxyError;
 use spooky_lb::{HealthTransition, UpstreamPool};
@@ -706,7 +707,8 @@ impl QUICListener {
                     let mut method = String::new();
                     let mut path = String::new();
                     let mut authority = None;
-                    let mut headers = Vec::with_capacity(list.len());
+                    let mut headers =
+                        SmallVec::<[(Vec<u8>, Vec<u8>); 16]>::with_capacity(list.len());
 
                     for header in list {
                         headers.push((header.name().to_vec(), header.value().to_vec()));
@@ -723,9 +725,13 @@ impl QUICListener {
                         }
                     }
 
+                    if !method.is_empty() && !path.is_empty() {
+                        info!("HTTP/3 request {} {}", method, path);
+                    }
+
                     let envelope = RequestEnvelope {
-                        method: method.clone(),
-                        path: path.clone(),
+                        method,
+                        path,
                         authority,
                         headers,
                         body: Vec::new(),
@@ -734,10 +740,6 @@ impl QUICListener {
 
                     metrics.inc_total();
                     connection.streams.insert(stream_id, envelope);
-
-                    if !method.is_empty() && !path.is_empty() {
-                        info!("HTTP/3 request {} {}", method, path);
-                    }
                 }
                 Ok((stream_id, quiche::h3::Event::Data)) => loop {
                     match h3.recv_body(&mut connection.quic, stream_id, &mut body_buf) {


### PR DESCRIPTION
Closes - #37 

Replaces `Vec<(Vec<u8>, Vec<u8>)>` in `RequestEnvelope` with `SmallVec<[(Vec<u8>, Vec<u8>); 16]>`,
eliminating the outer heap allocation for requests with ≤16 headers (the common case).
Also removes redundant `method`/`path` clones before envelope construction by logging first
and moving the owned strings in.

Includes a bench harness comparing `Vec` vs `SmallVec` for both small (8) and large (24)
header sets to validate the allocation reduction. Bridge API and protocol behaviour are unchanged.

## Changes

| File | Change |
|------|--------|
| `Cargo.toml` | Add `smallvec = "1"` to workspace deps |
| `crates/edge/Cargo.toml` | Add `smallvec.workspace = true` |
| `crates/edge/src/lib.rs` | `RequestEnvelope.headers`: `Vec` → `SmallVec<[_; 16]>` |
| `crates/edge/src/quic_listener.rs` | Use `SmallVec::with_capacity`; move `method`/`path` instead of clone |
| `crates/bench/src/main.rs` | Add `Vec` vs `SmallVec` header collection benchmark |