### PR TITLE
fix(bench): harden perf regression gates for RSS noise and flaky CI runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Run benchmark regression gates
         run: |
-          PROFILE=ci FAIL_ON=severe ./scripts/bench-gate.sh
+          PROFILE=ci FAIL_ON=severe BENCH_GATE_RETRIES=1 ./scripts/bench-gate.sh
       - name: Upload benchmark artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/bench/manifest.yaml
+++ b/bench/manifest.yaml
@@ -33,6 +33,7 @@ gates:
     warn_pct: 0.20
     severe_pct: 0.40
     zero_baseline_limit: 128
+    min_delta_abs: 256
   alloc_calls:
     warn_pct: 0.20
     severe_pct: 0.50

--- a/crates/bench/src/main.rs
+++ b/crates/bench/src/main.rs
@@ -240,6 +240,8 @@ struct GateMetric {
     severe_pct: f64,
     #[serde(default)]
     zero_baseline_limit: f64,
+    #[serde(default)]
+    min_delta_abs: f64,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -1038,6 +1040,11 @@ fn classify_regression(
         };
         let warn_limit = effective_baseline * (1.0 + warn);
         let severe_limit = effective_baseline * (1.0 + severe);
+        let delta = current - baseline;
+        let min_delta_abs = gate.min_delta_abs.max(0.0);
+        if delta < min_delta_abs {
+            return None;
+        }
         if current > severe_limit {
             return Some((RegressionSeverity::Severe, warn_limit, severe_limit));
         }
@@ -1061,6 +1068,42 @@ fn classify_regression(
         return Some((RegressionSeverity::Warn, warn_limit, severe_limit));
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GateMetric, RegressionSeverity, classify_regression};
+
+    fn gate(
+        warn_pct: f64,
+        severe_pct: f64,
+        zero_baseline_limit: f64,
+        min_delta_abs: f64,
+    ) -> GateMetric {
+        GateMetric {
+            warn_pct,
+            severe_pct,
+            zero_baseline_limit,
+            min_delta_abs,
+        }
+    }
+
+    #[test]
+    fn min_delta_abs_suppresses_small_absolute_memory_drift() {
+        let memory_gate = gate(0.20, 0.40, 128.0, 256.0);
+        let regression = classify_regression(320.0, 200.0, &memory_gate, 128.0);
+        assert!(regression.is_none());
+    }
+
+    #[test]
+    fn min_delta_abs_still_allows_large_absolute_memory_regressions() {
+        let memory_gate = gate(0.20, 0.40, 128.0, 256.0);
+        let regression = classify_regression(520.0, 200.0, &memory_gate, 128.0);
+        assert!(matches!(
+            regression,
+            Some((RegressionSeverity::Severe, _, _))
+        ));
+    }
 }
 
 fn median(values: &mut [f64]) -> f64 {

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -92,6 +92,7 @@ Outputs:
 ```
 
 This runs both micro and macro suites with baseline checks and fails on severe regressions by default.
+For noisy shared environments, you can set `BENCH_GATE_RETRIES=1` (or higher) to retry failed suites before final failure.
 
 ## Promote New Release Baseline
 
@@ -144,5 +145,6 @@ Regression gates evaluate:
 - tail latency regression (`latency_p99_ns`) for sampled-latency cases (macro suite and any sampled micro cases)
 
 For metrics with tiny baselines (especially allocation call counts), the gate logic applies a minimum baseline floor from the manifest to avoid false positives caused by allocator/runtime differences across environments.
+Memory gates also support an absolute increase floor (`min_delta_abs`) so small RSS movement does not fail CI when percentage deltas look large on tiny baselines.
 
 CI fails on severe regressions. Warn-level regressions remain visible in markdown artifacts for review.

--- a/scripts/bench-gate.sh
+++ b/scripts/bench-gate.sh
@@ -6,6 +6,7 @@ MANIFEST="${MANIFEST:-bench/manifest.yaml}"
 BASELINE_INDEX="${BASELINE_INDEX:-bench/baselines/releases.json}"
 BASELINE_RELEASE="${BASELINE_RELEASE:-}"
 FAIL_ON="${FAIL_ON:-severe}"
+BENCH_GATE_RETRIES="${BENCH_GATE_RETRIES:-1}"
 
 mkdir -p bench/micro bench/macro
 
@@ -21,19 +22,37 @@ if [[ -n "$BASELINE_RELEASE" ]]; then
   ARGS+=(--baseline-release "$BASELINE_RELEASE")
 fi
 
-cargo run -q -p spooky-bench --release -- \
-  --suite micro \
-  --output bench/micro/latest.json \
-  --markdown-out bench/micro/latest.md \
-  "${ARGS[@]}"
+run_suite_with_retries() {
+  local suite="$1"
+  local out_json="$2"
+  local out_md="$3"
+  local attempt=0
+  local max_attempts=$((BENCH_GATE_RETRIES + 1))
+
+  while [[ "$attempt" -lt "$max_attempts" ]]; do
+    if cargo run -q -p spooky-bench --release -- \
+      --suite "$suite" \
+      --output "$out_json" \
+      --markdown-out "$out_md" \
+      "${ARGS[@]}"; then
+      return 0
+    fi
+
+    attempt=$((attempt + 1))
+    if [[ "$attempt" -lt "$max_attempts" ]]; then
+      echo "Benchmark gate failed for suite '$suite' (attempt $attempt/$max_attempts); retrying..."
+    fi
+  done
+
+  echo "Benchmark gate failed for suite '$suite' after $max_attempts attempts."
+  return 1
+}
+
+run_suite_with_retries micro bench/micro/latest.json bench/micro/latest.md
 
 cp bench/micro/latest.json bench/latest.json
 cp bench/micro/latest.md bench/latest.md
 
-cargo run -q -p spooky-bench --release -- \
-  --suite macro \
-  --output bench/macro/latest.json \
-  --markdown-out bench/macro/latest.md \
-  "${ARGS[@]}"
+run_suite_with_retries macro bench/macro/latest.json bench/macro/latest.md
 
-echo "Benchmark regression gates passed (profile=$PROFILE, fail_on=$FAIL_ON)"
+echo "Benchmark regression gates passed (profile=$PROFILE, fail_on=$FAIL_ON, retries=$BENCH_GATE_RETRIES)"


### PR DESCRIPTION
## Summary
This PR stabilizes benchmark regression gating so CI fails on real regressions, not runner-level memory jitter.

## Changes
- Added absolute-delta support to gate evaluation (`min_delta_abs`) in benchmark comparator logic.
- Applied memory gate floor in manifest:
  - `gates.memory.min_delta_abs: 256`
- Added unit tests for regression classification behavior:
  - small absolute RSS drift is ignored even with high % delta
  - large absolute RSS drift still triggers severe regression
- Added retry support in gate script:
  - `BENCH_GATE_RETRIES` (default `1`)
  - retries failed suite runs before final failure
- Updated CI benchmark job to run with retry:
  - `PROFILE=ci FAIL_ON=severe BENCH_GATE_RETRIES=1 ./scripts/bench-gate.sh`
- Updated docs to explain:
  - percent + absolute memory gating
  - retry behavior for noisy shared environments

## Why
We observed post-merge failures from small absolute RSS changes (for example `200KB -> 320KB`) that produce large percentage deltas and false severe failures. This patch keeps gates strict while removing this class of flake.

## Validation
- `cargo test -q -p spooky-bench` passed
- `PROFILE=ci FAIL_ON=severe BENCH_GATE_RETRIES=1 ./scripts/bench-gate.sh` passed