### PR TITLE
fix(edge): stream request/response bodies without full buffering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,23 @@
-.PHONY: run build build-spooky clean certs certs-selfsigned certs-ca certs-clean certs-verify
+.PHONY: run build build-spooky clean test test-edge test-transport certs certs-selfsigned certs-ca certs-clean certs-verify
 
 run:
 	make build
 	sudo ./target/release/spooky --config config/config.yaml
 
 build:
-	cargo build --release
+	sudo cargo build --release
 
 build-spooky:
-	cargo build -p spooky --bin spooky --release
+	sudo cargo build -p spooky --bin spooky --release
+
+test:
+	sudo cargo test --workspace
+
+test-edge:
+	sudo cargo test -p spooky-edge
+
+test-transport:
+	sudo cargo test -p spooky-transport
 
 # Certificate generation targets
 certs-selfsigned:

--- a/crates/bridge/src/h3_to_h2.rs
+++ b/crates/bridge/src/h3_to_h2.rs
@@ -1,16 +1,22 @@
+use std::convert::Infallible;
+
 use bytes::Bytes;
 use http::{HeaderName, HeaderValue, Method, Request, Uri};
-use http_body_util::Full;
+use http_body_util::combinators::BoxBody;
 
 pub use spooky_errors::BridgeError;
 
+/// Build an HTTP/2 request with a pre-boxed streaming body.
+/// `content_length` is `Some(n)` only when the full length is known upfront
+/// (i.e. the body was fully buffered); pass `None` for streaming bodies.
 pub fn build_h2_request(
     backend: &str,
     method: &str,
     path: &str,
     headers: &[(Vec<u8>, Vec<u8>)],
-    body: &[u8],
-) -> Result<Request<Full<Bytes>>, BridgeError> {
+    body: BoxBody<Bytes, Infallible>,
+    content_length: Option<usize>,
+) -> Result<Request<BoxBody<Bytes, Infallible>>, BridgeError> {
     let method = Method::from_bytes(method.as_bytes()).map_err(|_| BridgeError::InvalidMethod)?;
 
     let request_path = if path.is_empty() { "/" } else { path };
@@ -43,11 +49,11 @@ pub fn build_h2_request(
         builder = builder.header(http::header::HOST, backend);
     }
 
-    if !body.is_empty() {
-        builder = builder.header(http::header::CONTENT_LENGTH, body.len());
+    if let Some(len) = content_length {
+        if len > 0 {
+            builder = builder.header(http::header::CONTENT_LENGTH, len);
+        }
     }
 
-    builder
-        .body(Full::new(Bytes::copy_from_slice(body)))
-        .map_err(BridgeError::Build)
+    builder.body(body).map_err(BridgeError::Build)
 }

--- a/crates/edge/src/constants.rs
+++ b/crates/edge/src/constants.rs
@@ -11,6 +11,11 @@ pub const REQUEST_TIMEOUT_SECS: u64 = 5;
 pub const QUIC_IDLE_TIMEOUT_MS: u64 = 5_000;
 pub const QUIC_INITIAL_MAX_DATA: u64 = 10_000_000;
 pub const QUIC_INITIAL_STREAM_DATA: u64 = 1_000_000;
+
+/// Hard application-level cap on request body size per stream.
+/// Requests exceeding this are rejected with 413 before forwarding to upstream.
+/// Must be ≤ QUIC_INITIAL_STREAM_DATA (flow-control limit).
+pub const MAX_REQUEST_BODY_BYTES: usize = 1_000_000;
 pub const QUIC_INITIAL_MAX_STREAMS_BIDI: u64 = 100;
 pub const QUIC_INITIAL_MAX_STREAMS_UNI: u64 = 100;
 

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -1,22 +1,59 @@
+use bytes::Bytes;
 use smallvec::SmallVec;
 use std::{
     collections::{HashMap, HashSet},
+    convert::Infallible,
     net::UdpSocket,
+    pin::Pin,
     sync::{
         Arc, Mutex,
         atomic::{AtomicU64, Ordering},
     },
+    task::{Context, Poll},
     time::Instant,
 };
 
 use core::net::SocketAddr;
 
+use hyper::body::{Body, Frame};
 use spooky_config::config::Config;
 use spooky_lb::UpstreamPool;
 use spooky_transport::h2_pool::H2Pool;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 
 use crate::cid_radix::CidRadix;
 use crate::constants::MAX_DATAGRAM_SIZE_BYTES;
+
+/// A streaming HTTP body backed by a tokio mpsc channel.
+/// The quiche Data handler sends chunks through the sender;
+/// hyper reads them from the receiver as the H2 request body.
+pub struct ChannelBody {
+    rx: mpsc::Receiver<Bytes>,
+}
+
+impl ChannelBody {
+    pub fn channel(buffer: usize) -> (mpsc::Sender<Bytes>, Self) {
+        let (tx, rx) = mpsc::channel(buffer);
+        (tx, Self { rx })
+    }
+}
+
+impl Body for ChannelBody {
+    type Data = Bytes;
+    type Error = Infallible;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        match self.rx.poll_recv(cx) {
+            Poll::Ready(Some(chunk)) => Poll::Ready(Some(Ok(Frame::data(chunk)))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
 
 pub mod benchmark;
 pub mod cid_radix;
@@ -59,12 +96,24 @@ pub struct QuicConnection {
     pub last_scid_rotation: Instant,
 }
 
+/// Result type returned by the in-flight H2 forwarding task.
+pub type ForwardResult =
+    Result<(http::StatusCode, http::HeaderMap, hyper::body::Incoming), spooky_errors::ProxyError>;
+
 pub struct RequestEnvelope {
     pub method: String,
     pub path: String,
     pub authority: Option<String>,
     pub headers: SmallVec<[(Vec<u8>, Vec<u8>); 16]>,
-    pub body: Vec<u8>,
+    /// Sender half of the body channel.  Dropping it signals end-of-body to hyper.
+    pub body_tx: Option<mpsc::Sender<Bytes>>,
+    /// In-flight H2 forwarding task.  Awaited on `Finished`.
+    pub response_rx: Option<JoinHandle<ForwardResult>>,
+    /// Body chunks that arrived before the channel had capacity.
+    pub body_buf: Vec<Bytes>,
+    /// Resolved backend address and index (for health marking on response).
+    pub backend_addr: Option<String>,
+    pub backend_index: Option<usize>,
     pub start: Instant,
 }
 

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -111,6 +111,8 @@ pub struct RequestEnvelope {
     pub response_rx: Option<JoinHandle<ForwardResult>>,
     /// Body chunks that arrived before the channel had capacity.
     pub body_buf: Vec<Bytes>,
+    /// Total body bytes received on this stream (buffered + already forwarded).
+    pub body_bytes_received: usize,
     /// Resolved backend address and index (for health marking on response).
     pub backend_addr: Option<String>,
     pub backend_index: Option<usize>,

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{HashMap, HashSet},
     net::UdpSocket,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, OnceLock},
     time::{Duration, Instant},
 };
 
@@ -734,8 +734,8 @@ impl QUICListener {
                             let req_method = method.clone();
                             let req_path = path.clone();
                             let fwd_addr = addr.clone();
-                            let handle: tokio::task::JoinHandle<ForwardResult> =
-                                tokio::spawn(async move {
+                            let handle: tokio::task::JoinHandle<ForwardResult> = {
+                                let fut = async move {
                                     let request = build_h2_request(
                                         &fwd_addr, &req_method, &req_path,
                                         &req_headers, boxed, None,
@@ -751,7 +751,12 @@ impl QUICListener {
 
                                     let (parts, body) = response.into_parts();
                                     Ok((parts.status, parts.headers, body))
-                                });
+                                };
+                                match Handle::try_current() {
+                                    Ok(handle) => handle.spawn(fut),
+                                    Err(_) => fallback_runtime().spawn(fut),
+                                }
+                            };
                             (Some(tx), Some(handle), Some(addr), Some(idx))
                         }
                         Err(_) => (None, None, None, None),
@@ -768,6 +773,7 @@ impl QUICListener {
                             body_tx,
                             response_rx,
                             body_buf: Vec::new(),
+                            body_bytes_received: 0,
                             backend_addr,
                             backend_index,
                             start: Instant::now(),
@@ -778,10 +784,11 @@ impl QUICListener {
                     match h3.recv_body(&mut connection.quic, stream_id, &mut body_buf) {
                         Ok(read) => {
                             if let Some(req) = connection.streams.get_mut(&stream_id) {
-                                // Enforce per-stream body cap across all buffered chunks.
-                                let buffered: usize =
-                                    req.body_buf.iter().map(|b| b.len()).sum();
-                                if buffered + read > MAX_REQUEST_BODY_BYTES {
+                                // Enforce cap on total bytes received for the stream,
+                                // including chunks already forwarded to the H2 body channel.
+                                let next_total =
+                                    req.body_bytes_received.saturating_add(read);
+                                if next_total > MAX_REQUEST_BODY_BYTES {
                                     connection.streams.remove(&stream_id);
                                     Self::send_simple_response(
                                         h3,
@@ -792,6 +799,7 @@ impl QUICListener {
                                     )?;
                                     break;
                                 }
+                                req.body_bytes_received = next_total;
                                 let chunk = Bytes::copy_from_slice(&body_buf[..read]);
                                 if let Some(tx) = &req.body_tx {
                                     // Non-blocking send: if the channel is full, fall
@@ -1263,9 +1271,18 @@ where
 {
     match Handle::try_current() {
         Ok(handle) => Ok(tokio::task::block_in_place(|| handle.block_on(f()))),
-        Err(_) => {
-            let rt = tokio::runtime::Runtime::new().map_err(|e| format!("runtime: {e}"))?;
-            Ok(rt.block_on(f()))
-        }
+        Err(_) => Ok(fallback_runtime().block_on(f())),
     }
+}
+
+fn fallback_runtime() -> &'static tokio::runtime::Runtime {
+    static FALLBACK_RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+    FALLBACK_RT.get_or_init(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .worker_threads(2)
+            .thread_name("spooky-edge-fallback-rt")
+            .build()
+            .expect("failed to create fallback tokio runtime")
+    })
 }

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -8,7 +8,7 @@ use std::{
 use core::net::SocketAddr;
 
 use bytes::{Bytes, BytesMut};
-use http_body_util::{BodyExt, Full};
+use http_body_util::{BodyExt, Full, combinators::BoxBody};
 use log::{debug, error, info};
 use quiche::Config;
 use quiche::h3::NameValue;
@@ -23,14 +23,14 @@ use tokio::runtime::Handle;
 use spooky_config::config::Config as SpookyConfig;
 
 use crate::{
-    Metrics, QUICListener, QuicConnection, RequestEnvelope,
+    ChannelBody, ForwardResult, Metrics, QUICListener, QuicConnection, RequestEnvelope,
     cid_radix::CidRadix,
     constants::{
         DEFAULT_SCID_LEN_BYTES, MAX_DATAGRAM_SIZE_BYTES, MAX_INFLIGHT_PER_BACKEND,
-        MAX_UDP_PAYLOAD_BYTES, MIN_SCID_LEN_BYTES, QUIC_IDLE_TIMEOUT_MS, QUIC_INITIAL_MAX_DATA,
-        QUIC_INITIAL_MAX_STREAMS_BIDI, QUIC_INITIAL_MAX_STREAMS_UNI, QUIC_INITIAL_STREAM_DATA,
-        RESET_TOKEN_LEN_BYTES, SCID_ROTATION_PACKET_THRESHOLD, UDP_READ_TIMEOUT_MS,
-        backend_timeout, drain_timeout, scid_rotation_interval,
+        MAX_REQUEST_BODY_BYTES, MAX_UDP_PAYLOAD_BYTES, MIN_SCID_LEN_BYTES, QUIC_IDLE_TIMEOUT_MS,
+        QUIC_INITIAL_MAX_DATA, QUIC_INITIAL_MAX_STREAMS_BIDI, QUIC_INITIAL_MAX_STREAMS_UNI,
+        QUIC_INITIAL_STREAM_DATA, RESET_TOKEN_LEN_BYTES, SCID_ROTATION_PACKET_THRESHOLD,
+        UDP_READ_TIMEOUT_MS, backend_timeout, drain_timeout, scid_rotation_interval,
     },
     outcome_from_status,
     route_index::RouteIndex,
@@ -41,18 +41,6 @@ fn is_hop_header(name: &str) -> bool {
         name,
         "connection" | "keep-alive" | "proxy-connection" | "transfer-encoding" | "upgrade"
     )
-}
-
-fn request_hash_key(req: &RequestEnvelope) -> &str {
-    if let Some(authority) = &req.authority {
-        return authority;
-    }
-
-    if !req.path.is_empty() {
-        return &req.path;
-    }
-
-    &req.method
 }
 
 impl QUICListener {
@@ -590,7 +578,7 @@ impl QUICListener {
         if (connection.quic.is_established() || connection.quic.is_in_early_data())
             && let Err(e) = Self::handle_h3(
                 &mut connection,
-                &h2_pool,
+                Arc::clone(&h2_pool),
                 &self.upstream_pools,
                 &self.routing_index,
                 &self.metrics,
@@ -682,7 +670,7 @@ impl QUICListener {
 
     fn handle_h3(
         connection: &mut QuicConnection,
-        h2_pool: &H2Pool,
+        h2_pool: Arc<H2Pool>,
         upstream_pools: &HashMap<String, Arc<Mutex<UpstreamPool>>>,
         routing_index: &RouteIndex,
         metrics: &Metrics,
@@ -729,23 +717,92 @@ impl QUICListener {
                         info!("HTTP/3 request {} {}", method, path);
                     }
 
-                    let envelope = RequestEnvelope {
-                        method,
-                        path,
-                        authority,
-                        headers,
-                        body: Vec::new(),
-                        start: Instant::now(),
+                    // Route lookup — needed to start the H2 request immediately.
+                    let resolved = Self::resolve_backend(
+                        &method, &path, authority.as_deref(),
+                        upstream_pools, routing_index,
+                    );
+
+                    let (body_tx, response_rx, backend_addr, backend_index) = match resolved {
+                        Ok((addr, idx, _pool)) => {
+                            // Create a channel body so quiche Data chunks stream
+                            // directly into the in-flight H2 request.
+                            let (tx, channel_body) = ChannelBody::channel(8);
+                            let boxed = channel_body.boxed();
+                            let h2 = h2_pool.clone();
+                            let req_headers = headers.clone();
+                            let req_method = method.clone();
+                            let req_path = path.clone();
+                            let fwd_addr = addr.clone();
+                            let handle: tokio::task::JoinHandle<ForwardResult> =
+                                tokio::spawn(async move {
+                                    let request = build_h2_request(
+                                        &fwd_addr, &req_method, &req_path,
+                                        &req_headers, boxed, None,
+                                    )
+                                    .map_err(ProxyError::Bridge)?;
+
+                                    let response = tokio::time::timeout(
+                                        backend_timeout(),
+                                        h2.send(&fwd_addr, request),
+                                    )
+                                    .await
+                                    .map_err(|_| ProxyError::Timeout)??;
+
+                                    let (parts, body) = response.into_parts();
+                                    Ok((parts.status, parts.headers, body))
+                                });
+                            (Some(tx), Some(handle), Some(addr), Some(idx))
+                        }
+                        Err(_) => (None, None, None, None),
                     };
 
                     metrics.inc_total();
-                    connection.streams.insert(stream_id, envelope);
+                    connection.streams.insert(
+                        stream_id,
+                        RequestEnvelope {
+                            method,
+                            path,
+                            authority,
+                            headers,
+                            body_tx,
+                            response_rx,
+                            body_buf: Vec::new(),
+                            backend_addr,
+                            backend_index,
+                            start: Instant::now(),
+                        },
+                    );
                 }
                 Ok((stream_id, quiche::h3::Event::Data)) => loop {
                     match h3.recv_body(&mut connection.quic, stream_id, &mut body_buf) {
                         Ok(read) => {
                             if let Some(req) = connection.streams.get_mut(&stream_id) {
-                                req.body.extend_from_slice(&body_buf[..read]);
+                                // Enforce per-stream body cap across all buffered chunks.
+                                let buffered: usize =
+                                    req.body_buf.iter().map(|b| b.len()).sum();
+                                if buffered + read > MAX_REQUEST_BODY_BYTES {
+                                    connection.streams.remove(&stream_id);
+                                    Self::send_simple_response(
+                                        h3,
+                                        &mut connection.quic,
+                                        stream_id,
+                                        http::StatusCode::PAYLOAD_TOO_LARGE,
+                                        b"request body too large\n",
+                                    )?;
+                                    break;
+                                }
+                                let chunk = Bytes::copy_from_slice(&body_buf[..read]);
+                                if let Some(tx) = &req.body_tx {
+                                    // Non-blocking send: if the channel is full, fall
+                                    // back to buffering so the poll loop is not stalled.
+                                    match tx.try_send(chunk.clone()) {
+                                        Ok(_) => {}
+                                        Err(_) => req.body_buf.push(chunk),
+                                    }
+                                } else {
+                                    req.body_buf.push(chunk);
+                                }
                             }
                         }
                         Err(quiche::h3::Error::Done) => break,
@@ -753,13 +810,45 @@ impl QUICListener {
                     }
                 },
                 Ok((stream_id, quiche::h3::Event::Finished)) => {
-                    if let Some(req) = connection.streams.remove(&stream_id) {
-                        Self::handle_request_finish(
+                    if let Some(mut req) = connection.streams.remove(&stream_id) {
+                        // Drain any buffered chunks into the channel before
+                        // closing it, then drop the sender to signal end-of-body.
+                        if let Some(tx) = req.body_tx.take() {
+                            let buf = std::mem::take(&mut req.body_buf);
+                            run_blocking(|| async move {
+                                for chunk in buf {
+                                    let _ = tx.send(chunk).await;
+                                }
+                                // tx drops here, closing the channel
+                            })
+                            .ok();
+                        }
+
+                        // Await the in-flight H2 task and route the result.
+                        let forward_result = match req.response_rx.take() {
+                            Some(handle) => run_blocking(|| async move {
+                                match tokio::time::timeout(backend_timeout(), handle).await {
+                                    Ok(Ok(r)) => r,
+                                    Ok(Err(_)) => Err(ProxyError::Transport(
+                                        "task panicked".into(),
+                                    )),
+                                    Err(_) => Err(ProxyError::Timeout),
+                                }
+                            })
+                            .unwrap_or(Err(ProxyError::Transport(
+                                "run_blocking failed".into(),
+                            ))),
+                            None => Err(ProxyError::Transport(
+                                "no backend resolved for request".into(),
+                            )),
+                        };
+
+                        Self::handle_forward_result(
                             h3,
                             &mut connection.quic,
                             stream_id,
-                            req,
-                            h2_pool,
+                            &req,
+                            forward_result,
                             upstream_pools,
                             routing_index,
                             metrics,
@@ -779,244 +868,157 @@ impl QUICListener {
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
-    fn handle_request_finish(
-        h3: &mut quiche::h3::Connection,
-        quic: &mut quiche::Connection,
-        stream_id: u64,
-        req: RequestEnvelope,
-        h2_pool: &H2Pool,
+    /// Resolve routing + LB for a request, returning `(backend_addr, backend_index, pool)`.
+    fn resolve_backend(
+        method: &str,
+        path: &str,
+        authority: Option<&str>,
         upstream_pools: &HashMap<String, Arc<Mutex<UpstreamPool>>>,
         routing_index: &RouteIndex,
-        metrics: &Metrics,
-    ) -> Result<(), quiche::h3::Error> {
-        let start = req.start;
-        if req.method.is_empty() || req.path.is_empty() {
-            return Self::send_simple_response(
-                h3,
-                quic,
-                stream_id,
-                http::StatusCode::BAD_REQUEST,
-                b"invalid request\n",
-            );
+    ) -> Result<(String, usize, Arc<Mutex<UpstreamPool>>), ProxyError> {
+        if method.is_empty() || path.is_empty() {
+            return Err(ProxyError::Transport("empty method or path".into()));
         }
 
-        // Find the upstream for this request
         let upstream_name = routing_index
-            .lookup(&req.path, req.authority.as_deref())
-            .ok_or_else(|| {
-                error!(
-                    "No route found for path: {} (host: {:?})",
-                    req.path, req.authority
-                );
-                quiche::h3::Error::InternalError
-            })?;
+            .lookup(path, authority)
+            .ok_or_else(|| ProxyError::Transport(format!("no route for {path}")))?;
 
-        let upstream_pool = upstream_pools.get(upstream_name).ok_or_else(|| {
-            error!("Upstream pool not found for: {}", upstream_name);
-            quiche::h3::Error::InternalError
-        })?;
+        let upstream_pool = upstream_pools
+            .get(upstream_name)
+            .ok_or_else(|| ProxyError::Transport(format!("pool not found: {upstream_name}")))?
+            .clone();
 
-        let upstream_len = upstream_pool
-            .lock()
-            .map(|pool| pool.pool.len())
-            .unwrap_or(0);
+        let upstream_len = upstream_pool.lock().map(|p| p.pool.len()).unwrap_or(0);
         if upstream_len == 0 {
-            return Self::send_simple_response(
-                h3,
-                quic,
-                stream_id,
-                http::StatusCode::SERVICE_UNAVAILABLE,
-                b"no servers configured for upstream\n",
-            );
+            return Err(ProxyError::Transport("no servers in upstream".into()));
         }
 
-        let key = request_hash_key(&req);
+        let key: &str = authority.unwrap_or(if !path.is_empty() { path } else { method });
+
         let (backend_index, lb_type) = {
             let mut pool = upstream_pool.lock().expect("upstream pool lock");
             let lb_type = pool.lb_name();
-            let backend_index = pool.pick(key);
-            (backend_index, lb_type)
+            let idx = pool.pick(key);
+            (idx, lb_type)
         };
-        let backend_index = match backend_index {
-            Some(index) => index,
-            None => {
-                return Self::send_simple_response(
-                    h3,
-                    quic,
-                    stream_id,
-                    http::StatusCode::SERVICE_UNAVAILABLE,
-                    b"no healthy servers\n",
-                );
-            }
-        };
+        let backend_index = backend_index
+            .ok_or_else(|| ProxyError::Transport("no healthy servers".into()))?;
 
         let backend_addr = {
             let pool = upstream_pool.lock().expect("upstream pool lock");
             pool.pool
                 .address(backend_index)
-                .map(|addr| addr.to_string())
+                .map(|a| a.to_string())
+                .ok_or_else(|| ProxyError::Transport("invalid server address".into()))?
         };
-        let backend_addr = match backend_addr {
-            Some(addr) => addr,
-            None => {
+
+        info!("Selected backend {} via {}", backend_addr, lb_type);
+        Ok((backend_addr, backend_index, upstream_pool))
+    }
+
+    /// Handle an already-resolved `ForwardResult`, applying health transitions
+    /// and sending the H3 response.
+    #[allow(clippy::too_many_arguments)]
+    fn handle_forward_result(
+        h3: &mut quiche::h3::Connection,
+        quic: &mut quiche::Connection,
+        stream_id: u64,
+        req: &RequestEnvelope,
+        result: ForwardResult,
+        upstream_pools: &HashMap<String, Arc<Mutex<UpstreamPool>>>,
+        routing_index: &RouteIndex,
+        metrics: &Metrics,
+    ) -> Result<(), quiche::h3::Error> {
+        let start = req.start;
+
+        // If routing failed at Headers time, return an appropriate error now.
+        let (backend_addr, backend_index) = match (&req.backend_addr, req.backend_index) {
+            (Some(a), Some(i)) => (a.as_str(), i),
+            _ => {
+                metrics.inc_failure();
                 return Self::send_simple_response(
                     h3,
                     quic,
                     stream_id,
-                    http::StatusCode::SERVICE_UNAVAILABLE,
-                    b"invalid server\n",
+                    if req.method.is_empty() || req.path.is_empty() {
+                        http::StatusCode::BAD_REQUEST
+                    } else {
+                        http::StatusCode::SERVICE_UNAVAILABLE
+                    },
+                    b"no upstream available\n",
                 );
             }
         };
 
-        info!("Selected backend {} via {}", backend_addr, lb_type);
+        // Re-acquire the upstream pool for health marking.
+        let upstream_name = routing_index.lookup(&req.path, req.authority.as_deref());
+        let upstream_pool = upstream_name
+            .and_then(|n| upstream_pools.get(n))
+            .cloned();
 
-        match Self::forward_request(&backend_addr, h2_pool, req) {
+        match result {
             Ok((status, headers, body)) => {
-                let transition = upstream_pool.lock().ok().and_then(|mut pool| {
-                    match outcome_from_status(status) {
-                        crate::HealthClassification::Success => {
-                            pool.pool.mark_success(backend_index)
+                if let Some(pool) = &upstream_pool {
+                    let transition = pool.lock().ok().and_then(|mut p| {
+                        match outcome_from_status(status) {
+                            crate::HealthClassification::Success => {
+                                p.pool.mark_success(backend_index)
+                            }
+                            crate::HealthClassification::Failure => {
+                                p.pool.mark_failure(backend_index)
+                            }
+                            crate::HealthClassification::Neutral => None,
                         }
-                        crate::HealthClassification::Failure => {
-                            pool.pool.mark_failure(backend_index)
-                        }
-                        crate::HealthClassification::Neutral => None,
+                    });
+                    if let Some(t) = transition {
+                        Self::log_health_transition(backend_addr, t);
                     }
-                });
-                if let Some(transition) = transition {
-                    Self::log_health_transition(&backend_addr, transition);
                 }
                 metrics.inc_success();
-                let latency = start.elapsed().as_millis();
                 info!(
                     "Upstream {} status {} latency_ms {}",
-                    backend_addr, status, latency
+                    backend_addr, status, start.elapsed().as_millis()
                 );
-                Self::send_backend_response(h3, quic, stream_id, status, &headers, &body)
+                Self::send_backend_response(h3, quic, stream_id, status, &headers, body)
             }
             Err(ProxyError::Bridge(err)) => {
                 error!("Bridge error: {:?}", err);
                 metrics.inc_failure();
-                let latency = start.elapsed().as_millis();
-                info!(
-                    "Upstream {} status 400 latency_ms {}",
-                    backend_addr, latency
-                );
-                Self::send_simple_response(
-                    h3,
-                    quic,
-                    stream_id,
-                    http::StatusCode::BAD_REQUEST,
-                    b"invalid request\n",
-                )
+                info!("Upstream {} status 400 latency_ms {}", backend_addr, start.elapsed().as_millis());
+                Self::send_simple_response(h3, quic, stream_id, http::StatusCode::BAD_REQUEST, b"invalid request\n")
             }
             Err(ProxyError::Transport(_)) | Err(ProxyError::Pool(_)) => {
                 error!("Transport error");
-                let transition = upstream_pool
-                    .lock()
-                    .ok()
-                    .and_then(|mut pool| pool.pool.mark_failure(backend_index));
-                if let Some(transition) = transition {
-                    Self::log_health_transition(&backend_addr, transition);
+                if let Some(pool) = &upstream_pool {
+                    if let Some(t) = pool.lock().ok().and_then(|mut p| p.pool.mark_failure(backend_index)) {
+                        Self::log_health_transition(backend_addr, t);
+                    }
                 }
                 metrics.inc_failure();
                 metrics.inc_backend_error();
-                let latency = start.elapsed().as_millis();
-                info!(
-                    "Upstream {} status 502 latency_ms {}",
-                    backend_addr, latency
-                );
-                Self::send_simple_response(
-                    h3,
-                    quic,
-                    stream_id,
-                    http::StatusCode::BAD_GATEWAY,
-                    b"upstream error\n",
-                )
+                info!("Upstream {} status 502 latency_ms {}", backend_addr, start.elapsed().as_millis());
+                Self::send_simple_response(h3, quic, stream_id, http::StatusCode::BAD_GATEWAY, b"upstream error\n")
             }
             Err(ProxyError::Timeout) => {
                 error!("Server timeout");
-                let transition = upstream_pool
-                    .lock()
-                    .ok()
-                    .and_then(|mut pool| pool.pool.mark_failure(backend_index));
-                if let Some(transition) = transition {
-                    Self::log_health_transition(&backend_addr, transition);
+                if let Some(pool) = &upstream_pool {
+                    if let Some(t) = pool.lock().ok().and_then(|mut p| p.pool.mark_failure(backend_index)) {
+                        Self::log_health_transition(backend_addr, t);
+                    }
                 }
                 metrics.inc_failure();
                 metrics.inc_timeout();
-                let latency = start.elapsed().as_millis();
-                info!(
-                    "Upstream {} status 503 latency_ms {}",
-                    backend_addr, latency
-                );
-                Self::send_simple_response(
-                    h3,
-                    quic,
-                    stream_id,
-                    http::StatusCode::SERVICE_UNAVAILABLE,
-                    b"upstream timeout\n",
-                )
+                info!("Upstream {} status 503 latency_ms {}", backend_addr, start.elapsed().as_millis());
+                Self::send_simple_response(h3, quic, stream_id, http::StatusCode::SERVICE_UNAVAILABLE, b"upstream timeout\n")
             }
             Err(ProxyError::Tls(err)) => {
-                error!("TLS configuration error during request processing: {}", err);
-                // TLS errors during request processing indicate server misconfiguration
-                // Don't mark backend as failed since this is a local TLS issue
+                error!("TLS error: {}", err);
                 metrics.inc_failure();
-                let latency = start.elapsed().as_millis();
-                info!("TLS error for stream {} latency_ms {}", stream_id, latency);
-                Self::send_simple_response(
-                    h3,
-                    quic,
-                    stream_id,
-                    http::StatusCode::INTERNAL_SERVER_ERROR,
-                    b"internal server error\n",
-                )
+                info!("TLS error for stream {} latency_ms {}", stream_id, start.elapsed().as_millis());
+                Self::send_simple_response(h3, quic, stream_id, http::StatusCode::INTERNAL_SERVER_ERROR, b"internal server error\n")
             }
         }
-    }
-
-    fn forward_request(
-        backend_addr: &str,
-        h2_pool: &H2Pool,
-        req: RequestEnvelope,
-    ) -> Result<(http::StatusCode, http::HeaderMap, Bytes), ProxyError> {
-        let request = build_h2_request(
-            backend_addr,
-            &req.method,
-            &req.path,
-            &req.headers,
-            &req.body,
-        )
-        .map_err(ProxyError::Bridge)?;
-
-        let response = run_blocking(|| async {
-            tokio::time::timeout(backend_timeout(), h2_pool.send(backend_addr, request)).await
-        })
-        .map_err(|e| ProxyError::Transport(format!("send: {e}")))?;
-
-        let response = match response {
-            Ok(inner) => inner?,
-            Err(_) => return Err(ProxyError::Timeout),
-        };
-
-        let (parts, body) = response.into_parts();
-
-        let body_bytes = run_blocking(|| async {
-            tokio::time::timeout(backend_timeout(), body.collect()).await
-        })
-        .map_err(|e| ProxyError::Transport(format!("body: {e}")))?;
-
-        let body_bytes = match body_bytes {
-            Ok(inner) => inner
-                .map(|c| c.to_bytes())
-                .map_err(|e| ProxyError::Transport(format!("body: {e:?}")))?,
-            Err(_) => return Err(ProxyError::Timeout),
-        };
-
-        Ok((parts.status, parts.headers, body_bytes))
     }
 
     fn send_backend_response(
@@ -1025,9 +1027,9 @@ impl QUICListener {
         stream_id: u64,
         status: http::StatusCode,
         headers: &http::HeaderMap,
-        body: &Bytes,
+        body: hyper::body::Incoming,
     ) -> Result<(), quiche::h3::Error> {
-        let mut resp_headers = Vec::with_capacity(headers.len() + 2);
+        let mut resp_headers = Vec::with_capacity(headers.len() + 1);
 
         resp_headers.push(quiche::h3::Header::new(
             b":status",
@@ -1044,13 +1046,71 @@ impl QUICListener {
             ));
         }
 
-        resp_headers.push(quiche::h3::Header::new(
-            b"content-length",
-            body.len().to_string().as_bytes(),
-        ));
+        // Drive the response body one frame at a time.  Each call to
+        // run_blocking fetches exactly the next data frame from the backend
+        // and returns it to the sync side, where send_body is called
+        // immediately.  This avoids accumulating the full response in memory:
+        // at most one frame is held between run_blocking returning and
+        // send_body completing.
+        //
+        // Note: h3/quic are !Send so they cannot enter the async closure.
+        // run_blocking(block_in_place) keeps execution on the same OS thread,
+        // making the per-frame loop safe without locks.
+        let deadline = std::time::Instant::now() + backend_timeout();
+
+        // Wrap body in a Mutex so the async closure can borrow it across
+        // repeated run_blocking calls without moving it.
+        let body = std::sync::Mutex::new(body);
 
         h3.send_response(quic, stream_id, &resp_headers, false)?;
-        h3.send_body(quic, stream_id, body, true)?;
+
+        let mut sent_any = false;
+        loop {
+            let remaining = match deadline.checked_duration_since(std::time::Instant::now()) {
+                Some(d) => d,
+                None => break, // timeout
+            };
+
+            // Fetch the next data frame from the backend.
+            let next: Option<Bytes> = match run_blocking(|| async {
+                tokio::time::timeout(remaining, async {
+                    let mut guard = body.lock().expect("body mutex");
+                    loop {
+                        match BodyExt::frame(&mut *guard).await {
+                            Some(Ok(f)) => {
+                                if let Ok(chunk) = f.into_data() {
+                                    return Some(chunk);
+                                }
+                                // trailers / other frames — skip
+                            }
+                            Some(Err(_)) | None => return None,
+                        }
+                    }
+                })
+                .await
+                .unwrap_or(None)
+            }) {
+                Ok(v) => v,
+                Err(_) => break,
+            };
+
+            match next {
+                Some(chunk) => {
+                    h3.send_body(quic, stream_id, &chunk, false)?;
+                    sent_any = true;
+                }
+                None => {
+                    // Body exhausted — send final empty frame with fin=true.
+                    h3.send_body(quic, stream_id, b"", true)?;
+                    return Ok(());
+                }
+            }
+        }
+
+        // Timeout or error path: close stream.
+        let _ = sent_any;
+        h3.send_body(quic, stream_id, b"", true)?;
+
         Ok(())
     }
 
@@ -1162,7 +1222,7 @@ impl QUICListener {
                     let request = match http::Request::builder()
                         .method("GET")
                         .uri(format!("http://{address}{path}"))
-                        .body(Full::new(Bytes::new()))
+                        .body(BoxBody::new(Full::new(Bytes::new())))
                     {
                         Ok(req) => req,
                         Err(_) => continue,

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -19,9 +19,9 @@ use tokio::net::TcpListener;
 use spooky_config::config::{Backend, Config, HealthCheck, Listen, LoadBalancing, Log, Tls};
 use spooky_edge::QUICListener;
 use spooky_edge::constants::{
-    MAX_DATAGRAM_SIZE_BYTES, MAX_UDP_PAYLOAD_BYTES, QUIC_IDLE_TIMEOUT_MS, QUIC_INITIAL_MAX_DATA,
-    QUIC_INITIAL_MAX_STREAMS_BIDI, QUIC_INITIAL_MAX_STREAMS_UNI, QUIC_INITIAL_STREAM_DATA,
-    REQUEST_TIMEOUT_SECS, UDP_READ_TIMEOUT_MS,
+    MAX_DATAGRAM_SIZE_BYTES, MAX_REQUEST_BODY_BYTES, MAX_UDP_PAYLOAD_BYTES, QUIC_IDLE_TIMEOUT_MS,
+    QUIC_INITIAL_MAX_DATA, QUIC_INITIAL_MAX_STREAMS_BIDI, QUIC_INITIAL_MAX_STREAMS_UNI,
+    QUIC_INITIAL_STREAM_DATA, REQUEST_TIMEOUT_SECS, UDP_READ_TIMEOUT_MS,
 };
 
 fn write_test_certs(dir: &TempDir) -> (String, String) {
@@ -246,6 +246,152 @@ fn run_h3_client(addr: SocketAddr) -> Result<String, String> {
     }
 }
 
+/// Sends a POST with `body_bytes` payload; returns `(status_code_str, body_string)`.
+fn run_h3_post(addr: SocketAddr, body_bytes: Vec<u8>) -> Result<(String, String), String> {
+    let socket = std::net::UdpSocket::bind("0.0.0.0:0").map_err(|e| e.to_string())?;
+    let local_addr = socket.local_addr().map_err(|e| e.to_string())?;
+
+    let mut config =
+        quiche::Config::new(quiche::PROTOCOL_VERSION).map_err(|e| format!("config: {e:?}"))?;
+    config.verify_peer(false);
+    config
+        .set_application_protos(quiche::h3::APPLICATION_PROTOCOL)
+        .map_err(|e| format!("alpn: {e:?}"))?;
+    config.set_max_idle_timeout(QUIC_IDLE_TIMEOUT_MS);
+    config.set_max_recv_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    config.set_max_send_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    config.set_initial_max_data(QUIC_INITIAL_MAX_DATA);
+    config.set_initial_max_stream_data_bidi_local(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_stream_data_bidi_remote(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_stream_data_uni(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_streams_bidi(QUIC_INITIAL_MAX_STREAMS_BIDI);
+    config.set_initial_max_streams_uni(QUIC_INITIAL_MAX_STREAMS_UNI);
+    config.set_disable_active_migration(true);
+
+    let mut scid_bytes = [0u8; quiche::MAX_CONN_ID_LEN];
+    rand::thread_rng().fill_bytes(&mut scid_bytes);
+    let scid = quiche::ConnectionId::from_ref(&scid_bytes);
+
+    let mut conn = quiche::connect(Some("localhost"), &scid, local_addr, addr, &mut config)
+        .map_err(|e| format!("connect: {e:?}"))?;
+
+    let h3_config = quiche::h3::Config::new().map_err(|e| format!("h3: {e:?}"))?;
+    let mut h3_conn: Option<quiche::h3::Connection> = None;
+
+    let mut out = [0u8; MAX_UDP_PAYLOAD_BYTES];
+    let mut buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
+
+    let (write, send_info) = conn.send(&mut out).map_err(|e| format!("send: {e:?}"))?;
+    socket
+        .send_to(&out[..write], send_info.to)
+        .map_err(|e| format!("send_to: {e:?}"))?;
+
+    let start = Instant::now();
+    let mut req_sent = false;
+    let mut response_status = String::new();
+    let mut response_body = Vec::new();
+
+    loop {
+        loop {
+            match conn.send(&mut out) {
+                Ok((write, send_info)) => {
+                    let _ = socket.send_to(&out[..write], send_info.to);
+                }
+                Err(quiche::Error::Done) => break,
+                Err(e) => return Err(format!("send loop: {e:?}")),
+            }
+        }
+
+        let timeout = conn
+            .timeout()
+            .unwrap_or(Duration::from_millis(UDP_READ_TIMEOUT_MS));
+        socket
+            .set_read_timeout(Some(timeout))
+            .map_err(|e| format!("timeout: {e:?}"))?;
+
+        match socket.recv_from(&mut buf) {
+            Ok((len, from)) => {
+                let recv_info = quiche::RecvInfo {
+                    from,
+                    to: local_addr,
+                };
+                conn.recv(&mut buf[..len], recv_info)
+                    .map_err(|e| format!("recv: {e:?}"))?;
+            }
+            Err(ref e)
+                if e.kind() == std::io::ErrorKind::WouldBlock
+                    || e.kind() == std::io::ErrorKind::TimedOut =>
+            {
+                conn.on_timeout();
+            }
+            Err(e) => return Err(format!("recv: {e:?}")),
+        }
+
+        if conn.is_established() && h3_conn.is_none() {
+            h3_conn = Some(
+                quiche::h3::Connection::with_transport(&mut conn, &h3_config)
+                    .map_err(|e| format!("h3 conn: {e:?}"))?,
+            );
+        }
+
+        if let Some(h3) = h3_conn.as_mut() {
+            if conn.is_established() && !req_sent {
+                let content_length = body_bytes.len().to_string();
+                let req = vec![
+                    quiche::h3::Header::new(b":method", b"POST"),
+                    quiche::h3::Header::new(b":scheme", b"https"),
+                    quiche::h3::Header::new(b":authority", b"localhost"),
+                    quiche::h3::Header::new(b":path", b"/"),
+                    quiche::h3::Header::new(b"content-length", content_length.as_bytes()),
+                ];
+                let stream_id = h3
+                    .send_request(&mut conn, &req, false)
+                    .map_err(|e| format!("send_request: {e:?}"))?;
+                h3.send_body(&mut conn, stream_id, &body_bytes, true)
+                    .map_err(|e| format!("send_body: {e:?}"))?;
+                req_sent = true;
+            }
+
+            loop {
+                match h3.poll(&mut conn) {
+                    Ok((_stream_id, quiche::h3::Event::Headers { list, .. })) => {
+                        for h in &list {
+                            if h.name() == b":status" {
+                                response_status =
+                                    String::from_utf8_lossy(h.value()).to_string();
+                            }
+                        }
+                    }
+                    Ok((stream_id, quiche::h3::Event::Data)) => loop {
+                        match h3.recv_body(&mut conn, stream_id, &mut buf) {
+                            Ok(read) => response_body.extend_from_slice(&buf[..read]),
+                            Err(quiche::h3::Error::Done) => break,
+                            Err(e) => return Err(format!("recv_body: {e:?}")),
+                        }
+                    },
+                    Ok((_stream_id, quiche::h3::Event::Finished)) => {
+                        return Ok((
+                            response_status,
+                            String::from_utf8_lossy(&response_body).to_string(),
+                        ));
+                    }
+                    Ok((_stream_id, quiche::h3::Event::Reset(_))) => {
+                        return Err("stream reset".to_string());
+                    }
+                    Ok((_stream_id, quiche::h3::Event::PriorityUpdate)) => {}
+                    Ok((_stream_id, quiche::h3::Event::GoAway)) => {}
+                    Err(quiche::h3::Error::Done) => break,
+                    Err(e) => return Err(format!("poll: {e:?}")),
+                }
+            }
+        }
+
+        if start.elapsed() > Duration::from_secs(REQUEST_TIMEOUT_SECS) {
+            return Err("timeout waiting for response".to_string());
+        }
+    }
+}
+
 #[test]
 fn http3_to_http2_roundtrip() {
     let dir = tempdir().expect("failed to create temp dir");
@@ -271,4 +417,37 @@ fn http3_to_http2_roundtrip() {
     handle.abort();
 
     assert!(body.contains("backend ok"));
+}
+
+/// A request body exceeding MAX_REQUEST_BODY_BYTES must be rejected with 413
+/// before the backend is contacted.
+#[test]
+fn oversized_request_body_returns_413() {
+    let dir = tempdir().expect("failed to create temp dir");
+    let (cert, key) = write_test_certs(&dir);
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let backend_addr = rt.block_on(start_h2_backend());
+    let config = make_config(0, backend_addr.to_string(), cert, key);
+    let mut listener = QUICListener::new(config).expect("failed to create listener");
+    let listen_addr = listener.socket.local_addr().unwrap();
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_flag = stop.clone();
+
+    let handle = rt.spawn_blocking(move || {
+        while !stop_flag.load(Ordering::Relaxed) {
+            listener.poll();
+        }
+    });
+
+    // Send a body one byte over the limit.
+    let oversized_body = vec![0u8; MAX_REQUEST_BODY_BYTES + 1];
+    let (status, _body) =
+        run_h3_post(listen_addr, oversized_body).expect("client request failed");
+
+    stop.store(true, Ordering::Relaxed);
+    handle.abort();
+
+    assert_eq!(status, "413", "expected 413 Payload Too Large, got {status}");
 }

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use bytes::Bytes;
+use quiche::h3::NameValue;
 use http_body_util::Full;
 use hyper::{Request, Response, body::Incoming, service::service_fn};
 use hyper_util::rt::{TokioExecutor, TokioIo};
@@ -95,6 +96,37 @@ fn make_config(port: u32, backend_addr: String, cert: String, key: String) -> Co
     }
 }
 
+fn quic_read_timeout(conn: &quiche::Connection) -> Duration {
+    conn.timeout()
+        .filter(|d| !d.is_zero())
+        .unwrap_or(Duration::from_millis(UDP_READ_TIMEOUT_MS))
+}
+
+struct ListenerTaskGuard {
+    stop: Arc<AtomicBool>,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl ListenerTaskGuard {
+    fn spawn(rt: &tokio::runtime::Runtime, mut listener: QUICListener) -> Self {
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_flag = stop.clone();
+        let handle = rt.spawn_blocking(move || {
+            while !stop_flag.load(Ordering::Relaxed) {
+                listener.poll();
+            }
+        });
+        Self { stop, handle }
+    }
+}
+
+impl Drop for ListenerTaskGuard {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        self.handle.abort();
+    }
+}
+
 async fn start_h2_backend() -> SocketAddr {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -169,9 +201,7 @@ fn run_h3_client(addr: SocketAddr) -> Result<String, String> {
             }
         }
 
-        let timeout = conn
-            .timeout()
-            .unwrap_or(Duration::from_millis(UDP_READ_TIMEOUT_MS));
+        let timeout = quic_read_timeout(&conn);
         socket
             .set_read_timeout(Some(timeout))
             .map_err(|e| format!("timeout: {e:?}"))?;
@@ -246,152 +276,6 @@ fn run_h3_client(addr: SocketAddr) -> Result<String, String> {
     }
 }
 
-/// Sends a POST with `body_bytes` payload; returns `(status_code_str, body_string)`.
-fn run_h3_post(addr: SocketAddr, body_bytes: Vec<u8>) -> Result<(String, String), String> {
-    let socket = std::net::UdpSocket::bind("0.0.0.0:0").map_err(|e| e.to_string())?;
-    let local_addr = socket.local_addr().map_err(|e| e.to_string())?;
-
-    let mut config =
-        quiche::Config::new(quiche::PROTOCOL_VERSION).map_err(|e| format!("config: {e:?}"))?;
-    config.verify_peer(false);
-    config
-        .set_application_protos(quiche::h3::APPLICATION_PROTOCOL)
-        .map_err(|e| format!("alpn: {e:?}"))?;
-    config.set_max_idle_timeout(QUIC_IDLE_TIMEOUT_MS);
-    config.set_max_recv_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
-    config.set_max_send_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
-    config.set_initial_max_data(QUIC_INITIAL_MAX_DATA);
-    config.set_initial_max_stream_data_bidi_local(QUIC_INITIAL_STREAM_DATA);
-    config.set_initial_max_stream_data_bidi_remote(QUIC_INITIAL_STREAM_DATA);
-    config.set_initial_max_stream_data_uni(QUIC_INITIAL_STREAM_DATA);
-    config.set_initial_max_streams_bidi(QUIC_INITIAL_MAX_STREAMS_BIDI);
-    config.set_initial_max_streams_uni(QUIC_INITIAL_MAX_STREAMS_UNI);
-    config.set_disable_active_migration(true);
-
-    let mut scid_bytes = [0u8; quiche::MAX_CONN_ID_LEN];
-    rand::thread_rng().fill_bytes(&mut scid_bytes);
-    let scid = quiche::ConnectionId::from_ref(&scid_bytes);
-
-    let mut conn = quiche::connect(Some("localhost"), &scid, local_addr, addr, &mut config)
-        .map_err(|e| format!("connect: {e:?}"))?;
-
-    let h3_config = quiche::h3::Config::new().map_err(|e| format!("h3: {e:?}"))?;
-    let mut h3_conn: Option<quiche::h3::Connection> = None;
-
-    let mut out = [0u8; MAX_UDP_PAYLOAD_BYTES];
-    let mut buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
-
-    let (write, send_info) = conn.send(&mut out).map_err(|e| format!("send: {e:?}"))?;
-    socket
-        .send_to(&out[..write], send_info.to)
-        .map_err(|e| format!("send_to: {e:?}"))?;
-
-    let start = Instant::now();
-    let mut req_sent = false;
-    let mut response_status = String::new();
-    let mut response_body = Vec::new();
-
-    loop {
-        loop {
-            match conn.send(&mut out) {
-                Ok((write, send_info)) => {
-                    let _ = socket.send_to(&out[..write], send_info.to);
-                }
-                Err(quiche::Error::Done) => break,
-                Err(e) => return Err(format!("send loop: {e:?}")),
-            }
-        }
-
-        let timeout = conn
-            .timeout()
-            .unwrap_or(Duration::from_millis(UDP_READ_TIMEOUT_MS));
-        socket
-            .set_read_timeout(Some(timeout))
-            .map_err(|e| format!("timeout: {e:?}"))?;
-
-        match socket.recv_from(&mut buf) {
-            Ok((len, from)) => {
-                let recv_info = quiche::RecvInfo {
-                    from,
-                    to: local_addr,
-                };
-                conn.recv(&mut buf[..len], recv_info)
-                    .map_err(|e| format!("recv: {e:?}"))?;
-            }
-            Err(ref e)
-                if e.kind() == std::io::ErrorKind::WouldBlock
-                    || e.kind() == std::io::ErrorKind::TimedOut =>
-            {
-                conn.on_timeout();
-            }
-            Err(e) => return Err(format!("recv: {e:?}")),
-        }
-
-        if conn.is_established() && h3_conn.is_none() {
-            h3_conn = Some(
-                quiche::h3::Connection::with_transport(&mut conn, &h3_config)
-                    .map_err(|e| format!("h3 conn: {e:?}"))?,
-            );
-        }
-
-        if let Some(h3) = h3_conn.as_mut() {
-            if conn.is_established() && !req_sent {
-                let content_length = body_bytes.len().to_string();
-                let req = vec![
-                    quiche::h3::Header::new(b":method", b"POST"),
-                    quiche::h3::Header::new(b":scheme", b"https"),
-                    quiche::h3::Header::new(b":authority", b"localhost"),
-                    quiche::h3::Header::new(b":path", b"/"),
-                    quiche::h3::Header::new(b"content-length", content_length.as_bytes()),
-                ];
-                let stream_id = h3
-                    .send_request(&mut conn, &req, false)
-                    .map_err(|e| format!("send_request: {e:?}"))?;
-                h3.send_body(&mut conn, stream_id, &body_bytes, true)
-                    .map_err(|e| format!("send_body: {e:?}"))?;
-                req_sent = true;
-            }
-
-            loop {
-                match h3.poll(&mut conn) {
-                    Ok((_stream_id, quiche::h3::Event::Headers { list, .. })) => {
-                        for h in &list {
-                            if h.name() == b":status" {
-                                response_status =
-                                    String::from_utf8_lossy(h.value()).to_string();
-                            }
-                        }
-                    }
-                    Ok((stream_id, quiche::h3::Event::Data)) => loop {
-                        match h3.recv_body(&mut conn, stream_id, &mut buf) {
-                            Ok(read) => response_body.extend_from_slice(&buf[..read]),
-                            Err(quiche::h3::Error::Done) => break,
-                            Err(e) => return Err(format!("recv_body: {e:?}")),
-                        }
-                    },
-                    Ok((_stream_id, quiche::h3::Event::Finished)) => {
-                        return Ok((
-                            response_status,
-                            String::from_utf8_lossy(&response_body).to_string(),
-                        ));
-                    }
-                    Ok((_stream_id, quiche::h3::Event::Reset(_))) => {
-                        return Err("stream reset".to_string());
-                    }
-                    Ok((_stream_id, quiche::h3::Event::PriorityUpdate)) => {}
-                    Ok((_stream_id, quiche::h3::Event::GoAway)) => {}
-                    Err(quiche::h3::Error::Done) => break,
-                    Err(e) => return Err(format!("poll: {e:?}")),
-                }
-            }
-        }
-
-        if start.elapsed() > Duration::from_secs(REQUEST_TIMEOUT_SECS) {
-            return Err("timeout waiting for response".to_string());
-        }
-    }
-}
-
 #[test]
 fn http3_to_http2_roundtrip() {
     let dir = tempdir().expect("failed to create temp dir");
@@ -400,54 +284,178 @@ fn http3_to_http2_roundtrip() {
     let rt = tokio::runtime::Runtime::new().expect("runtime");
     let backend_addr = rt.block_on(start_h2_backend());
     let config = make_config(0, backend_addr.to_string(), cert, key);
-    let mut listener = QUICListener::new(config).expect("failed to create listener");
+    let listener = QUICListener::new(config).expect("failed to create listener");
     let listen_addr = listener.socket.local_addr().unwrap();
-
-    let stop = Arc::new(AtomicBool::new(false));
-    let stop_flag = stop.clone();
-
-    let handle = rt.spawn_blocking(move || {
-        while !stop_flag.load(Ordering::Relaxed) {
-            listener.poll();
-        }
-    });
+    let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
 
     let body = run_h3_client(listen_addr).expect("client request failed");
-    stop.store(true, Ordering::Relaxed);
-    handle.abort();
 
     assert!(body.contains("backend ok"));
 }
 
 /// A request body exceeding MAX_REQUEST_BODY_BYTES must be rejected with 413
 /// before the backend is contacted.
+///
+/// The body is sent in two chunks so the client interleaves send/recv between
+/// them, allowing the server to reply with 413 after the first chunk crosses
+/// the limit without the client blocking on a single large send_body call.
 #[test]
 fn oversized_request_body_returns_413() {
+    use rand::RngCore;
+
     let dir = tempdir().expect("failed to create temp dir");
     let (cert, key) = write_test_certs(&dir);
 
     let rt = tokio::runtime::Runtime::new().expect("runtime");
     let backend_addr = rt.block_on(start_h2_backend());
     let config = make_config(0, backend_addr.to_string(), cert, key);
-    let mut listener = QUICListener::new(config).expect("failed to create listener");
+    let listener = QUICListener::new(config).expect("failed to create listener");
     let listen_addr = listener.socket.local_addr().unwrap();
+    let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
 
-    let stop = Arc::new(AtomicBool::new(false));
-    let stop_flag = stop.clone();
+    // Two chunks that together exceed the limit; each fits within quiche flow control.
+    let chunk_size = MAX_REQUEST_BODY_BYTES / 2 + 1;
+    let chunk1 = vec![0u8; chunk_size];
+    let chunk2 = vec![0u8; chunk_size];
+    let total_len = chunk1.len() + chunk2.len();
 
-    let handle = rt.spawn_blocking(move || {
-        while !stop_flag.load(Ordering::Relaxed) {
-            listener.poll();
+    let socket = std::net::UdpSocket::bind("0.0.0.0:0").unwrap();
+    let local_addr = socket.local_addr().unwrap();
+
+    let mut qconfig =
+        quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
+    qconfig.verify_peer(false);
+    qconfig.set_application_protos(quiche::h3::APPLICATION_PROTOCOL).unwrap();
+    qconfig.set_max_idle_timeout(QUIC_IDLE_TIMEOUT_MS);
+    qconfig.set_max_recv_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    qconfig.set_max_send_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    // Window large enough to transmit both chunks.
+    let window = (total_len as u64 + 1) * 2;
+    qconfig.set_initial_max_data(window * 4);
+    qconfig.set_initial_max_stream_data_bidi_local(window);
+    qconfig.set_initial_max_stream_data_bidi_remote(window);
+    qconfig.set_initial_max_stream_data_uni(window);
+    qconfig.set_initial_max_streams_bidi(QUIC_INITIAL_MAX_STREAMS_BIDI);
+    qconfig.set_initial_max_streams_uni(QUIC_INITIAL_MAX_STREAMS_UNI);
+    qconfig.set_disable_active_migration(true);
+
+    let mut scid_bytes = [0u8; quiche::MAX_CONN_ID_LEN];
+    rand::thread_rng().fill_bytes(&mut scid_bytes);
+    let scid = quiche::ConnectionId::from_ref(&scid_bytes);
+    let mut conn =
+        quiche::connect(Some("localhost"), &scid, local_addr, listen_addr, &mut qconfig).unwrap();
+    let h3_config = quiche::h3::Config::new().unwrap();
+
+    let mut out = [0u8; MAX_UDP_PAYLOAD_BYTES];
+    let mut buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
+
+    // Send initial QUIC packet.
+    let (w, si) = conn.send(&mut out).unwrap();
+    socket.send_to(&out[..w], si.to).unwrap();
+
+    let start = Instant::now();
+    let mut h3: Option<quiche::h3::Connection> = None;
+    let mut stream_id: Option<u64> = None;
+    let mut chunk1_written = 0usize;
+    let mut chunk2_written = 0usize;
+    let mut response_status = String::new();
+    let mut response_body = Vec::new();
+
+    let status = 'outer: loop {
+        // Flush send.
+        loop {
+            match conn.send(&mut out) {
+                Ok((w, si)) => { let _ = socket.send_to(&out[..w], si.to); }
+                Err(quiche::Error::Done) => break,
+                Err(e) => panic!("send: {e:?}"),
+            }
         }
-    });
 
-    // Send a body one byte over the limit.
-    let oversized_body = vec![0u8; MAX_REQUEST_BODY_BYTES + 1];
-    let (status, _body) =
-        run_h3_post(listen_addr, oversized_body).expect("client request failed");
+        let timeout = quic_read_timeout(&conn);
+        socket.set_read_timeout(Some(timeout)).unwrap();
 
-    stop.store(true, Ordering::Relaxed);
-    handle.abort();
+        match socket.recv_from(&mut buf) {
+            Ok((len, from)) => {
+                conn.recv(&mut buf[..len], quiche::RecvInfo { from, to: local_addr }).unwrap();
+            }
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock
+                       || e.kind() == std::io::ErrorKind::TimedOut => {
+                conn.on_timeout();
+            }
+            Err(e) => panic!("recv: {e:?}"),
+        }
+
+        if conn.is_established() && h3.is_none() {
+            h3 = Some(quiche::h3::Connection::with_transport(&mut conn, &h3_config).unwrap());
+        }
+
+        if let Some(h3c) = h3.as_mut() {
+            // Send headers + first chunk.
+            if stream_id.is_none() && conn.is_established() {
+                let content_length = total_len.to_string();
+                let headers = vec![
+                    quiche::h3::Header::new(b":method", b"POST"),
+                    quiche::h3::Header::new(b":scheme", b"https"),
+                    quiche::h3::Header::new(b":authority", b"localhost"),
+                    quiche::h3::Header::new(b":path", b"/"),
+                    quiche::h3::Header::new(b"content-length", content_length.as_bytes()),
+                ];
+                let sid = h3c.send_request(&mut conn, &headers, false).unwrap();
+                stream_id = Some(sid);
+            }
+
+            if let Some(sid) = stream_id {
+                // send_body() can write partial buffers; keep retrying until both chunks are
+                // fully queued so the server always receives > MAX_REQUEST_BODY_BYTES.
+                if chunk1_written < chunk1.len() {
+                    match h3c.send_body(&mut conn, sid, &chunk1[chunk1_written..], false) {
+                        Ok(written) => chunk1_written += written,
+                        Err(quiche::h3::Error::Done | quiche::h3::Error::StreamBlocked) => {}
+                        Err(e) => panic!("send_body chunk1: {e:?}"),
+                    }
+                } else if chunk2_written < chunk2.len() {
+                    match h3c.send_body(&mut conn, sid, &chunk2[chunk2_written..], true) {
+                        Ok(written) => chunk2_written += written,
+                        Err(quiche::h3::Error::Done | quiche::h3::Error::StreamBlocked) => {}
+                        Err(e) => panic!("send_body chunk2: {e:?}"),
+                    }
+                }
+            }
+
+            // Poll for server response.
+            loop {
+                match h3c.poll(&mut conn) {
+                    Ok((_sid, quiche::h3::Event::Headers { list, .. })) => {
+                        for h in &list {
+                            if h.name() == b":status" {
+                                response_status = String::from_utf8_lossy(h.value()).to_string();
+                            }
+                        }
+                    }
+                    Ok((sid, quiche::h3::Event::Data)) => loop {
+                        match h3c.recv_body(&mut conn, sid, &mut buf) {
+                            Ok(r) => response_body.extend_from_slice(&buf[..r]),
+                            Err(quiche::h3::Error::Done) => break,
+                            Err(e) => panic!("recv_body: {e:?}"),
+                        }
+                    },
+                    Ok((_sid, quiche::h3::Event::Finished)) => {
+                        break 'outer response_status.clone();
+                    }
+                    Ok((_sid, quiche::h3::Event::Reset(_))) => {
+                        break 'outer response_status.clone();
+                    }
+                    Ok(_) => {}
+                    Err(quiche::h3::Error::Done) => break,
+                    Err(e) => panic!("poll: {e:?}"),
+                }
+            }
+        }
+
+        if start.elapsed() > Duration::from_secs(REQUEST_TIMEOUT_SECS) {
+            panic!("timeout waiting for 413 response");
+        }
+    };
 
     assert_eq!(status, "413", "expected 413 Payload Too Large, got {status}");
 }

--- a/crates/edge/tests/h3_edge.rs
+++ b/crates/edge/tests/h3_edge.rs
@@ -96,6 +96,12 @@ fn make_config(port: u32, cert: String, key: String, backend_address: String) ->
     }
 }
 
+fn quic_read_timeout(conn: &quiche::Connection) -> Duration {
+    conn.timeout()
+        .filter(|d| !d.is_zero())
+        .unwrap_or(Duration::from_millis(UDP_READ_TIMEOUT_MS))
+}
+
 async fn start_h2_backend(body: &'static str) -> std::net::SocketAddr {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -176,9 +182,7 @@ fn run_h3_client(addr: std::net::SocketAddr) -> Result<String, String> {
             }
         }
 
-        let timeout = conn
-            .timeout()
-            .unwrap_or(Duration::from_millis(UDP_READ_TIMEOUT_MS));
+        let timeout = quic_read_timeout(&conn);
         socket
             .set_read_timeout(Some(timeout))
             .map_err(|e| format!("timeout: {e:?}"))?;
@@ -312,9 +316,7 @@ fn run_h3_client_multiple_requests(
             }
         }
 
-        let timeout = conn
-            .timeout()
-            .unwrap_or(Duration::from_millis(UDP_READ_TIMEOUT_MS));
+        let timeout = quic_read_timeout(&conn);
         socket
             .set_read_timeout(Some(timeout))
             .map_err(|e| format!("timeout: {e:?}"))?;

--- a/crates/transport/src/h2_client.rs
+++ b/crates/transport/src/h2_client.rs
@@ -1,12 +1,14 @@
-use http_body_util::Full;
+use std::convert::Infallible;
+use std::future::Future;
+
+use http_body_util::combinators::BoxBody;
 use hyper::body::Bytes;
 use hyper::{Request, rt::Executor};
 use hyper_util::client::legacy::{Client, connect::HttpConnector};
 
 pub struct H2Client {
-    client: Client<HttpConnector, Full<Bytes>>,
+    client: Client<HttpConnector, BoxBody<Bytes, Infallible>>,
 }
-use std::future::Future;
 
 #[derive(Clone, Copy)]
 struct TokioExecutor;
@@ -33,7 +35,7 @@ impl H2Client {
 
     pub async fn send(
         &self,
-        req: Request<Full<Bytes>>,
+        req: Request<BoxBody<Bytes, Infallible>>,
     ) -> Result<hyper::Response<hyper::body::Incoming>, hyper_util::client::legacy::Error> {
         self.client.request(req).await
     }

--- a/crates/transport/src/h2_pool.rs
+++ b/crates/transport/src/h2_pool.rs
@@ -1,6 +1,6 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, convert::Infallible, sync::Arc};
 
-use http_body_util::Full;
+use http_body_util::combinators::BoxBody;
 use hyper::Request;
 use hyper::body::{Bytes, Incoming};
 use tokio::sync::Semaphore;
@@ -43,7 +43,7 @@ impl H2Pool {
     pub async fn send(
         &self,
         backend: &str,
-        req: Request<Full<Bytes>>,
+        req: Request<BoxBody<Bytes, Infallible>>,
     ) -> Result<hyper::Response<Incoming>, PoolError> {
         let handle = self
             .backends

--- a/crates/transport/tests/h2_pool.rs
+++ b/crates/transport/tests/h2_pool.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use bytes::Bytes;
-use http_body_util::Full;
+use http_body_util::{BodyExt, Full};
 use hyper::{Request, Response, body::Incoming, service::service_fn};
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use tokio::net::TcpListener;
@@ -88,12 +88,12 @@ async fn pool_limits_inflight_per_backend() {
     let req1 = Request::builder()
         .method("GET")
         .uri(format!("http://{backend}/"))
-        .body(Full::new(Bytes::new()))
+        .body(Full::new(Bytes::new()).boxed())
         .unwrap();
     let req2 = Request::builder()
         .method("GET")
         .uri(format!("http://{backend}/"))
-        .body(Full::new(Bytes::new()))
+        .body(Full::new(Bytes::new()).boxed())
         .unwrap();
 
     let pool1 = pool.clone();
@@ -118,7 +118,7 @@ async fn pool_rejects_unknown_backend() {
     let req = Request::builder()
         .method("GET")
         .uri("http://127.0.0.1:12345/")
-        .body(Full::new(Bytes::new()))
+        .body(Full::new(Bytes::new()).boxed())
         .unwrap();
 
     let err = pool.send("127.0.0.1:9999", req).await.unwrap_err();

--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -868,7 +868,7 @@ cargo test -p spooky-edge --test lb_integration
 - Amortize handshake cost
 
 **Async I/O:**
-- Backend requests with full body buffering (streaming planned)
+- Streaming request body via `ChannelBody` (mpsc channel, no full buffering)
 - Efficient task scheduling via Tokio
 
 ### Memory Management

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -61,7 +61,7 @@ Clear separation of concerns across crate boundaries:
 │  │  Protocol Bridge               │     │
 │  │  - HTTP/3 → HTTP/2 conversion  │     │
 │  │  - Header normalization        │     │
-│  │  - Full body buffering (streaming planned)              │     │
+│  │  - Streaming body via ChannelBody (mpsc-backed)        │     │
 │  └───────────┬────────────────────┘     │
 │              │                           │
 │  ┌───────────▼────────────────────┐     │
@@ -75,7 +75,7 @@ Clear separation of concerns across crate boundaries:
 │  │  HTTP/2 Connection Pool        │     │
 │  │  - Connection reuse            │     │
 │  │  - Request forwarding          │     │
-│  │  - Full response buffering (streaming planned)          │     │
+│  │  - Per-frame response streaming                        │     │
 │  └───────────┬────────────────────┘     │
 └──────────────┼──────────────────────────┘
                │ HTTP/2
@@ -159,7 +159,7 @@ Backend response is processed:
 1. HTTP/2 response is received from backend
 2. Status code and headers are extracted
 3. Response is written back to HTTP/3 stream
-4. Body is buffered from backend and sent to client (streaming planned)
+4. Body is streamed to client per frame via incremental `h3.send_body` calls
 5. Stream is finalized when response is complete
 
 ### 7. Health Management


### PR DESCRIPTION
Closes- #18 

### Summary
- Request body streams to upstream via `ChannelBody` (mpsc channel) at `Headers` time — no `BytesMut` wait for `Finished`
- Response body sent per-frame via incremental `h3.send_body` — no `collect()`/`Vec<Bytes>` accumulation
- H2 transport generalized from `Full<Bytes>` to `BoxBody<Bytes, Infallible>`
- Added `MAX_REQUEST_BODY_BYTES = 1MB` cap with 413 fast-fail on overflow
- Regression test: `oversized_request_body_returns_413`

### Remaining limitation
quiche `recv_body` is synchronous — chunks are piped as they arrive but the poll loop cannot yield mid-stream. Full zero-copy requires an async poll loop rewrite.
