### PR TITLE
Runtime Resilience Hardening: Adaptive Admission, Circuit Breaking, Retry Budgets, and Brownout

### DIFF
--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -63,8 +63,10 @@ performance:
     global_inflight_limit: 4096
     per_upstream_inflight_limit: 1024
     backend_timeout_ms: 2000
+    backend_connect_timeout_ms: 500
     backend_body_idle_timeout_ms: 2000
     backend_body_total_timeout_ms: 30000
+    backend_total_request_timeout_ms: 35000
     udp_recv_buffer_bytes: 8388608
     udp_send_buffer_bytes: 8388608
     h2_pool_max_idle_per_backend: 256
@@ -77,3 +79,33 @@ observability:
         address: "127.0.0.1"
         port: 9901
         path: "/metrics"
+
+resilience:
+    adaptive_admission:
+        enabled: true
+        min_limit: 64
+        decrease_step: 16
+        increase_step: 8
+        high_latency_ms: 250
+    route_queue:
+        default_cap: 512
+        caps: {}
+    circuit_breaker:
+        enabled: true
+        failure_threshold: 5
+        open_ms: 10000
+        half_open_max_probes: 2
+    hedging:
+        enabled: false
+        delay_ms: 75
+        safe_methods: ["GET", "HEAD"]
+        route_allowlist: []
+    retry_budget:
+        enabled: true
+        ratio_percent: 20
+        per_route_ratio_percent: {}
+    brownout:
+        enabled: true
+        trigger_inflight_percent: 90
+        recover_inflight_percent: 60
+        core_routes: []

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -9,12 +9,21 @@ use crate::default::{
     get_default_protocol, get_default_success_threshold, get_default_version, get_default_weight,
     observe_default_address, observe_default_metrics_path, observe_default_port,
     perf_default_backend_body_idle_timeout_ms, perf_default_backend_body_total_timeout_ms,
-    perf_default_backend_timeout_ms, perf_default_control_plane_threads,
+    perf_default_backend_connect_timeout_ms, perf_default_backend_timeout_ms,
+    perf_default_backend_total_request_timeout_ms, perf_default_control_plane_threads,
     perf_default_global_inflight_limit, perf_default_h2_pool_idle_timeout_ms,
     perf_default_h2_pool_max_idle_per_backend, perf_default_per_backend_inflight_limit,
     perf_default_per_upstream_inflight_limit, perf_default_pin_workers, perf_default_reuseport,
     perf_default_udp_recv_buffer_bytes, perf_default_udp_send_buffer_bytes,
-    perf_default_worker_threads,
+    perf_default_worker_threads, resilience_default_adaptive_decrease_step,
+    resilience_default_adaptive_enabled, resilience_default_adaptive_high_latency_ms,
+    resilience_default_adaptive_increase_step, resilience_default_adaptive_min_limit,
+    resilience_default_brownout_enabled, resilience_default_brownout_recover_inflight_percent,
+    resilience_default_brownout_trigger_inflight_percent, resilience_default_cb_enabled,
+    resilience_default_cb_failure_threshold, resilience_default_cb_half_open_max_probes,
+    resilience_default_cb_open_ms, resilience_default_hedging_delay_ms,
+    resilience_default_hedging_enabled, resilience_default_retry_budget_enabled,
+    resilience_default_retry_budget_ratio_percent, resilience_default_route_queue_default_cap,
 };
 
 #[derive(Debug, Deserialize, Clone)]
@@ -37,6 +46,9 @@ pub struct Config {
 
     #[serde(default)]
     pub observability: Observability,
+
+    #[serde(default)]
+    pub resilience: Resilience,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
@@ -167,11 +179,17 @@ pub struct Performance {
     #[serde(default = "perf_default_backend_timeout_ms")]
     pub backend_timeout_ms: u64,
 
+    #[serde(default = "perf_default_backend_connect_timeout_ms")]
+    pub backend_connect_timeout_ms: u64,
+
     #[serde(default = "perf_default_backend_body_idle_timeout_ms")]
     pub backend_body_idle_timeout_ms: u64,
 
     #[serde(default = "perf_default_backend_body_total_timeout_ms")]
     pub backend_body_total_timeout_ms: u64,
+
+    #[serde(default = "perf_default_backend_total_request_timeout_ms")]
+    pub backend_total_request_timeout_ms: u64,
 
     #[serde(default = "perf_default_udp_recv_buffer_bytes")]
     pub udp_recv_buffer_bytes: usize,
@@ -199,13 +217,176 @@ impl Default for Performance {
             global_inflight_limit: perf_default_global_inflight_limit(),
             per_upstream_inflight_limit: perf_default_per_upstream_inflight_limit(),
             backend_timeout_ms: perf_default_backend_timeout_ms(),
+            backend_connect_timeout_ms: perf_default_backend_connect_timeout_ms(),
             backend_body_idle_timeout_ms: perf_default_backend_body_idle_timeout_ms(),
             backend_body_total_timeout_ms: perf_default_backend_body_total_timeout_ms(),
+            backend_total_request_timeout_ms: perf_default_backend_total_request_timeout_ms(),
             udp_recv_buffer_bytes: perf_default_udp_recv_buffer_bytes(),
             udp_send_buffer_bytes: perf_default_udp_send_buffer_bytes(),
             h2_pool_max_idle_per_backend: perf_default_h2_pool_max_idle_per_backend(),
             h2_pool_idle_timeout_ms: perf_default_h2_pool_idle_timeout_ms(),
             per_backend_inflight_limit: perf_default_per_backend_inflight_limit(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct Resilience {
+    #[serde(default)]
+    pub adaptive_admission: AdaptiveAdmission,
+    #[serde(default)]
+    pub route_queue: RouteQueue,
+    #[serde(default)]
+    pub circuit_breaker: CircuitBreaker,
+    #[serde(default)]
+    pub hedging: Hedging,
+    #[serde(default)]
+    pub retry_budget: RetryBudget,
+    #[serde(default)]
+    pub brownout: Brownout,
+}
+
+impl Default for Resilience {
+    fn default() -> Self {
+        Self {
+            adaptive_admission: AdaptiveAdmission::default(),
+            route_queue: RouteQueue::default(),
+            circuit_breaker: CircuitBreaker::default(),
+            hedging: Hedging::default(),
+            retry_budget: RetryBudget::default(),
+            brownout: Brownout::default(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct AdaptiveAdmission {
+    #[serde(default = "resilience_default_adaptive_enabled")]
+    pub enabled: bool,
+    #[serde(default = "resilience_default_adaptive_min_limit")]
+    pub min_limit: usize,
+    #[serde(default = "resilience_default_adaptive_decrease_step")]
+    pub decrease_step: usize,
+    #[serde(default = "resilience_default_adaptive_increase_step")]
+    pub increase_step: usize,
+    #[serde(default = "resilience_default_adaptive_high_latency_ms")]
+    pub high_latency_ms: u64,
+}
+
+impl Default for AdaptiveAdmission {
+    fn default() -> Self {
+        Self {
+            enabled: resilience_default_adaptive_enabled(),
+            min_limit: resilience_default_adaptive_min_limit(),
+            decrease_step: resilience_default_adaptive_decrease_step(),
+            increase_step: resilience_default_adaptive_increase_step(),
+            high_latency_ms: resilience_default_adaptive_high_latency_ms(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct RouteQueue {
+    #[serde(default = "resilience_default_route_queue_default_cap")]
+    pub default_cap: usize,
+    #[serde(default)]
+    pub caps: HashMap<String, usize>,
+}
+
+impl Default for RouteQueue {
+    fn default() -> Self {
+        Self {
+            default_cap: resilience_default_route_queue_default_cap(),
+            caps: HashMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct CircuitBreaker {
+    #[serde(default = "resilience_default_cb_enabled")]
+    pub enabled: bool,
+    #[serde(default = "resilience_default_cb_failure_threshold")]
+    pub failure_threshold: u32,
+    #[serde(default = "resilience_default_cb_open_ms")]
+    pub open_ms: u64,
+    #[serde(default = "resilience_default_cb_half_open_max_probes")]
+    pub half_open_max_probes: u32,
+}
+
+impl Default for CircuitBreaker {
+    fn default() -> Self {
+        Self {
+            enabled: resilience_default_cb_enabled(),
+            failure_threshold: resilience_default_cb_failure_threshold(),
+            open_ms: resilience_default_cb_open_ms(),
+            half_open_max_probes: resilience_default_cb_half_open_max_probes(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct Hedging {
+    #[serde(default = "resilience_default_hedging_enabled")]
+    pub enabled: bool,
+    #[serde(default = "resilience_default_hedging_delay_ms")]
+    pub delay_ms: u64,
+    #[serde(default)]
+    pub safe_methods: Vec<String>,
+    #[serde(default)]
+    pub route_allowlist: Vec<String>,
+}
+
+impl Default for Hedging {
+    fn default() -> Self {
+        Self {
+            enabled: resilience_default_hedging_enabled(),
+            delay_ms: resilience_default_hedging_delay_ms(),
+            safe_methods: vec!["GET".to_string(), "HEAD".to_string()],
+            route_allowlist: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct RetryBudget {
+    #[serde(default = "resilience_default_retry_budget_enabled")]
+    pub enabled: bool,
+    #[serde(default = "resilience_default_retry_budget_ratio_percent")]
+    pub ratio_percent: u8,
+    #[serde(default)]
+    pub per_route_ratio_percent: HashMap<String, u8>,
+}
+
+impl Default for RetryBudget {
+    fn default() -> Self {
+        Self {
+            enabled: resilience_default_retry_budget_enabled(),
+            ratio_percent: resilience_default_retry_budget_ratio_percent(),
+            per_route_ratio_percent: HashMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct Brownout {
+    #[serde(default = "resilience_default_brownout_enabled")]
+    pub enabled: bool,
+    #[serde(default = "resilience_default_brownout_trigger_inflight_percent")]
+    pub trigger_inflight_percent: u8,
+    #[serde(default = "resilience_default_brownout_recover_inflight_percent")]
+    pub recover_inflight_percent: u8,
+    #[serde(default)]
+    pub core_routes: Vec<String>,
+}
+
+impl Default for Brownout {
+    fn default() -> Self {
+        Self {
+            enabled: resilience_default_brownout_enabled(),
+            trigger_inflight_percent: resilience_default_brownout_trigger_inflight_percent(),
+            recover_inflight_percent: resilience_default_brownout_recover_inflight_percent(),
+            core_routes: Vec::new(),
         }
     }
 }

--- a/crates/config/src/default.rs
+++ b/crates/config/src/default.rs
@@ -98,12 +98,20 @@ pub fn perf_default_backend_timeout_ms() -> u64 {
     2_000
 }
 
+pub fn perf_default_backend_connect_timeout_ms() -> u64 {
+    500
+}
+
 pub fn perf_default_backend_body_idle_timeout_ms() -> u64 {
     2_000
 }
 
 pub fn perf_default_backend_body_total_timeout_ms() -> u64 {
     30_000
+}
+
+pub fn perf_default_backend_total_request_timeout_ms() -> u64 {
+    35_000
 }
 
 pub fn perf_default_udp_recv_buffer_bytes() -> usize {
@@ -124,6 +132,74 @@ pub fn perf_default_h2_pool_idle_timeout_ms() -> u64 {
 
 pub fn perf_default_per_backend_inflight_limit() -> usize {
     64
+}
+
+pub fn resilience_default_adaptive_enabled() -> bool {
+    true
+}
+
+pub fn resilience_default_adaptive_min_limit() -> usize {
+    64
+}
+
+pub fn resilience_default_adaptive_decrease_step() -> usize {
+    16
+}
+
+pub fn resilience_default_adaptive_increase_step() -> usize {
+    8
+}
+
+pub fn resilience_default_adaptive_high_latency_ms() -> u64 {
+    250
+}
+
+pub fn resilience_default_route_queue_default_cap() -> usize {
+    512
+}
+
+pub fn resilience_default_cb_enabled() -> bool {
+    true
+}
+
+pub fn resilience_default_cb_failure_threshold() -> u32 {
+    5
+}
+
+pub fn resilience_default_cb_open_ms() -> u64 {
+    10_000
+}
+
+pub fn resilience_default_cb_half_open_max_probes() -> u32 {
+    2
+}
+
+pub fn resilience_default_hedging_enabled() -> bool {
+    false
+}
+
+pub fn resilience_default_hedging_delay_ms() -> u64 {
+    75
+}
+
+pub fn resilience_default_retry_budget_enabled() -> bool {
+    true
+}
+
+pub fn resilience_default_retry_budget_ratio_percent() -> u8 {
+    20
+}
+
+pub fn resilience_default_brownout_enabled() -> bool {
+    true
+}
+
+pub fn resilience_default_brownout_trigger_inflight_percent() -> u8 {
+    90
+}
+
+pub fn resilience_default_brownout_recover_inflight_percent() -> u8 {
+    60
 }
 
 pub fn observe_default_address() -> String {

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -109,6 +109,11 @@ pub fn validate(config: &Config) -> bool {
         return false;
     }
 
+    if config.performance.backend_connect_timeout_ms == 0 {
+        error!("performance.backend_connect_timeout_ms must be greater than 0");
+        return false;
+    }
+
     if config.performance.backend_body_idle_timeout_ms == 0 {
         error!("performance.backend_body_idle_timeout_ms must be greater than 0");
         return false;
@@ -116,6 +121,11 @@ pub fn validate(config: &Config) -> bool {
 
     if config.performance.backend_body_total_timeout_ms == 0 {
         error!("performance.backend_body_total_timeout_ms must be greater than 0");
+        return false;
+    }
+
+    if config.performance.backend_total_request_timeout_ms == 0 {
+        error!("performance.backend_total_request_timeout_ms must be greater than 0");
         return false;
     }
 
@@ -144,10 +154,105 @@ pub fn validate(config: &Config) -> bool {
         return false;
     }
 
-    if config.performance.backend_body_total_timeout_ms
-        < config.performance.backend_body_idle_timeout_ms
+    if config.performance.backend_connect_timeout_ms > config.performance.backend_timeout_ms {
+        error!("performance.backend_connect_timeout_ms must be <= backend_timeout_ms");
+        return false;
+    }
+
+    if config.performance.backend_timeout_ms > config.performance.backend_body_idle_timeout_ms {
+        error!("performance.backend_timeout_ms must be <= backend_body_idle_timeout_ms");
+        return false;
+    }
+
+    if config.performance.backend_body_idle_timeout_ms
+        > config.performance.backend_body_total_timeout_ms
     {
-        error!("performance.backend_body_total_timeout_ms must be >= backend_body_idle_timeout_ms");
+        error!("performance.backend_body_idle_timeout_ms must be <= backend_body_total_timeout_ms");
+        return false;
+    }
+
+    if config.performance.backend_body_total_timeout_ms
+        > config.performance.backend_total_request_timeout_ms
+    {
+        error!(
+            "performance.backend_body_total_timeout_ms must be <= backend_total_request_timeout_ms"
+        );
+        return false;
+    }
+
+    if config.resilience.adaptive_admission.min_limit == 0 {
+        error!("resilience.adaptive_admission.min_limit must be greater than 0");
+        return false;
+    }
+
+    if config.resilience.adaptive_admission.decrease_step == 0 {
+        error!("resilience.adaptive_admission.decrease_step must be greater than 0");
+        return false;
+    }
+
+    if config.resilience.adaptive_admission.increase_step == 0 {
+        error!("resilience.adaptive_admission.increase_step must be greater than 0");
+        return false;
+    }
+
+    if config.resilience.route_queue.default_cap == 0 {
+        error!("resilience.route_queue.default_cap must be greater than 0");
+        return false;
+    }
+
+    if config
+        .resilience
+        .route_queue
+        .caps
+        .values()
+        .any(|cap| *cap == 0)
+    {
+        error!("resilience.route_queue.caps values must be greater than 0");
+        return false;
+    }
+
+    if config.resilience.circuit_breaker.failure_threshold == 0 {
+        error!("resilience.circuit_breaker.failure_threshold must be greater than 0");
+        return false;
+    }
+
+    if config.resilience.circuit_breaker.open_ms == 0 {
+        error!("resilience.circuit_breaker.open_ms must be greater than 0");
+        return false;
+    }
+
+    if config.resilience.circuit_breaker.half_open_max_probes == 0 {
+        error!("resilience.circuit_breaker.half_open_max_probes must be greater than 0");
+        return false;
+    }
+
+    if config.resilience.retry_budget.ratio_percent > 100 {
+        error!("resilience.retry_budget.ratio_percent must be <= 100");
+        return false;
+    }
+
+    if config
+        .resilience
+        .retry_budget
+        .per_route_ratio_percent
+        .values()
+        .any(|ratio| *ratio > 100)
+    {
+        error!("resilience.retry_budget.per_route_ratio_percent values must be <= 100");
+        return false;
+    }
+
+    if config.resilience.brownout.trigger_inflight_percent > 100
+        || config.resilience.brownout.recover_inflight_percent > 100
+    {
+        error!("resilience.brownout inflight percentages must be <= 100");
+        return false;
+    }
+
+    if config.resilience.brownout.recover_inflight_percent
+        >= config.resilience.brownout.trigger_inflight_percent
+    {
+        error!("resilience.brownout.recover_inflight_percent must be < trigger_inflight_percent");
         return false;
     }
 
@@ -372,7 +477,7 @@ mod tests {
     use super::validate;
     use crate::config::{
         Backend, Config, HealthCheck, Listen, LoadBalancing, Log, MetricsEndpoint, Observability,
-        Performance, RouteMatch, Tls, Upstream,
+        Performance, Resilience, RouteMatch, Tls, Upstream,
     };
     use std::collections::HashMap;
     use tempfile::tempdir;
@@ -429,6 +534,7 @@ mod tests {
             },
             performance: Performance::default(),
             observability: Observability::default(),
+            resilience: Resilience::default(),
         }
     }
 
@@ -474,8 +580,10 @@ upstream:
         assert_eq!(cfg.performance.global_inflight_limit, 4096);
         assert_eq!(cfg.performance.per_upstream_inflight_limit, 1024);
         assert_eq!(cfg.performance.backend_timeout_ms, 2000);
+        assert_eq!(cfg.performance.backend_connect_timeout_ms, 500);
         assert_eq!(cfg.performance.backend_body_idle_timeout_ms, 2000);
         assert_eq!(cfg.performance.backend_body_total_timeout_ms, 30000);
+        assert_eq!(cfg.performance.backend_total_request_timeout_ms, 35_000);
         assert_eq!(cfg.performance.udp_recv_buffer_bytes, 8 * 1024 * 1024);
         assert_eq!(cfg.performance.udp_send_buffer_bytes, 8 * 1024 * 1024);
         assert_eq!(cfg.performance.h2_pool_max_idle_per_backend, 256);
@@ -483,6 +591,8 @@ upstream:
         assert_eq!(cfg.performance.per_backend_inflight_limit, 64);
         assert!(!cfg.observability.metrics.enabled);
         assert_eq!(cfg.observability.metrics.path, "/metrics");
+        assert!(cfg.resilience.adaptive_admission.enabled);
+        assert_eq!(cfg.resilience.route_queue.default_cap, 512);
     }
 
     #[test]
@@ -500,6 +610,16 @@ upstream:
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.performance.worker_threads = 4;
         cfg.performance.reuseport = false;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.performance.backend_connect_timeout_ms = 2_001;
+        cfg.performance.backend_timeout_ms = 2_000;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.performance.backend_total_request_timeout_ms = 5_000;
+        cfg.performance.backend_body_total_timeout_ms = 6_000;
         assert!(!validate(&cfg));
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
@@ -525,6 +645,19 @@ upstream:
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.performance.per_backend_inflight_limit = 0;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.resilience.route_queue.default_cap = 0;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.resilience.retry_budget.ratio_percent = 101;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.resilience.brownout.trigger_inflight_percent = 50;
+        cfg.resilience.brownout.recover_inflight_percent = 50;
         assert!(!validate(&cfg));
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
@@ -554,14 +687,18 @@ upstream:
         cfg.performance.pin_workers = true;
         cfg.performance.global_inflight_limit = 10_000;
         cfg.performance.per_upstream_inflight_limit = 2_000;
+        cfg.performance.backend_connect_timeout_ms = 300;
         cfg.performance.backend_timeout_ms = 1500;
-        cfg.performance.backend_body_idle_timeout_ms = 500;
+        cfg.performance.backend_body_idle_timeout_ms = 2_500;
         cfg.performance.backend_body_total_timeout_ms = 10_000;
+        cfg.performance.backend_total_request_timeout_ms = 15_000;
         cfg.performance.udp_recv_buffer_bytes = 4 * 1024 * 1024;
         cfg.performance.udp_send_buffer_bytes = 4 * 1024 * 1024;
         cfg.performance.h2_pool_max_idle_per_backend = 128;
         cfg.performance.h2_pool_idle_timeout_ms = 120_000;
         cfg.performance.per_backend_inflight_limit = 32;
+        cfg.resilience.route_queue.default_cap = 256;
+        cfg.resilience.retry_budget.ratio_percent = 30;
         cfg.observability = Observability {
             metrics: MetricsEndpoint {
                 enabled: true,

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -24,6 +24,7 @@ use tokio::sync::{OwnedSemaphorePermit, Semaphore, mpsc, oneshot};
 
 use crate::cid_radix::CidRadix;
 use crate::constants::MAX_DATAGRAM_SIZE_BYTES;
+use crate::resilience::{AdaptivePermit, RouteQueuePermit, RuntimeResilience};
 
 /// A streaming HTTP body backed by a tokio mpsc channel.
 /// The quiche Data handler sends chunks through the sender;
@@ -59,6 +60,7 @@ pub mod benchmark;
 pub mod cid_radix;
 pub mod constants;
 pub mod quic_listener;
+mod resilience;
 mod route_index;
 
 pub use quic_listener::configure_async_runtime;
@@ -69,6 +71,7 @@ pub struct SharedRuntimeState {
     pub(crate) upstream_inflight: HashMap<String, Arc<Semaphore>>,
     pub(crate) global_inflight: Arc<Semaphore>,
     pub(crate) metrics: Arc<Metrics>,
+    pub(crate) resilience: Arc<RuntimeResilience>,
 }
 
 pub struct QUICListener {
@@ -82,11 +85,13 @@ pub struct QUICListener {
     pub global_inflight: Arc<Semaphore>,
     pub(crate) routing_index: route_index::RouteIndex,
     pub metrics: Arc<Metrics>,
+    pub resilience: Arc<RuntimeResilience>,
     pub draining: bool,
     pub drain_start: Option<Instant>,
     pub backend_timeout: Duration,
     pub backend_body_idle_timeout: Duration,
     pub backend_body_total_timeout: Duration,
+    pub backend_total_request_timeout: Duration,
 
     pub recv_buf: [u8; MAX_DATAGRAM_SIZE_BYTES],
     pub send_buf: [u8; MAX_DATAGRAM_SIZE_BYTES],
@@ -156,7 +161,11 @@ pub struct RequestEnvelope {
     pub upstream_name: Option<String>,
     pub global_inflight_permit: Option<OwnedSemaphorePermit>,
     pub upstream_inflight_permit: Option<OwnedSemaphorePermit>,
+    pub adaptive_admission_permit: Option<AdaptivePermit>,
+    pub route_queue_permit: Option<RouteQueuePermit>,
     pub start: Instant,
+    pub total_request_deadline: Instant,
+    pub bodyless_mode: bool,
 
     /// Current lifecycle phase of this stream.
     pub phase: StreamPhase,

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -50,6 +50,7 @@ use crate::{
         drain_timeout, scid_rotation_interval,
     },
     outcome_from_status,
+    resilience::RuntimeResilience,
     route_index::RouteIndex,
 };
 
@@ -61,6 +62,18 @@ fn is_hop_header(name: &str) -> bool {
 }
 
 type ResolvedBackend = (String, String, usize, Arc<Mutex<UpstreamPool>>);
+
+fn request_content_length(headers: &[quiche::h3::Header]) -> Option<usize> {
+    for header in headers {
+        if !header.name().eq_ignore_ascii_case(b"content-length") {
+            continue;
+        }
+        let value = std::str::from_utf8(header.value()).ok()?;
+        let parsed = value.trim().parse::<usize>().ok()?;
+        return Some(parsed);
+    }
+    None
+}
 
 impl QUICListener {
     pub fn new(config: SpookyConfig) -> Result<Self, ProxyError> {
@@ -80,7 +93,7 @@ impl QUICListener {
             .saturating_mul(worker_threads);
 
         info!(
-            "Performance profile: worker_threads={} control_plane_threads={} reuseport={} pin_workers={} global_inflight_limit={} per_upstream_inflight_limit={} per_backend_inflight_limit={} backend_timeout_ms={} backend_body_idle_timeout_ms={} backend_body_total_timeout_ms={} udp_recv_buffer_bytes={} udp_send_buffer_bytes={} h2_pool_max_idle_per_backend={} h2_pool_idle_timeout_ms={}",
+            "Performance profile: worker_threads={} control_plane_threads={} reuseport={} pin_workers={} global_inflight_limit={} per_upstream_inflight_limit={} per_backend_inflight_limit={} backend_connect_timeout_ms={} backend_timeout_ms={} backend_body_idle_timeout_ms={} backend_body_total_timeout_ms={} backend_total_request_timeout_ms={} udp_recv_buffer_bytes={} udp_send_buffer_bytes={} h2_pool_max_idle_per_backend={} h2_pool_idle_timeout_ms={}",
             worker_threads,
             config.performance.control_plane_threads.max(1),
             config.performance.reuseport,
@@ -88,9 +101,11 @@ impl QUICListener {
             global_inflight_limit,
             per_upstream_limit,
             config.performance.per_backend_inflight_limit,
+            config.performance.backend_connect_timeout_ms,
             config.performance.backend_timeout_ms,
             config.performance.backend_body_idle_timeout_ms,
             config.performance.backend_body_total_timeout_ms,
+            config.performance.backend_total_request_timeout_ms,
             config.performance.udp_recv_buffer_bytes,
             config.performance.udp_send_buffer_bytes,
             config.performance.h2_pool_max_idle_per_backend,
@@ -113,6 +128,7 @@ impl QUICListener {
             max_inflight_per_backend,
             config.performance.h2_pool_max_idle_per_backend,
             Duration::from_millis(config.performance.h2_pool_idle_timeout_ms),
+            Duration::from_millis(config.performance.backend_connect_timeout_ms),
         ));
         let mut upstream_pools = HashMap::new();
         let mut upstream_inflight = HashMap::new();
@@ -128,12 +144,18 @@ impl QUICListener {
             upstream_inflight.insert(name.clone(), Arc::new(Semaphore::new(per_upstream_limit)));
         }
 
+        let resilience = Arc::new(RuntimeResilience::from_config(
+            &config.resilience,
+            global_inflight_limit,
+        ));
+
         Ok(SharedRuntimeState {
             h2_pool,
             upstream_pools,
             upstream_inflight,
             global_inflight: Arc::new(Semaphore::new(global_inflight_limit)),
             metrics: Arc::new(Metrics::default()),
+            resilience,
         })
     }
 
@@ -195,6 +217,8 @@ impl QUICListener {
             Duration::from_millis(config.performance.backend_body_idle_timeout_ms);
         let backend_body_total_timeout =
             Duration::from_millis(config.performance.backend_body_total_timeout_ms);
+        let backend_total_request_timeout =
+            Duration::from_millis(config.performance.backend_total_request_timeout_ms);
 
         Ok(Self {
             socket,
@@ -207,11 +231,13 @@ impl QUICListener {
             global_inflight: Arc::clone(&shared_state.global_inflight),
             routing_index,
             metrics: Arc::clone(&shared_state.metrics),
+            resilience: Arc::clone(&shared_state.resilience),
             draining: false,
             drain_start: None,
             backend_timeout,
             backend_body_idle_timeout,
             backend_body_total_timeout,
+            backend_total_request_timeout,
             recv_buf: [0; MAX_DATAGRAM_SIZE_BYTES],
             send_buf: [0; MAX_DATAGRAM_SIZE_BYTES],
             connections: HashMap::new(),
@@ -791,8 +817,10 @@ impl QUICListener {
                 self.backend_timeout,
                 self.backend_body_idle_timeout,
                 self.backend_body_total_timeout,
+                self.backend_total_request_timeout,
                 &self.routing_index,
                 &self.metrics,
+                &self.resilience,
             )
         {
             error!("HTTP/3 handling failed: {:?}", e);
@@ -862,6 +890,8 @@ impl QUICListener {
                     self.backend_body_idle_timeout,
                     self.backend_body_total_timeout,
                     &self.metrics,
+                    self.backend_total_request_timeout,
+                    &self.resilience,
                 ) {
                     error!("advance_streams_non_blocking in timeout path: {:?}", e);
                 }
@@ -955,8 +985,10 @@ impl QUICListener {
         backend_timeout: Duration,
         backend_body_idle_timeout: Duration,
         backend_body_total_timeout: Duration,
+        backend_total_request_timeout: Duration,
         routing_index: &RouteIndex,
         metrics: &Metrics,
+        resilience: &RuntimeResilience,
     ) -> Result<(), quiche::h3::Error> {
         let mut body_buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
 
@@ -1017,8 +1049,86 @@ impl QUICListener {
                         upstream_name,
                         global_inflight_permit,
                         upstream_inflight_permit,
+                        adaptive_admission_permit,
+                        route_queue_permit,
+                        request_fin_received,
+                        bodyless_mode,
                     ) = match resolved {
-                        Ok((upstream_name, addr, idx, _pool)) => {
+                        Ok((upstream_name, addr, idx, upstream_pool)) => {
+                            resilience.brownout.observe_admission_pressure(
+                                resilience.adaptive_admission.inflight_percent(),
+                            );
+                            if !resilience.brownout.route_allowed(&upstream_name) {
+                                metrics.inc_failure();
+                                metrics.inc_overload_shed();
+                                metrics.record_route(
+                                    &upstream_name,
+                                    request_start.elapsed(),
+                                    RouteOutcome::OverloadShed,
+                                );
+                                Self::send_simple_response(
+                                    h3,
+                                    &mut connection.quic,
+                                    stream_id,
+                                    http::StatusCode::SERVICE_UNAVAILABLE,
+                                    b"brownout active, non-core route shed\n",
+                                )?;
+                                resilience
+                                    .adaptive_admission
+                                    .observe(request_start.elapsed(), true);
+                                continue;
+                            }
+
+                            let adaptive_permit = match resilience.adaptive_admission.try_acquire()
+                            {
+                                Some(permit) => permit,
+                                None => {
+                                    metrics.inc_failure();
+                                    metrics.inc_overload_shed();
+                                    metrics.record_route(
+                                        &upstream_name,
+                                        request_start.elapsed(),
+                                        RouteOutcome::OverloadShed,
+                                    );
+                                    Self::send_simple_response(
+                                        h3,
+                                        &mut connection.quic,
+                                        stream_id,
+                                        http::StatusCode::SERVICE_UNAVAILABLE,
+                                        b"adaptive admission overload\n",
+                                    )?;
+                                    resilience
+                                        .adaptive_admission
+                                        .observe(request_start.elapsed(), true);
+                                    continue;
+                                }
+                            };
+
+                            let route_queue_permit =
+                                match resilience.route_queue.try_acquire(&upstream_name) {
+                                    Some(permit) => permit,
+                                    None => {
+                                        metrics.inc_failure();
+                                        metrics.inc_overload_shed();
+                                        metrics.record_route(
+                                            &upstream_name,
+                                            request_start.elapsed(),
+                                            RouteOutcome::OverloadShed,
+                                        );
+                                        Self::send_simple_response(
+                                            h3,
+                                            &mut connection.quic,
+                                            stream_id,
+                                            http::StatusCode::SERVICE_UNAVAILABLE,
+                                            b"route queue cap exceeded\n",
+                                        )?;
+                                        resilience
+                                            .adaptive_admission
+                                            .observe(request_start.elapsed(), true);
+                                        continue;
+                                    }
+                                };
+
                             let global_permit =
                                 match Arc::clone(&global_inflight).try_acquire_owned() {
                                     Ok(permit) => permit,
@@ -1037,6 +1147,9 @@ impl QUICListener {
                                             http::StatusCode::SERVICE_UNAVAILABLE,
                                             b"overloaded, retry later\n",
                                         )?;
+                                        resilience
+                                            .adaptive_admission
+                                            .observe(request_start.elapsed(), true);
                                         continue;
                                     }
                                 };
@@ -1061,6 +1174,9 @@ impl QUICListener {
                                                 http::StatusCode::SERVICE_UNAVAILABLE,
                                                 b"upstream overloaded, retry later\n",
                                             )?;
+                                            resilience
+                                                .adaptive_admission
+                                                .observe(request_start.elapsed(), true);
                                             continue;
                                         }
                                     },
@@ -1080,6 +1196,9 @@ impl QUICListener {
                                             http::StatusCode::SERVICE_UNAVAILABLE,
                                             b"no upstream throttle configured\n",
                                         )?;
+                                        resilience
+                                            .adaptive_admission
+                                            .observe(request_start.elapsed(), true);
                                         continue;
                                     }
                                 };
@@ -1103,6 +1222,9 @@ impl QUICListener {
                                         http::StatusCode::SERVICE_UNAVAILABLE,
                                         b"backend overloaded, retry later\n",
                                     )?;
+                                    resilience
+                                        .adaptive_admission
+                                        .observe(request_start.elapsed(), true);
                                     continue;
                                 }
                                 Err(_) => {
@@ -1121,15 +1243,26 @@ impl QUICListener {
                                         http::StatusCode::SERVICE_UNAVAILABLE,
                                         b"no upstream available\n",
                                     )?;
+                                    resilience
+                                        .adaptive_admission
+                                        .observe(request_start.elapsed(), true);
                                     continue;
                                 }
                             }
 
-                            // Create a channel body so quiche Data chunks stream
-                            // directly into the in-flight H2 request.
-                            let (tx, channel_body) =
-                                ChannelBody::channel(REQUEST_CHUNK_CHANNEL_CAPACITY);
-                            let boxed = channel_body.boxed();
+                            let content_length = request_content_length(&list);
+                            let bodyless_mode = content_length.unwrap_or(0) == 0
+                                && (method.eq_ignore_ascii_case("GET")
+                                    || method.eq_ignore_ascii_case("HEAD"));
+                            let (tx, boxed, request_fin_received) = if bodyless_mode {
+                                (None, BoxBody::new(Full::new(Bytes::new())), true)
+                            } else {
+                                // Create a channel body so quiche Data chunks stream
+                                // directly into the in-flight H2 request.
+                                let (tx, channel_body) =
+                                    ChannelBody::channel(REQUEST_CHUNK_CHANNEL_CAPACITY);
+                                (Some(tx), channel_body.boxed(), false)
+                            };
                             let request =
                                 match build_h2_request(&addr, &method, &path, &list, boxed, None) {
                                     Ok(request) => request,
@@ -1150,21 +1283,152 @@ impl QUICListener {
                                             b"invalid request\n",
                                         )?;
                                         error!("failed to build upstream request: {}", err);
+                                        resilience
+                                            .adaptive_admission
+                                            .observe(request_start.elapsed(), true);
                                         continue;
                                     }
                                 };
 
                             let h2 = h2_pool.clone();
                             let fwd_addr = addr.clone();
+                            let cb = Arc::clone(&resilience.circuit_breakers);
+                            let retry_budget = Arc::clone(&resilience.retry_budget);
+                            let route_name = upstream_name.clone();
+                            let allow_hedge = bodyless_mode
+                                && resilience.hedging_allowed_for(&method, &upstream_name, true);
+                            let hedge_delay = resilience.hedging_delay;
+                            let alternate_backend =
+                                Self::pick_alternate_backend(&upstream_pool, idx);
+                            let method_owned = method.clone();
+                            let path_owned = path.clone();
+                            let headers_owned = list.clone();
                             let (result_tx, result_rx) = oneshot::channel::<ForwardResult>();
                             let fut = async move {
                                 let result = async {
-                                    let response = tokio::time::timeout(
-                                        backend_timeout,
-                                        h2.send(&fwd_addr, request),
-                                    )
-                                    .await
-                                    .map_err(|_| ProxyError::Timeout)??;
+                                    retry_budget.mark_primary(&route_name);
+
+                                    let send_once =
+                                        |backend: String,
+                                         req: http::Request<
+                                            BoxBody<Bytes, std::convert::Infallible>,
+                                        >,
+                                         cb: Arc<crate::resilience::CircuitBreakers>,
+                                         h2: Arc<H2Pool>| async move {
+                                            if !cb.allow_request(&backend) {
+                                                return Err(ProxyError::Pool(
+                                                    PoolError::CircuitOpen(backend),
+                                                ));
+                                            }
+                                            let send_result = tokio::time::timeout(
+                                                backend_timeout,
+                                                h2.send(&backend, req),
+                                            )
+                                            .await
+                                            .map_err(|_| ProxyError::Timeout);
+                                            match &send_result {
+                                                Ok(Ok(_)) => cb.record_success(&backend),
+                                                _ => cb.record_failure(&backend),
+                                            }
+                                            Ok(send_result??)
+                                        };
+
+                                    let response: Response<Incoming> = if allow_hedge {
+                                        let hedge_candidate = alternate_backend.clone().and_then(
+                                            |(backend, _idx)| {
+                                                build_h2_request(
+                                                    &backend,
+                                                    &method_owned,
+                                                    &path_owned,
+                                                    &headers_owned,
+                                                    BoxBody::new(Full::new(Bytes::new())),
+                                                    Some(0),
+                                                )
+                                                .ok()
+                                                .map(|req| (backend, req))
+                                            },
+                                        );
+
+                                        if let Some((hedge_backend, hedge_request)) =
+                                            hedge_candidate
+                                        {
+                                            let primary_backend = fwd_addr.clone();
+                                            let primary_fut = send_once(
+                                                primary_backend,
+                                                request,
+                                                Arc::clone(&cb),
+                                                Arc::clone(&h2),
+                                            );
+                                            tokio::pin!(primary_fut);
+                                            let hedge_sleep = tokio::time::sleep(hedge_delay);
+                                            tokio::pin!(hedge_sleep);
+
+                                            if let Some(result) = tokio::select! {
+                                                result = &mut primary_fut => Some(result),
+                                                _ = &mut hedge_sleep => None,
+                                            } {
+                                                result?
+                                            } else if retry_budget.allow_retry(&route_name) {
+                                                let hedge_fut = send_once(
+                                                    hedge_backend,
+                                                    hedge_request,
+                                                    Arc::clone(&cb),
+                                                    Arc::clone(&h2),
+                                                );
+                                                tokio::pin!(hedge_fut);
+                                                tokio::select! {
+                                                    result = &mut primary_fut => result?,
+                                                    result = &mut hedge_fut => result?,
+                                                }
+                                            } else {
+                                                primary_fut.await?
+                                            }
+                                        } else {
+                                            send_once(
+                                                fwd_addr.clone(),
+                                                request,
+                                                Arc::clone(&cb),
+                                                Arc::clone(&h2),
+                                            )
+                                            .await?
+                                        }
+                                    } else {
+                                        match send_once(
+                                            fwd_addr.clone(),
+                                            request,
+                                            Arc::clone(&cb),
+                                            Arc::clone(&h2),
+                                        )
+                                        .await
+                                        {
+                                            Ok(response) => response,
+                                            Err(primary_err) => {
+                                                if bodyless_mode
+                                                    && retry_budget.allow_retry(&route_name)
+                                                    && let Some((retry_backend, _)) =
+                                                        alternate_backend.clone()
+                                                    && let Ok(retry_request) = build_h2_request(
+                                                        &retry_backend,
+                                                        &method_owned,
+                                                        &path_owned,
+                                                        &headers_owned,
+                                                        BoxBody::new(Full::new(Bytes::new())),
+                                                        Some(0),
+                                                    )
+                                                {
+                                                    send_once(
+                                                        retry_backend,
+                                                        retry_request,
+                                                        Arc::clone(&cb),
+                                                        Arc::clone(&h2),
+                                                    )
+                                                    .await?
+                                                } else {
+                                                    return Err(primary_err);
+                                                }
+                                            }
+                                        }
+                                    };
 
                                     let (parts, body) = response.into_parts();
                                     Ok((parts.status, parts.headers, body))
@@ -1177,13 +1441,17 @@ impl QUICListener {
                                 error!("dropping upstream task: no runtime available");
                             }
                             (
-                                Some(tx),
+                                tx,
                                 Some(result_rx),
                                 Some(addr),
                                 Some(idx),
                                 Some(upstream_name),
                                 Some(global_permit),
                                 Some(upstream_permit),
+                                Some(adaptive_permit),
+                                Some(route_queue_permit),
+                                request_fin_received,
+                                bodyless_mode,
                             )
                         }
                         Err(err) => {
@@ -1213,6 +1481,9 @@ impl QUICListener {
                                 status,
                                 body,
                             )?;
+                            resilience
+                                .adaptive_admission
+                                .observe(request_start.elapsed(), true);
                             continue;
                         }
                     };
@@ -1232,9 +1503,13 @@ impl QUICListener {
                             upstream_name,
                             global_inflight_permit,
                             upstream_inflight_permit,
+                            adaptive_admission_permit,
+                            route_queue_permit,
                             start: request_start,
+                            total_request_deadline: request_start + backend_total_request_timeout,
+                            bodyless_mode,
                             phase: StreamPhase::ReceivingRequest,
-                            request_fin_received: false,
+                            request_fin_received,
                             upstream_result_rx,
                             response_chunk_rx: None,
                             pending_chunk: None,
@@ -1245,32 +1520,70 @@ impl QUICListener {
                     match h3.recv_body(&mut connection.quic, stream_id, &mut body_buf) {
                         Ok(read) => {
                             let mut shed_due_to_buffer_pressure = false;
+                            let mut reject_body_for_bodyless = None::<(String, Duration)>;
+                            let mut payload_too_large = None::<(String, Duration)>;
                             if let Some(req) = connection.streams.get_mut(&stream_id) {
-                                // Enforce cap on total bytes received for the stream,
-                                // including chunks already forwarded to the H2 body channel.
-                                let next_total = req.body_bytes_received.saturating_add(read);
-                                if next_total > MAX_REQUEST_BODY_BYTES {
-                                    connection.streams.remove(&stream_id);
-                                    Self::send_simple_response(
-                                        h3,
-                                        &mut connection.quic,
-                                        stream_id,
-                                        http::StatusCode::PAYLOAD_TOO_LARGE,
-                                        b"request body too large\n",
-                                    )?;
-                                    break;
+                                if req.bodyless_mode && read > 0 {
+                                    reject_body_for_bodyless = Some((
+                                        req.upstream_name
+                                            .clone()
+                                            .unwrap_or_else(|| "unrouted".to_string()),
+                                        req.start.elapsed(),
+                                    ));
                                 }
-                                req.body_bytes_received = next_total;
+                                if reject_body_for_bodyless.is_none() {
+                                    // Enforce cap on total bytes received for the stream,
+                                    // including chunks already forwarded to the H2 body channel.
+                                    let next_total = req.body_bytes_received.saturating_add(read);
+                                    if next_total > MAX_REQUEST_BODY_BYTES {
+                                        payload_too_large = Some((
+                                            req.upstream_name
+                                                .clone()
+                                                .unwrap_or_else(|| "unrouted".to_string()),
+                                            req.start.elapsed(),
+                                        ));
+                                    } else {
+                                        req.body_bytes_received = next_total;
 
-                                for chunk_slice in
-                                    body_buf[..read].chunks(REQUEST_CHUNK_BYTES_LIMIT)
-                                {
-                                    let chunk = Bytes::copy_from_slice(chunk_slice);
-                                    if Self::enqueue_request_chunk(req, chunk).is_err() {
-                                        shed_due_to_buffer_pressure = true;
-                                        break;
+                                        for chunk_slice in
+                                            body_buf[..read].chunks(REQUEST_CHUNK_BYTES_LIMIT)
+                                        {
+                                            let chunk = Bytes::copy_from_slice(chunk_slice);
+                                            if Self::enqueue_request_chunk(req, chunk).is_err() {
+                                                shed_due_to_buffer_pressure = true;
+                                                break;
+                                            }
+                                        }
                                     }
                                 }
+                            }
+                            if let Some((route_label, elapsed)) = reject_body_for_bodyless {
+                                metrics.inc_failure();
+                                metrics.record_route(&route_label, elapsed, RouteOutcome::Failure);
+                                Self::send_simple_response(
+                                    h3,
+                                    &mut connection.quic,
+                                    stream_id,
+                                    http::StatusCode::BAD_REQUEST,
+                                    b"request body not allowed for this request\n",
+                                )?;
+                                connection.streams.remove(&stream_id);
+                                resilience.adaptive_admission.observe(elapsed, true);
+                                break;
+                            }
+                            if let Some((route_label, elapsed)) = payload_too_large {
+                                metrics.inc_failure();
+                                metrics.record_route(&route_label, elapsed, RouteOutcome::Failure);
+                                Self::send_simple_response(
+                                    h3,
+                                    &mut connection.quic,
+                                    stream_id,
+                                    http::StatusCode::PAYLOAD_TOO_LARGE,
+                                    b"request body too large\n",
+                                )?;
+                                connection.streams.remove(&stream_id);
+                                resilience.adaptive_admission.observe(elapsed, true);
+                                break;
                             }
                             if shed_due_to_buffer_pressure
                                 && let Some(req) = connection.streams.remove(&stream_id)
@@ -1291,6 +1604,9 @@ impl QUICListener {
                                     http::StatusCode::SERVICE_UNAVAILABLE,
                                     b"request body backpressure overload\n",
                                 )?;
+                                resilience
+                                    .adaptive_admission
+                                    .observe(req.start.elapsed(), true);
                                 break;
                             }
                         }
@@ -1332,6 +1648,8 @@ impl QUICListener {
             backend_body_idle_timeout,
             backend_body_total_timeout,
             metrics,
+            backend_total_request_timeout,
+            resilience,
         )?;
 
         Ok(())
@@ -1365,10 +1683,32 @@ impl QUICListener {
         backend_body_idle_timeout: Duration,
         backend_body_total_timeout: Duration,
         metrics: &Metrics,
+        _backend_total_request_timeout: Duration,
+        resilience: &RuntimeResilience,
     ) -> Result<(), quiche::h3::Error> {
         let stream_ids: Vec<u64> = streams.keys().copied().collect();
 
         for stream_id in stream_ids {
+            if let Some(req) = streams.get(&stream_id)
+                && Instant::now() >= req.total_request_deadline
+            {
+                Self::handle_forward_result(
+                    h3,
+                    quic,
+                    stream_id,
+                    req,
+                    Err(ProxyError::Timeout),
+                    upstream_pools,
+                    routing_index,
+                    metrics,
+                )?;
+                resilience
+                    .adaptive_admission
+                    .observe(req.start.elapsed(), true);
+                streams.remove(&stream_id);
+                continue;
+            }
+
             // ── 1 & 2: request body drain ────────────────────────────────────
             if let Some(req) = streams.get_mut(&stream_id) {
                 Self::flush_request_buffer(req);
@@ -1543,6 +1883,9 @@ impl QUICListener {
                                 req.start.elapsed(),
                                 RouteOutcome::Success,
                             );
+                            resilience
+                                .adaptive_admission
+                                .observe(req.start.elapsed(), false);
                             info!(
                                 "Upstream {} status {} latency_ms {}",
                                 req.backend_addr.as_deref().unwrap_or("?"),
@@ -1565,6 +1908,9 @@ impl QUICListener {
                                 routing_index,
                                 metrics,
                             )?;
+                            resilience
+                                .adaptive_admission
+                                .observe(req.start.elapsed(), true);
                         }
                         streams.remove(&stream_id);
                         continue;
@@ -1638,6 +1984,9 @@ impl QUICListener {
                                         req.start.elapsed(),
                                         RouteOutcome::Timeout,
                                     );
+                                    resilience
+                                        .adaptive_admission
+                                        .observe(req.start.elapsed(), true);
                                     info!(
                                         "Upstream {} body timeout latency_ms {}",
                                         req.backend_addr.as_deref().unwrap_or("?"),
@@ -1654,6 +2003,9 @@ impl QUICListener {
                                         req.start.elapsed(),
                                         RouteOutcome::BackendError,
                                     );
+                                    resilience
+                                        .adaptive_admission
+                                        .observe(req.start.elapsed(), true);
                                     error!(
                                         "Upstream {} body error: {:?}",
                                         req.backend_addr.as_deref().unwrap_or("?"),
@@ -1725,6 +2077,23 @@ impl QUICListener {
             backend_index,
             upstream_pool,
         ))
+    }
+
+    fn pick_alternate_backend(
+        upstream_pool: &Arc<Mutex<UpstreamPool>>,
+        primary_index: usize,
+    ) -> Option<(String, usize)> {
+        let pool = upstream_pool.lock().ok()?;
+        let healthy = pool.pool.healthy_indices();
+        for index in healthy {
+            if index == primary_index {
+                continue;
+            }
+            if let Some(address) = pool.pool.address(index) {
+                return Some((address.to_string(), index));
+            }
+        }
+        None
     }
 
     /// Handle an already-resolved `ForwardResult`, applying health transitions
@@ -1804,6 +2173,24 @@ impl QUICListener {
                     stream_id,
                     http::StatusCode::SERVICE_UNAVAILABLE,
                     b"backend overloaded, retry later\n",
+                )
+            }
+            Err(ProxyError::Pool(PoolError::CircuitOpen(_))) => {
+                info!("Backend circuit open");
+                metrics.inc_failure();
+                metrics.inc_overload_shed();
+                metrics.record_route(route_label, start.elapsed(), RouteOutcome::OverloadShed);
+                info!(
+                    "Upstream {} status 503 latency_ms {}",
+                    backend_addr,
+                    start.elapsed().as_millis()
+                );
+                Self::send_simple_response(
+                    h3,
+                    quic,
+                    stream_id,
+                    http::StatusCode::SERVICE_UNAVAILABLE,
+                    b"backend circuit open, retry later\n",
                 )
             }
             Err(ProxyError::Transport(_))

--- a/crates/edge/src/resilience.rs
+++ b/crates/edge/src/resilience.rs
@@ -1,0 +1,523 @@
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+use spooky_config::config::Resilience as ResilienceConfig;
+
+pub struct AdaptiveAdmission {
+    enabled: bool,
+    min_limit: usize,
+    max_limit: usize,
+    increase_step: usize,
+    decrease_step: usize,
+    high_latency_ms: u64,
+    current_limit: AtomicUsize,
+    inflight: AtomicUsize,
+}
+
+impl AdaptiveAdmission {
+    pub fn new(
+        enabled: bool,
+        min_limit: usize,
+        max_limit: usize,
+        increase_step: usize,
+        decrease_step: usize,
+        high_latency_ms: u64,
+    ) -> Self {
+        let max_limit = max_limit.max(1);
+        let min_limit = min_limit.max(1).min(max_limit);
+        Self {
+            enabled,
+            min_limit,
+            max_limit,
+            increase_step: increase_step.max(1),
+            decrease_step: decrease_step.max(1),
+            high_latency_ms: high_latency_ms.max(1),
+            current_limit: AtomicUsize::new(max_limit),
+            inflight: AtomicUsize::new(0),
+        }
+    }
+
+    pub fn try_acquire(self: &Arc<Self>) -> Option<AdaptivePermit> {
+        loop {
+            let current = self.inflight.load(Ordering::Relaxed);
+            let limit = self.current_limit.load(Ordering::Relaxed).max(1);
+            if current >= limit {
+                return None;
+            }
+            if self
+                .inflight
+                .compare_exchange(current, current + 1, Ordering::AcqRel, Ordering::Relaxed)
+                .is_ok()
+            {
+                return Some(AdaptivePermit {
+                    admission: Arc::clone(self),
+                });
+            }
+        }
+    }
+
+    pub fn observe(&self, latency: Duration, overloaded: bool) {
+        if !self.enabled {
+            return;
+        }
+        let latency_ms = latency.as_millis() as u64;
+        if overloaded || latency_ms >= self.high_latency_ms {
+            let cur = self.current_limit.load(Ordering::Relaxed);
+            let next = cur.saturating_sub(self.decrease_step).max(self.min_limit);
+            self.current_limit.store(next, Ordering::Relaxed);
+            return;
+        }
+
+        let cur = self.current_limit.load(Ordering::Relaxed);
+        let next = cur.saturating_add(self.increase_step).min(self.max_limit);
+        self.current_limit.store(next, Ordering::Relaxed);
+    }
+
+    pub fn current_limit(&self) -> usize {
+        self.current_limit.load(Ordering::Relaxed)
+    }
+
+    pub fn inflight(&self) -> usize {
+        self.inflight.load(Ordering::Relaxed)
+    }
+
+    pub fn inflight_percent(&self) -> u8 {
+        let limit = self.current_limit().max(1);
+        ((self.inflight() * 100) / limit).min(100) as u8
+    }
+}
+
+pub struct AdaptivePermit {
+    admission: Arc<AdaptiveAdmission>,
+}
+
+impl Drop for AdaptivePermit {
+    fn drop(&mut self) {
+        self.admission.inflight.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+pub struct RouteQueueLimiter {
+    default_cap: usize,
+    caps: HashMap<String, usize>,
+    inflight: Mutex<HashMap<String, usize>>,
+}
+
+impl RouteQueueLimiter {
+    pub fn new(default_cap: usize, caps: HashMap<String, usize>) -> Self {
+        Self {
+            default_cap: default_cap.max(1),
+            caps,
+            inflight: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn try_acquire(self: &Arc<Self>, route: &str) -> Option<RouteQueuePermit> {
+        let cap = self
+            .caps
+            .get(route)
+            .copied()
+            .unwrap_or(self.default_cap)
+            .max(1);
+        let mut guard = self.inflight.lock().ok()?;
+        let current = guard.get(route).copied().unwrap_or(0);
+        if current >= cap {
+            return None;
+        }
+        guard.insert(route.to_string(), current + 1);
+        Some(RouteQueuePermit {
+            limiter: Arc::clone(self),
+            route: route.to_string(),
+        })
+    }
+}
+
+pub struct RouteQueuePermit {
+    limiter: Arc<RouteQueueLimiter>,
+    route: String,
+}
+
+impl Drop for RouteQueuePermit {
+    fn drop(&mut self) {
+        if let Ok(mut guard) = self.limiter.inflight.lock()
+            && let Some(current) = guard.get_mut(&self.route)
+        {
+            *current = current.saturating_sub(1);
+            if *current == 0 {
+                guard.remove(&self.route);
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct BreakerState {
+    consecutive_failures: u32,
+    open_until: Option<Instant>,
+    half_open_inflight: u32,
+    half_open: bool,
+}
+
+pub struct CircuitBreakers {
+    enabled: bool,
+    failure_threshold: u32,
+    open_for: Duration,
+    half_open_max_probes: u32,
+    states: Mutex<HashMap<String, BreakerState>>,
+}
+
+impl CircuitBreakers {
+    pub fn new(
+        enabled: bool,
+        failure_threshold: u32,
+        open_for: Duration,
+        half_open_max_probes: u32,
+    ) -> Self {
+        Self {
+            enabled,
+            failure_threshold: failure_threshold.max(1),
+            open_for,
+            half_open_max_probes: half_open_max_probes.max(1),
+            states: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn allow_request(&self, backend: &str) -> bool {
+        if !self.enabled {
+            return true;
+        }
+        let now = Instant::now();
+        let mut states = match self.states.lock() {
+            Ok(guard) => guard,
+            Err(_) => return true,
+        };
+        let state = states.entry(backend.to_string()).or_default();
+
+        if let Some(until) = state.open_until {
+            if now < until {
+                return false;
+            }
+            state.open_until = None;
+            state.half_open = true;
+            state.half_open_inflight = 0;
+            state.consecutive_failures = 0;
+        }
+
+        if state.half_open {
+            if state.half_open_inflight >= self.half_open_max_probes {
+                return false;
+            }
+            state.half_open_inflight += 1;
+        }
+
+        true
+    }
+
+    pub fn record_success(&self, backend: &str) {
+        if !self.enabled {
+            return;
+        }
+        let mut states = match self.states.lock() {
+            Ok(guard) => guard,
+            Err(_) => return,
+        };
+        let state = states.entry(backend.to_string()).or_default();
+        if state.half_open && state.half_open_inflight > 0 {
+            state.half_open_inflight -= 1;
+        }
+        state.consecutive_failures = 0;
+        state.open_until = None;
+        state.half_open = false;
+    }
+
+    pub fn record_failure(&self, backend: &str) {
+        if !self.enabled {
+            return;
+        }
+        let now = Instant::now();
+        let mut states = match self.states.lock() {
+            Ok(guard) => guard,
+            Err(_) => return,
+        };
+        let state = states.entry(backend.to_string()).or_default();
+
+        if state.half_open {
+            if state.half_open_inflight > 0 {
+                state.half_open_inflight -= 1;
+            }
+            state.open_until = Some(now + self.open_for);
+            state.half_open = false;
+            state.consecutive_failures = 0;
+            return;
+        }
+
+        state.consecutive_failures = state.consecutive_failures.saturating_add(1);
+        if state.consecutive_failures >= self.failure_threshold {
+            state.open_until = Some(now + self.open_for);
+            state.half_open = false;
+            state.consecutive_failures = 0;
+        }
+    }
+}
+
+pub struct RetryBudget {
+    enabled: bool,
+    global_ratio_percent: u8,
+    per_route_ratio_percent: HashMap<String, u8>,
+    global_primary: AtomicU64,
+    global_retries: AtomicU64,
+    route_stats: Mutex<HashMap<String, (u64, u64)>>,
+}
+
+impl RetryBudget {
+    pub fn new(
+        enabled: bool,
+        global_ratio_percent: u8,
+        per_route_ratio_percent: HashMap<String, u8>,
+    ) -> Self {
+        Self {
+            enabled,
+            global_ratio_percent,
+            per_route_ratio_percent,
+            global_primary: AtomicU64::new(0),
+            global_retries: AtomicU64::new(0),
+            route_stats: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn mark_primary(&self, route: &str) {
+        self.global_primary.fetch_add(1, Ordering::Relaxed);
+        if let Ok(mut stats) = self.route_stats.lock() {
+            let entry = stats.entry(route.to_string()).or_insert((0, 0));
+            entry.0 = entry.0.saturating_add(1);
+        }
+    }
+
+    pub fn allow_retry(&self, route: &str) -> bool {
+        if !self.enabled {
+            return false;
+        }
+
+        let ratio = self
+            .per_route_ratio_percent
+            .get(route)
+            .copied()
+            .unwrap_or(self.global_ratio_percent)
+            .min(100);
+
+        let primary = self.global_primary.load(Ordering::Relaxed);
+        let retries = self.global_retries.load(Ordering::Relaxed);
+        let global_limit = ((primary * ratio as u64) / 100).saturating_add(1);
+        if retries >= global_limit {
+            return false;
+        }
+
+        let mut route_allowed = true;
+        if let Ok(mut stats) = self.route_stats.lock() {
+            let entry = stats.entry(route.to_string()).or_insert((0, 0));
+            let route_limit = ((entry.0 * ratio as u64) / 100).saturating_add(1);
+            if entry.1 >= route_limit {
+                route_allowed = false;
+            } else {
+                entry.1 = entry.1.saturating_add(1);
+            }
+        }
+        if !route_allowed {
+            return false;
+        }
+
+        self.global_retries.fetch_add(1, Ordering::Relaxed);
+        true
+    }
+}
+
+pub struct BrownoutController {
+    enabled: bool,
+    trigger_inflight_percent: u8,
+    recover_inflight_percent: u8,
+    core_routes: HashSet<String>,
+    active: AtomicBool,
+}
+
+impl BrownoutController {
+    pub fn new(
+        enabled: bool,
+        trigger_inflight_percent: u8,
+        recover_inflight_percent: u8,
+        core_routes: Vec<String>,
+    ) -> Self {
+        Self {
+            enabled,
+            trigger_inflight_percent: trigger_inflight_percent.min(100),
+            recover_inflight_percent: recover_inflight_percent.min(100),
+            core_routes: core_routes.into_iter().collect(),
+            active: AtomicBool::new(false),
+        }
+    }
+
+    pub fn observe_admission_pressure(&self, inflight_percent: u8) {
+        if !self.enabled {
+            self.active.store(false, Ordering::Relaxed);
+            return;
+        }
+
+        let active = self.active.load(Ordering::Relaxed);
+        if !active && inflight_percent >= self.trigger_inflight_percent {
+            self.active.store(true, Ordering::Relaxed);
+            return;
+        }
+        if active && inflight_percent <= self.recover_inflight_percent {
+            self.active.store(false, Ordering::Relaxed);
+        }
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.active.load(Ordering::Relaxed)
+    }
+
+    pub fn route_allowed(&self, route: &str) -> bool {
+        if !self.enabled || !self.is_active() {
+            return true;
+        }
+        self.core_routes.contains(route)
+    }
+}
+
+pub struct RuntimeResilience {
+    pub adaptive_admission: Arc<AdaptiveAdmission>,
+    pub route_queue: Arc<RouteQueueLimiter>,
+    pub circuit_breakers: Arc<CircuitBreakers>,
+    pub retry_budget: Arc<RetryBudget>,
+    pub brownout: Arc<BrownoutController>,
+    pub hedging_enabled: bool,
+    pub hedging_delay: Duration,
+    safe_methods: HashSet<String>,
+    route_allowlist: HashSet<String>,
+}
+
+impl RuntimeResilience {
+    pub fn from_config(config: &ResilienceConfig, global_limit: usize) -> Self {
+        let adaptive = &config.adaptive_admission;
+        let admission = Arc::new(AdaptiveAdmission::new(
+            adaptive.enabled,
+            adaptive.min_limit,
+            global_limit.max(adaptive.min_limit),
+            adaptive.increase_step,
+            adaptive.decrease_step,
+            adaptive.high_latency_ms,
+        ));
+        let route_queue = Arc::new(RouteQueueLimiter::new(
+            config.route_queue.default_cap,
+            config.route_queue.caps.clone(),
+        ));
+        let cb = &config.circuit_breaker;
+        let circuit_breakers = Arc::new(CircuitBreakers::new(
+            cb.enabled,
+            cb.failure_threshold,
+            Duration::from_millis(cb.open_ms.max(1)),
+            cb.half_open_max_probes,
+        ));
+        let retry_budget = Arc::new(RetryBudget::new(
+            config.retry_budget.enabled,
+            config.retry_budget.ratio_percent,
+            config.retry_budget.per_route_ratio_percent.clone(),
+        ));
+        let brownout = Arc::new(BrownoutController::new(
+            config.brownout.enabled,
+            config.brownout.trigger_inflight_percent,
+            config.brownout.recover_inflight_percent,
+            config.brownout.core_routes.clone(),
+        ));
+
+        let safe_methods = config
+            .hedging
+            .safe_methods
+            .iter()
+            .map(|method| method.to_ascii_uppercase())
+            .collect::<HashSet<_>>();
+        let route_allowlist = config
+            .hedging
+            .route_allowlist
+            .iter()
+            .cloned()
+            .collect::<HashSet<_>>();
+
+        Self {
+            adaptive_admission: admission,
+            route_queue,
+            circuit_breakers,
+            retry_budget,
+            brownout,
+            hedging_enabled: config.hedging.enabled,
+            hedging_delay: Duration::from_millis(config.hedging.delay_ms.max(1)),
+            safe_methods,
+            route_allowlist,
+        }
+    }
+
+    pub fn hedging_allowed_for(&self, method: &str, route: &str, bodyless: bool) -> bool {
+        if !self.hedging_enabled || self.brownout.is_active() || !bodyless {
+            return false;
+        }
+        let safe_method = self.safe_methods.contains(&method.to_ascii_uppercase());
+        if !safe_method {
+            return false;
+        }
+        self.route_allowlist.is_empty() || self.route_allowlist.contains(route)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn adaptive_admission_adjusts_limit() {
+        let admission = AdaptiveAdmission::new(true, 2, 10, 2, 3, 100);
+        assert_eq!(admission.current_limit(), 10);
+        admission.observe(Duration::from_millis(150), false);
+        assert_eq!(admission.current_limit(), 7);
+        admission.observe(Duration::from_millis(10), false);
+        assert_eq!(admission.current_limit(), 9);
+    }
+
+    #[test]
+    fn route_queue_cap_enforced() {
+        let limiter = Arc::new(RouteQueueLimiter::new(1, HashMap::new()));
+        let _p1 = limiter.try_acquire("api").expect("first permit");
+        assert!(limiter.try_acquire("api").is_none());
+    }
+
+    #[test]
+    fn circuit_breaker_opens_after_threshold() {
+        let cb = CircuitBreakers::new(true, 2, Duration::from_secs(1), 1);
+        assert!(cb.allow_request("b1"));
+        cb.record_failure("b1");
+        assert!(cb.allow_request("b1"));
+        cb.record_failure("b1");
+        assert!(!cb.allow_request("b1"));
+    }
+
+    #[test]
+    fn retry_budget_respects_ratio() {
+        let rb = RetryBudget::new(true, 50, HashMap::new());
+        rb.mark_primary("api");
+        assert!(rb.allow_retry("api"));
+        assert!(!rb.allow_retry("api"));
+    }
+
+    #[test]
+    fn brownout_preserves_core_routes() {
+        let controller = BrownoutController::new(true, 90, 60, vec!["core".to_string()]);
+        controller.observe_admission_pressure(95);
+        assert!(controller.is_active());
+        assert!(controller.route_allowed("core"));
+        assert!(!controller.route_allowed("non_core"));
+    }
+}

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -107,6 +107,7 @@ fn make_config(port: u32, backend_addr: String, cert: String, key: String) -> Co
         },
         performance: spooky_config::config::Performance::default(),
         observability: spooky_config::config::Observability::default(),
+        resilience: spooky_config::config::Resilience::default(),
     }
 }
 

--- a/crates/edge/tests/h3_edge.rs
+++ b/crates/edge/tests/h3_edge.rs
@@ -95,6 +95,7 @@ fn make_config(port: u32, cert: String, key: String, backend_address: String) ->
         },
         performance: spooky_config::config::Performance::default(),
         observability: spooky_config::config::Observability::default(),
+        resilience: spooky_config::config::Resilience::default(),
     }
 }
 

--- a/crates/edge/tests/lb_integration.rs
+++ b/crates/edge/tests/lb_integration.rs
@@ -115,6 +115,7 @@ fn make_config(
         },
         performance: spooky_config::config::Performance::default(),
         observability: spooky_config::config::Observability::default(),
+        resilience: spooky_config::config::Resilience::default(),
     }
 }
 

--- a/crates/errors/src/lib.rs
+++ b/crates/errors/src/lib.rs
@@ -25,6 +25,9 @@ pub enum PoolError {
     #[error("backend overloaded: {0}")]
     BackendOverloaded(String),
 
+    #[error("backend circuit open: {0}")]
+    CircuitOpen(String),
+
     #[error("send failed: {0}")]
     Send(#[source] hyper_util::client::legacy::Error),
 

--- a/crates/transport/src/h2_client.rs
+++ b/crates/transport/src/h2_client.rs
@@ -25,9 +25,14 @@ where
 }
 
 impl H2Client {
-    pub fn new(max_idle_per_host: usize, pool_idle_timeout: Duration) -> Self {
+    pub fn new(
+        max_idle_per_host: usize,
+        pool_idle_timeout: Duration,
+        connect_timeout: Duration,
+    ) -> Self {
         let mut http = HttpConnector::new();
         http.enforce_http(false);
+        http.set_connect_timeout(Some(connect_timeout));
 
         let client = Client::builder(TokioExecutor)
             .http2_only(true)
@@ -48,6 +53,6 @@ impl H2Client {
 
 impl Default for H2Client {
     fn default() -> Self {
-        Self::new(64, Duration::from_secs(30))
+        Self::new(64, Duration::from_secs(30), Duration::from_secs(2))
     }
 }

--- a/crates/transport/src/h2_pool.rs
+++ b/crates/transport/src/h2_pool.rs
@@ -23,6 +23,7 @@ impl H2Pool {
         max_inflight: usize,
         max_idle_per_backend: usize,
         pool_idle_timeout: Duration,
+        connect_timeout: Duration,
     ) -> Self
     where
         I: IntoIterator<Item = String>,
@@ -34,7 +35,7 @@ impl H2Pool {
             map.insert(
                 backend,
                 BackendHandle {
-                    client: H2Client::new(max_idle_per_backend, pool_idle_timeout),
+                    client: H2Client::new(max_idle_per_backend, pool_idle_timeout, connect_timeout),
                     inflight: Arc::new(Semaphore::new(inflight)),
                 },
             );

--- a/crates/transport/tests/h2_pool.rs
+++ b/crates/transport/tests/h2_pool.rs
@@ -89,6 +89,7 @@ async fn pool_limits_inflight_per_backend() {
         1,
         64,
         Duration::from_secs(30),
+        Duration::from_secs(2),
     ));
     let req1 = Request::builder()
         .method("GET")
@@ -133,6 +134,7 @@ async fn pool_rejects_unknown_backend() {
         1,
         64,
         Duration::from_secs(30),
+        Duration::from_secs(2),
     );
     let req = Request::builder()
         .method("GET")
@@ -157,6 +159,7 @@ async fn pool_capacity_probe_reflects_inflight_state() {
         1,
         64,
         Duration::from_secs(30),
+        Duration::from_secs(2),
     ));
 
     assert!(pool.has_capacity(&backend).unwrap());


### PR DESCRIPTION
## Summary
This PR implements production-grade runtime resilience controls on the edge data path and wires them through config, validation, and transport:

- Adaptive admission control for overload shedding
- Per-route queue caps
- Circuit breaker integration for backend failures
- Safe-method hedging with retry budgets
- Strict backend timeout hierarchy (connect, request, body idle, body total, total request)
- Brownout mode to preserve core routes under pressure

## What Changed

### 1. Config + Validation
- Added `resilience` config section with:
  - `adaptive_admission`
  - `route_queue`
  - `circuit_breaker`
  - `hedging`
  - `retry_budget`
  - `brownout`
- Added performance timeout field:
  - `backend_connect_timeout_ms`
  - `backend_total_request_timeout_ms`
- Added validation rules for:
  - timeout ordering
  - non-zero caps/thresholds
  - retry budget bounds
  - brownout trigger/recover constraints
- Updated sample config accordingly.

### 2. Transport
- Added backend connect timeout wiring to H2 connector/pool creation.
- Added `PoolError::CircuitOpen(String)` for explicit circuit-open failures.

### 3. Edge Runtime Resilience
- Added runtime resilience module with:
  - adaptive admission permits (RAII)
  - per-route queue permits (RAII)
  - circuit breaker state machine
  - retry budget accounting
  - brownout controller
- Integrated into request handling path:
  - early admission/queue checks
  - brownout route shedding
  - circuit checks before backend send
  - safe hedging/retry on eligible bodyless requests
  - total request deadline enforcement
- Added handling for bodyless-mode violations and overload conditions with controlled responses.

## Test Coverage
Ran targeted checks/tests:

- `cargo check -q`
- `cargo test -q -p spooky-config`
- `cargo test -q -p spooky-transport --test h2_pool`
- `cargo test -q -p spooky-edge resilience`
- `cargo test -q -p spooky-edge --test h3_edge`
- `cargo test -q -p spooky-edge --test h3_bridge`

All passed.

## Commits
1. `config: add resilience and timeout hierarchy settings`
2. `transport: enforce backend connect timeout and circuit-open error`
3. `edge: add adaptive admission, brownout, and retry resilience path`