### PR TITLE
perf(edge): eliminate head-of-line blocking via non-blocking poll loop

### DIFF
--- a/crates/edge/src/cid_radix.rs
+++ b/crates/edge/src/cid_radix.rs
@@ -55,7 +55,10 @@ impl CidRadix {
 
         // Traverse/build trie path byte by byte
         for &byte in scid.iter() {
-            node = node.children.entry(byte).or_insert_with(CidTrieNode::default);
+            node = node
+                .children
+                .entry(byte)
+                .or_insert_with(CidTrieNode::default);
         }
 
         // Store the SCID at the leaf
@@ -278,10 +281,18 @@ mod tests {
         let scid = scid(&[1u8, 2, 3, 4, 5, 6, 7, 8]);
 
         radix.insert(scid.clone());
-        assert!(radix.longest_prefix_match(&[1u8, 2, 3, 4, 5, 6, 7, 8]).is_some());
+        assert!(
+            radix
+                .longest_prefix_match(&[1u8, 2, 3, 4, 5, 6, 7, 8])
+                .is_some()
+        );
 
         radix.remove(&[1u8, 2, 3, 4, 5, 6, 7, 8]);
-        assert!(radix.longest_prefix_match(&[1u8, 2, 3, 4, 5, 6, 7, 8]).is_none());
+        assert!(
+            radix
+                .longest_prefix_match(&[1u8, 2, 3, 4, 5, 6, 7, 8])
+                .is_none()
+        );
     }
 
     #[test]
@@ -294,7 +305,11 @@ mod tests {
         radix.remove(&[9u8, 8, 7, 6, 5, 4, 3, 2]);
 
         // Original should still be there
-        assert!(radix.longest_prefix_match(&[1u8, 2, 3, 4, 5, 6, 7, 8]).is_some());
+        assert!(
+            radix
+                .longest_prefix_match(&[1u8, 2, 3, 4, 5, 6, 7, 8])
+                .is_some()
+        );
     }
 
     #[test]
@@ -347,14 +362,18 @@ mod tests {
         // Simulate multiple connections with realistic 16-byte SCIDs
         let scid1 = scid(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
         let scid2 = scid(&[1, 2, 3, 4, 5, 6, 7, 8, 20, 21, 22, 23, 24, 25, 26, 27]);
-        let scid3 = scid(&[30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45]);
+        let scid3 = scid(&[
+            30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45,
+        ]);
 
         radix.insert(scid1.clone());
         radix.insert(scid2.clone());
         radix.insert(scid3.clone());
 
         // Client sends packet with DCID = SCID1 + extra bytes
-        let dcid1 = [1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 99, 100];
+        let dcid1 = [
+            1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 99, 100,
+        ];
         let result = radix.longest_prefix_match(&dcid1);
         assert_eq!(result.unwrap().len(), 16);
 

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -17,10 +17,10 @@ use core::net::SocketAddr;
 
 use hyper::body::{Body, Frame};
 use spooky_config::config::Config;
+use spooky_errors::ProxyError;
 use spooky_lb::UpstreamPool;
 use spooky_transport::h2_pool::H2Pool;
-use tokio::sync::mpsc;
-use tokio::task::JoinHandle;
+use tokio::sync::{mpsc, oneshot};
 
 use crate::cid_radix::CidRadix;
 use crate::constants::MAX_DATAGRAM_SIZE_BYTES;
@@ -98,7 +98,30 @@ pub struct QuicConnection {
 
 /// Result type returned by the in-flight H2 forwarding task.
 pub type ForwardResult =
-    Result<(http::StatusCode, http::HeaderMap, hyper::body::Incoming), spooky_errors::ProxyError>;
+    Result<(http::StatusCode, http::HeaderMap, hyper::body::Incoming), ProxyError>;
+
+/// Lifecycle phase of a single HTTP/3 request stream.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StreamPhase {
+    /// Still receiving request headers/body from the QUIC client.
+    ReceivingRequest,
+    /// Request fully received; waiting for the upstream H2 response.
+    AwaitingUpstream,
+    /// Upstream responded; streaming response back to the QUIC client.
+    SendingResponse,
+    /// Stream finished cleanly.
+    Completed,
+    /// Stream terminated with an error.
+    Failed,
+}
+
+/// A chunk of the upstream response being streamed back to the client.
+#[derive(Debug)]
+pub enum ResponseChunk {
+    Data(Bytes),
+    End,
+    Error(ProxyError),
+}
 
 pub struct RequestEnvelope {
     pub method: String,
@@ -107,8 +130,6 @@ pub struct RequestEnvelope {
     pub headers: SmallVec<[(Vec<u8>, Vec<u8>); 16]>,
     /// Sender half of the body channel.  Dropping it signals end-of-body to hyper.
     pub body_tx: Option<mpsc::Sender<Bytes>>,
-    /// In-flight H2 forwarding task.  Awaited on `Finished`.
-    pub response_rx: Option<JoinHandle<ForwardResult>>,
     /// Body chunks that arrived before the channel had capacity.
     pub body_buf: Vec<Bytes>,
     /// Total body bytes received on this stream (buffered + already forwarded).
@@ -117,6 +138,17 @@ pub struct RequestEnvelope {
     pub backend_addr: Option<String>,
     pub backend_index: Option<usize>,
     pub start: Instant,
+
+    /// Current lifecycle phase of this stream.
+    pub phase: StreamPhase,
+    /// True once the client has sent FIN on the request stream.
+    pub request_fin_received: bool,
+    /// Receives the upstream H2 response (status, headers, body stream).
+    pub upstream_result_rx: Option<oneshot::Receiver<ForwardResult>>,
+    /// Receives response body chunks to write back over QUIC.
+    pub response_chunk_rx: Option<mpsc::Receiver<ResponseChunk>>,
+    /// A chunk that could not be written due to QUIC send backpressure; retried next poll.
+    pub pending_chunk: Option<ResponseChunk>,
 }
 
 #[derive(Debug)]

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -739,11 +739,15 @@ impl QUICListener {
 
                     // Route lookup — needed to start the H2 request immediately.
                     let resolved = Self::resolve_backend(
-                        &method, &path, authority.as_deref(),
-                        upstream_pools, routing_index,
+                        &method,
+                        &path,
+                        authority.as_deref(),
+                        upstream_pools,
+                        routing_index,
                     );
 
-                    let (body_tx, upstream_result_rx, backend_addr, backend_index) = match resolved {
+                    let (body_tx, upstream_result_rx, backend_addr, backend_index) = match resolved
+                    {
                         Ok((addr, idx, _pool)) => {
                             // Create a channel body so quiche Data chunks stream
                             // directly into the in-flight H2 request.
@@ -758,8 +762,12 @@ impl QUICListener {
                             let fut = async move {
                                 let result = async {
                                     let request = build_h2_request(
-                                        &fwd_addr, &req_method, &req_path,
-                                        &req_headers, boxed, None,
+                                        &fwd_addr,
+                                        &req_method,
+                                        &req_path,
+                                        &req_headers,
+                                        boxed,
+                                        None,
                                     )
                                     .map_err(ProxyError::Bridge)?;
 
@@ -778,8 +786,12 @@ impl QUICListener {
                                 let _ = result_tx.send(result);
                             };
                             match Handle::try_current() {
-                                Ok(handle) => { handle.spawn(fut); }
-                                Err(_) => { fallback_runtime().spawn(fut); }
+                                Ok(handle) => {
+                                    handle.spawn(fut);
+                                }
+                                Err(_) => {
+                                    fallback_runtime().spawn(fut);
+                                }
                             }
                             (Some(tx), Some(result_rx), Some(addr), Some(idx))
                         }
@@ -814,8 +826,7 @@ impl QUICListener {
                             if let Some(req) = connection.streams.get_mut(&stream_id) {
                                 // Enforce cap on total bytes received for the stream,
                                 // including chunks already forwarded to the H2 body channel.
-                                let next_total =
-                                    req.body_bytes_received.saturating_add(read);
+                                let next_total = req.body_bytes_received.saturating_add(read);
                                 if next_total > MAX_REQUEST_BODY_BYTES {
                                     connection.streams.remove(&stream_id);
                                     Self::send_simple_response(
@@ -882,7 +893,14 @@ impl QUICListener {
             }
         }
 
-        Self::advance_streams_non_blocking(&mut connection.streams, &mut connection.quic, h3, upstream_pools, routing_index, metrics)?;
+        Self::advance_streams_non_blocking(
+            &mut connection.streams,
+            &mut connection.quic,
+            h3,
+            upstream_pools,
+            routing_index,
+            metrics,
+        )?;
 
         Ok(())
     }
@@ -935,20 +953,35 @@ impl QUICListener {
             }
 
             // ── 3: poll upstream oneshot ──────────────────────────────────────
+            // Only transition to response handling once request-body ingestion is
+            // complete. This preserves request-size enforcement semantics:
+            // oversized requests must still be able to terminate with 413 even if
+            // upstream produced an early response.
+            let can_poll_upstream = streams.get(&stream_id).is_some_and(|req| {
+                req.phase == StreamPhase::AwaitingUpstream
+                    && req.request_fin_received
+                    && req.body_tx.is_none()
+                    && req.body_buf.is_empty()
+            });
+
             // upstream_ready: Option<ForwardResult>
-            //   None          → oneshot not yet resolved, skip
+            //   None          → oneshot not yet resolved (or not eligible), skip
             //   Some(Ok(...)) → upstream responded successfully
             //   Some(Err(.))  → upstream error (or sender dropped)
-            let upstream_ready: Option<ForwardResult> = streams
-                .get_mut(&stream_id)
-                .and_then(|req| req.upstream_result_rx.as_mut())
-                .and_then(|rx| match rx.try_recv() {
-                    Ok(result) => Some(result),
-                    Err(oneshot::error::TryRecvError::Empty) => None,
-                    Err(oneshot::error::TryRecvError::Closed) => {
-                        Some(Err(ProxyError::Transport("upstream task dropped sender".into())))
-                    }
-                });
+            let upstream_ready: Option<ForwardResult> = if can_poll_upstream {
+                streams
+                    .get_mut(&stream_id)
+                    .and_then(|req| req.upstream_result_rx.as_mut())
+                    .and_then(|rx| match rx.try_recv() {
+                        Ok(result) => Some(result),
+                        Err(oneshot::error::TryRecvError::Empty) => None,
+                        Err(oneshot::error::TryRecvError::Closed) => Some(Err(
+                            ProxyError::Transport("upstream task dropped sender".into()),
+                        )),
+                    })
+            } else {
+                None
+            };
 
             if let Some(forward_result) = upstream_ready {
                 if let Some(req) = streams.get_mut(&stream_id) {
@@ -963,8 +996,7 @@ impl QUICListener {
                             status.as_str().as_bytes(),
                         ));
                         for (name, value) in resp_headers.iter() {
-                            if is_hop_header(name.as_str())
-                                || name == http::header::CONTENT_LENGTH
+                            if is_hop_header(name.as_str()) || name == http::header::CONTENT_LENGTH
                             {
                                 continue;
                             }
@@ -978,8 +1010,7 @@ impl QUICListener {
                         // Spawn a task that pumps body frames into a ResponseChunk channel.
                         // Enforces backend_timeout() so a slow upstream body does not
                         // leave the stream open indefinitely.
-                        let (chunk_tx, chunk_rx) =
-                            mpsc::channel::<ResponseChunk>(16);
+                        let (chunk_tx, chunk_rx) = mpsc::channel::<ResponseChunk>(16);
                         let deadline = tokio::time::Instant::now() + backend_timeout();
                         let fut = async move {
                             use http_body_util::BodyExt;
@@ -997,7 +1028,11 @@ impl QUICListener {
                                     }
                                     Ok(Some(Ok(f))) => {
                                         if let Ok(data) = f.into_data() {
-                                            if chunk_tx.send(ResponseChunk::Data(data)).await.is_err() {
+                                            if chunk_tx
+                                                .send(ResponseChunk::Data(data))
+                                                .await
+                                                .is_err()
+                                            {
                                                 return;
                                             }
                                         }
@@ -1019,8 +1054,12 @@ impl QUICListener {
                             }
                         };
                         match Handle::try_current() {
-                            Ok(h) => { h.spawn(fut); }
-                            Err(_) => { fallback_runtime().spawn(fut); }
+                            Ok(h) => {
+                                h.spawn(fut);
+                            }
+                            Err(_) => {
+                                fallback_runtime().spawn(fut);
+                            }
                         }
 
                         if let Some(req) = streams.get_mut(&stream_id) {
@@ -1030,17 +1069,16 @@ impl QUICListener {
 
                         // Update health/metrics for successful upstream response.
                         if let Some(req) = streams.get(&stream_id) {
-                            if let (Some(addr), Some(idx)) =
-                                (&req.backend_addr, req.backend_index)
+                            if let (Some(addr), Some(idx)) = (&req.backend_addr, req.backend_index)
                             {
                                 let upstream_name =
                                     routing_index.lookup(&req.path, req.authority.as_deref());
-                                if let Some(pool) = upstream_name
-                                    .and_then(|n| upstream_pools.get(n))
+                                if let Some(pool) =
+                                    upstream_name.and_then(|n| upstream_pools.get(n))
                                 {
                                     let transition =
-                                        pool.lock().ok().and_then(|mut p| {
-                                            match outcome_from_status(status) {
+                                        pool.lock().ok().and_then(
+                                            |mut p| match outcome_from_status(status) {
                                                 crate::HealthClassification::Success => {
                                                     p.pool.mark_success(idx)
                                                 }
@@ -1048,8 +1086,8 @@ impl QUICListener {
                                                     p.pool.mark_failure(idx)
                                                 }
                                                 crate::HealthClassification::Neutral => None,
-                                            }
-                                        });
+                                            },
+                                        );
                                     if let Some(t) = transition {
                                         Self::log_health_transition(addr, t);
                                     }
@@ -1105,8 +1143,7 @@ impl QUICListener {
                                     Ok(_) => {}
                                     Err(quiche::h3::Error::StreamBlocked) => {
                                         // QUIC flow-control backpressure — retry next poll.
-                                        req.pending_chunk =
-                                            Some(ResponseChunk::Data(data));
+                                        req.pending_chunk = Some(ResponseChunk::Data(data));
                                         break;
                                     }
                                     Err(e) => return Err(e),
@@ -1124,16 +1161,14 @@ impl QUICListener {
                                 req.phase = StreamPhase::Failed;
                                 // Mirror the health/metrics updates from the old
                                 // send_backend_response timeout/error paths.
-                                let upstream_name = routing_index
-                                    .lookup(&req.path, req.authority.as_deref());
+                                let upstream_name =
+                                    routing_index.lookup(&req.path, req.authority.as_deref());
                                 if let (Some(idx), Some(pool)) = (
                                     req.backend_index,
                                     upstream_name.and_then(|n| upstream_pools.get(n)),
                                 ) {
-                                    if let Some(t) = pool
-                                        .lock()
-                                        .ok()
-                                        .and_then(|mut p| p.pool.mark_failure(idx))
+                                    if let Some(t) =
+                                        pool.lock().ok().and_then(|mut p| p.pool.mark_failure(idx))
                                     {
                                         if let Some(addr) = &req.backend_addr {
                                             Self::log_health_transition(addr, t);
@@ -1211,8 +1246,8 @@ impl QUICListener {
             let idx = pool.pick(key);
             (idx, lb_type)
         };
-        let backend_index = backend_index
-            .ok_or_else(|| ProxyError::Transport("no healthy servers".into()))?;
+        let backend_index =
+            backend_index.ok_or_else(|| ProxyError::Transport("no healthy servers".into()))?;
 
         let backend_addr = {
             let pool = upstream_pool.lock().expect("upstream pool lock");
@@ -1262,9 +1297,7 @@ impl QUICListener {
 
         // Re-acquire the upstream pool for health marking.
         let upstream_name = routing_index.lookup(&req.path, req.authority.as_deref());
-        let upstream_pool = upstream_name
-            .and_then(|n| upstream_pools.get(n))
-            .cloned();
+        let upstream_pool = upstream_name.and_then(|n| upstream_pools.get(n)).cloned();
 
         match result {
             // Ok variant is handled upstream by advance_streams_non_blocking;
@@ -1273,38 +1306,86 @@ impl QUICListener {
             Err(ProxyError::Bridge(err)) => {
                 error!("Bridge error: {:?}", err);
                 metrics.inc_failure();
-                info!("Upstream {} status 400 latency_ms {}", backend_addr, start.elapsed().as_millis());
-                Self::send_simple_response(h3, quic, stream_id, http::StatusCode::BAD_REQUEST, b"invalid request\n")
+                info!(
+                    "Upstream {} status 400 latency_ms {}",
+                    backend_addr,
+                    start.elapsed().as_millis()
+                );
+                Self::send_simple_response(
+                    h3,
+                    quic,
+                    stream_id,
+                    http::StatusCode::BAD_REQUEST,
+                    b"invalid request\n",
+                )
             }
             Err(ProxyError::Transport(_)) | Err(ProxyError::Pool(_)) => {
                 error!("Transport error");
                 if let Some(pool) = &upstream_pool {
-                    if let Some(t) = pool.lock().ok().and_then(|mut p| p.pool.mark_failure(backend_index)) {
+                    if let Some(t) = pool
+                        .lock()
+                        .ok()
+                        .and_then(|mut p| p.pool.mark_failure(backend_index))
+                    {
                         Self::log_health_transition(backend_addr, t);
                     }
                 }
                 metrics.inc_failure();
                 metrics.inc_backend_error();
-                info!("Upstream {} status 502 latency_ms {}", backend_addr, start.elapsed().as_millis());
-                Self::send_simple_response(h3, quic, stream_id, http::StatusCode::BAD_GATEWAY, b"upstream error\n")
+                info!(
+                    "Upstream {} status 502 latency_ms {}",
+                    backend_addr,
+                    start.elapsed().as_millis()
+                );
+                Self::send_simple_response(
+                    h3,
+                    quic,
+                    stream_id,
+                    http::StatusCode::BAD_GATEWAY,
+                    b"upstream error\n",
+                )
             }
             Err(ProxyError::Timeout) => {
                 error!("Server timeout");
                 if let Some(pool) = &upstream_pool {
-                    if let Some(t) = pool.lock().ok().and_then(|mut p| p.pool.mark_failure(backend_index)) {
+                    if let Some(t) = pool
+                        .lock()
+                        .ok()
+                        .and_then(|mut p| p.pool.mark_failure(backend_index))
+                    {
                         Self::log_health_transition(backend_addr, t);
                     }
                 }
                 metrics.inc_failure();
                 metrics.inc_timeout();
-                info!("Upstream {} status 503 latency_ms {}", backend_addr, start.elapsed().as_millis());
-                Self::send_simple_response(h3, quic, stream_id, http::StatusCode::SERVICE_UNAVAILABLE, b"upstream timeout\n")
+                info!(
+                    "Upstream {} status 503 latency_ms {}",
+                    backend_addr,
+                    start.elapsed().as_millis()
+                );
+                Self::send_simple_response(
+                    h3,
+                    quic,
+                    stream_id,
+                    http::StatusCode::SERVICE_UNAVAILABLE,
+                    b"upstream timeout\n",
+                )
             }
             Err(ProxyError::Tls(err)) => {
                 error!("TLS error: {}", err);
                 metrics.inc_failure();
-                info!("TLS error for stream {} latency_ms {}", stream_id, start.elapsed().as_millis());
-                Self::send_simple_response(h3, quic, stream_id, http::StatusCode::INTERNAL_SERVER_ERROR, b"internal server error\n")
+                info!(
+                    "TLS error for stream {} latency_ms {}",
+                    stream_id,
+                    start.elapsed().as_millis()
+                );
+                Self::send_simple_response(
+                    h3,
+                    quic,
+                    stream_id,
+                    http::StatusCode::INTERNAL_SERVER_ERROR,
+                    b"internal server error\n",
+                )
             }
         }
     }

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -19,7 +19,7 @@ use spooky_errors::ProxyError;
 use spooky_lb::{HealthTransition, UpstreamPool};
 use spooky_transport::h2_pool::H2Pool;
 use tokio::runtime::Handle;
-use tokio::sync::oneshot;
+use tokio::sync::{mpsc, oneshot};
 
 use spooky_config::config::Config as SpookyConfig;
 
@@ -647,6 +647,24 @@ impl QUICListener {
 
             if connection.quic.is_closed() {
                 to_remove.push(scid.clone());
+                continue;
+            }
+
+            // Advance in-flight streams independent of inbound packets.
+            if connection.h3.is_some() {
+                let mut h3 = connection.h3.take().unwrap();
+                if let Err(e) = Self::advance_streams_non_blocking(
+                    &mut connection.streams,
+                    &mut connection.quic,
+                    &mut h3,
+                    &self.upstream_pools,
+                    &self.routing_index,
+                    &self.metrics,
+                ) {
+                    error!("advance_streams_non_blocking in timeout path: {:?}", e);
+                }
+                connection.h3 = Some(h3);
+                Self::flush_send(&socket, &mut send_buf, connection);
             }
         }
 
@@ -844,54 +862,12 @@ impl QUICListener {
                             }
                             req.body_buf = overflow;
                         }
-                        // If nothing is left buffered, drop body_tx to signal end-of-body.
+                        // If buffer is now empty, drop body_tx to signal end-of-body.
                         if req.body_buf.is_empty() {
                             req.body_tx = None;
                         }
-
-                        // Non-blocking poll of the upstream oneshot.
-                        let ready = req
-                            .upstream_result_rx
-                            .as_mut()
-                            .and_then(|rx| match rx.try_recv() {
-                                Ok(result) => Some(Ok(result)),
-                                Err(oneshot::error::TryRecvError::Empty) => None,
-                                Err(oneshot::error::TryRecvError::Closed) => Some(Err(())),
-                            });
-
-                        match ready {
-                            Some(Ok(forward_result)) => {
-                                req.upstream_result_rx = None;
-                                let req = connection.streams.remove(&stream_id).unwrap();
-                                Self::handle_forward_result(
-                                    h3,
-                                    &mut connection.quic,
-                                    stream_id,
-                                    &req,
-                                    forward_result,
-                                    upstream_pools,
-                                    routing_index,
-                                    metrics,
-                                )?;
-                            }
-                            Some(Err(())) => {
-                                // Sender dropped without sending — treat as error.
-                                let req = connection.streams.remove(&stream_id).unwrap();
-                                Self::handle_forward_result(
-                                    h3,
-                                    &mut connection.quic,
-                                    stream_id,
-                                    &req,
-                                    Err(ProxyError::Transport("upstream task dropped sender".into())),
-                                    upstream_pools,
-                                    routing_index,
-                                    metrics,
-                                )?;
-                            }
-                            // Not ready yet — leave the stream in the map; the
-                            // deferred poll below will pick it up on a later iteration.
-                            None => {}
-                        }
+                        // Upstream polling and response dispatch are handled entirely
+                        // by advance_streams_non_blocking, called unconditionally below.
                     }
                 }
                 Ok((stream_id, quiche::h3::Event::Reset(_))) => {
@@ -904,25 +880,43 @@ impl QUICListener {
             }
         }
 
-        // Deferred stream poll: for any stream where the request FIN has been
-        // received but the upstream oneshot wasn't ready at Finished time,
-        // try again now.  Collect IDs first to avoid borrowing streams while
-        // also calling handle_forward_result (which needs &mut connection.quic).
-        let deferred: Vec<u64> = connection
-            .streams
-            .iter()
-            .filter_map(|(&id, req)| {
-                if req.request_fin_received && req.upstream_result_rx.is_some() {
-                    Some(id)
-                } else {
-                    None
-                }
-            })
-            .collect();
+        Self::advance_streams_non_blocking(&mut connection.streams, &mut connection.quic, h3, upstream_pools, routing_index, metrics)?;
 
-        for stream_id in deferred {
-            // Retry non-blocking body flush for any overflow chunks.
-            if let Some(req) = connection.streams.get_mut(&stream_id) {
+        Ok(())
+    }
+
+    /// Advance all in-flight streams without blocking.
+    ///
+    /// Called after every packet-driven `handle_h3` pass and from
+    /// `handle_timeouts` so progress continues even when no new client
+    /// packets arrive.
+    ///
+    /// Per stream, in order:
+    /// 1. Drain request body buffer → body channel (`try_send`).
+    /// 2. Close body channel once FIN received and buffer empty.
+    /// 3. Poll `upstream_result_rx` (`try_recv`).
+    ///    - Error result  → send error response, mark terminal.
+    ///    - Ok result     → send H3 response headers, spawn body-pump task,
+    ///                      store `response_chunk_rx`, transition to SendingResponse.
+    /// 4. Flush `response_chunk_rx` chunks into H3 (`try_recv` loop).
+    ///    - `Data`  → `h3.send_body(..., false)`
+    ///    - `End`   → `h3.send_body(..., true)`, mark Completed
+    ///    - `Error` → send 502, mark Failed
+    /// 5. Remove streams in terminal phase (Completed / Failed).
+    #[allow(clippy::too_many_arguments)]
+    fn advance_streams_non_blocking(
+        streams: &mut HashMap<u64, RequestEnvelope>,
+        quic: &mut quiche::Connection,
+        h3: &mut quiche::h3::Connection,
+        upstream_pools: &HashMap<String, Arc<Mutex<UpstreamPool>>>,
+        routing_index: &RouteIndex,
+        metrics: &Metrics,
+    ) -> Result<(), quiche::h3::Error> {
+        let stream_ids: Vec<u64> = streams.keys().copied().collect();
+
+        for stream_id in stream_ids {
+            // ── 1 & 2: request body drain ────────────────────────────────────
+            if let Some(req) = streams.get_mut(&stream_id) {
                 if let Some(tx) = &req.body_tx {
                     let buf = std::mem::take(&mut req.body_buf);
                     let mut overflow = Vec::new();
@@ -933,49 +927,195 @@ impl QUICListener {
                     }
                     req.body_buf = overflow;
                 }
-                if req.body_buf.is_empty() {
-                    req.body_tx = None;
+                if req.request_fin_received && req.body_buf.is_empty() {
+                    req.body_tx = None; // signals EOF to the upstream H2 task
                 }
             }
 
-            let ready = connection
-                .streams
+            // ── 3: poll upstream oneshot ──────────────────────────────────────
+            // upstream_ready: Option<ForwardResult>
+            //   None          → oneshot not yet resolved, skip
+            //   Some(Ok(...)) → upstream responded successfully
+            //   Some(Err(.))  → upstream error (or sender dropped)
+            let upstream_ready: Option<ForwardResult> = streams
                 .get_mut(&stream_id)
                 .and_then(|req| req.upstream_result_rx.as_mut())
                 .and_then(|rx| match rx.try_recv() {
-                    Ok(result) => Some(Ok(result)),
+                    Ok(result) => Some(result),
                     Err(oneshot::error::TryRecvError::Empty) => None,
-                    Err(oneshot::error::TryRecvError::Closed) => Some(Err(())),
+                    Err(oneshot::error::TryRecvError::Closed) => {
+                        Some(Err(ProxyError::Transport("upstream task dropped sender".into())))
+                    }
                 });
 
-            match ready {
-                Some(Ok(forward_result)) => {
-                    let req = connection.streams.remove(&stream_id).unwrap();
-                    Self::handle_forward_result(
-                        h3,
-                        &mut connection.quic,
-                        stream_id,
-                        &req,
-                        forward_result,
-                        upstream_pools,
-                        routing_index,
-                        metrics,
-                    )?;
+            if let Some(forward_result) = upstream_ready {
+                if let Some(req) = streams.get_mut(&stream_id) {
+                    req.upstream_result_rx = None;
                 }
-                Some(Err(())) => {
-                    let req = connection.streams.remove(&stream_id).unwrap();
-                    Self::handle_forward_result(
-                        h3,
-                        &mut connection.quic,
-                        stream_id,
-                        &req,
-                        Err(ProxyError::Transport("upstream task dropped sender".into())),
-                        upstream_pools,
-                        routing_index,
-                        metrics,
-                    )?;
+                match forward_result {
+                    Ok((status, resp_headers, body)) => {
+                        // Send H3 response headers immediately (non-blocking).
+                        let mut h3_headers = Vec::with_capacity(resp_headers.len() + 1);
+                        h3_headers.push(quiche::h3::Header::new(
+                            b":status",
+                            status.as_str().as_bytes(),
+                        ));
+                        for (name, value) in resp_headers.iter() {
+                            if is_hop_header(name.as_str())
+                                || name == http::header::CONTENT_LENGTH
+                            {
+                                continue;
+                            }
+                            h3_headers.push(quiche::h3::Header::new(
+                                name.as_str().as_bytes(),
+                                value.as_bytes(),
+                            ));
+                        }
+                        h3.send_response(quic, stream_id, &h3_headers, false)?;
+
+                        // Spawn a task that pumps body frames into a ResponseChunk channel.
+                        let (chunk_tx, chunk_rx) =
+                            mpsc::channel::<ResponseChunk>(16);
+                        let fut = async move {
+                            use http_body_util::BodyExt;
+                            let mut body: hyper::body::Incoming = body;
+                            loop {
+                                match BodyExt::frame(&mut body).await {
+                                    Some(Ok(f)) => {
+                                        if let Ok(data) = f.into_data() {
+                                            if chunk_tx.send(ResponseChunk::Data(data)).await.is_err() {
+                                                return;
+                                            }
+                                        }
+                                        // skip trailers / other frame types
+                                    }
+                                    Some(Err(_)) => {
+                                        let _ = chunk_tx
+                                            .send(ResponseChunk::Error(ProxyError::Transport(
+                                                "upstream body error".into(),
+                                            )))
+                                            .await;
+                                        return;
+                                    }
+                                    None => {
+                                        let _ = chunk_tx.send(ResponseChunk::End).await;
+                                        return;
+                                    }
+                                }
+                            }
+                        };
+                        match Handle::try_current() {
+                            Ok(h) => { h.spawn(fut); }
+                            Err(_) => { fallback_runtime().spawn(fut); }
+                        }
+
+                        if let Some(req) = streams.get_mut(&stream_id) {
+                            req.response_chunk_rx = Some(chunk_rx);
+                            req.phase = StreamPhase::SendingResponse;
+                        }
+
+                        // Update health/metrics for successful upstream response.
+                        if let Some(req) = streams.get(&stream_id) {
+                            if let (Some(addr), Some(idx)) =
+                                (&req.backend_addr, req.backend_index)
+                            {
+                                let upstream_name =
+                                    routing_index.lookup(&req.path, req.authority.as_deref());
+                                if let Some(pool) = upstream_name
+                                    .and_then(|n| upstream_pools.get(n))
+                                {
+                                    let transition =
+                                        pool.lock().ok().and_then(|mut p| {
+                                            match outcome_from_status(status) {
+                                                crate::HealthClassification::Success => {
+                                                    p.pool.mark_success(idx)
+                                                }
+                                                crate::HealthClassification::Failure => {
+                                                    p.pool.mark_failure(idx)
+                                                }
+                                                crate::HealthClassification::Neutral => None,
+                                            }
+                                        });
+                                    if let Some(t) = transition {
+                                        Self::log_health_transition(addr, t);
+                                    }
+                                }
+                            }
+                            metrics.inc_success();
+                            info!(
+                                "Upstream {} status {} latency_ms {}",
+                                req.backend_addr.as_deref().unwrap_or("?"),
+                                status,
+                                req.start.elapsed().as_millis()
+                            );
+                        }
+                    }
+                    Err(err) => {
+                        // Remove stream, send error response via existing helper.
+                        let req = streams.remove(&stream_id).unwrap();
+                        Self::handle_forward_result(
+                            h3,
+                            quic,
+                            stream_id,
+                            &req,
+                            Err(err),
+                            upstream_pools,
+                            routing_index,
+                            metrics,
+                        )?;
+                        continue;
+                    }
                 }
-                None => {} // still waiting — try again next poll
+            }
+
+            // ── 4: flush response chunks ──────────────────────────────────────
+            let mut terminal = false;
+            if let Some(req) = streams.get_mut(&stream_id) {
+                if let Some(rx) = &mut req.response_chunk_rx {
+                    // Drain as many chunks as quiche will accept this iteration.
+                    loop {
+                        // Retry any chunk that previously hit backpressure.
+                        let chunk = match req.pending_chunk.take() {
+                            Some(c) => c,
+                            None => match rx.try_recv() {
+                                Ok(c) => c,
+                                Err(_) => break, // Empty or closed — nothing to flush
+                            },
+                        };
+                        match chunk {
+                            ResponseChunk::Data(data) => {
+                                match h3.send_body(quic, stream_id, &data, false) {
+                                    Ok(_) => {}
+                                    Err(quiche::h3::Error::StreamBlocked) => {
+                                        // QUIC flow-control backpressure — retry next poll.
+                                        req.pending_chunk =
+                                            Some(ResponseChunk::Data(data));
+                                        break;
+                                    }
+                                    Err(e) => return Err(e),
+                                }
+                            }
+                            ResponseChunk::End => {
+                                h3.send_body(quic, stream_id, b"", true)?;
+                                req.phase = StreamPhase::Completed;
+                                terminal = true;
+                                break;
+                            }
+                            ResponseChunk::Error(_) => {
+                                // Best-effort: close the stream.
+                                let _ = h3.send_body(quic, stream_id, b"", true);
+                                req.phase = StreamPhase::Failed;
+                                terminal = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // ── 5: remove terminal streams ────────────────────────────────────
+            if terminal {
+                streams.remove(&stream_id);
             }
         }
 

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -866,6 +866,8 @@ impl QUICListener {
                         if req.body_buf.is_empty() {
                             req.body_tx = None;
                         }
+                        // Request body fully handed off — now waiting on upstream.
+                        req.phase = StreamPhase::AwaitingUpstream;
                         // Upstream polling and response dispatch are handled entirely
                         // by advance_streams_non_blocking, called unconditionally below.
                     }

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -976,14 +976,26 @@ impl QUICListener {
                         h3.send_response(quic, stream_id, &h3_headers, false)?;
 
                         // Spawn a task that pumps body frames into a ResponseChunk channel.
+                        // Enforces backend_timeout() so a slow upstream body does not
+                        // leave the stream open indefinitely.
                         let (chunk_tx, chunk_rx) =
                             mpsc::channel::<ResponseChunk>(16);
+                        let deadline = tokio::time::Instant::now() + backend_timeout();
                         let fut = async move {
                             use http_body_util::BodyExt;
                             let mut body: hyper::body::Incoming = body;
                             loop {
-                                match BodyExt::frame(&mut body).await {
-                                    Some(Ok(f)) => {
+                                let frame_fut = BodyExt::frame(&mut body);
+                                let result = tokio::time::timeout_at(deadline, frame_fut).await;
+                                match result {
+                                    Err(_elapsed) => {
+                                        // Body read timed out — signal timeout to flush loop.
+                                        let _ = chunk_tx
+                                            .send(ResponseChunk::Error(ProxyError::Timeout))
+                                            .await;
+                                        return;
+                                    }
+                                    Ok(Some(Ok(f))) => {
                                         if let Ok(data) = f.into_data() {
                                             if chunk_tx.send(ResponseChunk::Data(data)).await.is_err() {
                                                 return;
@@ -991,7 +1003,7 @@ impl QUICListener {
                                         }
                                         // skip trailers / other frame types
                                     }
-                                    Some(Err(_)) => {
+                                    Ok(Some(Err(_))) => {
                                         let _ = chunk_tx
                                             .send(ResponseChunk::Error(ProxyError::Transport(
                                                 "upstream body error".into(),
@@ -999,7 +1011,7 @@ impl QUICListener {
                                             .await;
                                         return;
                                     }
-                                    None => {
+                                    Ok(None) => {
                                         let _ = chunk_tx.send(ResponseChunk::End).await;
                                         return;
                                     }
@@ -1053,18 +1065,21 @@ impl QUICListener {
                         }
                     }
                     Err(err) => {
-                        // Remove stream, send error response via existing helper.
-                        let req = streams.remove(&stream_id).unwrap();
-                        Self::handle_forward_result(
-                            h3,
-                            quic,
-                            stream_id,
-                            &req,
-                            Err(err),
-                            upstream_pools,
-                            routing_index,
-                            metrics,
-                        )?;
+                        // Send error response first, then remove the stream so
+                        // cleanup only happens after the response has been emitted.
+                        if let Some(req) = streams.get(&stream_id) {
+                            Self::handle_forward_result(
+                                h3,
+                                quic,
+                                stream_id,
+                                req,
+                                Err(err),
+                                upstream_pools,
+                                routing_index,
+                                metrics,
+                            )?;
+                        }
+                        streams.remove(&stream_id);
                         continue;
                     }
                 }
@@ -1103,10 +1118,48 @@ impl QUICListener {
                                 terminal = true;
                                 break;
                             }
-                            ResponseChunk::Error(_) => {
+                            ResponseChunk::Error(err) => {
                                 // Best-effort: close the stream.
                                 let _ = h3.send_body(quic, stream_id, b"", true);
                                 req.phase = StreamPhase::Failed;
+                                // Mirror the health/metrics updates from the old
+                                // send_backend_response timeout/error paths.
+                                let upstream_name = routing_index
+                                    .lookup(&req.path, req.authority.as_deref());
+                                if let (Some(idx), Some(pool)) = (
+                                    req.backend_index,
+                                    upstream_name.and_then(|n| upstream_pools.get(n)),
+                                ) {
+                                    if let Some(t) = pool
+                                        .lock()
+                                        .ok()
+                                        .and_then(|mut p| p.pool.mark_failure(idx))
+                                    {
+                                        if let Some(addr) = &req.backend_addr {
+                                            Self::log_health_transition(addr, t);
+                                        }
+                                    }
+                                }
+                                match err {
+                                    ProxyError::Timeout => {
+                                        metrics.inc_failure();
+                                        metrics.inc_timeout();
+                                        info!(
+                                            "Upstream {} body timeout latency_ms {}",
+                                            req.backend_addr.as_deref().unwrap_or("?"),
+                                            req.start.elapsed().as_millis()
+                                        );
+                                    }
+                                    _ => {
+                                        metrics.inc_failure();
+                                        metrics.inc_backend_error();
+                                        error!(
+                                            "Upstream {} body error: {:?}",
+                                            req.backend_addr.as_deref().unwrap_or("?"),
+                                            err
+                                        );
+                                    }
+                                }
                                 terminal = true;
                                 break;
                             }
@@ -1214,30 +1267,9 @@ impl QUICListener {
             .cloned();
 
         match result {
-            Ok((status, headers, body)) => {
-                if let Some(pool) = &upstream_pool {
-                    let transition = pool.lock().ok().and_then(|mut p| {
-                        match outcome_from_status(status) {
-                            crate::HealthClassification::Success => {
-                                p.pool.mark_success(backend_index)
-                            }
-                            crate::HealthClassification::Failure => {
-                                p.pool.mark_failure(backend_index)
-                            }
-                            crate::HealthClassification::Neutral => None,
-                        }
-                    });
-                    if let Some(t) = transition {
-                        Self::log_health_transition(backend_addr, t);
-                    }
-                }
-                metrics.inc_success();
-                info!(
-                    "Upstream {} status {} latency_ms {}",
-                    backend_addr, status, start.elapsed().as_millis()
-                );
-                Self::send_backend_response(h3, quic, stream_id, status, &headers, body)
-            }
+            // Ok variant is handled upstream by advance_streams_non_blocking;
+            // handle_forward_result is only called with Err variants.
+            Ok(_) => unreachable!("handle_forward_result called with Ok result"),
             Err(ProxyError::Bridge(err)) => {
                 error!("Bridge error: {:?}", err);
                 metrics.inc_failure();
@@ -1275,99 +1307,6 @@ impl QUICListener {
                 Self::send_simple_response(h3, quic, stream_id, http::StatusCode::INTERNAL_SERVER_ERROR, b"internal server error\n")
             }
         }
-    }
-
-    fn send_backend_response(
-        h3: &mut quiche::h3::Connection,
-        quic: &mut quiche::Connection,
-        stream_id: u64,
-        status: http::StatusCode,
-        headers: &http::HeaderMap,
-        body: hyper::body::Incoming,
-    ) -> Result<(), quiche::h3::Error> {
-        let mut resp_headers = Vec::with_capacity(headers.len() + 1);
-
-        resp_headers.push(quiche::h3::Header::new(
-            b":status",
-            status.as_str().as_bytes(),
-        ));
-
-        for (name, value) in headers.iter() {
-            if is_hop_header(name.as_str()) || name == http::header::CONTENT_LENGTH {
-                continue;
-            }
-            resp_headers.push(quiche::h3::Header::new(
-                name.as_str().as_bytes(),
-                value.as_bytes(),
-            ));
-        }
-
-        // Drive the response body one frame at a time.  Each call to
-        // run_blocking fetches exactly the next data frame from the backend
-        // and returns it to the sync side, where send_body is called
-        // immediately.  This avoids accumulating the full response in memory:
-        // at most one frame is held between run_blocking returning and
-        // send_body completing.
-        //
-        // Note: h3/quic are !Send so they cannot enter the async closure.
-        // run_blocking(block_in_place) keeps execution on the same OS thread,
-        // making the per-frame loop safe without locks.
-        let deadline = std::time::Instant::now() + backend_timeout();
-
-        // Wrap body in a Mutex so the async closure can borrow it across
-        // repeated run_blocking calls without moving it.
-        let body = std::sync::Mutex::new(body);
-
-        h3.send_response(quic, stream_id, &resp_headers, false)?;
-
-        let mut sent_any = false;
-        loop {
-            let remaining = match deadline.checked_duration_since(std::time::Instant::now()) {
-                Some(d) => d,
-                None => break, // timeout
-            };
-
-            // Fetch the next data frame from the backend.
-            let next: Option<Bytes> = match run_blocking(|| async {
-                tokio::time::timeout(remaining, async {
-                    let mut guard = body.lock().expect("body mutex");
-                    loop {
-                        match BodyExt::frame(&mut *guard).await {
-                            Some(Ok(f)) => {
-                                if let Ok(chunk) = f.into_data() {
-                                    return Some(chunk);
-                                }
-                                // trailers / other frames — skip
-                            }
-                            Some(Err(_)) | None => return None,
-                        }
-                    }
-                })
-                .await
-                .unwrap_or(None)
-            }) {
-                Ok(v) => v,
-                Err(_) => break,
-            };
-
-            match next {
-                Some(chunk) => {
-                    h3.send_body(quic, stream_id, &chunk, false)?;
-                    sent_any = true;
-                }
-                None => {
-                    // Body exhausted — send final empty frame with fin=true.
-                    h3.send_body(quic, stream_id, b"", true)?;
-                    return Ok(());
-                }
-            }
-        }
-
-        // Timeout or error path: close stream.
-        let _ = sent_any;
-        h3.send_body(quic, stream_id, b"", true)?;
-
-        Ok(())
     }
 
     fn send_simple_response(
@@ -1509,17 +1448,6 @@ impl QUICListener {
                 }
             });
         }
-    }
-}
-
-fn run_blocking<F, Fut, T>(f: F) -> Result<T, String>
-where
-    F: FnOnce() -> Fut,
-    Fut: std::future::Future<Output = T>,
-{
-    match Handle::try_current() {
-        Ok(handle) => Ok(tokio::task::block_in_place(|| handle.block_on(f()))),
-        Err(_) => Ok(fallback_runtime().block_on(f())),
     }
 }
 

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -19,11 +19,13 @@ use spooky_errors::ProxyError;
 use spooky_lb::{HealthTransition, UpstreamPool};
 use spooky_transport::h2_pool::H2Pool;
 use tokio::runtime::Handle;
+use tokio::sync::oneshot;
 
 use spooky_config::config::Config as SpookyConfig;
 
 use crate::{
     ChannelBody, ForwardResult, Metrics, QUICListener, QuicConnection, RequestEnvelope,
+    ResponseChunk, StreamPhase,
     cid_radix::CidRadix,
     constants::{
         DEFAULT_SCID_LEN_BYTES, MAX_DATAGRAM_SIZE_BYTES, MAX_INFLIGHT_PER_BACKEND,
@@ -723,7 +725,7 @@ impl QUICListener {
                         upstream_pools, routing_index,
                     );
 
-                    let (body_tx, response_rx, backend_addr, backend_index) = match resolved {
+                    let (body_tx, upstream_result_rx, backend_addr, backend_index) = match resolved {
                         Ok((addr, idx, _pool)) => {
                             // Create a channel body so quiche Data chunks stream
                             // directly into the in-flight H2 request.
@@ -734,8 +736,9 @@ impl QUICListener {
                             let req_method = method.clone();
                             let req_path = path.clone();
                             let fwd_addr = addr.clone();
-                            let handle: tokio::task::JoinHandle<ForwardResult> = {
-                                let fut = async move {
+                            let (result_tx, result_rx) = oneshot::channel::<ForwardResult>();
+                            let fut = async move {
+                                let result = async {
                                     let request = build_h2_request(
                                         &fwd_addr, &req_method, &req_path,
                                         &req_headers, boxed, None,
@@ -751,13 +754,16 @@ impl QUICListener {
 
                                     let (parts, body) = response.into_parts();
                                     Ok((parts.status, parts.headers, body))
-                                };
-                                match Handle::try_current() {
-                                    Ok(handle) => handle.spawn(fut),
-                                    Err(_) => fallback_runtime().spawn(fut),
                                 }
+                                .await;
+                                // Ignore send error: receiver dropped means the stream was reset.
+                                let _ = result_tx.send(result);
                             };
-                            (Some(tx), Some(handle), Some(addr), Some(idx))
+                            match Handle::try_current() {
+                                Ok(handle) => { handle.spawn(fut); }
+                                Err(_) => { fallback_runtime().spawn(fut); }
+                            }
+                            (Some(tx), Some(result_rx), Some(addr), Some(idx))
                         }
                         Err(_) => (None, None, None, None),
                     };
@@ -771,12 +777,16 @@ impl QUICListener {
                             authority,
                             headers,
                             body_tx,
-                            response_rx,
                             body_buf: Vec::new(),
                             body_bytes_received: 0,
                             backend_addr,
                             backend_index,
                             start: Instant::now(),
+                            phase: StreamPhase::ReceivingRequest,
+                            request_fin_received: false,
+                            upstream_result_rx,
+                            response_chunk_rx: None,
+                            pending_chunk: None,
                         },
                     );
                 }
@@ -818,49 +828,70 @@ impl QUICListener {
                     }
                 },
                 Ok((stream_id, quiche::h3::Event::Finished)) => {
-                    if let Some(mut req) = connection.streams.remove(&stream_id) {
-                        // Drain any buffered chunks into the channel before
-                        // closing it, then drop the sender to signal end-of-body.
-                        if let Some(tx) = req.body_tx.take() {
+                    if let Some(req) = connection.streams.get_mut(&stream_id) {
+                        req.request_fin_received = true;
+
+                        // Non-blocking body flush: push buffered chunks into the
+                        // channel with try_send.  Any that don't fit stay in body_buf
+                        // and will be retried on the next poll iteration.
+                        if let Some(tx) = &req.body_tx {
                             let buf = std::mem::take(&mut req.body_buf);
-                            run_blocking(|| async move {
-                                for chunk in buf {
-                                    let _ = tx.send(chunk).await;
+                            let mut overflow = Vec::new();
+                            for chunk in buf {
+                                if tx.try_send(chunk.clone()).is_err() {
+                                    overflow.push(chunk);
                                 }
-                                // tx drops here, closing the channel
-                            })
-                            .ok();
+                            }
+                            req.body_buf = overflow;
+                        }
+                        // If nothing is left buffered, drop body_tx to signal end-of-body.
+                        if req.body_buf.is_empty() {
+                            req.body_tx = None;
                         }
 
-                        // Await the in-flight H2 task and route the result.
-                        let forward_result = match req.response_rx.take() {
-                            Some(handle) => run_blocking(|| async move {
-                                match tokio::time::timeout(backend_timeout(), handle).await {
-                                    Ok(Ok(r)) => r,
-                                    Ok(Err(_)) => Err(ProxyError::Transport(
-                                        "task panicked".into(),
-                                    )),
-                                    Err(_) => Err(ProxyError::Timeout),
-                                }
-                            })
-                            .unwrap_or(Err(ProxyError::Transport(
-                                "run_blocking failed".into(),
-                            ))),
-                            None => Err(ProxyError::Transport(
-                                "no backend resolved for request".into(),
-                            )),
-                        };
+                        // Non-blocking poll of the upstream oneshot.
+                        let ready = req
+                            .upstream_result_rx
+                            .as_mut()
+                            .and_then(|rx| match rx.try_recv() {
+                                Ok(result) => Some(Ok(result)),
+                                Err(oneshot::error::TryRecvError::Empty) => None,
+                                Err(oneshot::error::TryRecvError::Closed) => Some(Err(())),
+                            });
 
-                        Self::handle_forward_result(
-                            h3,
-                            &mut connection.quic,
-                            stream_id,
-                            &req,
-                            forward_result,
-                            upstream_pools,
-                            routing_index,
-                            metrics,
-                        )?;
+                        match ready {
+                            Some(Ok(forward_result)) => {
+                                req.upstream_result_rx = None;
+                                let req = connection.streams.remove(&stream_id).unwrap();
+                                Self::handle_forward_result(
+                                    h3,
+                                    &mut connection.quic,
+                                    stream_id,
+                                    &req,
+                                    forward_result,
+                                    upstream_pools,
+                                    routing_index,
+                                    metrics,
+                                )?;
+                            }
+                            Some(Err(())) => {
+                                // Sender dropped without sending — treat as error.
+                                let req = connection.streams.remove(&stream_id).unwrap();
+                                Self::handle_forward_result(
+                                    h3,
+                                    &mut connection.quic,
+                                    stream_id,
+                                    &req,
+                                    Err(ProxyError::Transport("upstream task dropped sender".into())),
+                                    upstream_pools,
+                                    routing_index,
+                                    metrics,
+                                )?;
+                            }
+                            // Not ready yet — leave the stream in the map; the
+                            // deferred poll below will pick it up on a later iteration.
+                            None => {}
+                        }
                     }
                 }
                 Ok((stream_id, quiche::h3::Event::Reset(_))) => {
@@ -870,6 +901,81 @@ impl QUICListener {
                 Ok((_stream_id, quiche::h3::Event::GoAway)) => {}
                 Err(quiche::h3::Error::Done) => break,
                 Err(e) => return Err(e),
+            }
+        }
+
+        // Deferred stream poll: for any stream where the request FIN has been
+        // received but the upstream oneshot wasn't ready at Finished time,
+        // try again now.  Collect IDs first to avoid borrowing streams while
+        // also calling handle_forward_result (which needs &mut connection.quic).
+        let deferred: Vec<u64> = connection
+            .streams
+            .iter()
+            .filter_map(|(&id, req)| {
+                if req.request_fin_received && req.upstream_result_rx.is_some() {
+                    Some(id)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        for stream_id in deferred {
+            // Retry non-blocking body flush for any overflow chunks.
+            if let Some(req) = connection.streams.get_mut(&stream_id) {
+                if let Some(tx) = &req.body_tx {
+                    let buf = std::mem::take(&mut req.body_buf);
+                    let mut overflow = Vec::new();
+                    for chunk in buf {
+                        if tx.try_send(chunk.clone()).is_err() {
+                            overflow.push(chunk);
+                        }
+                    }
+                    req.body_buf = overflow;
+                }
+                if req.body_buf.is_empty() {
+                    req.body_tx = None;
+                }
+            }
+
+            let ready = connection
+                .streams
+                .get_mut(&stream_id)
+                .and_then(|req| req.upstream_result_rx.as_mut())
+                .and_then(|rx| match rx.try_recv() {
+                    Ok(result) => Some(Ok(result)),
+                    Err(oneshot::error::TryRecvError::Empty) => None,
+                    Err(oneshot::error::TryRecvError::Closed) => Some(Err(())),
+                });
+
+            match ready {
+                Some(Ok(forward_result)) => {
+                    let req = connection.streams.remove(&stream_id).unwrap();
+                    Self::handle_forward_result(
+                        h3,
+                        &mut connection.quic,
+                        stream_id,
+                        &req,
+                        forward_result,
+                        upstream_pools,
+                        routing_index,
+                        metrics,
+                    )?;
+                }
+                Some(Err(())) => {
+                    let req = connection.streams.remove(&stream_id).unwrap();
+                    Self::handle_forward_result(
+                        h3,
+                        &mut connection.quic,
+                        stream_id,
+                        &req,
+                        Err(ProxyError::Transport("upstream task dropped sender".into())),
+                        upstream_pools,
+                        routing_index,
+                        metrics,
+                    )?;
+                }
+                None => {} // still waiting — try again next poll
             }
         }
 

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -1,17 +1,25 @@
 use std::{
+    collections::HashMap,
+    convert::Infallible,
     net::SocketAddr,
+    pin::Pin,
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
     },
+    task::{Context, Poll},
     time::{Duration, Instant},
 };
 
 use bytes::Bytes;
-use quiche::h3::NameValue;
-use http_body_util::Full;
-use hyper::{Request, Response, body::Incoming, service::service_fn};
+use http_body_util::{BodyExt, Full, combinators::BoxBody};
+use hyper::{
+    Request, Response,
+    body::{Body, Frame, Incoming},
+    service::service_fn,
+};
 use hyper_util::rt::{TokioExecutor, TokioIo};
+use quiche::h3::NameValue;
 use rand::RngCore;
 use rcgen::{Certificate, CertificateParams, SanType};
 use tempfile::{TempDir, tempdir};
@@ -20,9 +28,10 @@ use tokio::net::TcpListener;
 use spooky_config::config::{Backend, Config, HealthCheck, Listen, LoadBalancing, Log, Tls};
 use spooky_edge::QUICListener;
 use spooky_edge::constants::{
-    MAX_DATAGRAM_SIZE_BYTES, MAX_REQUEST_BODY_BYTES, MAX_UDP_PAYLOAD_BYTES, QUIC_IDLE_TIMEOUT_MS,
-    QUIC_INITIAL_MAX_DATA, QUIC_INITIAL_MAX_STREAMS_BIDI, QUIC_INITIAL_MAX_STREAMS_UNI,
-    QUIC_INITIAL_STREAM_DATA, REQUEST_TIMEOUT_SECS, UDP_READ_TIMEOUT_MS,
+    BACKEND_TIMEOUT_SECS, MAX_DATAGRAM_SIZE_BYTES, MAX_REQUEST_BODY_BYTES, MAX_UDP_PAYLOAD_BYTES,
+    QUIC_IDLE_TIMEOUT_MS, QUIC_INITIAL_MAX_DATA, QUIC_INITIAL_MAX_STREAMS_BIDI,
+    QUIC_INITIAL_MAX_STREAMS_UNI, QUIC_INITIAL_STREAM_DATA, REQUEST_TIMEOUT_SECS,
+    UDP_READ_TIMEOUT_MS,
 };
 
 fn write_test_certs(dir: &TempDir) -> (String, String) {
@@ -276,6 +285,281 @@ fn run_h3_client(addr: SocketAddr) -> Result<String, String> {
     }
 }
 
+type TestBody = BoxBody<Bytes, Infallible>;
+
+struct DelayedChunkBody {
+    rx: tokio::sync::mpsc::Receiver<Bytes>,
+}
+
+impl DelayedChunkBody {
+    fn channel(buffer: usize) -> (tokio::sync::mpsc::Sender<Bytes>, Self) {
+        let (tx, rx) = tokio::sync::mpsc::channel(buffer);
+        (tx, Self { rx })
+    }
+}
+
+impl Body for DelayedChunkBody {
+    type Data = Bytes;
+    type Error = Infallible;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        match self.rx.poll_recv(cx) {
+            Poll::Ready(Some(chunk)) => Poll::Ready(Some(Ok(Frame::data(chunk)))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct StreamObservation {
+    path: String,
+    status: Option<String>,
+    body: Vec<u8>,
+    data_events: Vec<Duration>,
+    finished_at: Option<Duration>,
+}
+
+fn observation_for<'a>(observations: &'a [StreamObservation], path: &str) -> &'a StreamObservation {
+    observations
+        .iter()
+        .find(|o| o.path == path)
+        .unwrap_or_else(|| panic!("missing observation for path {path}"))
+}
+
+fn run_h3_client_concurrent_get(
+    addr: SocketAddr,
+    paths: &[&str],
+    timeout: Duration,
+) -> Result<Vec<StreamObservation>, String> {
+    let socket = std::net::UdpSocket::bind("0.0.0.0:0").map_err(|e| e.to_string())?;
+    let local_addr = socket.local_addr().map_err(|e| e.to_string())?;
+
+    let mut config =
+        quiche::Config::new(quiche::PROTOCOL_VERSION).map_err(|e| format!("config: {e:?}"))?;
+    config.verify_peer(false);
+    config
+        .set_application_protos(quiche::h3::APPLICATION_PROTOCOL)
+        .map_err(|e| format!("alpn: {e:?}"))?;
+    config.set_max_idle_timeout(QUIC_IDLE_TIMEOUT_MS);
+    config.set_max_recv_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    config.set_max_send_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    config.set_initial_max_data(QUIC_INITIAL_MAX_DATA);
+    config.set_initial_max_stream_data_bidi_local(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_stream_data_bidi_remote(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_stream_data_uni(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_streams_bidi(QUIC_INITIAL_MAX_STREAMS_BIDI);
+    config.set_initial_max_streams_uni(QUIC_INITIAL_MAX_STREAMS_UNI);
+    config.set_disable_active_migration(true);
+
+    let mut scid_bytes = [0u8; quiche::MAX_CONN_ID_LEN];
+    rand::thread_rng().fill_bytes(&mut scid_bytes);
+    let scid = quiche::ConnectionId::from_ref(&scid_bytes);
+
+    let mut conn = quiche::connect(Some("localhost"), &scid, local_addr, addr, &mut config)
+        .map_err(|e| format!("connect: {e:?}"))?;
+
+    let h3_config = quiche::h3::Config::new().map_err(|e| format!("h3: {e:?}"))?;
+    let mut h3_conn: Option<quiche::h3::Connection> = None;
+    let mut out = [0u8; MAX_UDP_PAYLOAD_BYTES];
+    let mut buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
+    let mut requests_sent = false;
+    let mut finished = 0usize;
+    let start = Instant::now();
+
+    let mut stream_to_observation: HashMap<u64, usize> = HashMap::new();
+    let mut observations: Vec<StreamObservation> = paths
+        .iter()
+        .map(|path| StreamObservation {
+            path: (*path).to_string(),
+            status: None,
+            body: Vec::new(),
+            data_events: Vec::new(),
+            finished_at: None,
+        })
+        .collect();
+
+    let (write, send_info) = conn.send(&mut out).map_err(|e| format!("send: {e:?}"))?;
+    socket
+        .send_to(&out[..write], send_info.to)
+        .map_err(|e| format!("send_to: {e:?}"))?;
+
+    loop {
+        loop {
+            match conn.send(&mut out) {
+                Ok((write, send_info)) => {
+                    let _ = socket.send_to(&out[..write], send_info.to);
+                }
+                Err(quiche::Error::Done) => break,
+                Err(e) => return Err(format!("send loop: {e:?}")),
+            }
+        }
+
+        let read_timeout = quic_read_timeout(&conn);
+        socket
+            .set_read_timeout(Some(read_timeout))
+            .map_err(|e| format!("timeout: {e:?}"))?;
+
+        match socket.recv_from(&mut buf) {
+            Ok((len, from)) => {
+                let recv_info = quiche::RecvInfo {
+                    from,
+                    to: local_addr,
+                };
+                conn.recv(&mut buf[..len], recv_info)
+                    .map_err(|e| format!("recv: {e:?}"))?;
+            }
+            Err(ref e)
+                if e.kind() == std::io::ErrorKind::WouldBlock
+                    || e.kind() == std::io::ErrorKind::TimedOut =>
+            {
+                conn.on_timeout();
+            }
+            Err(e) => return Err(format!("recv: {e:?}")),
+        }
+
+        if conn.is_established() && h3_conn.is_none() {
+            h3_conn = Some(
+                quiche::h3::Connection::with_transport(&mut conn, &h3_config)
+                    .map_err(|e| format!("h3 conn: {e:?}"))?,
+            );
+        }
+
+        if let Some(h3) = h3_conn.as_mut() {
+            if conn.is_established() && !requests_sent {
+                for (idx, path) in paths.iter().enumerate() {
+                    let req = vec![
+                        quiche::h3::Header::new(b":method", b"GET"),
+                        quiche::h3::Header::new(b":scheme", b"https"),
+                        quiche::h3::Header::new(b":authority", b"localhost"),
+                        quiche::h3::Header::new(b":path", path.as_bytes()),
+                        quiche::h3::Header::new(b"user-agent", b"spooky-regression-test"),
+                    ];
+                    let stream_id = h3
+                        .send_request(&mut conn, &req, true)
+                        .map_err(|e| format!("send_request: {e:?}"))?;
+                    stream_to_observation.insert(stream_id, idx);
+                }
+                requests_sent = true;
+            }
+
+            loop {
+                match h3.poll(&mut conn) {
+                    Ok((stream_id, quiche::h3::Event::Headers { list, .. })) => {
+                        if let Some(idx) = stream_to_observation.get(&stream_id).copied() {
+                            for header in &list {
+                                if header.name() == b":status" {
+                                    observations[idx].status =
+                                        Some(String::from_utf8_lossy(header.value()).to_string());
+                                }
+                            }
+                        }
+                    }
+                    Ok((stream_id, quiche::h3::Event::Data)) => {
+                        let Some(idx) = stream_to_observation.get(&stream_id).copied() else {
+                            break;
+                        };
+                        loop {
+                            match h3.recv_body(&mut conn, stream_id, &mut buf) {
+                                Ok(read) => {
+                                    observations[idx].body.extend_from_slice(&buf[..read]);
+                                    observations[idx].data_events.push(start.elapsed());
+                                }
+                                Err(quiche::h3::Error::Done) => break,
+                                Err(e) => return Err(format!("recv_body: {e:?}")),
+                            }
+                        }
+                    }
+                    Ok((stream_id, quiche::h3::Event::Finished)) => {
+                        if let Some(idx) = stream_to_observation.get(&stream_id).copied() {
+                            if observations[idx].finished_at.is_none() {
+                                observations[idx].finished_at = Some(start.elapsed());
+                                finished += 1;
+                            }
+                        }
+                    }
+                    Ok((_stream_id, quiche::h3::Event::PriorityUpdate)) => {}
+                    Ok((_stream_id, quiche::h3::Event::GoAway)) => {}
+                    Ok((stream_id, quiche::h3::Event::Reset(_))) => {
+                        return Err(format!("stream reset on id {stream_id}"));
+                    }
+                    Err(quiche::h3::Error::Done) => break,
+                    Err(e) => return Err(format!("poll: {e:?}")),
+                }
+            }
+        }
+
+        if finished == paths.len() {
+            return Ok(observations);
+        }
+
+        if start.elapsed() > timeout {
+            return Err(format!(
+                "timeout waiting for responses (done={finished}, expected={})",
+                paths.len()
+            ));
+        }
+    }
+}
+
+async fn start_h2_backend_with_regression_routes() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = match listener.accept().await {
+                Ok(v) => v,
+                Err(_) => break,
+            };
+
+            let io = TokioIo::new(stream);
+            let service = service_fn(|req: Request<Incoming>| async move {
+                let path = req.uri().path().to_string();
+                let response: Response<TestBody> = match path.as_str() {
+                    "/fast" => Response::new(Full::new(Bytes::from_static(b"fast\n")).boxed()),
+                    "/slow" => {
+                        tokio::time::sleep(Duration::from_millis(700)).await;
+                        Response::new(Full::new(Bytes::from_static(b"slow\n")).boxed())
+                    }
+                    "/status500" => Response::builder()
+                        .status(500)
+                        .body(Full::new(Bytes::from_static(b"backend 500\n")).boxed())
+                        .unwrap(),
+                    "/timeout" => {
+                        tokio::time::sleep(Duration::from_secs(BACKEND_TIMEOUT_SECS + 1)).await;
+                        Response::new(Full::new(Bytes::from_static(b"late\n")).boxed())
+                    }
+                    "/stream" => {
+                        let (tx, body) = DelayedChunkBody::channel(8);
+                        tokio::spawn(async move {
+                            let _ = tx.send(Bytes::from_static(b"chunk-1")).await;
+                            tokio::time::sleep(Duration::from_millis(140)).await;
+                            let _ = tx.send(Bytes::from_static(b"chunk-2")).await;
+                            tokio::time::sleep(Duration::from_millis(140)).await;
+                            let _ = tx.send(Bytes::from_static(b"chunk-3")).await;
+                        });
+                        Response::new(body.boxed())
+                    }
+                    _ => Response::new(Full::new(Bytes::from_static(b"default\n")).boxed()),
+                };
+                Ok::<_, hyper::Error>(response)
+            });
+
+            tokio::spawn(async move {
+                let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
+                    .serve_connection(io, service)
+                    .await;
+            });
+        }
+    });
+
+    addr
+}
+
 #[test]
 fn http3_to_http2_roundtrip() {
     let dir = tempdir().expect("failed to create temp dir");
@@ -322,10 +606,11 @@ fn oversized_request_body_returns_413() {
     let socket = std::net::UdpSocket::bind("0.0.0.0:0").unwrap();
     let local_addr = socket.local_addr().unwrap();
 
-    let mut qconfig =
-        quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
+    let mut qconfig = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
     qconfig.verify_peer(false);
-    qconfig.set_application_protos(quiche::h3::APPLICATION_PROTOCOL).unwrap();
+    qconfig
+        .set_application_protos(quiche::h3::APPLICATION_PROTOCOL)
+        .unwrap();
     qconfig.set_max_idle_timeout(QUIC_IDLE_TIMEOUT_MS);
     qconfig.set_max_recv_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
     qconfig.set_max_send_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
@@ -342,8 +627,14 @@ fn oversized_request_body_returns_413() {
     let mut scid_bytes = [0u8; quiche::MAX_CONN_ID_LEN];
     rand::thread_rng().fill_bytes(&mut scid_bytes);
     let scid = quiche::ConnectionId::from_ref(&scid_bytes);
-    let mut conn =
-        quiche::connect(Some("localhost"), &scid, local_addr, listen_addr, &mut qconfig).unwrap();
+    let mut conn = quiche::connect(
+        Some("localhost"),
+        &scid,
+        local_addr,
+        listen_addr,
+        &mut qconfig,
+    )
+    .unwrap();
     let h3_config = quiche::h3::Config::new().unwrap();
 
     let mut out = [0u8; MAX_UDP_PAYLOAD_BYTES];
@@ -365,7 +656,9 @@ fn oversized_request_body_returns_413() {
         // Flush send.
         loop {
             match conn.send(&mut out) {
-                Ok((w, si)) => { let _ = socket.send_to(&out[..w], si.to); }
+                Ok((w, si)) => {
+                    let _ = socket.send_to(&out[..w], si.to);
+                }
                 Err(quiche::Error::Done) => break,
                 Err(e) => panic!("send: {e:?}"),
             }
@@ -376,10 +669,19 @@ fn oversized_request_body_returns_413() {
 
         match socket.recv_from(&mut buf) {
             Ok((len, from)) => {
-                conn.recv(&mut buf[..len], quiche::RecvInfo { from, to: local_addr }).unwrap();
+                conn.recv(
+                    &mut buf[..len],
+                    quiche::RecvInfo {
+                        from,
+                        to: local_addr,
+                    },
+                )
+                .unwrap();
             }
-            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock
-                       || e.kind() == std::io::ErrorKind::TimedOut => {
+            Err(ref e)
+                if e.kind() == std::io::ErrorKind::WouldBlock
+                    || e.kind() == std::io::ErrorKind::TimedOut =>
+            {
                 conn.on_timeout();
             }
             Err(e) => panic!("recv: {e:?}"),
@@ -457,5 +759,164 @@ fn oversized_request_body_returns_413() {
         }
     };
 
-    assert_eq!(status, "413", "expected 413 Payload Too Large, got {status}");
+    assert_eq!(
+        status, "413",
+        "expected 413 Payload Too Large, got {status}"
+    );
+}
+
+#[test]
+fn slow_stream_does_not_block_fast_stream() {
+    let dir = tempdir().expect("failed to create temp dir");
+    let (cert, key) = write_test_certs(&dir);
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let backend_addr = rt.block_on(start_h2_backend_with_regression_routes());
+    let config = make_config(0, backend_addr.to_string(), cert, key);
+    let listener = QUICListener::new(config).expect("failed to create listener");
+    let listen_addr = listener.socket.local_addr().unwrap();
+    let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
+
+    let observations = run_h3_client_concurrent_get(
+        listen_addr,
+        &["/slow", "/fast"],
+        Duration::from_secs(REQUEST_TIMEOUT_SECS + 4),
+    )
+    .expect("client requests failed");
+
+    let slow = observation_for(&observations, "/slow");
+    let fast = observation_for(&observations, "/fast");
+    assert_eq!(slow.status.as_deref(), Some("200"));
+    assert_eq!(fast.status.as_deref(), Some("200"));
+
+    let slow_done = slow.finished_at.expect("slow stream should finish");
+    let fast_done = fast.finished_at.expect("fast stream should finish");
+    assert!(
+        fast_done < slow_done,
+        "fast stream should complete before slow stream (fast={fast_done:?}, slow={slow_done:?})"
+    );
+}
+
+#[test]
+fn finished_stream_does_not_block_other_stream_progress() {
+    let dir = tempdir().expect("failed to create temp dir");
+    let (cert, key) = write_test_certs(&dir);
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let backend_addr = rt.block_on(start_h2_backend_with_regression_routes());
+    let config = make_config(0, backend_addr.to_string(), cert, key);
+    let listener = QUICListener::new(config).expect("failed to create listener");
+    let listen_addr = listener.socket.local_addr().unwrap();
+    let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
+
+    let observations = run_h3_client_concurrent_get(
+        listen_addr,
+        &["/slow", "/stream"],
+        Duration::from_secs(REQUEST_TIMEOUT_SECS + 4),
+    )
+    .expect("client requests failed");
+
+    let slow = observation_for(&observations, "/slow");
+    let stream = observation_for(&observations, "/stream");
+    let slow_done = slow.finished_at.expect("slow stream should finish");
+    let first_stream_data = stream
+        .data_events
+        .first()
+        .copied()
+        .expect("stream path should produce at least one data chunk");
+
+    assert!(
+        first_stream_data < slow_done,
+        "stream data should arrive while slow stream is still pending (first_stream_data={first_stream_data:?}, slow_done={slow_done:?})"
+    );
+}
+
+#[test]
+fn response_body_is_streamed_progressively() {
+    let dir = tempdir().expect("failed to create temp dir");
+    let (cert, key) = write_test_certs(&dir);
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let backend_addr = rt.block_on(start_h2_backend_with_regression_routes());
+    let config = make_config(0, backend_addr.to_string(), cert, key);
+    let listener = QUICListener::new(config).expect("failed to create listener");
+    let listen_addr = listener.socket.local_addr().unwrap();
+    let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
+
+    let observations = run_h3_client_concurrent_get(
+        listen_addr,
+        &["/stream"],
+        Duration::from_secs(REQUEST_TIMEOUT_SECS + 4),
+    )
+    .expect("stream request failed");
+
+    let stream = observation_for(&observations, "/stream");
+    assert_eq!(stream.status.as_deref(), Some("200"));
+
+    let body = String::from_utf8_lossy(&stream.body);
+    assert_eq!(body, "chunk-1chunk-2chunk-3");
+    assert!(
+        stream.data_events.len() >= 2,
+        "expected at least two data events, got {}",
+        stream.data_events.len()
+    );
+    let first = stream.data_events.first().copied().unwrap();
+    let last = stream.data_events.last().copied().unwrap();
+    let span = last.saturating_sub(first);
+    assert!(
+        span >= Duration::from_millis(200),
+        "expected delayed progressive delivery across chunks, got span {span:?}"
+    );
+}
+
+#[test]
+fn error_status_mapping_parity_is_preserved() {
+    let dir = tempdir().expect("failed to create temp dir");
+    let (cert, key) = write_test_certs(&dir);
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+
+    let backend_addr = rt.block_on(start_h2_backend_with_regression_routes());
+    let config = make_config(0, backend_addr.to_string(), cert.clone(), key.clone());
+    let listener = QUICListener::new(config).expect("failed to create listener");
+    let listen_addr = listener.socket.local_addr().unwrap();
+    let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
+
+    let status_500 = run_h3_client_concurrent_get(
+        listen_addr,
+        &["/status500"],
+        Duration::from_secs(REQUEST_TIMEOUT_SECS + 4),
+    )
+    .expect("status500 request failed");
+    let status_500_obs = observation_for(&status_500, "/status500");
+    assert_eq!(status_500_obs.status.as_deref(), Some("500"));
+
+    let timeout = run_h3_client_concurrent_get(
+        listen_addr,
+        &["/timeout"],
+        Duration::from_secs(REQUEST_TIMEOUT_SECS + 6),
+    )
+    .expect("timeout request failed");
+    let timeout_obs = observation_for(&timeout, "/timeout");
+    assert_eq!(timeout_obs.status.as_deref(), Some("503"));
+    assert!(
+        String::from_utf8_lossy(&timeout_obs.body).contains("upstream timeout"),
+        "timeout body should indicate upstream timeout"
+    );
+
+    // Separate listener with unreachable backend to validate transport mapping.
+    let transport_config = make_config(0, "127.0.0.1:1".to_string(), cert, key);
+    let transport_listener =
+        QUICListener::new(transport_config).expect("failed to create transport listener");
+    let transport_addr = transport_listener.socket.local_addr().unwrap();
+    let _transport_task = ListenerTaskGuard::spawn(&rt, transport_listener);
+
+    let transport = run_h3_client_concurrent_get(
+        transport_addr,
+        &["/"],
+        Duration::from_secs(REQUEST_TIMEOUT_SECS + 4),
+    )
+    .expect("transport error request failed");
+    let transport_obs = observation_for(&transport, "/");
+    assert_eq!(transport_obs.status.as_deref(), Some("502"));
+    assert!(
+        String::from_utf8_lossy(&transport_obs.body).contains("upstream error"),
+        "transport error body should indicate upstream error"
+    );
 }

--- a/crates/edge/tests/health_classification_tests.rs
+++ b/crates/edge/tests/health_classification_tests.rs
@@ -1,25 +1,23 @@
+use http::StatusCode;
+use spooky_config::config::{Backend, HealthCheck};
 use spooky_edge::{HealthClassification, outcome_from_status};
 use spooky_lb::{BackendPool, HealthTransition};
-use spooky_config::config::{Backend, HealthCheck};
-use http::StatusCode;
 
 /// Mock setup for backend pool testing
 fn create_test_backend_pool() -> BackendPool {
-    let backends = vec![
-        Backend {
-            id: "bk-1".to_string(),
-            address: "127.0.0.1:8001".to_string(),
-            weight: 1,
-            health_check: HealthCheck {
-                path: "/health".to_string(),
-                interval: 1000,
-                timeout_ms: 5000,
-                failure_threshold: 3,
-                success_threshold: 2,
-                cooldown_ms: 10000,
-            },
+    let backends = vec![Backend {
+        id: "bk-1".to_string(),
+        address: "127.0.0.1:8001".to_string(),
+        weight: 1,
+        health_check: HealthCheck {
+            path: "/health".to_string(),
+            interval: 1000,
+            timeout_ms: 5000,
+            failure_threshold: 3,
+            success_threshold: 2,
+            cooldown_ms: 10000,
         },
-    ];
+    }];
     let backend_states = backends.iter().map(spooky_lb::BackendState::new).collect();
     BackendPool::new_from_states(backend_states)
 }
@@ -34,13 +32,13 @@ fn test_4xx_response_does_not_change_health() {
 
     // All 4xx status codes should return Neutral outcome
     let test_cases = vec![
-        StatusCode::BAD_REQUEST,        // 400
-        StatusCode::FORBIDDEN,          // 403
-        StatusCode::NOT_FOUND,          // 404
-        StatusCode::METHOD_NOT_ALLOWED, // 405
-        StatusCode::CONFLICT,           // 409
+        StatusCode::BAD_REQUEST,          // 400
+        StatusCode::FORBIDDEN,            // 403
+        StatusCode::NOT_FOUND,            // 404
+        StatusCode::METHOD_NOT_ALLOWED,   // 405
+        StatusCode::CONFLICT,             // 409
         StatusCode::UNPROCESSABLE_ENTITY, // 422
-        StatusCode::TOO_MANY_REQUESTS,  // 429
+        StatusCode::TOO_MANY_REQUESTS,    // 429
     ];
 
     for status in test_cases {
@@ -76,10 +74,10 @@ fn test_5xx_response_marks_failure() {
 
     // All 5xx status codes should return Failure outcome
     let test_cases = vec![
-        StatusCode::INTERNAL_SERVER_ERROR,     // 500
-        StatusCode::BAD_GATEWAY,               // 502
-        StatusCode::SERVICE_UNAVAILABLE,       // 503
-        StatusCode::GATEWAY_TIMEOUT,           // 504
+        StatusCode::INTERNAL_SERVER_ERROR, // 500
+        StatusCode::BAD_GATEWAY,           // 502
+        StatusCode::SERVICE_UNAVAILABLE,   // 503
+        StatusCode::GATEWAY_TIMEOUT,       // 504
     ];
 
     for status in test_cases {
@@ -100,7 +98,11 @@ fn test_5xx_response_marks_failure() {
             let transition = pool.mark_failure(backend_index);
             if i < 2 {
                 // First 2 failures don't cause transition
-                assert!(transition.is_none(), "Transition should be None for failure {}", i + 1);
+                assert!(
+                    transition.is_none(),
+                    "Transition should be None for failure {}",
+                    i + 1
+                );
             } else {
                 // 3rd failure causes transition to unhealthy
                 assert!(
@@ -127,13 +129,13 @@ fn test_5xx_response_marks_failure() {
 #[test]
 fn test_2xx_3xx_response_marks_success() {
     let test_cases = vec![
-        StatusCode::OK,                      // 200
-        StatusCode::CREATED,                 // 201
-        StatusCode::ACCEPTED,                // 202
-        StatusCode::NO_CONTENT,              // 204
-        StatusCode::MOVED_PERMANENTLY,       // 301
-        StatusCode::FOUND,                   // 302
-        StatusCode::NOT_MODIFIED,            // 304
+        StatusCode::OK,                // 200
+        StatusCode::CREATED,           // 201
+        StatusCode::ACCEPTED,          // 202
+        StatusCode::NO_CONTENT,        // 204
+        StatusCode::MOVED_PERMANENTLY, // 301
+        StatusCode::FOUND,             // 302
+        StatusCode::NOT_MODIFIED,      // 304
     ];
 
     for status in test_cases {
@@ -188,7 +190,10 @@ fn test_2xx_response_recovers_failed_backend() {
         let transition = pool.mark_success(backend_index);
         if i < 1 {
             // First success doesn't cause transition (within cooldown)
-            assert!(transition.is_none(), "First success shouldn't transition yet");
+            assert!(
+                transition.is_none(),
+                "First success shouldn't transition yet"
+            );
         } else {
             // Second success causes transition to healthy (after cooldown expires)
             // Note: This test assumes cooldown has passed; in real code, time check happens
@@ -218,7 +223,10 @@ fn test_bridge_error_does_not_change_health() {
     // Simulate Bridge error (no health transition should occur)
     // In real code, this is handled by: Err(ProxyError::Bridge(_)) => no mark_success/mark_failure
     let transition = pool.mark_success(backend_index);
-    assert!(transition.is_none(), "Bridge error should not cause health transition");
+    assert!(
+        transition.is_none(),
+        "Bridge error should not cause health transition"
+    );
 
     // Verify backend health unchanged
     let healthy_indices = pool.healthy_indices();
@@ -243,7 +251,11 @@ fn test_transport_error_marks_failure() {
     for i in 0..3 {
         let transition = pool.mark_failure(backend_index);
         if i < 2 {
-            assert!(transition.is_none(), "Failure {} should not transition yet", i + 1);
+            assert!(
+                transition.is_none(),
+                "Failure {} should not transition yet",
+                i + 1
+            );
         } else {
             assert!(
                 matches!(transition, Some(HealthTransition::BecameUnhealthy)),
@@ -275,7 +287,11 @@ fn test_timeout_marks_failure() {
     for i in 0..3 {
         let transition = pool.mark_failure(backend_index);
         if i < 2 {
-            assert!(transition.is_none(), "Timeout {} should not transition yet", i + 1);
+            assert!(
+                transition.is_none(),
+                "Timeout {} should not transition yet",
+                i + 1
+            );
         } else {
             assert!(
                 matches!(transition, Some(HealthTransition::BecameUnhealthy)),
@@ -315,7 +331,10 @@ fn test_tls_error_does_not_change_health() {
     // Simulate TLS error (no health transition should occur)
     // In real code, this is handled by: Err(ProxyError::Tls(_)) => no mark_success/mark_failure
     let transition = pool.mark_success(backend_index);
-    assert!(transition.is_none(), "TLS error should not cause health transition");
+    assert!(
+        transition.is_none(),
+        "TLS error should not cause health transition"
+    );
 
     // Verify backend health unchanged
     let healthy_indices = pool.healthy_indices();
@@ -337,7 +356,10 @@ fn test_mixed_error_and_success_responses() {
     // Scenario: Backend receives mixed responses
     // 1. 200 OK -> stays healthy
     let transition = pool.mark_success(backend_index);
-    assert!(transition.is_none(), "200 OK should not transition healthy backend");
+    assert!(
+        transition.is_none(),
+        "200 OK should not transition healthy backend"
+    );
 
     // 2. 5xx -> trigger failure threshold (3 failures needed)
     let _ = pool.mark_failure(backend_index);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -335,38 +335,57 @@ pub struct UpstreamPool {
 
 ## Concurrency Model
 
-### Main Thread (Synchronous)
+### Poll Thread (Synchronous, Non-Blocking)
+
+The main poll thread never blocks on I/O:
 
 - UDP socket polling with 50ms timeout
 - QUIC packet processing via quiche
-- HTTP/3 stream handling
+- HTTP/3 stream event dispatch (`h3.poll`)
 - Route matching and backend selection
-- Synchronous backend calls via `run_blocking`
+- Non-blocking stream state advancement via `advance_streams_non_blocking`
+
+All per-stream work follows a state machine driven by `try_recv` / `try_send`:
+
+```
+ReceivingRequest
+    │  (Event::Finished — body drained to channel, body_tx dropped)
+    ▼
+AwaitingUpstream
+    │  (upstream_result_rx.try_recv() returns Ok)
+    ▼
+SendingResponse       ← H3 response headers sent; body-pump task spawned
+    │  (response_chunk_rx.try_recv() drains Data/End/Error chunks)
+    ▼
+Completed / Failed    → stream removed from map
+```
+
+`advance_streams_non_blocking` is called:
+1. After every packet-driven `handle_h3` pass.
+2. On every `handle_timeouts` tick — so streams progress even when no new
+   client packets arrive.
 
 ### Async Tasks (Tokio Runtime)
 
 - Health check probes (one task per backend)
+- H2 request forwarding (one task per in-flight stream)
+- Response body pump (one task per in-flight stream, enforces `backend_timeout()`)
 - Shutdown signal handling
 
-### Blocking Operations
+### Why No Blocking Calls
 
-Backend forwarding temporarily enters Tokio runtime:
+The poll thread owns `quiche::Connection` and `quiche::h3::Connection`, both of
+which are `!Send`. Blocking the poll thread on async I/O would stall all QUIC
+connections sharing the thread. Instead:
 
-```rust
-fn run_blocking<F, T>(f: F) -> Result<T>
-where
-    F: FnOnce() -> Future<Output = T>,
-{
-    if let Ok(handle) = Handle::try_current() {
-        // Within Tokio context
-        tokio::task::block_in_place(|| handle.block_on(f()))
-    } else {
-        // Outside Tokio context
-        let rt = Runtime::new()?;
-        rt.block_on(f())
-    }
-}
-```
+- **Request body** is streamed to the H2 task via `mpsc::channel` using
+  `try_send`; overflow chunks are buffered in `body_buf` and retried.
+- **Upstream result** is delivered via `oneshot::channel`; the poll thread
+  polls it with `try_recv` each maintenance pass.
+- **Response body** is pumped by an async task into a bounded
+  `mpsc::channel<ResponseChunk>`; the poll thread drains it with `try_recv`
+  and writes to H3 with `h3.send_body`. QUIC flow-control backpressure
+  (`StreamBlocked`) parks the current chunk in `pending_chunk` for retry.
 
 ## Configuration System
 
@@ -440,10 +459,8 @@ YAML file → Parse → Validate → Build runtime structures
 
 Current architectural bottlenecks:
 
-1. **Synchronous backend calls**: Block main thread during HTTP/2 roundtrip
-2. **Full body buffering**: Materializes entire request/response in memory
-3. **Consistent hash ring**: Rebuilds on every request
-4. **Single-threaded poll loop**: All QUIC processing on one thread
+1. **Consistent hash ring**: Rebuilds on every request
+2. **Single-threaded poll loop**: All QUIC processing on one thread
 
 See [roadmap](roadmap.md) for planned improvements.
 

--- a/spooky/src/main.rs
+++ b/spooky/src/main.rs
@@ -21,9 +21,7 @@ struct Cli {
 #[tokio::main]
 async fn main() {
     // Check user (only root allowed)
-    let uid = unsafe {
-        libc::getuid()
-    };
+    let uid = unsafe { libc::getuid() };
 
     if uid != 0 {
         eprintln!("This program must be run as root.");
@@ -47,7 +45,11 @@ async fn main() {
     };
 
     // Initialize the Logger
-    spooky_utils::logger::init_logger(&config_yaml.log.level, config_yaml.log.file.enabled, &config_yaml.log.file.path);
+    spooky_utils::logger::init_logger(
+        &config_yaml.log.level,
+        config_yaml.log.file.enabled,
+        &config_yaml.log.file.path,
+    );
 
     // Validate Configurations
     if !validate_config(&config_yaml) {


### PR DESCRIPTION
Closes- #17 

**Problem:** `handle_request_finish()` called `run_blocking()` on every upstream
request, serializing all streams on the QUIC poll thread. One slow backend stalled
packet reception, stream processing, and health checks for the entire connection.

**Fix:** State-machine-driven non-blocking poll loop.

- `StreamPhase` tracks each stream: `ReceivingRequest → AwaitingUpstream → SendingResponse → Completed/Failed`
- Upstream H2 requests fire-and-forget via `oneshot` channel; result polled with `try_recv`
- Response body pumped off-thread via `mpsc` channel with `backend_timeout()` enforcement
- `advance_streams_non_blocking()` called after every packet and every timeout tick
- `run_blocking` / `send_backend_response` deleted

**Tests:** 6 regression tests covering HOL ordering, concurrent `Finished` events,
progressive streaming, 502/5xx passthrough, and 503 on timeout.
