### PR TITLE
Runtime perf hardening: UDP burst tuning, backend backpressure propagation, and copy-light H3→H2 bridge

### DIFF
--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -69,6 +69,7 @@ performance:
     udp_send_buffer_bytes: 8388608
     h2_pool_max_idle_per_backend: 256
     h2_pool_idle_timeout_ms: 90000
+    per_backend_inflight_limit: 64
 
 observability:
     metrics:

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -65,6 +65,8 @@ performance:
     backend_timeout_ms: 2000
     backend_body_idle_timeout_ms: 2000
     backend_body_total_timeout_ms: 30000
+    udp_recv_buffer_bytes: 8388608
+    udp_send_buffer_bytes: 8388608
 
 observability:
     metrics:

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -67,6 +67,8 @@ performance:
     backend_body_total_timeout_ms: 30000
     udp_recv_buffer_bytes: 8388608
     udp_send_buffer_bytes: 8388608
+    h2_pool_max_idle_per_backend: 256
+    h2_pool_idle_timeout_ms: 90000
 
 observability:
     metrics:

--- a/crates/bridge/src/h3_to_h2.rs
+++ b/crates/bridge/src/h3_to_h2.rs
@@ -3,6 +3,7 @@ use std::convert::Infallible;
 use bytes::Bytes;
 use http::{HeaderName, HeaderValue, Method, Request, Uri};
 use http_body_util::combinators::BoxBody;
+use quiche::h3::NameValue;
 
 pub use spooky_errors::BridgeError;
 
@@ -13,7 +14,7 @@ pub fn build_h2_request(
     backend: &str,
     method: &str,
     path: &str,
-    headers: &[(Vec<u8>, Vec<u8>)],
+    headers: &[quiche::h3::Header],
     body: BoxBody<Bytes, Infallible>,
     content_length: Option<usize>,
 ) -> Result<Request<BoxBody<Bytes, Infallible>>, BridgeError> {
@@ -26,7 +27,8 @@ pub fn build_h2_request(
     let mut builder = Request::builder().method(method).uri(uri);
 
     let mut saw_host = false;
-    for (name, value) in headers {
+    for header in headers {
+        let name = header.name();
         if name.starts_with(b":") {
             continue;
         }
@@ -41,7 +43,7 @@ pub fn build_h2_request(
         }
 
         let header_value =
-            HeaderValue::from_bytes(value).map_err(|_| BridgeError::InvalidHeader)?;
+            HeaderValue::from_bytes(header.value()).map_err(|_| BridgeError::InvalidHeader)?;
         builder = builder.header(header_name, header_value);
     }
 

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -11,7 +11,8 @@ use crate::default::{
     perf_default_backend_body_idle_timeout_ms, perf_default_backend_body_total_timeout_ms,
     perf_default_backend_timeout_ms, perf_default_control_plane_threads,
     perf_default_global_inflight_limit, perf_default_per_upstream_inflight_limit,
-    perf_default_pin_workers, perf_default_reuseport, perf_default_worker_threads,
+    perf_default_pin_workers, perf_default_reuseport, perf_default_udp_recv_buffer_bytes,
+    perf_default_udp_send_buffer_bytes, perf_default_worker_threads,
 };
 
 #[derive(Debug, Deserialize, Clone)]
@@ -169,6 +170,12 @@ pub struct Performance {
 
     #[serde(default = "perf_default_backend_body_total_timeout_ms")]
     pub backend_body_total_timeout_ms: u64,
+
+    #[serde(default = "perf_default_udp_recv_buffer_bytes")]
+    pub udp_recv_buffer_bytes: usize,
+
+    #[serde(default = "perf_default_udp_send_buffer_bytes")]
+    pub udp_send_buffer_bytes: usize,
 }
 
 impl Default for Performance {
@@ -183,6 +190,8 @@ impl Default for Performance {
             backend_timeout_ms: perf_default_backend_timeout_ms(),
             backend_body_idle_timeout_ms: perf_default_backend_body_idle_timeout_ms(),
             backend_body_total_timeout_ms: perf_default_backend_body_total_timeout_ms(),
+            udp_recv_buffer_bytes: perf_default_udp_recv_buffer_bytes(),
+            udp_send_buffer_bytes: perf_default_udp_send_buffer_bytes(),
         }
     }
 }

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -10,7 +10,8 @@ use crate::default::{
     observe_default_address, observe_default_metrics_path, observe_default_port,
     perf_default_backend_body_idle_timeout_ms, perf_default_backend_body_total_timeout_ms,
     perf_default_backend_timeout_ms, perf_default_control_plane_threads,
-    perf_default_global_inflight_limit, perf_default_per_upstream_inflight_limit,
+    perf_default_global_inflight_limit, perf_default_h2_pool_idle_timeout_ms,
+    perf_default_h2_pool_max_idle_per_backend, perf_default_per_upstream_inflight_limit,
     perf_default_pin_workers, perf_default_reuseport, perf_default_udp_recv_buffer_bytes,
     perf_default_udp_send_buffer_bytes, perf_default_worker_threads,
 };
@@ -176,6 +177,12 @@ pub struct Performance {
 
     #[serde(default = "perf_default_udp_send_buffer_bytes")]
     pub udp_send_buffer_bytes: usize,
+
+    #[serde(default = "perf_default_h2_pool_max_idle_per_backend")]
+    pub h2_pool_max_idle_per_backend: usize,
+
+    #[serde(default = "perf_default_h2_pool_idle_timeout_ms")]
+    pub h2_pool_idle_timeout_ms: u64,
 }
 
 impl Default for Performance {
@@ -192,6 +199,8 @@ impl Default for Performance {
             backend_body_total_timeout_ms: perf_default_backend_body_total_timeout_ms(),
             udp_recv_buffer_bytes: perf_default_udp_recv_buffer_bytes(),
             udp_send_buffer_bytes: perf_default_udp_send_buffer_bytes(),
+            h2_pool_max_idle_per_backend: perf_default_h2_pool_max_idle_per_backend(),
+            h2_pool_idle_timeout_ms: perf_default_h2_pool_idle_timeout_ms(),
         }
     }
 }

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -11,9 +11,10 @@ use crate::default::{
     perf_default_backend_body_idle_timeout_ms, perf_default_backend_body_total_timeout_ms,
     perf_default_backend_timeout_ms, perf_default_control_plane_threads,
     perf_default_global_inflight_limit, perf_default_h2_pool_idle_timeout_ms,
-    perf_default_h2_pool_max_idle_per_backend, perf_default_per_upstream_inflight_limit,
-    perf_default_pin_workers, perf_default_reuseport, perf_default_udp_recv_buffer_bytes,
-    perf_default_udp_send_buffer_bytes, perf_default_worker_threads,
+    perf_default_h2_pool_max_idle_per_backend, perf_default_per_backend_inflight_limit,
+    perf_default_per_upstream_inflight_limit, perf_default_pin_workers, perf_default_reuseport,
+    perf_default_udp_recv_buffer_bytes, perf_default_udp_send_buffer_bytes,
+    perf_default_worker_threads,
 };
 
 #[derive(Debug, Deserialize, Clone)]
@@ -183,6 +184,9 @@ pub struct Performance {
 
     #[serde(default = "perf_default_h2_pool_idle_timeout_ms")]
     pub h2_pool_idle_timeout_ms: u64,
+
+    #[serde(default = "perf_default_per_backend_inflight_limit")]
+    pub per_backend_inflight_limit: usize,
 }
 
 impl Default for Performance {
@@ -201,6 +205,7 @@ impl Default for Performance {
             udp_send_buffer_bytes: perf_default_udp_send_buffer_bytes(),
             h2_pool_max_idle_per_backend: perf_default_h2_pool_max_idle_per_backend(),
             h2_pool_idle_timeout_ms: perf_default_h2_pool_idle_timeout_ms(),
+            per_backend_inflight_limit: perf_default_per_backend_inflight_limit(),
         }
     }
 }

--- a/crates/config/src/default.rs
+++ b/crates/config/src/default.rs
@@ -122,6 +122,10 @@ pub fn perf_default_h2_pool_idle_timeout_ms() -> u64 {
     90_000
 }
 
+pub fn perf_default_per_backend_inflight_limit() -> usize {
+    64
+}
+
 pub fn observe_default_address() -> String {
     String::from("127.0.0.1")
 }

--- a/crates/config/src/default.rs
+++ b/crates/config/src/default.rs
@@ -114,6 +114,14 @@ pub fn perf_default_udp_send_buffer_bytes() -> usize {
     8 * 1024 * 1024
 }
 
+pub fn perf_default_h2_pool_max_idle_per_backend() -> usize {
+    256
+}
+
+pub fn perf_default_h2_pool_idle_timeout_ms() -> u64 {
+    90_000
+}
+
 pub fn observe_default_address() -> String {
     String::from("127.0.0.1")
 }

--- a/crates/config/src/default.rs
+++ b/crates/config/src/default.rs
@@ -106,6 +106,14 @@ pub fn perf_default_backend_body_total_timeout_ms() -> u64 {
     30_000
 }
 
+pub fn perf_default_udp_recv_buffer_bytes() -> usize {
+    8 * 1024 * 1024
+}
+
+pub fn perf_default_udp_send_buffer_bytes() -> usize {
+    8 * 1024 * 1024
+}
+
 pub fn observe_default_address() -> String {
     String::from("127.0.0.1")
 }

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -139,6 +139,11 @@ pub fn validate(config: &Config) -> bool {
         return false;
     }
 
+    if config.performance.per_backend_inflight_limit == 0 {
+        error!("performance.per_backend_inflight_limit must be greater than 0");
+        return false;
+    }
+
     if config.performance.backend_body_total_timeout_ms
         < config.performance.backend_body_idle_timeout_ms
     {
@@ -457,6 +462,7 @@ upstream:
         assert_eq!(cfg.performance.udp_send_buffer_bytes, 8 * 1024 * 1024);
         assert_eq!(cfg.performance.h2_pool_max_idle_per_backend, 256);
         assert_eq!(cfg.performance.h2_pool_idle_timeout_ms, 90_000);
+        assert_eq!(cfg.performance.per_backend_inflight_limit, 64);
         assert!(!cfg.observability.metrics.enabled);
         assert_eq!(cfg.observability.metrics.path, "/metrics");
     }
@@ -500,6 +506,10 @@ upstream:
         assert!(!validate(&cfg));
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.performance.per_backend_inflight_limit = 0;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.observability = Observability {
             metrics: MetricsEndpoint {
                 enabled: true,
@@ -533,6 +543,7 @@ upstream:
         cfg.performance.udp_send_buffer_bytes = 4 * 1024 * 1024;
         cfg.performance.h2_pool_max_idle_per_backend = 128;
         cfg.performance.h2_pool_idle_timeout_ms = 120_000;
+        cfg.performance.per_backend_inflight_limit = 32;
         cfg.observability = Observability {
             metrics: MetricsEndpoint {
                 enabled: true,

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -129,6 +129,16 @@ pub fn validate(config: &Config) -> bool {
         return false;
     }
 
+    if config.performance.h2_pool_max_idle_per_backend == 0 {
+        error!("performance.h2_pool_max_idle_per_backend must be greater than 0");
+        return false;
+    }
+
+    if config.performance.h2_pool_idle_timeout_ms == 0 {
+        error!("performance.h2_pool_idle_timeout_ms must be greater than 0");
+        return false;
+    }
+
     if config.performance.backend_body_total_timeout_ms
         < config.performance.backend_body_idle_timeout_ms
     {
@@ -445,6 +455,8 @@ upstream:
         assert_eq!(cfg.performance.backend_body_total_timeout_ms, 30000);
         assert_eq!(cfg.performance.udp_recv_buffer_bytes, 8 * 1024 * 1024);
         assert_eq!(cfg.performance.udp_send_buffer_bytes, 8 * 1024 * 1024);
+        assert_eq!(cfg.performance.h2_pool_max_idle_per_backend, 256);
+        assert_eq!(cfg.performance.h2_pool_idle_timeout_ms, 90_000);
         assert!(!cfg.observability.metrics.enabled);
         assert_eq!(cfg.observability.metrics.path, "/metrics");
     }
@@ -480,6 +492,14 @@ upstream:
         assert!(!validate(&cfg));
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.performance.h2_pool_max_idle_per_backend = 0;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.performance.h2_pool_idle_timeout_ms = 0;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.observability = Observability {
             metrics: MetricsEndpoint {
                 enabled: true,
@@ -511,6 +531,8 @@ upstream:
         cfg.performance.backend_body_total_timeout_ms = 10_000;
         cfg.performance.udp_recv_buffer_bytes = 4 * 1024 * 1024;
         cfg.performance.udp_send_buffer_bytes = 4 * 1024 * 1024;
+        cfg.performance.h2_pool_max_idle_per_backend = 128;
+        cfg.performance.h2_pool_idle_timeout_ms = 120_000;
         cfg.observability = Observability {
             metrics: MetricsEndpoint {
                 enabled: true,

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -119,6 +119,16 @@ pub fn validate(config: &Config) -> bool {
         return false;
     }
 
+    if config.performance.udp_recv_buffer_bytes == 0 {
+        error!("performance.udp_recv_buffer_bytes must be greater than 0");
+        return false;
+    }
+
+    if config.performance.udp_send_buffer_bytes == 0 {
+        error!("performance.udp_send_buffer_bytes must be greater than 0");
+        return false;
+    }
+
     if config.performance.backend_body_total_timeout_ms
         < config.performance.backend_body_idle_timeout_ms
     {
@@ -433,6 +443,8 @@ upstream:
         assert_eq!(cfg.performance.backend_timeout_ms, 2000);
         assert_eq!(cfg.performance.backend_body_idle_timeout_ms, 2000);
         assert_eq!(cfg.performance.backend_body_total_timeout_ms, 30000);
+        assert_eq!(cfg.performance.udp_recv_buffer_bytes, 8 * 1024 * 1024);
+        assert_eq!(cfg.performance.udp_send_buffer_bytes, 8 * 1024 * 1024);
         assert!(!cfg.observability.metrics.enabled);
         assert_eq!(cfg.observability.metrics.path, "/metrics");
     }
@@ -457,6 +469,14 @@ upstream:
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.performance.backend_body_total_timeout_ms = 100;
         cfg.performance.backend_body_idle_timeout_ms = 200;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.performance.udp_recv_buffer_bytes = 0;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.performance.udp_send_buffer_bytes = 0;
         assert!(!validate(&cfg));
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
@@ -489,6 +509,8 @@ upstream:
         cfg.performance.backend_timeout_ms = 1500;
         cfg.performance.backend_body_idle_timeout_ms = 500;
         cfg.performance.backend_body_total_timeout_ms = 10_000;
+        cfg.performance.udp_recv_buffer_bytes = 4 * 1024 * 1024;
+        cfg.performance.udp_send_buffer_bytes = 4 * 1024 * 1024;
         cfg.observability = Observability {
             metrics: MetricsEndpoint {
                 enabled: true,

--- a/crates/edge/Cargo.toml
+++ b/crates/edge/Cargo.toml
@@ -20,7 +20,6 @@ hyper-util.workspace = true
 tokio.workspace = true
 serial_test = "3"
 rand.workspace = true
-smallvec.workspace = true
 hmac = "0.12"
 sha2 = "0.10"
 hex = "0.4"

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -25,7 +25,7 @@ use rand::RngCore;
 use smallvec::SmallVec;
 use socket2::{Domain, Protocol, Socket, Type};
 use spooky_bridge::h3_to_h2::build_h2_request;
-use spooky_errors::ProxyError;
+use spooky_errors::{PoolError, ProxyError};
 use spooky_lb::{HealthTransition, UpstreamPool};
 use spooky_transport::h2_pool::H2Pool;
 use tokio::runtime::Handle;
@@ -78,7 +78,7 @@ impl QUICListener {
         let max_inflight_per_backend = MAX_INFLIGHT_PER_BACKEND.saturating_mul(worker_threads);
 
         info!(
-            "Performance profile: worker_threads={} control_plane_threads={} reuseport={} pin_workers={} global_inflight_limit={} per_upstream_inflight_limit={} backend_timeout_ms={} backend_body_idle_timeout_ms={} backend_body_total_timeout_ms={} udp_recv_buffer_bytes={} udp_send_buffer_bytes={}",
+            "Performance profile: worker_threads={} control_plane_threads={} reuseport={} pin_workers={} global_inflight_limit={} per_upstream_inflight_limit={} backend_timeout_ms={} backend_body_idle_timeout_ms={} backend_body_total_timeout_ms={} udp_recv_buffer_bytes={} udp_send_buffer_bytes={} h2_pool_max_idle_per_backend={} h2_pool_idle_timeout_ms={}",
             worker_threads,
             config.performance.control_plane_threads.max(1),
             config.performance.reuseport,
@@ -89,7 +89,9 @@ impl QUICListener {
             config.performance.backend_body_idle_timeout_ms,
             config.performance.backend_body_total_timeout_ms,
             config.performance.udp_recv_buffer_bytes,
-            config.performance.udp_send_buffer_bytes
+            config.performance.udp_send_buffer_bytes,
+            config.performance.h2_pool_max_idle_per_backend,
+            config.performance.h2_pool_idle_timeout_ms
         );
 
         let backend_addresses = config
@@ -103,7 +105,12 @@ impl QUICListener {
             })
             .collect::<Vec<_>>();
 
-        let h2_pool = Arc::new(H2Pool::new(backend_addresses, max_inflight_per_backend));
+        let h2_pool = Arc::new(H2Pool::new(
+            backend_addresses,
+            max_inflight_per_backend,
+            config.performance.h2_pool_max_idle_per_backend,
+            Duration::from_millis(config.performance.h2_pool_idle_timeout_ms),
+        ));
         let mut upstream_pools = HashMap::new();
         let mut upstream_inflight = HashMap::new();
 
@@ -1077,6 +1084,47 @@ impl QUICListener {
                                     }
                                 };
 
+                            match h2_pool.has_capacity(&addr) {
+                                Ok(true) => {}
+                                Ok(false) => {
+                                    drop(upstream_permit);
+                                    drop(global_permit);
+                                    metrics.inc_failure();
+                                    metrics.inc_overload_shed();
+                                    metrics.record_route(
+                                        &upstream_name,
+                                        request_start.elapsed(),
+                                        RouteOutcome::OverloadShed,
+                                    );
+                                    Self::send_simple_response(
+                                        h3,
+                                        &mut connection.quic,
+                                        stream_id,
+                                        http::StatusCode::SERVICE_UNAVAILABLE,
+                                        b"backend overloaded, retry later\n",
+                                    )?;
+                                    continue;
+                                }
+                                Err(_) => {
+                                    drop(upstream_permit);
+                                    drop(global_permit);
+                                    metrics.inc_failure();
+                                    metrics.record_route(
+                                        &upstream_name,
+                                        request_start.elapsed(),
+                                        RouteOutcome::Failure,
+                                    );
+                                    Self::send_simple_response(
+                                        h3,
+                                        &mut connection.quic,
+                                        stream_id,
+                                        http::StatusCode::SERVICE_UNAVAILABLE,
+                                        b"no upstream available\n",
+                                    )?;
+                                    continue;
+                                }
+                            }
+
                             // Create a channel body so quiche Data chunks stream
                             // directly into the in-flight H2 request.
                             let (tx, channel_body) =
@@ -1729,7 +1777,28 @@ impl QUICListener {
                     b"invalid request\n",
                 )
             }
-            Err(ProxyError::Transport(_)) | Err(ProxyError::Pool(_)) => {
+            Err(ProxyError::Pool(PoolError::BackendOverloaded(_))) => {
+                info!("Backend overloaded");
+                metrics.inc_failure();
+                metrics.inc_overload_shed();
+                metrics.record_route(route_label, start.elapsed(), RouteOutcome::OverloadShed);
+                info!(
+                    "Upstream {} status 503 latency_ms {}",
+                    backend_addr,
+                    start.elapsed().as_millis()
+                );
+                Self::send_simple_response(
+                    h3,
+                    quic,
+                    stream_id,
+                    http::StatusCode::SERVICE_UNAVAILABLE,
+                    b"backend overloaded, retry later\n",
+                )
+            }
+            Err(ProxyError::Transport(_))
+            | Err(ProxyError::Pool(PoolError::Send(_)))
+            | Err(ProxyError::Pool(PoolError::InflightLimiterClosed))
+            | Err(ProxyError::Pool(PoolError::UnknownBackend(_))) => {
                 error!("Transport error");
                 if let Some(pool) = &upstream_pool
                     && let Some(t) = pool

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -78,7 +78,7 @@ impl QUICListener {
         let max_inflight_per_backend = MAX_INFLIGHT_PER_BACKEND.saturating_mul(worker_threads);
 
         info!(
-            "Performance profile: worker_threads={} control_plane_threads={} reuseport={} pin_workers={} global_inflight_limit={} per_upstream_inflight_limit={} backend_timeout_ms={} backend_body_idle_timeout_ms={} backend_body_total_timeout_ms={}",
+            "Performance profile: worker_threads={} control_plane_threads={} reuseport={} pin_workers={} global_inflight_limit={} per_upstream_inflight_limit={} backend_timeout_ms={} backend_body_idle_timeout_ms={} backend_body_total_timeout_ms={} udp_recv_buffer_bytes={} udp_send_buffer_bytes={}",
             worker_threads,
             config.performance.control_plane_threads.max(1),
             config.performance.reuseport,
@@ -87,7 +87,9 @@ impl QUICListener {
             per_upstream_limit,
             config.performance.backend_timeout_ms,
             config.performance.backend_body_idle_timeout_ms,
-            config.performance.backend_body_total_timeout_ms
+            config.performance.backend_body_total_timeout_ms,
+            config.performance.udp_recv_buffer_bytes,
+            config.performance.udp_send_buffer_bytes
         );
 
         let backend_addresses = config
@@ -147,7 +149,12 @@ impl QUICListener {
 
     pub fn bind_socket(config: &SpookyConfig, reuse_port: bool) -> Result<UdpSocket, ProxyError> {
         let bind_addr = Self::resolve_bind_addr(config)?;
-        let socket = Self::create_udp_socket(bind_addr, reuse_port)?;
+        let socket = Self::create_udp_socket(
+            bind_addr,
+            reuse_port,
+            config.performance.udp_recv_buffer_bytes,
+            config.performance.udp_send_buffer_bytes,
+        )?;
         socket
             .set_read_timeout(Some(Duration::from_millis(UDP_READ_TIMEOUT_MS)))
             .map_err(|err| {
@@ -220,7 +227,12 @@ impl QUICListener {
             })
     }
 
-    fn create_udp_socket(bind_addr: SocketAddr, reuse_port: bool) -> Result<UdpSocket, ProxyError> {
+    fn create_udp_socket(
+        bind_addr: SocketAddr,
+        reuse_port: bool,
+        udp_recv_buffer_bytes: usize,
+        udp_send_buffer_bytes: usize,
+    ) -> Result<UdpSocket, ProxyError> {
         let domain = if bind_addr.is_ipv4() {
             Domain::IPV4
         } else {
@@ -232,6 +244,22 @@ impl QUICListener {
         socket
             .set_reuse_address(true)
             .map_err(|err| ProxyError::Transport(format!("failed to set SO_REUSEADDR: {}", err)))?;
+        socket
+            .set_recv_buffer_size(udp_recv_buffer_bytes)
+            .map_err(|err| {
+                ProxyError::Transport(format!(
+                    "failed to set UDP recv buffer size ({}): {}",
+                    udp_recv_buffer_bytes, err
+                ))
+            })?;
+        socket
+            .set_send_buffer_size(udp_send_buffer_bytes)
+            .map_err(|err| {
+                ProxyError::Transport(format!(
+                    "failed to set UDP send buffer size ({}): {}",
+                    udp_send_buffer_bytes, err
+                ))
+            })?;
 
         #[cfg(all(
             unix,
@@ -251,6 +279,27 @@ impl QUICListener {
                 bind_addr, err
             ))
         })?;
+
+        match (socket.recv_buffer_size(), socket.send_buffer_size()) {
+            (Ok(actual_recv), Ok(actual_send)) => {
+                debug!(
+                    "UDP socket buffers on {}: recv={} (requested={}) send={} (requested={}) reuseport={}",
+                    bind_addr,
+                    actual_recv,
+                    udp_recv_buffer_bytes,
+                    actual_send,
+                    udp_send_buffer_bytes,
+                    reuse_port
+                );
+            }
+            _ => {
+                debug!(
+                    "UDP socket bound on {} with requested buffers recv={} send={} reuseport={}",
+                    bind_addr, udp_recv_buffer_bytes, udp_send_buffer_bytes, reuse_port
+                );
+            }
+        }
+
         Ok(socket.into())
     }
 

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -22,7 +22,6 @@ use log::{debug, error, info, warn};
 use quiche::Config;
 use quiche::h3::NameValue;
 use rand::RngCore;
-use smallvec::SmallVec;
 use socket2::{Domain, Protocol, Socket, Type};
 use spooky_bridge::h3_to_h2::build_h2_request;
 use spooky_errors::{PoolError, ProxyError};
@@ -42,10 +41,10 @@ use crate::{
     ResponseChunk, RouteOutcome, SharedRuntimeState, StreamPhase,
     cid_radix::CidRadix,
     constants::{
-        DEFAULT_SCID_LEN_BYTES, MAX_DATAGRAM_SIZE_BYTES, MAX_INFLIGHT_PER_BACKEND,
-        MAX_REQUEST_BODY_BYTES, MAX_UDP_PAYLOAD_BYTES, MIN_SCID_LEN_BYTES, QUIC_IDLE_TIMEOUT_MS,
-        QUIC_INITIAL_MAX_DATA, QUIC_INITIAL_MAX_STREAMS_BIDI, QUIC_INITIAL_MAX_STREAMS_UNI,
-        QUIC_INITIAL_STREAM_DATA, REQUEST_BUFFERED_CHUNK_BYTES_LIMIT, REQUEST_CHUNK_BYTES_LIMIT,
+        DEFAULT_SCID_LEN_BYTES, MAX_DATAGRAM_SIZE_BYTES, MAX_REQUEST_BODY_BYTES,
+        MAX_UDP_PAYLOAD_BYTES, MIN_SCID_LEN_BYTES, QUIC_IDLE_TIMEOUT_MS, QUIC_INITIAL_MAX_DATA,
+        QUIC_INITIAL_MAX_STREAMS_BIDI, QUIC_INITIAL_MAX_STREAMS_UNI, QUIC_INITIAL_STREAM_DATA,
+        REQUEST_BUFFERED_CHUNK_BYTES_LIMIT, REQUEST_CHUNK_BYTES_LIMIT,
         REQUEST_CHUNK_CHANNEL_CAPACITY, RESET_TOKEN_LEN_BYTES, RESPONSE_CHUNK_BYTES_LIMIT,
         RESPONSE_CHUNK_CHANNEL_CAPACITY, SCID_ROTATION_PACKET_THRESHOLD, UDP_READ_TIMEOUT_MS,
         drain_timeout, scid_rotation_interval,
@@ -75,16 +74,20 @@ impl QUICListener {
         let worker_threads = config.performance.worker_threads.max(1);
         let per_upstream_limit = config.performance.per_upstream_inflight_limit.max(1);
         let global_inflight_limit = config.performance.global_inflight_limit.max(1);
-        let max_inflight_per_backend = MAX_INFLIGHT_PER_BACKEND.saturating_mul(worker_threads);
+        let max_inflight_per_backend = config
+            .performance
+            .per_backend_inflight_limit
+            .saturating_mul(worker_threads);
 
         info!(
-            "Performance profile: worker_threads={} control_plane_threads={} reuseport={} pin_workers={} global_inflight_limit={} per_upstream_inflight_limit={} backend_timeout_ms={} backend_body_idle_timeout_ms={} backend_body_total_timeout_ms={} udp_recv_buffer_bytes={} udp_send_buffer_bytes={} h2_pool_max_idle_per_backend={} h2_pool_idle_timeout_ms={}",
+            "Performance profile: worker_threads={} control_plane_threads={} reuseport={} pin_workers={} global_inflight_limit={} per_upstream_inflight_limit={} per_backend_inflight_limit={} backend_timeout_ms={} backend_body_idle_timeout_ms={} backend_body_total_timeout_ms={} udp_recv_buffer_bytes={} udp_send_buffer_bytes={} h2_pool_max_idle_per_backend={} h2_pool_idle_timeout_ms={}",
             worker_threads,
             config.performance.control_plane_threads.max(1),
             config.performance.reuseport,
             config.performance.pin_workers,
             global_inflight_limit,
             per_upstream_limit,
+            config.performance.per_backend_inflight_limit,
             config.performance.backend_timeout_ms,
             config.performance.backend_body_idle_timeout_ms,
             config.performance.backend_body_total_timeout_ms,
@@ -975,11 +978,8 @@ impl QUICListener {
                     let mut method = String::new();
                     let mut path = String::new();
                     let mut authority = None;
-                    let mut headers =
-                        SmallVec::<[(Vec<u8>, Vec<u8>); 16]>::with_capacity(list.len());
 
-                    for header in list {
-                        headers.push((header.name().to_vec(), header.value().to_vec()));
+                    for header in &list {
                         match header.name() {
                             b":method" => {
                                 method = String::from_utf8_lossy(header.value()).to_string()
@@ -1130,24 +1130,35 @@ impl QUICListener {
                             let (tx, channel_body) =
                                 ChannelBody::channel(REQUEST_CHUNK_CHANNEL_CAPACITY);
                             let boxed = channel_body.boxed();
+                            let request =
+                                match build_h2_request(&addr, &method, &path, &list, boxed, None) {
+                                    Ok(request) => request,
+                                    Err(err) => {
+                                        drop(upstream_permit);
+                                        drop(global_permit);
+                                        metrics.inc_failure();
+                                        metrics.record_route(
+                                            &upstream_name,
+                                            request_start.elapsed(),
+                                            RouteOutcome::Failure,
+                                        );
+                                        Self::send_simple_response(
+                                            h3,
+                                            &mut connection.quic,
+                                            stream_id,
+                                            http::StatusCode::BAD_REQUEST,
+                                            b"invalid request\n",
+                                        )?;
+                                        error!("failed to build upstream request: {}", err);
+                                        continue;
+                                    }
+                                };
+
                             let h2 = h2_pool.clone();
-                            let req_method = method.clone();
-                            let req_path = path.clone();
                             let fwd_addr = addr.clone();
-                            let request_headers = headers;
                             let (result_tx, result_rx) = oneshot::channel::<ForwardResult>();
                             let fut = async move {
                                 let result = async {
-                                    let request = build_h2_request(
-                                        &fwd_addr,
-                                        &req_method,
-                                        &req_path,
-                                        &request_headers,
-                                        boxed,
-                                        None,
-                                    )
-                                    .map_err(ProxyError::Bridge)?;
-
                                     let response = tokio::time::timeout(
                                         backend_timeout,
                                         h2.send(&fwd_addr, request),

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -1132,6 +1132,51 @@ fn upstream_inflight_limit_sheds_excess_requests() {
 }
 
 #[test]
+fn backend_pool_inflight_limit_sheds_excess_requests() {
+    let dir = tempdir().expect("failed to create temp dir");
+    let (cert, key) = write_test_certs(&dir);
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+
+    let backend_addr = rt.block_on(start_h2_backend_with_regression_routes());
+    let mut config = make_config(0, backend_addr.to_string(), cert, key);
+    config.performance.global_inflight_limit = 64;
+    config.performance.per_upstream_inflight_limit = 64;
+    config.performance.per_backend_inflight_limit = 1;
+
+    let listener = QUICListener::new(config).expect("failed to create listener");
+    let listen_addr = listener.socket.local_addr().unwrap();
+    let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
+
+    let observations = run_h3_client_concurrent_get(
+        listen_addr,
+        &["/slow", "/slow"],
+        Duration::from_secs(REQUEST_TIMEOUT_SECS + 4),
+    )
+    .expect("concurrent requests should complete");
+
+    let mut status_200 = 0usize;
+    let mut status_503 = 0usize;
+    let mut shed_body = String::new();
+    for obs in &observations {
+        match obs.status.as_deref() {
+            Some("200") => status_200 += 1,
+            Some("503") => {
+                status_503 += 1;
+                shed_body = String::from_utf8_lossy(&obs.body).to_string();
+            }
+            other => panic!("unexpected status: {:?}", other),
+        }
+    }
+
+    assert_eq!(status_200, 1, "expected one successful request");
+    assert_eq!(status_503, 1, "expected one shed request");
+    assert!(
+        shed_body.contains("backend overloaded"),
+        "shed body should mention backend overload, got: {shed_body}"
+    );
+}
+
+#[test]
 fn backend_timeout_respects_configured_performance_value() {
     let dir = tempdir().expect("failed to create temp dir");
     let (cert, key) = write_test_certs(&dir);

--- a/crates/errors/src/lib.rs
+++ b/crates/errors/src/lib.rs
@@ -22,6 +22,9 @@ pub enum PoolError {
     #[error("unknown backend: {0}")]
     UnknownBackend(String),
 
+    #[error("backend overloaded: {0}")]
+    BackendOverloaded(String),
+
     #[error("send failed: {0}")]
     Send(#[source] hyper_util::client::legacy::Error),
 

--- a/crates/transport/src/h2_client.rs
+++ b/crates/transport/src/h2_client.rs
@@ -1,5 +1,6 @@
 use std::convert::Infallible;
 use std::future::Future;
+use std::time::Duration;
 
 use http_body_util::combinators::BoxBody;
 use hyper::body::Bytes;
@@ -24,11 +25,15 @@ where
 }
 
 impl H2Client {
-    pub fn new() -> Self {
+    pub fn new(max_idle_per_host: usize, pool_idle_timeout: Duration) -> Self {
         let mut http = HttpConnector::new();
         http.enforce_http(false);
 
-        let client = Client::builder(TokioExecutor).http2_only(true).build(http);
+        let client = Client::builder(TokioExecutor)
+            .http2_only(true)
+            .pool_max_idle_per_host(max_idle_per_host)
+            .pool_idle_timeout(pool_idle_timeout)
+            .build(http);
 
         Self { client }
     }
@@ -43,6 +48,6 @@ impl H2Client {
 
 impl Default for H2Client {
     fn default() -> Self {
-        Self::new()
+        Self::new(64, Duration::from_secs(30))
     }
 }

--- a/crates/transport/src/h2_pool.rs
+++ b/crates/transport/src/h2_pool.rs
@@ -1,9 +1,9 @@
-use std::{collections::HashMap, convert::Infallible, sync::Arc};
+use std::{collections::HashMap, convert::Infallible, sync::Arc, time::Duration};
 
 use http_body_util::combinators::BoxBody;
 use hyper::Request;
 use hyper::body::{Bytes, Incoming};
-use tokio::sync::Semaphore;
+use tokio::sync::{Semaphore, TryAcquireError};
 
 use crate::h2_client::H2Client;
 pub use spooky_errors::PoolError;
@@ -18,17 +18,23 @@ pub struct H2Pool {
 }
 
 impl H2Pool {
-    pub fn new<I>(backends: I, max_inflight: usize) -> Self
+    pub fn new<I>(
+        backends: I,
+        max_inflight: usize,
+        max_idle_per_backend: usize,
+        pool_idle_timeout: Duration,
+    ) -> Self
     where
         I: IntoIterator<Item = String>,
     {
         let inflight = max_inflight.max(1);
+        let max_idle_per_backend = max_idle_per_backend.max(1);
         let mut map = HashMap::new();
         for backend in backends {
             map.insert(
                 backend,
                 BackendHandle {
-                    client: H2Client::new(),
+                    client: H2Client::new(max_idle_per_backend, pool_idle_timeout),
                     inflight: Arc::new(Semaphore::new(inflight)),
                 },
             );
@@ -38,6 +44,14 @@ impl H2Pool {
 
     pub fn has_backend(&self, backend: &str) -> bool {
         self.backends.contains_key(backend)
+    }
+
+    pub fn has_capacity(&self, backend: &str) -> Result<bool, PoolError> {
+        let handle = self
+            .backends
+            .get(backend)
+            .ok_or_else(|| PoolError::UnknownBackend(backend.to_string()))?;
+        Ok(handle.inflight.available_permits() > 0)
     }
 
     pub async fn send(
@@ -50,11 +64,13 @@ impl H2Pool {
             .get(backend)
             .ok_or_else(|| PoolError::UnknownBackend(backend.to_string()))?;
 
-        let _permit = handle
-            .inflight
-            .acquire()
-            .await
-            .map_err(|_| PoolError::InflightLimiterClosed)?;
+        let _permit = match Arc::clone(&handle.inflight).try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(TryAcquireError::NoPermits) => {
+                return Err(PoolError::BackendOverloaded(backend.to_string()));
+            }
+            Err(TryAcquireError::Closed) => return Err(PoolError::InflightLimiterClosed),
+        };
         handle.client.send(req).await.map_err(PoolError::Send)
     }
 }

--- a/crates/transport/tests/h2_pool.rs
+++ b/crates/transport/tests/h2_pool.rs
@@ -84,7 +84,12 @@ async fn pool_limits_inflight_per_backend() {
     let port = start_h2_server(tracker.clone()).await.unwrap();
     let backend = format!("127.0.0.1:{port}");
 
-    let pool = Arc::new(H2Pool::new(vec![backend.clone()], 1));
+    let pool = Arc::new(H2Pool::new(
+        vec![backend.clone()],
+        1,
+        64,
+        Duration::from_secs(30),
+    ));
     let req1 = Request::builder()
         .method("GET")
         .uri(format!("http://{backend}/"))
@@ -105,8 +110,17 @@ async fn pool_limits_inflight_per_backend() {
     let r2 = tokio::spawn(async move { pool2.send(&backend2, req2).await });
 
     let (r1, r2) = tokio::join!(r1, r2);
-    assert!(r1.unwrap().is_ok());
-    assert!(r2.unwrap().is_ok());
+    let r1 = r1.unwrap();
+    let r2 = r2.unwrap();
+    assert!(
+        r1.is_ok() || r2.is_ok(),
+        "at least one request should be admitted"
+    );
+    assert!(
+        matches!(r1, Err(PoolError::BackendOverloaded(_)))
+            || matches!(r2, Err(PoolError::BackendOverloaded(_))),
+        "one request should be rejected by backend inflight admission"
+    );
 
     let max = tracker.max.load(Ordering::SeqCst);
     assert_eq!(max, 1);
@@ -114,7 +128,12 @@ async fn pool_limits_inflight_per_backend() {
 
 #[tokio::test]
 async fn pool_rejects_unknown_backend() {
-    let pool = H2Pool::new(vec!["127.0.0.1:12345".to_string()], 1);
+    let pool = H2Pool::new(
+        vec!["127.0.0.1:12345".to_string()],
+        1,
+        64,
+        Duration::from_secs(30),
+    );
     let req = Request::builder()
         .method("GET")
         .uri("http://127.0.0.1:12345/")
@@ -126,4 +145,34 @@ async fn pool_rejects_unknown_backend() {
         PoolError::UnknownBackend(name) => assert_eq!(name, "127.0.0.1:9999"),
         _ => panic!("unexpected error"),
     }
+}
+
+#[tokio::test]
+async fn pool_capacity_probe_reflects_inflight_state() {
+    let tracker = Arc::new(ConcurrencyTracker::new());
+    let port = start_h2_server(tracker).await.unwrap();
+    let backend = format!("127.0.0.1:{port}");
+    let pool = Arc::new(H2Pool::new(
+        vec![backend.clone()],
+        1,
+        64,
+        Duration::from_secs(30),
+    ));
+
+    assert!(pool.has_capacity(&backend).unwrap());
+
+    let req = Request::builder()
+        .method("GET")
+        .uri(format!("http://{backend}/"))
+        .body(Full::new(Bytes::new()).boxed())
+        .unwrap();
+
+    let pool_task = Arc::clone(&pool);
+    let backend_task = backend.clone();
+    let handle = tokio::spawn(async move { pool_task.send(&backend_task, req).await });
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    assert!(!pool.has_capacity(&backend).unwrap());
+
+    let _ = handle.await.expect("request task join");
 }

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -74,6 +74,9 @@ Recommended runtime config pairing in `performance`:
 
 - `udp_recv_buffer_bytes: 8388608`
 - `udp_send_buffer_bytes: 8388608`
+- `h2_pool_max_idle_per_backend: 256`
+- `h2_pool_idle_timeout_ms: 90000`
+- `per_backend_inflight_limit: 64` (reduce for stricter overload shedding)
 
 ## Memory Guardrail Policy
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -62,6 +62,19 @@ Current thresholds:
 
 Regression checks fail if benchmark metrics exceed thresholds versus baseline.
 
+## Linux Burst-Tolerance Tuning
+
+For high-burst UDP traffic tests, tune host kernel networking before benchmarking:
+
+```bash
+sudo ./scripts/sysctl-linux-network-tuning.sh
+```
+
+Recommended runtime config pairing in `performance`:
+
+- `udp_recv_buffer_bytes: 8388608`
+- `udp_send_buffer_bytes: 8388608`
+
 ## Memory Guardrail Policy
 
 All performance-related changes must include memory deltas in reports.

--- a/scripts/sysctl-linux-network-tuning.sh
+++ b/scripts/sysctl-linux-network-tuning.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "This script only supports Linux."
+  exit 1
+fi
+
+if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
+  echo "Run as root: sudo $0"
+  exit 1
+fi
+
+declare -A TUNING=(
+  ["net.core.rmem_max"]="33554432"
+  ["net.core.wmem_max"]="33554432"
+  ["net.core.rmem_default"]="8388608"
+  ["net.core.wmem_default"]="8388608"
+  ["net.core.netdev_max_backlog"]="250000"
+  ["net.ipv4.udp_rmem_min"]="16384"
+  ["net.ipv4.udp_wmem_min"]="16384"
+)
+
+echo "Applying Spooky network sysctl tuning..."
+for key in "${!TUNING[@]}"; do
+  value="${TUNING[$key]}"
+  sysctl -w "${key}=${value}" >/dev/null
+  current="$(sysctl -n "$key")"
+  echo "${key}=${current}"
+done
+
+echo
+echo "Done. Persist these values in /etc/sysctl.d/99-spooky-network.conf if needed."


### PR DESCRIPTION
## Summary
This PR hardens Spooky’s runtime hot path for burst traffic and overload control by:
- tuning UDP socket buffering and documenting kernel sysctl settings,
- enforcing bounded backend admission with explicit backpressure propagation,
- improving H2 connection reuse controls, and
- removing clone-heavy header copying in the H3→H2 bridge path.

## What changed

### 1) UDP burst tolerance
- Added performance config:
  - `udp_recv_buffer_bytes`
  - `udp_send_buffer_bytes`
- Applied socket buffer sizing at UDP socket creation.
- Added debug logging for requested vs effective UDP buffer sizes.
- Added Linux sysctl tuning helper:
  - `scripts/sysctl-linux-network-tuning.sh`
- Updated benchmark docs with tuning guidance.

### 2) Backend reuse + bounded inflight
- Added performance config:
  - `h2_pool_max_idle_per_backend`
  - `h2_pool_idle_timeout_ms`
  - `per_backend_inflight_limit`
- H2 pool now uses non-blocking per-backend inflight admission (`try_acquire_owned`).
- Introduced explicit pool overload error:
  - `PoolError::BackendOverloaded(String)`
- H2 client pool builder now honors idle pool tuning knobs.

### 3) Backpressure propagation to edge admission
- Edge now checks backend pool capacity before spawning upstream forward task.
- Saturated backend admission returns `503 Service Unavailable` with overload message.
- Preserved/updated overload metrics accounting (`overload_shed`, route-level outcomes).

### 4) Copy reduction in protocol bridge
- Refactored `build_h2_request` to consume `&[quiche::h3::Header]` directly.
- Removed per-request clone-heavy `SmallVec<(Vec<u8>, Vec<u8>)>` header buffering on the hot path.
- Request build failure now handled early with immediate `400` response.

## Config updates
`performance` now includes:
- `udp_recv_buffer_bytes`
- `udp_send_buffer_bytes`
- `h2_pool_max_idle_per_backend`
- `h2_pool_idle_timeout_ms`
- `per_backend_inflight_limit`

`config/config.sample.yaml` updated accordingly.

## Tests and validation
- `cargo fmt`
- `cargo check`
- `cargo test -p spooky-config`
- `cargo test -p spooky-transport --test h2_pool`
- `cargo test -p spooky-edge --test h3_edge`
- `cargo test -p spooky-edge --test h3_bridge metrics_endpoint_exposes_route_slo_metrics`
- `cargo test -p spooky-edge --test h3_bridge backend_pool_inflight_limit_sheds_excess_requests`

Added/updated tests:
- H2 pool overload/capacity behavior in `crates/transport/tests/h2_pool.rs`
- Edge integration test for backend pool inflight shedding in `crates/edge/tests/h3_bridge.rs`

## Notes
- This PR focuses on runtime safety and admission behavior under load; long-running soak/load benchmarks are intentionally left for manual execution.