### PR TITLE
Runtime hardening: multi-worker QUIC ingest with SO_REUSEPORT and control/data plane split

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ thiserror = "1"
 tokio = { version = "1", features = ["full"] }
 libc = "0.2"
 smallvec = "1"
+socket2 = { version = "0.5", features = ["all"] }
+core_affinity = "0.8"
 
 [workspace.package]
 version = "0.1.0"

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -57,6 +57,9 @@ log:
 
 performance:
     worker_threads: 1
+    control_plane_threads: 2
+    reuseport: true
+    pin_workers: false
     global_inflight_limit: 4096
     per_upstream_inflight_limit: 1024
     backend_timeout_ms: 2000

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -10,7 +10,8 @@ use crate::default::{
     observe_default_address, observe_default_metrics_path, observe_default_port,
     perf_default_backend_body_idle_timeout_ms, perf_default_backend_body_total_timeout_ms,
     perf_default_backend_timeout_ms, perf_default_global_inflight_limit,
-    perf_default_per_upstream_inflight_limit, perf_default_worker_threads,
+    perf_default_control_plane_threads, perf_default_per_upstream_inflight_limit,
+    perf_default_pin_workers, perf_default_reuseport, perf_default_worker_threads,
 };
 
 #[derive(Debug, Deserialize, Clone)]
@@ -145,6 +146,15 @@ pub struct Performance {
     #[serde(default = "perf_default_worker_threads")]
     pub worker_threads: usize,
 
+    #[serde(default = "perf_default_control_plane_threads")]
+    pub control_plane_threads: usize,
+
+    #[serde(default = "perf_default_reuseport")]
+    pub reuseport: bool,
+
+    #[serde(default = "perf_default_pin_workers")]
+    pub pin_workers: bool,
+
     #[serde(default = "perf_default_global_inflight_limit")]
     pub global_inflight_limit: usize,
 
@@ -165,6 +175,9 @@ impl Default for Performance {
     fn default() -> Self {
         Self {
             worker_threads: perf_default_worker_threads(),
+            control_plane_threads: perf_default_control_plane_threads(),
+            reuseport: perf_default_reuseport(),
+            pin_workers: perf_default_pin_workers(),
             global_inflight_limit: perf_default_global_inflight_limit(),
             per_upstream_inflight_limit: perf_default_per_upstream_inflight_limit(),
             backend_timeout_ms: perf_default_backend_timeout_ms(),

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -9,8 +9,8 @@ use crate::default::{
     get_default_protocol, get_default_success_threshold, get_default_version, get_default_weight,
     observe_default_address, observe_default_metrics_path, observe_default_port,
     perf_default_backend_body_idle_timeout_ms, perf_default_backend_body_total_timeout_ms,
-    perf_default_backend_timeout_ms, perf_default_global_inflight_limit,
-    perf_default_control_plane_threads, perf_default_per_upstream_inflight_limit,
+    perf_default_backend_timeout_ms, perf_default_control_plane_threads,
+    perf_default_global_inflight_limit, perf_default_per_upstream_inflight_limit,
     perf_default_pin_workers, perf_default_reuseport, perf_default_worker_threads,
 };
 

--- a/crates/config/src/default.rs
+++ b/crates/config/src/default.rs
@@ -74,6 +74,18 @@ pub fn perf_default_worker_threads() -> usize {
     1
 }
 
+pub fn perf_default_control_plane_threads() -> usize {
+    2
+}
+
+pub fn perf_default_reuseport() -> bool {
+    true
+}
+
+pub fn perf_default_pin_workers() -> bool {
+    false
+}
+
 pub fn perf_default_global_inflight_limit() -> usize {
     4096
 }

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -84,6 +84,16 @@ pub fn validate(config: &Config) -> bool {
         return false;
     }
 
+    if config.performance.control_plane_threads == 0 {
+        error!("performance.control_plane_threads must be greater than 0");
+        return false;
+    }
+
+    if config.performance.worker_threads > 1 && !config.performance.reuseport {
+        error!("performance.reuseport must be true when performance.worker_threads > 1");
+        return false;
+    }
+
     if config.performance.global_inflight_limit == 0 {
         error!("performance.global_inflight_limit must be greater than 0");
         return false;
@@ -415,6 +425,9 @@ upstream:
 
         let cfg: Config = serde_yaml::from_str(&yaml).expect("parse");
         assert_eq!(cfg.performance.worker_threads, 1);
+        assert_eq!(cfg.performance.control_plane_threads, 2);
+        assert!(cfg.performance.reuseport);
+        assert!(!cfg.performance.pin_workers);
         assert_eq!(cfg.performance.global_inflight_limit, 4096);
         assert_eq!(cfg.performance.per_upstream_inflight_limit, 1024);
         assert_eq!(cfg.performance.backend_timeout_ms, 2000);
@@ -434,6 +447,11 @@ upstream:
 
         let mut cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.performance.worker_threads = 0;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.performance.worker_threads = 4;
+        cfg.performance.reuseport = false;
         assert!(!validate(&cfg));
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
@@ -463,6 +481,9 @@ upstream:
 
         let mut cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.performance.worker_threads = 4;
+        cfg.performance.control_plane_threads = 2;
+        cfg.performance.reuseport = true;
+        cfg.performance.pin_workers = true;
         cfg.performance.global_inflight_limit = 10_000;
         cfg.performance.per_upstream_inflight_limit = 2_000;
         cfg.performance.backend_timeout_ms = 1500;

--- a/crates/edge/Cargo.toml
+++ b/crates/edge/Cargo.toml
@@ -24,6 +24,7 @@ smallvec.workspace = true
 hmac = "0.12"
 sha2 = "0.10"
 hex = "0.4"
+socket2.workspace = true
 
 [dev-dependencies]
 rand.workspace = true

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -61,6 +61,16 @@ pub mod constants;
 pub mod quic_listener;
 mod route_index;
 
+pub use quic_listener::configure_async_runtime;
+
+pub struct SharedRuntimeState {
+    pub(crate) h2_pool: Arc<H2Pool>,
+    pub(crate) upstream_pools: HashMap<String, Arc<Mutex<UpstreamPool>>>,
+    pub(crate) upstream_inflight: HashMap<String, Arc<Semaphore>>,
+    pub(crate) global_inflight: Arc<Semaphore>,
+    pub(crate) metrics: Arc<Metrics>,
+}
+
 pub struct QUICListener {
     pub socket: UdpSocket,
     pub config: Config,

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -1,7 +1,11 @@
 use std::{
     collections::{HashMap, HashSet},
-    net::UdpSocket,
-    sync::{Arc, Mutex, OnceLock},
+    future::Future,
+    net::{ToSocketAddrs, UdpSocket},
+    sync::{
+        Arc, Mutex, OnceLock,
+        atomic::{AtomicUsize, Ordering},
+    },
     time::{Duration, Instant},
 };
 
@@ -14,11 +18,12 @@ use hyper::body::Incoming;
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper_util::rt::TokioIo;
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 use quiche::Config;
 use quiche::h3::NameValue;
 use rand::RngCore;
 use smallvec::SmallVec;
+use socket2::{Domain, Protocol, Socket, Type};
 use spooky_bridge::h3_to_h2::build_h2_request;
 use spooky_errors::ProxyError;
 use spooky_lb::{HealthTransition, UpstreamPool};
@@ -34,7 +39,7 @@ use spooky_config::config::Config as SpookyConfig;
 
 use crate::{
     ChannelBody, ForwardResult, Metrics, QUICListener, QuicConnection, RequestEnvelope,
-    ResponseChunk, RouteOutcome, StreamPhase,
+    ResponseChunk, RouteOutcome, SharedRuntimeState, StreamPhase,
     cid_radix::CidRadix,
     constants::{
         DEFAULT_SCID_LEN_BYTES, MAX_DATAGRAM_SIZE_BYTES, MAX_INFLIGHT_PER_BACKEND,
@@ -60,20 +65,196 @@ type ResolvedBackend = (String, String, usize, Arc<Mutex<UpstreamPool>>);
 
 impl QUICListener {
     pub fn new(config: SpookyConfig) -> Result<Self, ProxyError> {
-        let socket_address = format!("{}:{}", &config.listen.address, &config.listen.port);
+        let shared_state = Arc::new(Self::build_shared_state(&config)?);
+        Self::spawn_control_plane_tasks(&config, &shared_state);
+        let socket = Self::bind_socket(&config, false)?;
+        Self::new_with_socket_and_shared_state(config, socket, shared_state)
+    }
 
-        let socket = UdpSocket::bind(socket_address.as_str()).map_err(|err| {
-            ProxyError::Transport(format!(
-                "failed to bind UDP socket on '{}': {}",
-                socket_address, err
-            ))
-        })?;
+    pub fn build_shared_state(config: &SpookyConfig) -> Result<SharedRuntimeState, ProxyError> {
+        let worker_threads = config.performance.worker_threads.max(1);
+        let per_upstream_limit = config.performance.per_upstream_inflight_limit.max(1);
+        let global_inflight_limit = config.performance.global_inflight_limit.max(1);
+        let max_inflight_per_backend = MAX_INFLIGHT_PER_BACKEND.saturating_mul(worker_threads);
+
+        info!(
+            "Performance profile: worker_threads={} control_plane_threads={} reuseport={} pin_workers={} global_inflight_limit={} per_upstream_inflight_limit={} backend_timeout_ms={} backend_body_idle_timeout_ms={} backend_body_total_timeout_ms={}",
+            worker_threads,
+            config.performance.control_plane_threads.max(1),
+            config.performance.reuseport,
+            config.performance.pin_workers,
+            global_inflight_limit,
+            per_upstream_limit,
+            config.performance.backend_timeout_ms,
+            config.performance.backend_body_idle_timeout_ms,
+            config.performance.backend_body_total_timeout_ms
+        );
+
+        let backend_addresses = config
+            .upstream
+            .values()
+            .flat_map(|upstream| {
+                upstream
+                    .backends
+                    .iter()
+                    .map(|backend| backend.address.clone())
+            })
+            .collect::<Vec<_>>();
+
+        let h2_pool = Arc::new(H2Pool::new(backend_addresses, max_inflight_per_backend));
+        let mut upstream_pools = HashMap::new();
+        let mut upstream_inflight = HashMap::new();
+
+        for (name, upstream) in &config.upstream {
+            let upstream_pool = UpstreamPool::from_upstream(upstream).map_err(|err| {
+                ProxyError::Transport(format!(
+                    "failed to create upstream pool '{}': {}",
+                    name, err
+                ))
+            })?;
+            upstream_pools.insert(name.clone(), Arc::new(Mutex::new(upstream_pool)));
+            upstream_inflight.insert(name.clone(), Arc::new(Semaphore::new(per_upstream_limit)));
+        }
+
+        Ok(SharedRuntimeState {
+            h2_pool,
+            upstream_pools,
+            upstream_inflight,
+            global_inflight: Arc::new(Semaphore::new(global_inflight_limit)),
+            metrics: Arc::new(Metrics::default()),
+        })
+    }
+
+    pub fn spawn_control_plane_tasks(config: &SpookyConfig, shared_state: &SharedRuntimeState) {
+        Self::spawn_health_checks(
+            shared_state.upstream_pools.clone(),
+            Arc::clone(&shared_state.h2_pool),
+        );
+        Self::spawn_metrics_endpoint(config, Arc::clone(&shared_state.metrics));
+    }
+
+    pub fn bind_reuseport_sockets(
+        config: &SpookyConfig,
+        workers: usize,
+    ) -> Result<Vec<UdpSocket>, ProxyError> {
+        let workers = workers.max(1);
+        let mut sockets = Vec::with_capacity(workers);
+        for _ in 0..workers {
+            sockets.push(Self::bind_socket(config, true)?);
+        }
+        Ok(sockets)
+    }
+
+    pub fn bind_socket(config: &SpookyConfig, reuse_port: bool) -> Result<UdpSocket, ProxyError> {
+        let bind_addr = Self::resolve_bind_addr(config)?;
+        let socket = Self::create_udp_socket(bind_addr, reuse_port)?;
         socket
             .set_read_timeout(Some(Duration::from_millis(UDP_READ_TIMEOUT_MS)))
             .map_err(|err| {
                 ProxyError::Transport(format!("failed to set UDP read timeout: {}", err))
             })?;
 
+        Ok(socket)
+    }
+
+    pub fn new_with_socket_and_shared_state(
+        config: SpookyConfig,
+        socket: UdpSocket,
+        shared_state: Arc<SharedRuntimeState>,
+    ) -> Result<Self, ProxyError> {
+        let local_addr = socket.local_addr().map_err(|err| {
+            ProxyError::Transport(format!("failed to read UDP socket local address: {}", err))
+        })?;
+        debug!("Listening on {}", local_addr);
+
+        let quic_config = Self::build_quic_config(&config)?;
+        let h3_config =
+            Arc::new(quiche::h3::Config::new().map_err(|err| {
+                ProxyError::Transport(format!("failed to create h3 config: {err}"))
+            })?);
+        let routing_index = RouteIndex::from_upstreams(&config.upstream);
+        let backend_timeout = Duration::from_millis(config.performance.backend_timeout_ms);
+        let backend_body_idle_timeout =
+            Duration::from_millis(config.performance.backend_body_idle_timeout_ms);
+        let backend_body_total_timeout =
+            Duration::from_millis(config.performance.backend_body_total_timeout_ms);
+
+        Ok(Self {
+            socket,
+            config,
+            quic_config,
+            h3_config,
+            h2_pool: Arc::clone(&shared_state.h2_pool),
+            upstream_pools: shared_state.upstream_pools.clone(),
+            upstream_inflight: shared_state.upstream_inflight.clone(),
+            global_inflight: Arc::clone(&shared_state.global_inflight),
+            routing_index,
+            metrics: Arc::clone(&shared_state.metrics),
+            draining: false,
+            drain_start: None,
+            backend_timeout,
+            backend_body_idle_timeout,
+            backend_body_total_timeout,
+            recv_buf: [0; MAX_DATAGRAM_SIZE_BYTES],
+            send_buf: [0; MAX_DATAGRAM_SIZE_BYTES],
+            connections: HashMap::new(),
+            cid_routes: HashMap::new(),
+            peer_routes: HashMap::new(),
+            cid_radix: CidRadix::new(),
+        })
+    }
+
+    fn resolve_bind_addr(config: &SpookyConfig) -> Result<SocketAddr, ProxyError> {
+        let socket_address = format!("{}:{}", config.listen.address, config.listen.port);
+        socket_address
+            .to_socket_addrs()
+            .map_err(|err| {
+                ProxyError::Transport(format!(
+                    "failed to resolve listen address '{}': {}",
+                    socket_address, err
+                ))
+            })?
+            .next()
+            .ok_or_else(|| {
+                ProxyError::Transport(format!("no socket addresses found for '{socket_address}'"))
+            })
+    }
+
+    fn create_udp_socket(bind_addr: SocketAddr, reuse_port: bool) -> Result<UdpSocket, ProxyError> {
+        let domain = if bind_addr.is_ipv4() {
+            Domain::IPV4
+        } else {
+            Domain::IPV6
+        };
+        let socket = Socket::new(domain, Type::DGRAM, Some(Protocol::UDP)).map_err(|err| {
+            ProxyError::Transport(format!("failed to create UDP socket: {}", err))
+        })?;
+        socket
+            .set_reuse_address(true)
+            .map_err(|err| ProxyError::Transport(format!("failed to set SO_REUSEADDR: {}", err)))?;
+
+        #[cfg(all(
+            unix,
+            not(target_os = "solaris"),
+            not(target_os = "illumos"),
+            not(target_os = "cygwin")
+        ))]
+        {
+            socket.set_reuse_port(reuse_port).map_err(|err| {
+                ProxyError::Transport(format!("failed to set SO_REUSEPORT: {}", err))
+            })?;
+        }
+
+        socket.bind(&bind_addr.into()).map_err(|err| {
+            ProxyError::Transport(format!(
+                "failed to bind UDP socket on '{}': {}",
+                bind_addr, err
+            ))
+        })?;
+        Ok(socket.into())
+    }
+
+    fn build_quic_config(config: &SpookyConfig) -> Result<Config, ProxyError> {
         let mut quic_config = Config::new(quiche::PROTOCOL_VERSION)
             .map_err(|err| ProxyError::Transport(format!("failed to create QUIC config: {err}")))?;
 
@@ -114,87 +295,7 @@ impl QUICListener {
         quic_config.set_disable_active_migration(true);
         quic_config.verify_peer(false);
 
-        // CRITICAL FIX: Explicitly disable 0-RTT/early data
-        // This prevents clients from attempting 0-RTT that we can't handle
-
-        debug!("Listening on {}", socket_address);
-        let worker_threads = config.performance.worker_threads.max(1);
-        let per_upstream_limit = config.performance.per_upstream_inflight_limit.max(1);
-        let global_inflight_limit = config.performance.global_inflight_limit.max(1);
-        let max_inflight_per_backend = MAX_INFLIGHT_PER_BACKEND.saturating_mul(worker_threads);
-        info!(
-            "Performance profile: worker_threads={} global_inflight_limit={} per_upstream_inflight_limit={} backend_timeout_ms={} backend_body_idle_timeout_ms={} backend_body_total_timeout_ms={}",
-            worker_threads,
-            global_inflight_limit,
-            per_upstream_limit,
-            config.performance.backend_timeout_ms,
-            config.performance.backend_body_idle_timeout_ms,
-            config.performance.backend_body_total_timeout_ms
-        );
-
-        let h3_config =
-            Arc::new(quiche::h3::Config::new().map_err(|err| {
-                ProxyError::Transport(format!("failed to create h3 config: {err}"))
-            })?);
-        let backend_addresses = config
-            .upstream
-            .values()
-            .flat_map(|upstream| {
-                upstream
-                    .backends
-                    .iter()
-                    .map(|backend| backend.address.clone())
-            })
-            .collect::<Vec<_>>();
-        let h2_pool = Arc::new(H2Pool::new(backend_addresses, max_inflight_per_backend));
-
-        let mut upstream_pools = HashMap::new();
-        let mut upstream_inflight = HashMap::new();
-        let backend_timeout = Duration::from_millis(config.performance.backend_timeout_ms);
-        let backend_body_idle_timeout =
-            Duration::from_millis(config.performance.backend_body_idle_timeout_ms);
-        let backend_body_total_timeout =
-            Duration::from_millis(config.performance.backend_body_total_timeout_ms);
-        for (name, upstream) in &config.upstream {
-            let upstream_pool = UpstreamPool::from_upstream(upstream).map_err(|err| {
-                ProxyError::Transport(format!(
-                    "failed to create upstream pool '{}': {}",
-                    name, err
-                ))
-            })?;
-            upstream_pools.insert(name.clone(), Arc::new(Mutex::new(upstream_pool)));
-            upstream_inflight.insert(name.clone(), Arc::new(Semaphore::new(per_upstream_limit)));
-        }
-        let routing_index = RouteIndex::from_upstreams(&config.upstream);
-
-        let metrics = Arc::new(Metrics::default());
-
-        Self::spawn_health_checks(upstream_pools.clone(), h2_pool.clone());
-        Self::spawn_metrics_endpoint(&config, Arc::clone(&metrics));
-
-        Ok(Self {
-            socket,
-            config,
-            quic_config,
-            h3_config,
-            h2_pool,
-            upstream_pools,
-            upstream_inflight,
-            global_inflight: Arc::new(Semaphore::new(global_inflight_limit)),
-            routing_index,
-            metrics,
-            draining: false,
-            drain_start: None,
-            backend_timeout,
-            backend_body_idle_timeout,
-            backend_body_total_timeout,
-            recv_buf: [0; MAX_DATAGRAM_SIZE_BYTES],
-            send_buf: [0; MAX_DATAGRAM_SIZE_BYTES],
-            connections: HashMap::new(),
-            cid_routes: HashMap::new(),
-            peer_routes: HashMap::new(),
-            cid_radix: CidRadix::new(),
-        })
+        Ok(quic_config)
     }
 
     pub fn start_draining(&mut self) {
@@ -226,18 +327,10 @@ impl QUICListener {
     }
 
     fn close_all(&mut self) {
-        let socket = match self.socket.try_clone() {
-            Ok(sock) => sock,
-            Err(e) => {
-                error!("Failed to clone UDP socket: {:?}", e);
-                return;
-            }
-        };
-
         let mut send_buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
         for connection in self.connections.values_mut() {
             let _ = connection.quic.close(true, 0x0, b"draining");
-            Self::flush_send(&socket, &mut send_buf, connection);
+            Self::flush_send(&self.socket, &mut send_buf, connection);
         }
 
         self.connections.clear();
@@ -484,14 +577,6 @@ impl QUICListener {
             Err(_) => return,
         };
 
-        let socket = match self.socket.try_clone() {
-            Ok(sock) => sock,
-            Err(e) => {
-                error!("Failed to clone UDP socket: {:?}", e);
-                return;
-            }
-        };
-
         // let mut recv_data = self.recv_buf[..len].to_vec();
         let mut recv_data = BytesMut::from(&self.recv_buf[..len]);
 
@@ -513,7 +598,7 @@ impl QUICListener {
                     }
                 };
 
-            if let Err(e) = socket.send_to(&self.send_buf[..len], peer) {
+            if let Err(e) = self.socket.send_to(&self.send_buf[..len], peer) {
                 error!("Failed to send version negotiation: {:?}", e);
             }
             return;
@@ -658,8 +743,8 @@ impl QUICListener {
 
         let mut send_buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
 
-        Self::flush_send(&socket, &mut send_buf, &mut connection);
-        Self::handle_timeout(&socket, &mut send_buf, &mut connection);
+        Self::flush_send(&self.socket, &mut send_buf, &mut connection);
+        Self::handle_timeout(&self.socket, &mut send_buf, &mut connection);
 
         if !connection.quic.is_closed() {
             let new_primary = self.sync_connection_routes(&mut connection);
@@ -682,14 +767,6 @@ impl QUICListener {
             return;
         }
 
-        let socket = match self.socket.try_clone() {
-            Ok(sock) => sock,
-            Err(e) => {
-                error!("Failed to clone UDP socket: {:?}", e);
-                return;
-            }
-        };
-
         let mut send_buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
         let mut to_remove = Vec::new();
 
@@ -707,7 +784,7 @@ impl QUICListener {
             if connection.last_activity.elapsed() >= timeout {
                 connection.quic.on_timeout();
                 connection.last_activity = Instant::now();
-                Self::flush_send(&socket, &mut send_buf, connection);
+                Self::flush_send(&self.socket, &mut send_buf, connection);
             }
 
             if connection.quic.is_closed() {
@@ -730,7 +807,7 @@ impl QUICListener {
                     error!("advance_streams_non_blocking in timeout path: {:?}", e);
                 }
                 connection.h3 = Some(h3);
-                Self::flush_send(&socket, &mut send_buf, connection);
+                Self::flush_send(&self.socket, &mut send_buf, connection);
             }
         }
 
@@ -988,20 +1065,8 @@ impl QUICListener {
                                 // Ignore send error: receiver dropped means the stream was reset.
                                 let _ = result_tx.send(result);
                             };
-                            match Handle::try_current() {
-                                Ok(handle) => {
-                                    handle.spawn(fut);
-                                }
-                                Err(err) => {
-                                    if let Some(rt) = fallback_runtime() {
-                                        rt.spawn(fut);
-                                    } else {
-                                        error!(
-                                            "dropping upstream task: no runtime available ({})",
-                                            err
-                                        );
-                                    }
-                                }
+                            if !spawn_async_task(fut, "upstream") {
+                                error!("dropping upstream task: no runtime available");
                             }
                             (
                                 Some(tx),
@@ -1325,23 +1390,7 @@ impl QUICListener {
                                 }
                             }
                         };
-                        let mut spawned = true;
-                        match Handle::try_current() {
-                            Ok(h) => {
-                                h.spawn(fut);
-                            }
-                            Err(err) => {
-                                if let Some(rt) = fallback_runtime() {
-                                    rt.spawn(fut);
-                                } else {
-                                    error!(
-                                        "dropping body pump task: no runtime available ({})",
-                                        err
-                                    );
-                                    spawned = false;
-                                }
-                            }
-                        }
+                        let spawned = spawn_async_task(fut, "body-pump");
                         if !spawned {
                             let _ = fail_tx.try_send(ResponseChunk::Error(ProxyError::Transport(
                                 "runtime unavailable".into(),
@@ -1767,10 +1816,10 @@ impl QUICListener {
         let bind = format!("{}:{}", endpoint.address, endpoint.port);
         let metrics_path = endpoint.path.clone();
 
-        let handle = match Handle::try_current() {
-            Ok(h) => h,
-            Err(err) => {
-                error!("Metrics endpoint disabled (no Tokio runtime): {}", err);
+        let handle = match runtime_handle() {
+            Some(handle) => handle,
+            None => {
+                error!("Metrics endpoint disabled (no Tokio runtime available)");
                 return;
             }
         };
@@ -1894,9 +1943,9 @@ impl QUICListener {
             all_entries
         };
 
-        let handle = match Handle::try_current() {
-            Ok(handle) => handle,
-            Err(_) => {
+        let handle = match runtime_handle() {
+            Some(handle) => handle,
+            None => {
                 error!("Health checks disabled: no Tokio runtime available");
                 return;
             }
@@ -1954,16 +2003,50 @@ impl QUICListener {
     }
 }
 
+pub fn configure_async_runtime(worker_threads: usize) {
+    let threads = worker_threads.max(1);
+    if FALLBACK_RT.get().is_some() {
+        warn!(
+            "async runtime already initialized; ignoring new worker_threads={}",
+            threads
+        );
+        return;
+    }
+    FALLBACK_RT_THREADS.store(threads, Ordering::Relaxed);
+}
+
+fn runtime_handle() -> Option<Handle> {
+    if let Ok(handle) = Handle::try_current() {
+        return Some(handle);
+    }
+    fallback_runtime().map(|rt| rt.handle().clone())
+}
+
+fn spawn_async_task<F>(fut: F, _task_name: &str) -> bool
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    if let Some(handle) = runtime_handle() {
+        handle.spawn(fut);
+        true
+    } else {
+        false
+    }
+}
+
 fn fallback_runtime() -> Option<&'static tokio::runtime::Runtime> {
-    static FALLBACK_RT: OnceLock<Option<tokio::runtime::Runtime>> = OnceLock::new();
     FALLBACK_RT
         .get_or_init(|| {
             tokio::runtime::Builder::new_multi_thread()
                 .enable_all()
-                .worker_threads(2)
+                .worker_threads(FALLBACK_RT_THREADS.load(Ordering::Relaxed))
                 .thread_name("spooky-edge-fallback-rt")
                 .build()
                 .ok()
         })
         .as_ref()
 }
+
+static FALLBACK_RT: OnceLock<Option<tokio::runtime::Runtime>> = OnceLock::new();
+static FALLBACK_RT_THREADS: AtomicUsize = AtomicUsize::new(2);

--- a/spooky/Cargo.toml
+++ b/spooky/Cargo.toml
@@ -19,6 +19,7 @@ http-body-util.workspace = true
 hyper.workspace = true
 hyper-util.workspace = true
 libc.workspace = true
+core_affinity.workspace = true
 
 spooky-config = { path = "../crates/config" }
 spooky-edge = { path = "../crates/edge" }

--- a/spooky/src/main.rs
+++ b/spooky/src/main.rs
@@ -4,11 +4,13 @@ use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
 };
+use std::{thread, time::Duration};
 
 use clap::Parser;
-use log::{error, info};
+use log::{error, info, warn};
 
 use spooky_config::validator::validate as validate_config;
+use spooky_edge::{QUICListener, configure_async_runtime};
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
@@ -57,14 +59,53 @@ async fn main() {
         std::process::exit(1);
     }
 
-    info!("Spooky is starting");
-    let mut spooky = match spooky_edge::QUICListener::new(config_yaml) {
-        Ok(listener) => listener,
+    configure_async_runtime(config_yaml.performance.control_plane_threads.max(1));
+
+    let shared_state = match QUICListener::build_shared_state(&config_yaml) {
+        Ok(shared_state) => Arc::new(shared_state),
         Err(e) => {
-            error!("Failed to create QUIC listener: {}", e);
+            error!("Failed to initialize shared runtime state: {}", e);
             std::process::exit(1);
         }
     };
+    QUICListener::spawn_control_plane_tasks(&config_yaml, &shared_state);
+
+    let requested_workers = config_yaml.performance.worker_threads.max(1);
+    let worker_count = if requested_workers > 1 && !config_yaml.performance.reuseport {
+        warn!(
+            "reuseport disabled while worker_threads={} configured; running a single data-plane worker",
+            requested_workers
+        );
+        1
+    } else {
+        requested_workers
+    };
+
+    let sockets = if worker_count > 1 {
+        match QUICListener::bind_reuseport_sockets(&config_yaml, worker_count) {
+            Ok(sockets) => sockets,
+            Err(e) => {
+                error!("Failed to bind SO_REUSEPORT sockets: {}", e);
+                std::process::exit(1);
+            }
+        }
+    } else {
+        match QUICListener::bind_socket(&config_yaml, false) {
+            Ok(socket) => vec![socket],
+            Err(e) => {
+                error!("Failed to bind UDP socket: {}", e);
+                std::process::exit(1);
+            }
+        }
+    };
+
+    info!("Spooky is starting");
+    info!(
+        "Data-plane workers={} reuseport={} pin_workers={}",
+        sockets.len(),
+        config_yaml.performance.reuseport,
+        config_yaml.performance.pin_workers
+    );
 
     let shutdown = Arc::new(AtomicBool::new(false));
     let shutdown_flag = shutdown.clone();
@@ -74,14 +115,87 @@ async fn main() {
         shutdown_flag.store(true, Ordering::Relaxed);
     });
 
+    let pin_workers = config_yaml.performance.pin_workers;
+    let mut worker_handles = Vec::with_capacity(sockets.len());
+    for (worker_idx, socket) in sockets.into_iter().enumerate() {
+        let worker_config = config_yaml.clone();
+        let worker_shutdown = Arc::clone(&shutdown);
+        let worker_shared = Arc::clone(&shared_state);
+        let thread_name = format!("spooky-data-plane-{}", worker_idx);
+        let handle = thread::Builder::new().name(thread_name.clone()).spawn(
+            move || -> Result<(), String> {
+                maybe_pin_worker(worker_idx, pin_workers);
+                let mut listener = QUICListener::new_with_socket_and_shared_state(
+                    worker_config,
+                    socket,
+                    worker_shared,
+                )
+                .map_err(|err| format!("worker {} listener init failed: {}", worker_idx, err))?;
+
+                while !worker_shutdown.load(Ordering::Relaxed) {
+                    listener.poll();
+                }
+
+                listener.start_draining();
+                while !listener.drain_complete() {
+                    listener.poll();
+                }
+                Ok(())
+            },
+        );
+
+        match handle {
+            Ok(handle) => worker_handles.push(handle),
+            Err(err) => {
+                error!("Failed to spawn worker thread {}: {}", worker_idx, err);
+                shutdown.store(true, Ordering::Relaxed);
+                break;
+            }
+        }
+    }
+
     while !shutdown.load(Ordering::Relaxed) {
-        spooky.poll();
+        tokio::time::sleep(Duration::from_millis(100)).await;
     }
 
-    spooky.start_draining();
-    while !spooky.drain_complete() {
-        spooky.poll();
+    let mut worker_failed = false;
+    for handle in worker_handles {
+        match handle.join() {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => {
+                worker_failed = true;
+                error!("Worker exited with error: {}", err);
+            }
+            Err(_) => {
+                worker_failed = true;
+                error!("Worker thread panicked");
+            }
+        }
     }
 
+    if worker_failed {
+        std::process::exit(1);
+    }
     info!("Spooky shutdown complete");
+}
+
+fn maybe_pin_worker(worker_idx: usize, pin_workers: bool) {
+    if !pin_workers {
+        return;
+    }
+
+    let Some(core_ids) = core_affinity::get_core_ids() else {
+        warn!("Worker pinning requested but core list is unavailable");
+        return;
+    };
+
+    if core_ids.is_empty() {
+        warn!("Worker pinning requested but no cores were reported");
+        return;
+    }
+
+    let core_id = core_ids[worker_idx % core_ids.len()];
+    if !core_affinity::set_for_current(core_id) {
+        warn!("Failed to pin worker {} to core {}", worker_idx, core_id.id);
+    }
 }


### PR DESCRIPTION
## Summary
This PR upgrades Spooky’s runtime architecture for production load by introducing multi-worker QUIC packet ingestion, separating control-plane tasks from data-plane workers, and adding worker pinning/tuning controls.

## What changed
- Added multi-worker data-plane startup in `spooky/src/main.rs`.
- Added `SO_REUSEPORT`-based UDP socket fanout for multiple QUIC workers.
- Split control-plane startup (health checks, metrics endpoint) from data-plane worker loops.
- Added shared runtime state so workers reuse common upstream pools, inflight limits, H2 pool, and metrics.
- Added runtime config knobs:
  - `performance.control_plane_threads`
  - `performance.reuseport`
  - `performance.pin_workers`
- Enforced config validation for safe runtime combinations (`worker_threads > 1` requires `reuseport: true`).
- Added optional CPU core pinning for workers using `core_affinity`.
- Reduced hot-path overhead by removing repeated UDP socket cloning in poll/timeout/drain paths.
- Updated sample config and dependencies (`socket2` with `all` feature, `core_affinity`).

## Why
- Improves throughput scaling on multicore systems.
- Isolates control-plane work from packet/stream hot paths.
- Reduces runtime contention and improves operational predictability under sustained concurrency.

## Validation
- `cargo check`
- `cargo test -p spooky-config`
- `cargo test -p spooky-edge --test h3_edge`
- `cargo test -p spooky-edge --test h3_bridge metrics_endpoint_exposes_route_slo_metrics`