### PR TITLE
Runtime Resilience Hardening: Watchdog Safe Restart, Recoverable Protocol Errors, and Chaos Coverage

### DIFF
--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -109,3 +109,14 @@ resilience:
         trigger_inflight_percent: 90
         recover_inflight_percent: 60
         core_routes: []
+    watchdog:
+        enabled: false
+        check_interval_ms: 1000
+        poll_stall_timeout_ms: 5000
+        timeout_error_rate_percent: 60
+        min_requests_per_window: 20
+        overload_inflight_percent: 95
+        unhealthy_consecutive_windows: 3
+        drain_grace_ms: 8000
+        restart_cooldown_ms: 120000
+        restart_hook: null

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -24,6 +24,13 @@ use crate::default::{
     resilience_default_cb_open_ms, resilience_default_hedging_delay_ms,
     resilience_default_hedging_enabled, resilience_default_retry_budget_enabled,
     resilience_default_retry_budget_ratio_percent, resilience_default_route_queue_default_cap,
+    resilience_default_watchdog_check_interval_ms, resilience_default_watchdog_drain_grace_ms,
+    resilience_default_watchdog_enabled, resilience_default_watchdog_min_requests_per_window,
+    resilience_default_watchdog_overload_inflight_percent,
+    resilience_default_watchdog_poll_stall_timeout_ms,
+    resilience_default_watchdog_restart_cooldown_ms,
+    resilience_default_watchdog_timeout_error_rate_percent,
+    resilience_default_watchdog_unhealthy_consecutive_windows,
 };
 
 #[derive(Debug, Deserialize, Clone)]
@@ -244,6 +251,8 @@ pub struct Resilience {
     pub retry_budget: RetryBudget,
     #[serde(default)]
     pub brownout: Brownout,
+    #[serde(default)]
+    pub watchdog: Watchdog,
 }
 
 impl Default for Resilience {
@@ -255,6 +264,7 @@ impl Default for Resilience {
             hedging: Hedging::default(),
             retry_budget: RetryBudget::default(),
             brownout: Brownout::default(),
+            watchdog: Watchdog::default(),
         }
     }
 }
@@ -387,6 +397,48 @@ impl Default for Brownout {
             trigger_inflight_percent: resilience_default_brownout_trigger_inflight_percent(),
             recover_inflight_percent: resilience_default_brownout_recover_inflight_percent(),
             core_routes: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct Watchdog {
+    #[serde(default = "resilience_default_watchdog_enabled")]
+    pub enabled: bool,
+    #[serde(default = "resilience_default_watchdog_check_interval_ms")]
+    pub check_interval_ms: u64,
+    #[serde(default = "resilience_default_watchdog_poll_stall_timeout_ms")]
+    pub poll_stall_timeout_ms: u64,
+    #[serde(default = "resilience_default_watchdog_timeout_error_rate_percent")]
+    pub timeout_error_rate_percent: u8,
+    #[serde(default = "resilience_default_watchdog_min_requests_per_window")]
+    pub min_requests_per_window: u64,
+    #[serde(default = "resilience_default_watchdog_overload_inflight_percent")]
+    pub overload_inflight_percent: u8,
+    #[serde(default = "resilience_default_watchdog_unhealthy_consecutive_windows")]
+    pub unhealthy_consecutive_windows: u32,
+    #[serde(default = "resilience_default_watchdog_drain_grace_ms")]
+    pub drain_grace_ms: u64,
+    #[serde(default = "resilience_default_watchdog_restart_cooldown_ms")]
+    pub restart_cooldown_ms: u64,
+    #[serde(default)]
+    pub restart_hook: Option<String>,
+}
+
+impl Default for Watchdog {
+    fn default() -> Self {
+        Self {
+            enabled: resilience_default_watchdog_enabled(),
+            check_interval_ms: resilience_default_watchdog_check_interval_ms(),
+            poll_stall_timeout_ms: resilience_default_watchdog_poll_stall_timeout_ms(),
+            timeout_error_rate_percent: resilience_default_watchdog_timeout_error_rate_percent(),
+            min_requests_per_window: resilience_default_watchdog_min_requests_per_window(),
+            overload_inflight_percent: resilience_default_watchdog_overload_inflight_percent(),
+            unhealthy_consecutive_windows:
+                resilience_default_watchdog_unhealthy_consecutive_windows(),
+            drain_grace_ms: resilience_default_watchdog_drain_grace_ms(),
+            restart_cooldown_ms: resilience_default_watchdog_restart_cooldown_ms(),
+            restart_hook: None,
         }
     }
 }

--- a/crates/config/src/default.rs
+++ b/crates/config/src/default.rs
@@ -202,6 +202,42 @@ pub fn resilience_default_brownout_recover_inflight_percent() -> u8 {
     60
 }
 
+pub fn resilience_default_watchdog_enabled() -> bool {
+    false
+}
+
+pub fn resilience_default_watchdog_check_interval_ms() -> u64 {
+    1_000
+}
+
+pub fn resilience_default_watchdog_poll_stall_timeout_ms() -> u64 {
+    5_000
+}
+
+pub fn resilience_default_watchdog_timeout_error_rate_percent() -> u8 {
+    60
+}
+
+pub fn resilience_default_watchdog_min_requests_per_window() -> u64 {
+    20
+}
+
+pub fn resilience_default_watchdog_overload_inflight_percent() -> u8 {
+    95
+}
+
+pub fn resilience_default_watchdog_unhealthy_consecutive_windows() -> u32 {
+    3
+}
+
+pub fn resilience_default_watchdog_drain_grace_ms() -> u64 {
+    8_000
+}
+
+pub fn resilience_default_watchdog_restart_cooldown_ms() -> u64 {
+    120_000
+}
+
 pub fn observe_default_address() -> String {
     String::from("127.0.0.1")
 }

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -256,6 +256,46 @@ pub fn validate(config: &Config) -> bool {
         return false;
     }
 
+    if config.resilience.watchdog.check_interval_ms == 0 {
+        error!("resilience.watchdog.check_interval_ms must be greater than 0");
+        return false;
+    }
+
+    if config.resilience.watchdog.poll_stall_timeout_ms == 0 {
+        error!("resilience.watchdog.poll_stall_timeout_ms must be greater than 0");
+        return false;
+    }
+
+    if config.resilience.watchdog.timeout_error_rate_percent > 100 {
+        error!("resilience.watchdog.timeout_error_rate_percent must be <= 100");
+        return false;
+    }
+
+    if config.resilience.watchdog.min_requests_per_window == 0 {
+        error!("resilience.watchdog.min_requests_per_window must be greater than 0");
+        return false;
+    }
+
+    if config.resilience.watchdog.overload_inflight_percent > 100 {
+        error!("resilience.watchdog.overload_inflight_percent must be <= 100");
+        return false;
+    }
+
+    if config.resilience.watchdog.unhealthy_consecutive_windows == 0 {
+        error!("resilience.watchdog.unhealthy_consecutive_windows must be greater than 0");
+        return false;
+    }
+
+    if config.resilience.watchdog.drain_grace_ms == 0 {
+        error!("resilience.watchdog.drain_grace_ms must be greater than 0");
+        return false;
+    }
+
+    if config.resilience.watchdog.restart_cooldown_ms == 0 {
+        error!("resilience.watchdog.restart_cooldown_ms must be greater than 0");
+        return false;
+    }
+
     // --- Validate observability ---
     if config.observability.metrics.enabled {
         if config.observability.metrics.address.is_empty() {
@@ -593,6 +633,8 @@ upstream:
         assert_eq!(cfg.observability.metrics.path, "/metrics");
         assert!(cfg.resilience.adaptive_admission.enabled);
         assert_eq!(cfg.resilience.route_queue.default_cap, 512);
+        assert!(!cfg.resilience.watchdog.enabled);
+        assert_eq!(cfg.resilience.watchdog.check_interval_ms, 1_000);
     }
 
     #[test]
@@ -658,6 +700,14 @@ upstream:
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.resilience.brownout.trigger_inflight_percent = 50;
         cfg.resilience.brownout.recover_inflight_percent = 50;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.resilience.watchdog.timeout_error_rate_percent = 101;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.resilience.watchdog.unhealthy_consecutive_windows = 0;
         assert!(!validate(&cfg));
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -407,14 +407,18 @@ impl Metrics {
             self.watchdog_restart_requests.load(Ordering::Relaxed)
         ));
 
-        out.push_str("# HELP spooky_watchdog_restart_hooks Total executed watchdog restart hooks.\n");
+        out.push_str(
+            "# HELP spooky_watchdog_restart_hooks Total executed watchdog restart hooks.\n",
+        );
         out.push_str("# TYPE spooky_watchdog_restart_hooks counter\n");
         out.push_str(&format!(
             "spooky_watchdog_restart_hooks {}\n",
             self.watchdog_restart_hooks.load(Ordering::Relaxed)
         ));
 
-        out.push_str("# HELP spooky_watchdog_degraded_windows Total degraded watchdog evaluation windows.\n");
+        out.push_str(
+            "# HELP spooky_watchdog_degraded_windows Total degraded watchdog evaluation windows.\n",
+        );
         out.push_str("# TYPE spooky_watchdog_degraded_windows counter\n");
         out.push_str(&format!(
             "spooky_watchdog_degraded_windows {}\n",

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -25,6 +25,7 @@ use tokio::sync::{OwnedSemaphorePermit, Semaphore, mpsc, oneshot};
 use crate::cid_radix::CidRadix;
 use crate::constants::MAX_DATAGRAM_SIZE_BYTES;
 use crate::resilience::{AdaptivePermit, RouteQueuePermit, RuntimeResilience};
+use crate::watchdog::WatchdogCoordinator;
 
 /// A streaming HTTP body backed by a tokio mpsc channel.
 /// The quiche Data handler sends chunks through the sender;
@@ -62,6 +63,7 @@ pub mod constants;
 pub mod quic_listener;
 mod resilience;
 mod route_index;
+mod watchdog;
 
 pub use quic_listener::configure_async_runtime;
 
@@ -72,6 +74,7 @@ pub struct SharedRuntimeState {
     pub(crate) global_inflight: Arc<Semaphore>,
     pub(crate) metrics: Arc<Metrics>,
     pub(crate) resilience: Arc<RuntimeResilience>,
+    pub(crate) watchdog: Arc<WatchdogCoordinator>,
 }
 
 pub struct QUICListener {
@@ -86,8 +89,10 @@ pub struct QUICListener {
     pub(crate) routing_index: route_index::RouteIndex,
     pub metrics: Arc<Metrics>,
     pub resilience: Arc<RuntimeResilience>,
+    pub watchdog: Arc<WatchdogCoordinator>,
     pub draining: bool,
     pub drain_start: Option<Instant>,
+    pub watchdog_worker_drained: bool,
     pub backend_timeout: Duration,
     pub backend_body_idle_timeout: Duration,
     pub backend_body_total_timeout: Duration,
@@ -207,6 +212,9 @@ pub struct Metrics {
     pub backend_errors: AtomicU64,
     pub overload_shed: AtomicU64,
     pub scid_rotations: AtomicU64,
+    pub watchdog_restart_requests: AtomicU64,
+    pub watchdog_restart_hooks: AtomicU64,
+    pub watchdog_degraded_windows: AtomicU64,
     route_stats_shards: Vec<Mutex<HashMap<String, RouteStats>>>,
 }
 
@@ -248,6 +256,9 @@ impl Default for Metrics {
             backend_errors: AtomicU64::new(0),
             overload_shed: AtomicU64::new(0),
             scid_rotations: AtomicU64::new(0),
+            watchdog_restart_requests: AtomicU64::new(0),
+            watchdog_restart_hooks: AtomicU64::new(0),
+            watchdog_degraded_windows: AtomicU64::new(0),
             route_stats_shards: shards,
         }
     }
@@ -280,6 +291,20 @@ impl Metrics {
 
     pub fn inc_scid_rotation(&self) {
         self.scid_rotations.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_watchdog_restart_request(&self) {
+        self.watchdog_restart_requests
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_watchdog_restart_hook(&self) {
+        self.watchdog_restart_hooks.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_watchdog_degraded_window(&self) {
+        self.watchdog_degraded_windows
+            .fetch_add(1, Ordering::Relaxed);
     }
 
     pub fn record_route(&self, route: &str, latency: Duration, outcome: RouteOutcome) {
@@ -373,6 +398,27 @@ impl Metrics {
         out.push_str(&format!(
             "spooky_scid_rotations {}\n",
             self.scid_rotations.load(Ordering::Relaxed)
+        ));
+
+        out.push_str("# HELP spooky_watchdog_restart_requests Total watchdog restart requests.\n");
+        out.push_str("# TYPE spooky_watchdog_restart_requests counter\n");
+        out.push_str(&format!(
+            "spooky_watchdog_restart_requests {}\n",
+            self.watchdog_restart_requests.load(Ordering::Relaxed)
+        ));
+
+        out.push_str("# HELP spooky_watchdog_restart_hooks Total executed watchdog restart hooks.\n");
+        out.push_str("# TYPE spooky_watchdog_restart_hooks counter\n");
+        out.push_str(&format!(
+            "spooky_watchdog_restart_hooks {}\n",
+            self.watchdog_restart_hooks.load(Ordering::Relaxed)
+        ));
+
+        out.push_str("# HELP spooky_watchdog_degraded_windows Total degraded watchdog evaluation windows.\n");
+        out.push_str("# TYPE spooky_watchdog_degraded_windows counter\n");
+        out.push_str(&format!(
+            "spooky_watchdog_degraded_windows {}\n",
+            self.watchdog_degraded_windows.load(Ordering::Relaxed)
         ));
 
         let mut snapshot: Vec<(String, RouteStats)> = Vec::new();

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -52,6 +52,7 @@ use crate::{
     outcome_from_status,
     resilience::RuntimeResilience,
     route_index::RouteIndex,
+    watchdog::{WatchdogCoordinator, WatchdogRuntimeConfig, now_millis},
 };
 
 fn is_hop_header(name: &str) -> bool {
@@ -78,7 +79,7 @@ fn request_content_length(headers: &[quiche::h3::Header]) -> Option<usize> {
 impl QUICListener {
     pub fn new(config: SpookyConfig) -> Result<Self, ProxyError> {
         let shared_state = Arc::new(Self::build_shared_state(&config)?);
-        Self::spawn_control_plane_tasks(&config, &shared_state);
+        Self::spawn_control_plane_tasks(&config, &shared_state, 1);
         let socket = Self::bind_socket(&config, false)?;
         Self::new_with_socket_and_shared_state(config, socket, shared_state)
     }
@@ -148,6 +149,7 @@ impl QUICListener {
             &config.resilience,
             global_inflight_limit,
         ));
+        let watchdog = Arc::new(WatchdogCoordinator::new(&config.resilience.watchdog));
 
         Ok(SharedRuntimeState {
             h2_pool,
@@ -156,15 +158,27 @@ impl QUICListener {
             global_inflight: Arc::new(Semaphore::new(global_inflight_limit)),
             metrics: Arc::new(Metrics::default()),
             resilience,
+            watchdog,
         })
     }
 
-    pub fn spawn_control_plane_tasks(config: &SpookyConfig, shared_state: &SharedRuntimeState) {
+    pub fn spawn_control_plane_tasks(
+        config: &SpookyConfig,
+        shared_state: &SharedRuntimeState,
+        worker_count: usize,
+    ) {
+        shared_state.watchdog.set_expected_workers(worker_count.max(1));
         Self::spawn_health_checks(
             shared_state.upstream_pools.clone(),
             Arc::clone(&shared_state.h2_pool),
         );
         Self::spawn_metrics_endpoint(config, Arc::clone(&shared_state.metrics));
+        Self::spawn_watchdog(
+            config,
+            Arc::clone(&shared_state.metrics),
+            Arc::clone(&shared_state.resilience),
+            Arc::clone(&shared_state.watchdog),
+        );
     }
 
     pub fn bind_reuseport_sockets(
@@ -232,8 +246,10 @@ impl QUICListener {
             routing_index,
             metrics: Arc::clone(&shared_state.metrics),
             resilience: Arc::clone(&shared_state.resilience),
+            watchdog: Arc::clone(&shared_state.watchdog),
             draining: false,
             drain_start: None,
+            watchdog_worker_drained: false,
             backend_timeout,
             backend_body_idle_timeout,
             backend_body_total_timeout,
@@ -642,6 +658,22 @@ impl QUICListener {
     }
 
     pub fn poll(&mut self) {
+        self.watchdog.mark_poll_progress();
+        if !self.watchdog.restart_requested() {
+            self.watchdog_worker_drained = false;
+        }
+        if self.watchdog.restart_requested() && !self.draining {
+            warn!("Watchdog requested restart; entering draining mode");
+            self.start_draining();
+        }
+        if self.draining && self.drain_complete() {
+            if self.watchdog.restart_requested() && !self.watchdog_worker_drained {
+                self.watchdog.mark_worker_drained();
+                self.watchdog_worker_drained = true;
+            }
+            return;
+        }
+
         // Read a UDP datagram and feed it into quiche.
         let (len, peer) = match self.socket.recv_from(&mut self.recv_buf) {
             Ok(v) => v,
@@ -2430,6 +2462,165 @@ impl QUICListener {
             Ok(resp) => resp,
             Err(_) => Response::new(Full::new(Bytes::from_static(b"failed to render metrics\n"))),
         }
+    }
+
+    fn spawn_watchdog(
+        config: &SpookyConfig,
+        metrics: Arc<Metrics>,
+        resilience: Arc<RuntimeResilience>,
+        watchdog: Arc<WatchdogCoordinator>,
+    ) {
+        let watchdog_config = WatchdogRuntimeConfig::from(&config.resilience.watchdog);
+        if !watchdog_config.enabled || !watchdog.enabled() {
+            return;
+        }
+
+        let handle = match runtime_handle() {
+            Some(handle) => handle,
+            None => {
+                error!("Watchdog disabled: no Tokio runtime available");
+                return;
+            }
+        };
+
+        handle.spawn(async move {
+            info!(
+                "Watchdog enabled: check_interval_ms={} poll_stall_timeout_ms={} timeout_error_rate_percent={} overload_inflight_percent={} unhealthy_windows={} drain_grace_ms={} restart_cooldown_ms={}",
+                watchdog_config.check_interval_ms,
+                watchdog_config.poll_stall_timeout_ms,
+                watchdog_config.timeout_error_rate_percent,
+                watchdog_config.overload_inflight_percent,
+                watchdog_config.unhealthy_consecutive_windows,
+                watchdog_config.drain_grace_ms,
+                watchdog_config.restart_cooldown_ms,
+            );
+
+            let mut interval =
+                tokio::time::interval(Duration::from_millis(watchdog_config.check_interval_ms));
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            let has_restart_hook = watchdog_config
+                .restart_hook
+                .as_deref()
+                .map(str::trim)
+                .is_some_and(|value| !value.is_empty());
+
+            let mut previous_requests = metrics.requests_total.load(Ordering::Relaxed);
+            let mut previous_timeouts = metrics.backend_timeouts.load(Ordering::Relaxed);
+            let mut degraded_windows = 0u32;
+
+            loop {
+                interval.tick().await;
+                let now = now_millis();
+                let stalled = now.saturating_sub(watchdog.last_poll_progress_ms())
+                    > watchdog_config.poll_stall_timeout_ms;
+
+                let current_requests = metrics.requests_total.load(Ordering::Relaxed);
+                let current_timeouts = metrics.backend_timeouts.load(Ordering::Relaxed);
+                let request_delta = current_requests.saturating_sub(previous_requests);
+                let timeout_delta = current_timeouts.saturating_sub(previous_timeouts);
+                previous_requests = current_requests;
+                previous_timeouts = current_timeouts;
+
+                let timeout_rate_percent = if request_delta == 0 {
+                    0
+                } else {
+                    timeout_delta.saturating_mul(100) / request_delta
+                };
+
+                let timeout_pressure = request_delta >= watchdog_config.min_requests_per_window
+                    && timeout_rate_percent >= watchdog_config.timeout_error_rate_percent as u64;
+                let overload_pressure = resilience.adaptive_admission.inflight_percent()
+                    >= watchdog_config.overload_inflight_percent;
+
+                if stalled || timeout_pressure || overload_pressure {
+                    degraded_windows = degraded_windows.saturating_add(1);
+                    watchdog.set_degraded(true);
+                    metrics.inc_watchdog_degraded_window();
+                } else {
+                    degraded_windows = 0;
+                    watchdog.set_degraded(false);
+                }
+
+                if degraded_windows >= watchdog_config.unhealthy_consecutive_windows {
+                    if !has_restart_hook {
+                        warn!(
+                            "Watchdog detected unhealthy runtime state, but restart_hook is not configured"
+                        );
+                        degraded_windows = 0;
+                        continue;
+                    }
+                    let mut reasons = Vec::new();
+                    if stalled {
+                        reasons.push("poll_stall");
+                    }
+                    if timeout_pressure {
+                        reasons.push("timeout_spike");
+                    }
+                    if overload_pressure {
+                        reasons.push("inflight_overload");
+                    }
+                    let reason = reasons.join("+");
+                    if watchdog.request_restart(&reason) {
+                        metrics.inc_watchdog_restart_request();
+                        warn!("Watchdog requested safe restart: {}", reason);
+                    }
+                    degraded_windows = 0;
+                }
+
+                if !watchdog.restart_requested() {
+                    continue;
+                }
+
+                let requested_at = watchdog.restart_requested_at_ms();
+                let grace_elapsed = requested_at != 0
+                    && now.saturating_sub(requested_at) >= watchdog_config.drain_grace_ms;
+                if !watchdog.workers_drained() && !grace_elapsed {
+                    continue;
+                }
+
+                let restart_reason = watchdog.restart_reason();
+                if watchdog.workers_drained() {
+                    info!(
+                        "Watchdog safe restart condition reached (all workers drained): {}",
+                        restart_reason
+                    );
+                } else {
+                    warn!(
+                        "Watchdog restart drain grace elapsed; executing hook without full drain: {}",
+                        restart_reason
+                    );
+                }
+
+                let cmd = watchdog_config
+                    .restart_hook
+                    .as_deref()
+                    .map(str::trim)
+                    .unwrap_or_default();
+                let status = tokio::process::Command::new("/bin/sh")
+                    .arg("-c")
+                    .arg(cmd)
+                    .env("SPOOKY_WATCHDOG_REASON", &restart_reason)
+                    .status()
+                    .await;
+                match status {
+                    Ok(status) => {
+                        info!(
+                            "Watchdog restart hook exited with status {}",
+                            status
+                                .code()
+                                .map(|code| code.to_string())
+                                .unwrap_or_else(|| "signal".to_string())
+                        );
+                    }
+                    Err(err) => {
+                        error!("Watchdog restart hook execution failed: {}", err);
+                    }
+                }
+                metrics.inc_watchdog_restart_hook();
+
+                watchdog.complete_restart_cycle();
+            }
+        });
     }
 
     fn spawn_health_checks(

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -167,7 +167,9 @@ impl QUICListener {
         shared_state: &SharedRuntimeState,
         worker_count: usize,
     ) {
-        shared_state.watchdog.set_expected_workers(worker_count.max(1));
+        shared_state
+            .watchdog
+            .set_expected_workers(worker_count.max(1));
         Self::spawn_health_checks(
             shared_state.upstream_pools.clone(),
             Arc::clone(&shared_state.h2_pool),
@@ -1653,7 +1655,8 @@ impl QUICListener {
                             );
                             if let Some(req) = connection.streams.remove(&stream_id) {
                                 metrics.inc_failure();
-                                let route_label = req.upstream_name.as_deref().unwrap_or("unrouted");
+                                let route_label =
+                                    req.upstream_name.as_deref().unwrap_or("unrouted");
                                 metrics.record_route(
                                     route_label,
                                     req.start.elapsed(),
@@ -2067,40 +2070,38 @@ impl QUICListener {
                                 }
                             }
                         }
-                        ResponseChunk::End => {
-                            match h3.send_body(quic, stream_id, b"", true) {
-                                Ok(_) => {
-                                    req.phase = StreamPhase::Completed;
-                                    terminal = true;
-                                    break;
-                                }
-                                Err(quiche::h3::Error::StreamBlocked) => {
-                                    req.pending_chunk = Some(ResponseChunk::End);
-                                    break;
-                                }
-                                Err(err) => {
-                                    error!(
-                                        "HTTP/3 send_body end protocol error on stream {}: {:?}",
-                                        stream_id, err
-                                    );
-                                    req.phase = StreamPhase::Failed;
-                                    metrics.inc_failure();
-                                    metrics.inc_backend_error();
-                                    let route_label =
-                                        req.upstream_name.as_deref().unwrap_or("unrouted");
-                                    metrics.record_route(
-                                        route_label,
-                                        req.start.elapsed(),
-                                        RouteOutcome::BackendError,
-                                    );
-                                    resilience
-                                        .adaptive_admission
-                                        .observe(req.start.elapsed(), true);
-                                    terminal = true;
-                                    break;
-                                }
+                        ResponseChunk::End => match h3.send_body(quic, stream_id, b"", true) {
+                            Ok(_) => {
+                                req.phase = StreamPhase::Completed;
+                                terminal = true;
+                                break;
                             }
-                        }
+                            Err(quiche::h3::Error::StreamBlocked) => {
+                                req.pending_chunk = Some(ResponseChunk::End);
+                                break;
+                            }
+                            Err(err) => {
+                                error!(
+                                    "HTTP/3 send_body end protocol error on stream {}: {:?}",
+                                    stream_id, err
+                                );
+                                req.phase = StreamPhase::Failed;
+                                metrics.inc_failure();
+                                metrics.inc_backend_error();
+                                let route_label =
+                                    req.upstream_name.as_deref().unwrap_or("unrouted");
+                                metrics.record_route(
+                                    route_label,
+                                    req.start.elapsed(),
+                                    RouteOutcome::BackendError,
+                                );
+                                resilience
+                                    .adaptive_admission
+                                    .observe(req.start.elapsed(), true);
+                                terminal = true;
+                                break;
+                            }
+                        },
                         ResponseChunk::Error(err) => {
                             // Best-effort: close the stream.
                             let _ = h3.send_body(quic, stream_id, b"", true);

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -856,6 +856,9 @@ impl QUICListener {
             )
         {
             error!("HTTP/3 handling failed: {:?}", e);
+            let _ = connection
+                .quic
+                .close(true, 0x1, b"http3 protocol handling error");
         }
 
         Self::maybe_rotate_scid(&mut connection, &self.metrics);
@@ -1643,7 +1646,32 @@ impl QUICListener {
                             }
                         }
                         Err(quiche::h3::Error::Done) => break,
-                        Err(e) => return Err(e),
+                        Err(err) => {
+                            error!(
+                                "HTTP/3 recv_body protocol error on stream {}: {:?}",
+                                stream_id, err
+                            );
+                            if let Some(req) = connection.streams.remove(&stream_id) {
+                                metrics.inc_failure();
+                                let route_label = req.upstream_name.as_deref().unwrap_or("unrouted");
+                                metrics.record_route(
+                                    route_label,
+                                    req.start.elapsed(),
+                                    RouteOutcome::Failure,
+                                );
+                                resilience
+                                    .adaptive_admission
+                                    .observe(req.start.elapsed(), true);
+                            }
+                            let _ = Self::send_simple_response(
+                                h3,
+                                &mut connection.quic,
+                                stream_id,
+                                http::StatusCode::BAD_REQUEST,
+                                b"malformed request stream\n",
+                            );
+                            break;
+                        }
                     }
                 },
                 Ok((stream_id, quiche::h3::Event::Finished)) => {
@@ -1724,7 +1752,7 @@ impl QUICListener {
             if let Some(req) = streams.get(&stream_id)
                 && Instant::now() >= req.total_request_deadline
             {
-                Self::handle_forward_result(
+                if let Err(protocol_err) = Self::handle_forward_result(
                     h3,
                     quic,
                     stream_id,
@@ -1733,7 +1761,12 @@ impl QUICListener {
                     upstream_pools,
                     routing_index,
                     metrics,
-                )?;
+                ) {
+                    error!(
+                        "failed to emit timeout response for stream {}: {:?}",
+                        stream_id, protocol_err
+                    );
+                }
                 resilience
                     .adaptive_admission
                     .observe(req.start.elapsed(), true);
@@ -1802,7 +1835,34 @@ impl QUICListener {
                                 value.as_bytes(),
                             ));
                         }
-                        h3.send_response(quic, stream_id, &h3_headers, false)?;
+                        if let Err(err) = h3.send_response(quic, stream_id, &h3_headers, false) {
+                            if let Some(req) = streams.get(&stream_id) {
+                                let protocol = ProxyError::Protocol(format!(
+                                    "failed to send HTTP/3 response headers: {:?}",
+                                    err
+                                ));
+                                if let Err(protocol_err) = Self::handle_forward_result(
+                                    h3,
+                                    quic,
+                                    stream_id,
+                                    req,
+                                    Err(protocol),
+                                    upstream_pools,
+                                    routing_index,
+                                    metrics,
+                                ) {
+                                    error!(
+                                        "failed to emit protocol recovery response on stream {}: {:?}",
+                                        stream_id, protocol_err
+                                    );
+                                }
+                                resilience
+                                    .adaptive_admission
+                                    .observe(req.start.elapsed(), true);
+                            }
+                            streams.remove(&stream_id);
+                            continue;
+                        }
 
                         // Spawn a task that pumps body frames into a ResponseChunk channel.
                         // Enforces both body idle and total deadlines so slow upstream bodies
@@ -1930,7 +1990,7 @@ impl QUICListener {
                         // Send error response first, then remove the stream so
                         // cleanup only happens after the response has been emitted.
                         if let Some(req) = streams.get(&stream_id) {
-                            Self::handle_forward_result(
+                            if let Err(protocol_err) = Self::handle_forward_result(
                                 h3,
                                 quic,
                                 stream_id,
@@ -1939,7 +1999,12 @@ impl QUICListener {
                                 upstream_pools,
                                 routing_index,
                                 metrics,
-                            )?;
+                            ) {
+                                error!(
+                                    "failed to emit recoverable forward error response on stream {}: {:?}",
+                                    stream_id, protocol_err
+                                );
+                            }
                             resilience
                                 .adaptive_admission
                                 .observe(req.start.elapsed(), true);
@@ -1979,14 +2044,62 @@ impl QUICListener {
                                     req.pending_chunk = Some(ResponseChunk::Data(data));
                                     break;
                                 }
-                                Err(e) => return Err(e),
+                                Err(err) => {
+                                    error!(
+                                        "HTTP/3 send_body data protocol error on stream {}: {:?}",
+                                        stream_id, err
+                                    );
+                                    req.phase = StreamPhase::Failed;
+                                    metrics.inc_failure();
+                                    metrics.inc_backend_error();
+                                    let route_label =
+                                        req.upstream_name.as_deref().unwrap_or("unrouted");
+                                    metrics.record_route(
+                                        route_label,
+                                        req.start.elapsed(),
+                                        RouteOutcome::BackendError,
+                                    );
+                                    resilience
+                                        .adaptive_admission
+                                        .observe(req.start.elapsed(), true);
+                                    terminal = true;
+                                    break;
+                                }
                             }
                         }
                         ResponseChunk::End => {
-                            h3.send_body(quic, stream_id, b"", true)?;
-                            req.phase = StreamPhase::Completed;
-                            terminal = true;
-                            break;
+                            match h3.send_body(quic, stream_id, b"", true) {
+                                Ok(_) => {
+                                    req.phase = StreamPhase::Completed;
+                                    terminal = true;
+                                    break;
+                                }
+                                Err(quiche::h3::Error::StreamBlocked) => {
+                                    req.pending_chunk = Some(ResponseChunk::End);
+                                    break;
+                                }
+                                Err(err) => {
+                                    error!(
+                                        "HTTP/3 send_body end protocol error on stream {}: {:?}",
+                                        stream_id, err
+                                    );
+                                    req.phase = StreamPhase::Failed;
+                                    metrics.inc_failure();
+                                    metrics.inc_backend_error();
+                                    let route_label =
+                                        req.upstream_name.as_deref().unwrap_or("unrouted");
+                                    metrics.record_route(
+                                        route_label,
+                                        req.start.elapsed(),
+                                        RouteOutcome::BackendError,
+                                    );
+                                    resilience
+                                        .adaptive_admission
+                                        .observe(req.start.elapsed(), true);
+                                    terminal = true;
+                                    break;
+                                }
+                            }
                         }
                         ResponseChunk::Error(err) => {
                             // Best-effort: close the stream.
@@ -2169,9 +2282,19 @@ impl QUICListener {
         let upstream_pool = upstream_name.and_then(|n| upstream_pools.get(n)).cloned();
 
         match result {
-            // Ok variant is handled upstream by advance_streams_non_blocking;
-            // handle_forward_result is only called with Err variants.
-            Ok(_) => unreachable!("handle_forward_result called with Ok result"),
+            Ok(_) => {
+                error!("Unexpected successful forward result in error handler path");
+                metrics.inc_failure();
+                metrics.inc_backend_error();
+                metrics.record_route(route_label, start.elapsed(), RouteOutcome::BackendError);
+                Self::send_simple_response(
+                    h3,
+                    quic,
+                    stream_id,
+                    http::StatusCode::BAD_GATEWAY,
+                    b"unexpected upstream state\n",
+                )
+            }
             Err(ProxyError::Bridge(err)) => {
                 error!("Bridge error: {:?}", err);
                 metrics.inc_failure();
@@ -2252,6 +2375,19 @@ impl QUICListener {
                     stream_id,
                     http::StatusCode::BAD_GATEWAY,
                     b"upstream error\n",
+                )
+            }
+            Err(ProxyError::Protocol(err)) => {
+                error!("Protocol error: {}", err);
+                metrics.inc_failure();
+                metrics.inc_backend_error();
+                metrics.record_route(route_label, start.elapsed(), RouteOutcome::BackendError);
+                Self::send_simple_response(
+                    h3,
+                    quic,
+                    stream_id,
+                    http::StatusCode::BAD_GATEWAY,
+                    b"upstream protocol error\n",
                 )
             }
             Err(ProxyError::Timeout) => {

--- a/crates/edge/src/watchdog.rs
+++ b/crates/edge/src/watchdog.rs
@@ -1,0 +1,208 @@
+use std::sync::{
+    Mutex,
+    atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
+};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use spooky_config::config::Watchdog as WatchdogConfig;
+
+#[derive(Debug, Clone)]
+pub struct WatchdogRuntimeConfig {
+    pub enabled: bool,
+    pub check_interval_ms: u64,
+    pub poll_stall_timeout_ms: u64,
+    pub timeout_error_rate_percent: u8,
+    pub min_requests_per_window: u64,
+    pub overload_inflight_percent: u8,
+    pub unhealthy_consecutive_windows: u32,
+    pub drain_grace_ms: u64,
+    pub restart_cooldown_ms: u64,
+    pub restart_hook: Option<String>,
+}
+
+impl From<&WatchdogConfig> for WatchdogRuntimeConfig {
+    fn from(value: &WatchdogConfig) -> Self {
+        Self {
+            enabled: value.enabled,
+            check_interval_ms: value.check_interval_ms.max(1),
+            poll_stall_timeout_ms: value.poll_stall_timeout_ms.max(1),
+            timeout_error_rate_percent: value.timeout_error_rate_percent.min(100),
+            min_requests_per_window: value.min_requests_per_window.max(1),
+            overload_inflight_percent: value.overload_inflight_percent.min(100),
+            unhealthy_consecutive_windows: value.unhealthy_consecutive_windows.max(1),
+            drain_grace_ms: value.drain_grace_ms.max(1),
+            restart_cooldown_ms: value.restart_cooldown_ms.max(1),
+            restart_hook: value.restart_hook.clone(),
+        }
+    }
+}
+
+pub struct WatchdogCoordinator {
+    enabled: bool,
+    restart_cooldown_ms: u64,
+    last_poll_progress_ms: AtomicU64,
+    degraded: AtomicBool,
+    restart_requested: AtomicBool,
+    restart_requested_at_ms: AtomicU64,
+    last_restart_at_ms: AtomicU64,
+    expected_workers: AtomicUsize,
+    drained_workers: AtomicUsize,
+    restart_reason: Mutex<String>,
+}
+
+impl WatchdogCoordinator {
+    pub fn new(config: &WatchdogConfig) -> Self {
+        let now_ms = now_millis();
+        Self {
+            enabled: config.enabled,
+            restart_cooldown_ms: config.restart_cooldown_ms.max(1),
+            last_poll_progress_ms: AtomicU64::new(now_ms),
+            degraded: AtomicBool::new(false),
+            restart_requested: AtomicBool::new(false),
+            restart_requested_at_ms: AtomicU64::new(0),
+            last_restart_at_ms: AtomicU64::new(0),
+            expected_workers: AtomicUsize::new(1),
+            drained_workers: AtomicUsize::new(0),
+            restart_reason: Mutex::new(String::new()),
+        }
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    pub fn set_expected_workers(&self, workers: usize) {
+        self.expected_workers.store(workers.max(1), Ordering::Relaxed);
+    }
+
+    pub fn mark_poll_progress(&self) {
+        self.last_poll_progress_ms
+            .store(now_millis(), Ordering::Relaxed);
+    }
+
+    pub fn last_poll_progress_ms(&self) -> u64 {
+        self.last_poll_progress_ms.load(Ordering::Relaxed)
+    }
+
+    pub fn set_degraded(&self, degraded: bool) {
+        self.degraded.store(degraded, Ordering::Relaxed);
+    }
+
+    pub fn is_degraded(&self) -> bool {
+        self.degraded.load(Ordering::Relaxed)
+    }
+
+    pub fn request_restart(&self, reason: &str) -> bool {
+        if !self.enabled {
+            return false;
+        }
+        let now_ms = now_millis();
+        let last_restart = self.last_restart_at_ms.load(Ordering::Relaxed);
+        if last_restart != 0 && now_ms.saturating_sub(last_restart) < self.restart_cooldown_ms {
+            return false;
+        }
+        if self
+            .restart_requested
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed)
+            .is_err()
+        {
+            return false;
+        }
+
+        self.restart_requested_at_ms.store(now_ms, Ordering::Relaxed);
+        self.drained_workers.store(0, Ordering::Relaxed);
+        if let Ok(mut current) = self.restart_reason.lock() {
+            *current = reason.to_string();
+        }
+        true
+    }
+
+    pub fn restart_requested(&self) -> bool {
+        self.restart_requested.load(Ordering::Relaxed)
+    }
+
+    pub fn restart_reason(&self) -> String {
+        self.restart_reason
+            .lock()
+            .map(|reason| reason.clone())
+            .unwrap_or_else(|_| String::from("watchdog restart requested"))
+    }
+
+    pub fn restart_requested_at_ms(&self) -> u64 {
+        self.restart_requested_at_ms.load(Ordering::Relaxed)
+    }
+
+    pub fn mark_worker_drained(&self) {
+        if !self.restart_requested() {
+            return;
+        }
+        self.drained_workers.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn workers_drained(&self) -> bool {
+        let expected = self.expected_workers.load(Ordering::Relaxed).max(1);
+        self.drained_workers.load(Ordering::Relaxed) >= expected
+    }
+
+    pub fn complete_restart_cycle(&self) {
+        self.last_restart_at_ms.store(now_millis(), Ordering::Relaxed);
+        self.restart_requested.store(false, Ordering::Relaxed);
+        self.restart_requested_at_ms.store(0, Ordering::Relaxed);
+        self.drained_workers.store(0, Ordering::Relaxed);
+        self.degraded.store(false, Ordering::Relaxed);
+    }
+}
+
+pub fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn restart_request_respects_single_pending_cycle() {
+        let cfg = WatchdogConfig {
+            enabled: true,
+            check_interval_ms: 1000,
+            poll_stall_timeout_ms: 5000,
+            timeout_error_rate_percent: 60,
+            min_requests_per_window: 20,
+            overload_inflight_percent: 90,
+            unhealthy_consecutive_windows: 3,
+            drain_grace_ms: 5_000,
+            restart_cooldown_ms: 60_000,
+            restart_hook: None,
+        };
+        let watchdog = WatchdogCoordinator::new(&cfg);
+        assert!(watchdog.request_restart("overload"));
+        assert!(!watchdog.request_restart("stall"));
+    }
+
+    #[test]
+    fn worker_drain_tracking_uses_expected_worker_count() {
+        let cfg = WatchdogConfig {
+            enabled: true,
+            check_interval_ms: 1000,
+            poll_stall_timeout_ms: 5000,
+            timeout_error_rate_percent: 60,
+            min_requests_per_window: 20,
+            overload_inflight_percent: 90,
+            unhealthy_consecutive_windows: 3,
+            drain_grace_ms: 5_000,
+            restart_cooldown_ms: 60_000,
+            restart_hook: None,
+        };
+        let watchdog = WatchdogCoordinator::new(&cfg);
+        watchdog.set_expected_workers(2);
+        assert!(watchdog.request_restart("stall"));
+        watchdog.mark_worker_drained();
+        assert!(!watchdog.workers_drained());
+        watchdog.mark_worker_drained();
+        assert!(watchdog.workers_drained());
+    }
+}

--- a/crates/edge/src/watchdog.rs
+++ b/crates/edge/src/watchdog.rs
@@ -72,7 +72,8 @@ impl WatchdogCoordinator {
     }
 
     pub fn set_expected_workers(&self, workers: usize) {
-        self.expected_workers.store(workers.max(1), Ordering::Relaxed);
+        self.expected_workers
+            .store(workers.max(1), Ordering::Relaxed);
     }
 
     pub fn mark_poll_progress(&self) {
@@ -109,7 +110,8 @@ impl WatchdogCoordinator {
             return false;
         }
 
-        self.restart_requested_at_ms.store(now_ms, Ordering::Relaxed);
+        self.restart_requested_at_ms
+            .store(now_ms, Ordering::Relaxed);
         self.drained_workers.store(0, Ordering::Relaxed);
         if let Ok(mut current) = self.restart_reason.lock() {
             *current = reason.to_string();
@@ -145,7 +147,8 @@ impl WatchdogCoordinator {
     }
 
     pub fn complete_restart_cycle(&self) {
-        self.last_restart_at_ms.store(now_millis(), Ordering::Relaxed);
+        self.last_restart_at_ms
+            .store(now_millis(), Ordering::Relaxed);
         self.restart_requested.store(false, Ordering::Relaxed);
         self.restart_requested_at_ms.store(0, Ordering::Relaxed);
         self.drained_workers.store(0, Ordering::Relaxed);

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -5,7 +5,7 @@ use std::{
     pin::Pin,
     sync::{
         Arc,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     task::{Context, Poll},
     time::{Duration, Instant},
@@ -630,6 +630,89 @@ async fn start_h2_backend_with_regression_routes() -> SocketAddr {
     addr
 }
 
+async fn start_h2_backend_with_chaos_routes() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let jitter_counter = Arc::new(AtomicUsize::new(0));
+    let flap_counter = Arc::new(AtomicUsize::new(0));
+
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = match listener.accept().await {
+                Ok(v) => v,
+                Err(_) => break,
+            };
+
+            let io = TokioIo::new(stream);
+            let jitter_counter = Arc::clone(&jitter_counter);
+            let flap_counter = Arc::clone(&flap_counter);
+            let service = service_fn(move |req: Request<Incoming>| {
+                let path = req.uri().path().to_string();
+                let jitter_counter = Arc::clone(&jitter_counter);
+                let flap_counter = Arc::clone(&flap_counter);
+                async move {
+                    let response: Response<TestBody> = match path.as_str() {
+                        "/jitter" => {
+                            let jitter =
+                                15 + (jitter_counter.fetch_add(1, Ordering::Relaxed) % 120) as u64;
+                            tokio::time::sleep(Duration::from_millis(jitter)).await;
+                            Response::new(Full::new(Bytes::from_static(b"jitter-ok\n")).boxed())
+                        }
+                        "/loss" => {
+                            tokio::time::sleep(Duration::from_secs(BACKEND_TIMEOUT_SECS + 2)).await;
+                            Response::new(Full::new(Bytes::from_static(b"late-loss\n")).boxed())
+                        }
+                        "/flap" => {
+                            if flap_counter.fetch_add(1, Ordering::Relaxed) % 2 == 0 {
+                                Response::new(Full::new(Bytes::from_static(b"flap-ok\n")).boxed())
+                            } else {
+                                Response::builder()
+                                    .status(503)
+                                    .body(Full::new(Bytes::from_static(b"flap-fail\n")).boxed())
+                                    .unwrap()
+                            }
+                        }
+                        "/health" => Response::new(Full::new(Bytes::from_static(b"ok\n")).boxed()),
+                        _ => Response::new(Full::new(Bytes::from_static(b"fast-ok\n")).boxed()),
+                    };
+                    Ok::<_, hyper::Error>(response)
+                }
+            });
+
+            tokio::spawn(async move {
+                let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
+                    .serve_connection(io, service)
+                    .await;
+            });
+        }
+    });
+
+    addr
+}
+
+fn make_config_with_backends(
+    port: u32,
+    backends: Vec<Backend>,
+    lb_type: &str,
+    cert: String,
+    key: String,
+) -> Config {
+    let mut config = make_config(
+        port,
+        backends
+            .first()
+            .map(|backend| backend.address.clone())
+            .unwrap_or_else(|| "127.0.0.1:1".to_string()),
+        cert,
+        key,
+    );
+    if let Some(upstream) = config.upstream.get_mut("test_pool") {
+        upstream.backends = backends;
+        upstream.load_balancing.lb_type = lb_type.to_string();
+    }
+    config
+}
+
 #[test]
 fn http3_to_http2_roundtrip() {
     let dir = tempdir().expect("failed to create temp dir");
@@ -1209,5 +1292,183 @@ fn backend_timeout_respects_configured_performance_value() {
     assert!(
         elapsed < Duration::from_secs(2),
         "configured backend timeout should fail fast, observed elapsed={elapsed:?}"
+    );
+}
+
+#[test]
+#[serial_test::serial]
+fn chaos_high_jitter_remains_responsive() {
+    let dir = tempdir().expect("failed to create temp dir");
+    let (cert, key) = write_test_certs(&dir);
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+
+    let backend_addr = rt.block_on(start_h2_backend_with_chaos_routes());
+    let mut config = make_config(0, backend_addr.to_string(), cert, key);
+    config.performance.backend_timeout_ms = 1_500;
+
+    let listener = QUICListener::new(config).expect("failed to create listener");
+    let listen_addr = listener.socket.local_addr().unwrap();
+    let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
+
+    let paths: Vec<&str> = vec!["/jitter"; 24];
+    let observations = run_h3_client_concurrent_get(
+        listen_addr,
+        &paths,
+        Duration::from_secs(REQUEST_TIMEOUT_SECS + 6),
+    )
+    .expect("jitter workload should complete");
+
+    let success = observations
+        .iter()
+        .filter(|obs| obs.status.as_deref() == Some("200"))
+        .count();
+    assert_eq!(
+        success,
+        observations.len(),
+        "all jitter requests should succeed"
+    );
+}
+
+#[test]
+#[serial_test::serial]
+fn chaos_packet_loss_like_timeout_maps_to_recoverable_response() {
+    let dir = tempdir().expect("failed to create temp dir");
+    let (cert, key) = write_test_certs(&dir);
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+
+    let backend_addr = rt.block_on(start_h2_backend_with_chaos_routes());
+    let mut config = make_config(0, backend_addr.to_string(), cert, key);
+    config.performance.backend_timeout_ms = 120;
+
+    let listener = QUICListener::new(config).expect("failed to create listener");
+    let listen_addr = listener.socket.local_addr().unwrap();
+    let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
+
+    let observations = run_h3_client_concurrent_get(
+        listen_addr,
+        &["/fast", "/loss", "/fast", "/loss"],
+        Duration::from_secs(REQUEST_TIMEOUT_SECS + 6),
+    )
+    .expect("loss-like workload should complete");
+
+    let fast_ok = observations
+        .iter()
+        .filter(|obs| obs.path == "/fast" && obs.status.as_deref() == Some("200"))
+        .count();
+    let loss_timeout = observations
+        .iter()
+        .filter(|obs| obs.path == "/loss" && obs.status.as_deref() == Some("503"))
+        .count();
+    assert_eq!(fast_ok, 2, "fast paths must remain healthy");
+    assert_eq!(
+        loss_timeout, 2,
+        "loss paths must map to recoverable timeout response"
+    );
+}
+
+#[test]
+#[serial_test::serial]
+fn chaos_backend_flapping_is_stable_under_concurrency() {
+    let dir = tempdir().expect("failed to create temp dir");
+    let (cert, key) = write_test_certs(&dir);
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+
+    let backend_addr = rt.block_on(start_h2_backend_with_chaos_routes());
+    let mut config = make_config(0, backend_addr.to_string(), cert, key);
+    config.performance.backend_timeout_ms = 500;
+
+    let listener = QUICListener::new(config).expect("failed to create listener");
+    let listen_addr = listener.socket.local_addr().unwrap();
+    let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
+
+    let paths: Vec<&str> = vec!["/flap"; 20];
+    let observations = run_h3_client_concurrent_get(
+        listen_addr,
+        &paths,
+        Duration::from_secs(REQUEST_TIMEOUT_SECS + 6),
+    )
+    .expect("flapping workload should complete");
+
+    let success = observations
+        .iter()
+        .filter(|obs| obs.status.as_deref() == Some("200"))
+        .count();
+    let service_unavailable = observations
+        .iter()
+        .filter(|obs| obs.status.as_deref() == Some("503"))
+        .count();
+    assert!(
+        success > 0,
+        "flapping workload should still serve successes"
+    );
+    assert!(
+        service_unavailable > 0,
+        "flapping workload should surface recoverable failures without collapse"
+    );
+}
+
+#[test]
+#[serial_test::serial]
+fn chaos_partial_outage_preserves_some_availability() {
+    let dir = tempdir().expect("failed to create temp dir");
+    let (cert, key) = write_test_certs(&dir);
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+
+    let healthy_backend = rt.block_on(start_h2_backend_with_chaos_routes());
+    let backends = vec![
+        Backend {
+            id: "dead-backend".to_string(),
+            address: "127.0.0.1:1".to_string(),
+            weight: 1,
+            health_check: HealthCheck {
+                path: "/health".to_string(),
+                interval: 1000,
+                timeout_ms: 100,
+                failure_threshold: 1,
+                success_threshold: 1,
+                cooldown_ms: 0,
+            },
+        },
+        Backend {
+            id: "healthy-backend".to_string(),
+            address: healthy_backend.to_string(),
+            weight: 1,
+            health_check: HealthCheck {
+                path: "/health".to_string(),
+                interval: 1000,
+                timeout_ms: 1000,
+                failure_threshold: 1,
+                success_threshold: 1,
+                cooldown_ms: 0,
+            },
+        },
+    ];
+    let mut config = make_config_with_backends(0, backends, "round-robin", cert, key);
+    config.performance.backend_timeout_ms = 250;
+
+    let listener = QUICListener::new(config).expect("failed to create listener");
+    let listen_addr = listener.socket.local_addr().unwrap();
+    let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
+
+    let paths: Vec<&str> = vec!["/fast"; 20];
+    let observations = run_h3_client_concurrent_get(
+        listen_addr,
+        &paths,
+        Duration::from_secs(REQUEST_TIMEOUT_SECS + 6),
+    )
+    .expect("partial outage workload should complete");
+
+    let success = observations
+        .iter()
+        .filter(|obs| obs.status.as_deref() == Some("200"))
+        .count();
+    let failures = observations
+        .iter()
+        .filter(|obs| obs.status.as_deref() != Some("200"))
+        .count();
+    assert!(success >= 5, "healthy backend should preserve availability");
+    assert!(
+        failures > 0,
+        "partial outage should still surface some failures"
     );
 }

--- a/crates/errors/src/lib.rs
+++ b/crates/errors/src/lib.rs
@@ -47,6 +47,9 @@ pub enum ProxyError {
     #[error("transport error: {0}")]
     Transport(String),
 
+    #[error("protocol error: {0}")]
+    Protocol(String),
+
     #[error("backend timeout")]
     Timeout,
 

--- a/spooky/src/main.rs
+++ b/spooky/src/main.rs
@@ -70,7 +70,6 @@ async fn main() {
             std::process::exit(1);
         }
     };
-    QUICListener::spawn_control_plane_tasks(&config_yaml, &shared_state);
 
     let requested_workers = config_yaml.performance.worker_threads.max(1);
     let worker_count = if requested_workers > 1 && !config_yaml.performance.reuseport {
@@ -82,6 +81,7 @@ async fn main() {
     } else {
         requested_workers
     };
+    QUICListener::spawn_control_plane_tasks(&config_yaml, &shared_state, worker_count);
 
     let sockets = if worker_count > 1 {
         match QUICListener::bind_reuseport_sockets(&config_yaml, worker_count) {


### PR DESCRIPTION
## Summary
This PR hardens Spooky’s runtime resilience for production by adding watchdog-based safe restart flow, removing panic-style handling in critical forwarding paths, classifying protocol failures into recoverable responses, and adding chaos integration coverage.

## What’s Included

### 1. Watchdog monitoring + safe restart hooks
- Added `resilience.watchdog` config block:
  - `enabled`
  - `check_interval_ms`
  - `poll_stall_timeout_ms`
  - `timeout_error_rate_percent`
  - `min_requests_per_window`
  - `overload_inflight_percent`
  - `unhealthy_consecutive_windows`
  - `drain_grace_ms`
  - `restart_cooldown_ms`
  - `restart_hook`
- Added watchdog runtime coordinator and control-plane loop:
  - Detects runtime degradation (poll stall / timeout spike / inflight pressure)
  - Requests safe restart only after configurable unhealthy windows
  - Uses graceful drain signal before restart action
  - Supports restart cooldown to avoid restart loops
  - Executes optional restart hook with reason env var
- Added watchdog metrics:
  - `spooky_watchdog_restart_requests`
  - `spooky_watchdog_restart_hooks`
  - `spooky_watchdog_degraded_windows`

### 2. Recoverable failure classification in runtime-critical path
- Added `ProxyError::Protocol(String)` for explicit protocol-level failure signaling.
- Replaced panic-style path in forwarding error handler (`unreachable!`) with safe recoverable handling.
- Hardened HTTP/3 response/body send/recv failure handling to:
  - classify as recoverable protocol/backend errors
  - emit controlled client responses where possible
  - update route/timeout/backend metrics consistently
  - avoid crashing hot path on protocol anomalies

### 3. Chaos integration tests
Added chaos scenarios in `h3_bridge` integration tests:
- high jitter workload remains responsive
- packet-loss-like timeout mapping returns recoverable response
- backend flapping under concurrency remains stable
- partial outage preserves at least partial availability
