### PR TITLE
feat(runtime): harden QUIC ingress with malformed-packet safety, connection flood limiting, and tunable transport limits

### DIFF
--- a/config/config.minimal.yaml
+++ b/config/config.minimal.yaml
@@ -1,0 +1,16 @@
+version: 1
+
+listen:
+  tls:
+    cert: certs/proxy-fullchain.pem
+    key: certs/proxy-key-pkcs8.pem
+
+upstream:
+  default:
+    route:
+      path_prefix: "/"
+    backends:
+      - id: "backend1"
+        address: "127.0.0.1:8080"
+        health_check:
+          path: "/health"

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -74,6 +74,11 @@ performance:
     per_backend_inflight_limit: 64
     new_connections_per_sec: 2000   # max new QUIC connections accepted per second (token-bucket refill rate)
     new_connections_burst: 500      # burst capacity above the steady-state rate; must be >= 1
+    quic_max_idle_timeout_ms: 5000          # close idle QUIC connections after this many ms
+    quic_initial_max_data: 10000000         # connection-level flow control window (bytes)
+    quic_initial_max_stream_data: 1000000   # per-stream flow control window (bytes); must be <= quic_initial_max_data
+    quic_initial_max_streams_bidi: 100      # max concurrent bidirectional streams per connection
+    quic_initial_max_streams_uni: 100       # max concurrent unidirectional streams per connection
 
 observability:
     metrics:

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -72,6 +72,8 @@ performance:
     h2_pool_max_idle_per_backend: 256
     h2_pool_idle_timeout_ms: 90000
     per_backend_inflight_limit: 64
+    new_connections_per_sec: 2000   # max new QUIC connections accepted per second (token-bucket refill rate)
+    new_connections_burst: 500      # burst capacity above the steady-state rate; must be >= 1
 
 observability:
     metrics:

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -12,7 +12,8 @@ use crate::default::{
     perf_default_backend_connect_timeout_ms, perf_default_backend_timeout_ms,
     perf_default_backend_total_request_timeout_ms, perf_default_control_plane_threads,
     perf_default_global_inflight_limit, perf_default_h2_pool_idle_timeout_ms,
-    perf_default_h2_pool_max_idle_per_backend, perf_default_per_backend_inflight_limit,
+    perf_default_h2_pool_max_idle_per_backend, perf_default_new_connections_burst,
+    perf_default_new_connections_per_sec, perf_default_per_backend_inflight_limit,
     perf_default_per_upstream_inflight_limit, perf_default_pin_workers, perf_default_reuseport,
     perf_default_udp_recv_buffer_bytes, perf_default_udp_send_buffer_bytes,
     perf_default_worker_threads, resilience_default_adaptive_decrease_step,
@@ -212,6 +213,15 @@ pub struct Performance {
 
     #[serde(default = "perf_default_per_backend_inflight_limit")]
     pub per_backend_inflight_limit: usize,
+
+    /// Steady-state new QUIC connections allowed per second (token-bucket refill rate).
+    #[serde(default = "perf_default_new_connections_per_sec")]
+    pub new_connections_per_sec: u32,
+
+    /// Maximum burst of new QUIC connections above the steady-state rate.
+    /// Must be >= 1; values below 1 are clamped to 1 at runtime.
+    #[serde(default = "perf_default_new_connections_burst")]
+    pub new_connections_burst: u32,
 }
 
 impl Default for Performance {
@@ -233,6 +243,8 @@ impl Default for Performance {
             h2_pool_max_idle_per_backend: perf_default_h2_pool_max_idle_per_backend(),
             h2_pool_idle_timeout_ms: perf_default_h2_pool_idle_timeout_ms(),
             per_backend_inflight_limit: perf_default_per_backend_inflight_limit(),
+            new_connections_per_sec: perf_default_new_connections_per_sec(),
+            new_connections_burst: perf_default_new_connections_burst(),
         }
     }
 }

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -14,7 +14,10 @@ use crate::default::{
     perf_default_global_inflight_limit, perf_default_h2_pool_idle_timeout_ms,
     perf_default_h2_pool_max_idle_per_backend, perf_default_new_connections_burst,
     perf_default_new_connections_per_sec, perf_default_per_backend_inflight_limit,
-    perf_default_per_upstream_inflight_limit, perf_default_pin_workers, perf_default_reuseport,
+    perf_default_per_upstream_inflight_limit, perf_default_pin_workers,
+    perf_default_quic_initial_max_data, perf_default_quic_initial_max_stream_data,
+    perf_default_quic_initial_max_streams_bidi, perf_default_quic_initial_max_streams_uni,
+    perf_default_quic_max_idle_timeout_ms, perf_default_reuseport,
     perf_default_udp_recv_buffer_bytes, perf_default_udp_send_buffer_bytes,
     perf_default_worker_threads, resilience_default_adaptive_decrease_step,
     resilience_default_adaptive_enabled, resilience_default_adaptive_high_latency_ms,
@@ -222,6 +225,28 @@ pub struct Performance {
     /// Must be >= 1; values below 1 are clamped to 1 at runtime.
     #[serde(default = "perf_default_new_connections_burst")]
     pub new_connections_burst: u32,
+
+    /// QUIC idle timeout: connection is closed after this many ms of inactivity.
+    #[serde(default = "perf_default_quic_max_idle_timeout_ms")]
+    pub quic_max_idle_timeout_ms: u64,
+
+    /// QUIC connection-level flow control: total bytes the client may send before
+    /// receiving a MAX_DATA frame.
+    #[serde(default = "perf_default_quic_initial_max_data")]
+    pub quic_initial_max_data: u64,
+
+    /// QUIC stream-level flow control: bytes allowed per stream (bidi and uni).
+    /// Must be <= `quic_initial_max_data`.
+    #[serde(default = "perf_default_quic_initial_max_stream_data")]
+    pub quic_initial_max_stream_data: u64,
+
+    /// Maximum number of concurrent bidirectional streams per connection.
+    #[serde(default = "perf_default_quic_initial_max_streams_bidi")]
+    pub quic_initial_max_streams_bidi: u64,
+
+    /// Maximum number of concurrent unidirectional streams per connection.
+    #[serde(default = "perf_default_quic_initial_max_streams_uni")]
+    pub quic_initial_max_streams_uni: u64,
 }
 
 impl Default for Performance {
@@ -245,6 +270,11 @@ impl Default for Performance {
             per_backend_inflight_limit: perf_default_per_backend_inflight_limit(),
             new_connections_per_sec: perf_default_new_connections_per_sec(),
             new_connections_burst: perf_default_new_connections_burst(),
+            quic_max_idle_timeout_ms: perf_default_quic_max_idle_timeout_ms(),
+            quic_initial_max_data: perf_default_quic_initial_max_data(),
+            quic_initial_max_stream_data: perf_default_quic_initial_max_stream_data(),
+            quic_initial_max_streams_bidi: perf_default_quic_initial_max_streams_bidi(),
+            quic_initial_max_streams_uni: perf_default_quic_initial_max_streams_uni(),
         }
     }
 }

--- a/crates/config/src/default.rs
+++ b/crates/config/src/default.rs
@@ -142,6 +142,26 @@ pub fn perf_default_new_connections_burst() -> u32 {
     500
 }
 
+pub fn perf_default_quic_max_idle_timeout_ms() -> u64 {
+    5_000
+}
+
+pub fn perf_default_quic_initial_max_data() -> u64 {
+    10_000_000
+}
+
+pub fn perf_default_quic_initial_max_stream_data() -> u64 {
+    1_000_000
+}
+
+pub fn perf_default_quic_initial_max_streams_bidi() -> u64 {
+    100
+}
+
+pub fn perf_default_quic_initial_max_streams_uni() -> u64 {
+    100
+}
+
 pub fn resilience_default_adaptive_enabled() -> bool {
     true
 }

--- a/crates/config/src/default.rs
+++ b/crates/config/src/default.rs
@@ -134,6 +134,14 @@ pub fn perf_default_per_backend_inflight_limit() -> usize {
     64
 }
 
+pub fn perf_default_new_connections_per_sec() -> u32 {
+    2000
+}
+
+pub fn perf_default_new_connections_burst() -> u32 {
+    500
+}
+
 pub fn resilience_default_adaptive_enabled() -> bool {
     true
 }

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -164,6 +164,40 @@ pub fn validate(config: &Config) -> bool {
         return false;
     }
 
+    if config.performance.quic_max_idle_timeout_ms == 0 {
+        error!("performance.quic_max_idle_timeout_ms must be greater than 0");
+        return false;
+    }
+
+    if config.performance.quic_initial_max_data == 0 {
+        error!("performance.quic_initial_max_data must be greater than 0");
+        return false;
+    }
+
+    if config.performance.quic_initial_max_stream_data == 0 {
+        error!("performance.quic_initial_max_stream_data must be greater than 0");
+        return false;
+    }
+
+    if config.performance.quic_initial_max_stream_data > config.performance.quic_initial_max_data {
+        error!(
+            "performance.quic_initial_max_stream_data ({}) must be <= quic_initial_max_data ({})",
+            config.performance.quic_initial_max_stream_data,
+            config.performance.quic_initial_max_data
+        );
+        return false;
+    }
+
+    if config.performance.quic_initial_max_streams_bidi == 0 {
+        error!("performance.quic_initial_max_streams_bidi must be greater than 0");
+        return false;
+    }
+
+    if config.performance.quic_initial_max_streams_uni == 0 {
+        error!("performance.quic_initial_max_streams_uni must be greater than 0");
+        return false;
+    }
+
     if config.performance.backend_connect_timeout_ms > config.performance.backend_timeout_ms {
         error!("performance.backend_connect_timeout_ms must be <= backend_timeout_ms");
         return false;
@@ -705,6 +739,32 @@ upstream:
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.performance.new_connections_burst = 0;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.performance.quic_max_idle_timeout_ms = 0;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.performance.quic_initial_max_data = 0;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.performance.quic_initial_max_stream_data = 0;
+        assert!(!validate(&cfg));
+
+        // stream limit exceeds connection limit — cross-field violation
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.performance.quic_initial_max_data = 1_000_000;
+        cfg.performance.quic_initial_max_stream_data = 2_000_000;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.performance.quic_initial_max_streams_bidi = 0;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.performance.quic_initial_max_streams_uni = 0;
         assert!(!validate(&cfg));
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -154,6 +154,16 @@ pub fn validate(config: &Config) -> bool {
         return false;
     }
 
+    if config.performance.new_connections_per_sec == 0 {
+        error!("performance.new_connections_per_sec must be greater than 0");
+        return false;
+    }
+
+    if config.performance.new_connections_burst == 0 {
+        error!("performance.new_connections_burst must be greater than 0");
+        return false;
+    }
+
     if config.performance.backend_connect_timeout_ms > config.performance.backend_timeout_ms {
         error!("performance.backend_connect_timeout_ms must be <= backend_timeout_ms");
         return false;
@@ -687,6 +697,14 @@ upstream:
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.performance.per_backend_inflight_limit = 0;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.performance.new_connections_per_sec = 0;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.performance.new_connections_burst = 0;
         assert!(!validate(&cfg));
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -105,6 +105,7 @@ pub struct QUICListener {
     pub cid_routes: HashMap<Arc<[u8]>, Arc<[u8]>>,       // KEY: alias SCID, VALUE: primary SCID
     pub peer_routes: HashMap<SocketAddr, Arc<[u8]>>,     // KEY: peer address, VALUE: primary SCID
     pub cid_radix: CidRadix,
+    pub(crate) conn_rate_limiter: crate::quic_listener::TokenBucket,
 }
 
 pub struct QuicConnection {

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -42,9 +42,8 @@ use crate::{
     cid_radix::CidRadix,
     constants::{
         DEFAULT_SCID_LEN_BYTES, MAX_DATAGRAM_SIZE_BYTES, MAX_REQUEST_BODY_BYTES,
-        MAX_UDP_PAYLOAD_BYTES, MIN_SCID_LEN_BYTES, QUIC_IDLE_TIMEOUT_MS, QUIC_INITIAL_MAX_DATA,
-        QUIC_INITIAL_MAX_STREAMS_BIDI, QUIC_INITIAL_MAX_STREAMS_UNI, QUIC_INITIAL_STREAM_DATA,
-        REQUEST_BUFFERED_CHUNK_BYTES_LIMIT, REQUEST_CHUNK_BYTES_LIMIT,
+        MAX_UDP_PAYLOAD_BYTES, MIN_SCID_LEN_BYTES, REQUEST_BUFFERED_CHUNK_BYTES_LIMIT,
+        REQUEST_CHUNK_BYTES_LIMIT,
         REQUEST_CHUNK_CHANNEL_CAPACITY, RESET_TOKEN_LEN_BYTES, RESPONSE_CHUNK_BYTES_LIMIT,
         RESPONSE_CHUNK_CHANNEL_CAPACITY, SCID_ROTATION_PACKET_THRESHOLD, UDP_READ_TIMEOUT_MS,
         drain_timeout, scid_rotation_interval,
@@ -460,15 +459,15 @@ impl QUICListener {
             .map_err(|err| {
                 ProxyError::Transport(format!("failed to set ALPN protocols: {:?}", err))
             })?;
-        quic_config.set_max_idle_timeout(QUIC_IDLE_TIMEOUT_MS);
+        quic_config.set_max_idle_timeout(config.performance.quic_max_idle_timeout_ms);
         quic_config.set_max_recv_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
         quic_config.set_max_send_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
-        quic_config.set_initial_max_data(QUIC_INITIAL_MAX_DATA);
-        quic_config.set_initial_max_stream_data_bidi_local(QUIC_INITIAL_STREAM_DATA);
-        quic_config.set_initial_max_stream_data_bidi_remote(QUIC_INITIAL_STREAM_DATA);
-        quic_config.set_initial_max_stream_data_uni(QUIC_INITIAL_STREAM_DATA);
-        quic_config.set_initial_max_streams_bidi(QUIC_INITIAL_MAX_STREAMS_BIDI);
-        quic_config.set_initial_max_streams_uni(QUIC_INITIAL_MAX_STREAMS_UNI);
+        quic_config.set_initial_max_data(config.performance.quic_initial_max_data);
+        quic_config.set_initial_max_stream_data_bidi_local(config.performance.quic_initial_max_stream_data);
+        quic_config.set_initial_max_stream_data_bidi_remote(config.performance.quic_initial_max_stream_data);
+        quic_config.set_initial_max_stream_data_uni(config.performance.quic_initial_max_stream_data);
+        quic_config.set_initial_max_streams_bidi(config.performance.quic_initial_max_streams_bidi);
+        quic_config.set_initial_max_streams_uni(config.performance.quic_initial_max_streams_uni);
         quic_config.set_disable_active_migration(true);
         quic_config.verify_peer(false);
 

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -55,6 +55,50 @@ use crate::{
     watchdog::{WatchdogCoordinator, WatchdogRuntimeConfig, now_millis},
 };
 
+/// A leaky token-bucket rate limiter for new QUIC connection accepts.
+///
+/// Tokens refill at `rate_per_sec` tokens/second up to a cap of `burst`.
+/// Each new `quiche::accept` call consumes one token; if the bucket is empty
+/// the packet is silently dropped (no panic, no connection state allocated).
+pub(crate) struct TokenBucket {
+    /// Maximum tokens the bucket can hold (burst capacity).
+    burst: f64,
+    /// Tokens added per nanosecond (= rate_per_sec / 1_000_000_000).
+    tokens_per_ns: f64,
+    /// Current available tokens.
+    tokens: f64,
+    /// Last time tokens were refilled.
+    last_refill: Instant,
+}
+
+impl TokenBucket {
+    fn new(rate_per_sec: u32, burst: u32) -> Self {
+        let burst = (burst.max(1)) as f64;
+        let rate_per_sec = rate_per_sec.max(1) as f64;
+        Self {
+            burst,
+            tokens_per_ns: rate_per_sec / 1_000_000_000.0,
+            tokens: burst, // start full so the first burst of legitimate connections succeeds
+            last_refill: Instant::now(),
+        }
+    }
+
+    /// Try to consume one token. Returns `true` if a token was available
+    /// (connection may proceed), `false` if the bucket is empty (drop).
+    fn try_consume(&mut self) -> bool {
+        let now = Instant::now();
+        let elapsed_ns = now.saturating_duration_since(self.last_refill).as_nanos() as f64;
+        self.last_refill = now;
+        self.tokens = (self.tokens + elapsed_ns * self.tokens_per_ns).min(self.burst);
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0;
+            true
+        } else {
+            false
+        }
+    }
+}
+
 fn is_hop_header(name: &str) -> bool {
     matches!(
         name,
@@ -260,6 +304,10 @@ impl QUICListener {
             Duration::from_millis(config.performance.backend_body_total_timeout_ms);
         let backend_total_request_timeout =
             Duration::from_millis(config.performance.backend_total_request_timeout_ms);
+        let conn_rate_limiter = TokenBucket::new(
+            config.performance.new_connections_per_sec,
+            config.performance.new_connections_burst,
+        );
 
         Ok(Self {
             socket,
@@ -287,6 +335,7 @@ impl QUICListener {
             cid_routes: HashMap::new(),
             peer_routes: HashMap::new(),
             cid_radix: CidRadix::new(),
+            conn_rate_limiter,
         })
     }
 
@@ -535,6 +584,13 @@ impl QUICListener {
         if header.token.is_some() {
             debug!("Received 0-RTT attempt, will negotiate fresh connection");
             // return None;
+        }
+
+        // Rate-limit new connection creation to prevent unbounded memory growth
+        // under connection floods. Existing connections are never affected.
+        if !self.conn_rate_limiter.try_consume() {
+            debug!("New connection rate limit exceeded, dropping Initial packet from {}", peer);
+            return None;
         }
 
         let mut scid_bytes = [0u8; DEFAULT_SCID_LEN_BYTES];
@@ -2930,7 +2986,7 @@ mod tests {
 
     use crate::cid_radix::CidRadix;
 
-    use super::resolve_primary_from_radix_prefix;
+    use super::{TokenBucket, resolve_primary_from_radix_prefix};
 
     fn cid(bytes: &[u8]) -> Arc<[u8]> {
         Arc::from(bytes)
@@ -2994,6 +3050,68 @@ mod tests {
         assert!(
             cid_radix.longest_prefix_match(alias.as_ref()).is_none(),
             "stale alias should be removed from radix"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // TokenBucket unit tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn token_bucket_allows_up_to_burst_immediately() {
+        let mut tb = TokenBucket::new(100, 5);
+        // Bucket starts full; first 5 tokens should all succeed.
+        for i in 0..5 {
+            assert!(tb.try_consume(), "token {} should be available (burst=5)", i);
+        }
+        // 6th token must fail — bucket is empty.
+        assert!(!tb.try_consume(), "6th token must be denied when burst exhausted");
+    }
+
+    #[test]
+    fn token_bucket_refills_over_time() {
+        let mut tb = TokenBucket::new(1_000_000, 2); // 1 M tokens/sec = 1 per µs
+        // Drain the bucket.
+        assert!(tb.try_consume());
+        assert!(tb.try_consume());
+        assert!(!tb.try_consume());
+
+        // Sleep slightly longer than 1 token's worth at 1M/s (1µs).
+        std::thread::sleep(std::time::Duration::from_micros(5));
+
+        // At least one token must have been refilled.
+        assert!(
+            tb.try_consume(),
+            "bucket should have refilled at least one token after sleep"
+        );
+    }
+
+    #[test]
+    fn token_bucket_rate_zero_clamps_to_one() {
+        // rate=0 is clamped to 1; burst=0 is clamped to 1.
+        let mut tb = TokenBucket::new(0, 0);
+        // Starts with 1 token (burst=1).
+        assert!(tb.try_consume(), "first token should succeed with clamped burst=1");
+        assert!(!tb.try_consume(), "second token must fail when burst=1");
+    }
+
+    #[test]
+    fn token_bucket_never_exceeds_burst() {
+        // With rate=1/s a burst of 3 should yield exactly 3 tokens on a fresh
+        // bucket, then nothing more (refill is 1ns per second — negligible in a
+        // tight loop running for microseconds).
+        let burst = 3u32;
+        let mut tb = TokenBucket::new(1, burst); // 1 token/sec → ~1ns per token
+        let mut consumed = 0;
+        for _ in 0..(burst + 10) {
+            if tb.try_consume() {
+                consumed += 1;
+            }
+        }
+        assert_eq!(
+            consumed, burst as usize,
+            "fresh bucket must yield exactly burst={} tokens in a tight loop, got {}",
+            burst, consumed
         );
     }
 }

--- a/crates/edge/tests/h3_edge.rs
+++ b/crates/edge/tests/h3_edge.rs
@@ -548,3 +548,192 @@ fn server_rotates_scids_for_active_connection() {
     assert!(rotations > 0, "server did not rotate any SCID");
     assert_cid_sync_invariants(&listener_guard);
 }
+
+// ---------------------------------------------------------------------------
+// Malformed packet hardening tests (task 1.1)
+//
+// Each test fires one or more invalid UDP datagrams at a fresh listener and
+// asserts that:
+//  (a) the listener does not panic,
+//  (b) all routing maps remain empty / unchanged after the bad traffic.
+//
+// The listener is driven by a single poll() call per datagram so the test
+// stays synchronous and deterministic.
+// ---------------------------------------------------------------------------
+
+fn make_listener() -> (QUICListener, std::net::SocketAddr) {
+    let dir = tempdir().expect("failed to create temp dir");
+    let (cert, key) = write_test_certs(&dir);
+    let config = make_config(0, cert, key, "127.0.0.1:1".to_string());
+    let listener = QUICListener::new(config).expect("failed to create listener");
+    let addr = listener.socket.local_addr().expect("local_addr");
+    (listener, addr)
+}
+
+fn send_udp(to: std::net::SocketAddr, payload: &[u8]) {
+    let sock = UdpSocket::bind("127.0.0.1:0").expect("bind sender");
+    sock.send_to(payload, to).expect("send_to");
+}
+
+fn assert_maps_empty(listener: &QUICListener) {
+    assert!(
+        listener.connections.is_empty(),
+        "connections map must be empty after malformed traffic, had {} entries",
+        listener.connections.len()
+    );
+    assert!(
+        listener.cid_routes.is_empty(),
+        "cid_routes must be empty after malformed traffic, had {} entries",
+        listener.cid_routes.len()
+    );
+    assert!(
+        listener.peer_routes.is_empty(),
+        "peer_routes must be empty after malformed traffic, had {} entries",
+        listener.peer_routes.len()
+    );
+}
+
+/// A single zero-byte UDP datagram must be dropped without panic and leave all
+/// maps empty.
+#[test]
+fn malformed_zero_length_datagram_is_dropped() {
+    let (mut listener, addr) = make_listener();
+    send_udp(addr, &[]);
+    listener.poll();
+    assert_maps_empty(&listener);
+}
+
+/// A single-byte payload cannot be a valid QUIC header; listener must drop it.
+#[test]
+fn malformed_single_byte_datagram_is_dropped() {
+    let (mut listener, addr) = make_listener();
+    send_udp(addr, &[0xFF]);
+    listener.poll();
+    assert_maps_empty(&listener);
+}
+
+/// Completely random garbage bytes must not panic and must leave maps clean.
+#[test]
+fn malformed_random_garbage_is_dropped() {
+    let (mut listener, addr) = make_listener();
+    let garbage: Vec<u8> = (0u8..64).collect();
+    send_udp(addr, &garbage);
+    listener.poll();
+    assert_maps_empty(&listener);
+}
+
+/// A valid-looking QUIC long header with a plausible type byte but truncated
+/// body should be rejected cleanly.
+#[test]
+fn malformed_truncated_long_header_is_dropped() {
+    let (mut listener, addr) = make_listener();
+    // Long-header first byte: version-specific Initial packet marker (0xC0 | 0x00)
+    // followed by the QUIC version, then truncated before DCIL/SCIL fields.
+    let truncated: &[u8] = &[
+        0xC0,       // long-header flag + Initial type bits
+        0x00, 0x00, 0x00, 0x01, // QUIC v1
+        // deliberately truncated here (no DCIL/SCIL/lengths)
+    ];
+    send_udp(addr, truncated);
+    listener.poll();
+    assert_maps_empty(&listener);
+}
+
+/// A long header with a DCID length that overflows the packet should be
+/// rejected without panicking.
+#[test]
+fn malformed_dcid_length_overflow_is_dropped() {
+    let (mut listener, addr) = make_listener();
+    // Craft a packet whose DCID length field claims 255 bytes but the packet
+    // ends immediately after.
+    let mut pkt = vec![
+        0xC0,                   // long-header Initial
+        0x00, 0x00, 0x00, 0x01, // QUIC v1
+        0xFF,                   // DCID length = 255 (but no bytes follow)
+    ];
+    // pad with some bytes but far fewer than 255
+    pkt.extend_from_slice(&[0xAB; 8]);
+    send_udp(addr, &pkt);
+    listener.poll();
+    assert_maps_empty(&listener);
+}
+
+/// A short-header packet destined for an unknown connection must be silently
+/// dropped; it must not create a new connection entry.
+#[test]
+fn short_header_unknown_connection_is_dropped() {
+    let (mut listener, addr) = make_listener();
+    // Short header: first bit 0, remaining bits arbitrary. Use a 20-byte DCID
+    // that does not correspond to any established connection.
+    let mut pkt = vec![0x40u8]; // short-header flag (bit 7 = 0, bit 6 = 1 for fixed bit)
+    pkt.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0x00, 0x01,
+                             0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
+                             0x0A, 0x0B, 0x0C, 0x0D]);
+    send_udp(addr, &pkt);
+    listener.poll();
+    assert_maps_empty(&listener);
+}
+
+/// A Retry packet from an unknown peer must be ignored without creating state.
+#[test]
+fn retry_packet_for_unknown_connection_is_dropped() {
+    let (mut listener, addr) = make_listener();
+    // Long-header Retry type: bits 0xF0 with version and minimal fields.
+    // quiche will parse the header but the listener should not create a conn.
+    let mut pkt = vec![
+        0xF0,                   // long-header, Retry type bits
+        0x00, 0x00, 0x00, 0x01, // QUIC v1
+        0x08,                   // DCID len = 8
+    ];
+    pkt.extend_from_slice(&[0x11; 8]); // DCID
+    pkt.push(0x08);                    // SCID len = 8
+    pkt.extend_from_slice(&[0x22; 8]); // SCID
+    // Retry token (arbitrary, no integrity tag)
+    pkt.extend_from_slice(&[0x99; 16]);
+    send_udp(addr, &pkt);
+    listener.poll();
+    assert_maps_empty(&listener);
+}
+
+/// A Handshake packet for which no connection exists must be dropped cleanly.
+#[test]
+fn handshake_packet_unknown_connection_is_dropped() {
+    let (mut listener, addr) = make_listener();
+    // Long-header Handshake type: 0xE0
+    let mut pkt = vec![
+        0xE0,                   // long-header, Handshake type bits
+        0x00, 0x00, 0x00, 0x01, // QUIC v1
+        0x08,                   // DCID len = 8
+    ];
+    pkt.extend_from_slice(&[0x33; 8]); // DCID
+    pkt.push(0x08);                    // SCID len = 8
+    pkt.extend_from_slice(&[0x44; 8]); // SCID
+    // Packet number + payload (garbage)
+    pkt.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
+    pkt.extend_from_slice(&[0xAA; 20]);
+    send_udp(addr, &pkt);
+    listener.poll();
+    assert_maps_empty(&listener);
+}
+
+/// Repeated bursts of malformed packets must not accumulate any routing state.
+#[test]
+fn repeated_malformed_packets_leave_maps_consistent() {
+    let (mut listener, addr) = make_listener();
+
+    let payloads: &[&[u8]] = &[
+        &[],                                      // zero-length
+        &[0xFF],                                  // single byte
+        &[0x00; 16],                              // all-zero short
+        &[0xFF; 64],                              // all-ones garbage
+        &[0xC0, 0x00, 0x00, 0x00, 0x01, 0xFF],   // truncated long header
+        &[0x40, 0xDE, 0xAD, 0xBE, 0xEF, 0x00],   // short header, unknown DCID
+    ];
+
+    for payload in payloads {
+        send_udp(addr, payload);
+        listener.poll();
+    }
+
+    assert_maps_empty(&listener);
+}

--- a/crates/edge/tests/h3_edge.rs
+++ b/crates/edge/tests/h3_edge.rs
@@ -737,3 +737,164 @@ fn repeated_malformed_packets_leave_maps_consistent() {
 
     assert_maps_empty(&listener);
 }
+
+// ---------------------------------------------------------------------------
+// Connection flood / rate-limit tests (task 1.2)
+// ---------------------------------------------------------------------------
+
+fn make_config_with_rate_limit(
+    port: u32,
+    cert: String,
+    key: String,
+    backend_address: String,
+    new_connections_per_sec: u32,
+    new_connections_burst: u32,
+) -> Config {
+    use spooky_config::config::{Performance, RouteMatch, Upstream};
+    use std::collections::HashMap;
+
+    let mut upstream = HashMap::new();
+    upstream.insert(
+        "test_pool".to_string(),
+        Upstream {
+            load_balancing: LoadBalancing {
+                lb_type: "random".to_string(),
+                key: None,
+            },
+            route: RouteMatch {
+                path_prefix: Some("/".to_string()),
+                ..Default::default()
+            },
+            backends: vec![Backend {
+                id: "backend1".to_string(),
+                address: backend_address,
+                weight: 1,
+                health_check: HealthCheck {
+                    path: "/health".to_string(),
+                    interval: 1000,
+                    timeout_ms: 1000,
+                    failure_threshold: 3,
+                    success_threshold: 1,
+                    cooldown_ms: 0,
+                },
+            }],
+        },
+    );
+
+    Config {
+        version: 1,
+        listen: Listen {
+            protocol: "http3".to_string(),
+            port,
+            address: "127.0.0.1".to_string(),
+            tls: Tls { cert, key },
+        },
+        upstream,
+        load_balancing: Some(LoadBalancing {
+            lb_type: "random".to_string(),
+            key: None,
+        }),
+        log: Log {
+            level: "error".to_string(),
+            file: Default::default(),
+        },
+        performance: Performance {
+            new_connections_per_sec,
+            new_connections_burst,
+            ..Performance::default()
+        },
+        observability: spooky_config::config::Observability::default(),
+        resilience: spooky_config::config::Resilience::default(),
+    }
+}
+
+/// Build a minimal valid QUIC Initial packet using quiche so the listener can
+/// parse the header and attempt `quiche::accept`. Returns the encoded bytes.
+fn build_initial_packet(dest_addr: std::net::SocketAddr) -> Vec<u8> {
+    let local_addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
+
+    let mut config =
+        quiche::Config::new(quiche::PROTOCOL_VERSION).expect("quiche config");
+    config.verify_peer(false);
+    config
+        .set_application_protos(quiche::h3::APPLICATION_PROTOCOL)
+        .expect("alpn");
+    config.set_max_idle_timeout(QUIC_IDLE_TIMEOUT_MS);
+    config.set_max_recv_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    config.set_max_send_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    config.set_initial_max_data(QUIC_INITIAL_MAX_DATA);
+    config.set_initial_max_stream_data_bidi_local(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_stream_data_bidi_remote(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_stream_data_uni(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_streams_bidi(QUIC_INITIAL_MAX_STREAMS_BIDI);
+    config.set_initial_max_streams_uni(QUIC_INITIAL_MAX_STREAMS_UNI);
+
+    let mut scid_bytes = [0u8; quiche::MAX_CONN_ID_LEN];
+    rand::thread_rng().fill_bytes(&mut scid_bytes);
+    let scid = quiche::ConnectionId::from_ref(&scid_bytes);
+
+    let mut conn = quiche::connect(Some("localhost"), &scid, local_addr, dest_addr, &mut config)
+        .expect("quiche connect");
+
+    let mut out = vec![0u8; MAX_UDP_PAYLOAD_BYTES];
+    let (len, _send_info) = conn.send(&mut out).expect("quiche send");
+    out.truncate(len);
+    out
+}
+
+/// When burst=1 and rate is near-zero, the first Initial packet creates a
+/// connection, and subsequent ones in the same instant are dropped.
+#[test]
+fn connection_flood_is_rate_limited() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_certs(&dir);
+    // burst=1, rate=1/s: after the first accept the bucket is empty.
+    let config = make_config_with_rate_limit(0, cert, key, "127.0.0.1:1".to_string(), 1, 1);
+    let mut listener = QUICListener::new(config).expect("listener");
+    let addr = listener.socket.local_addr().unwrap();
+
+    // Send enough distinct Initial packets to saturate the rate limit.
+    // Each packet comes from a different SCID so the listener sees each as a
+    // new connection attempt (no existing DCID match).
+    const FLOOD_COUNT: usize = 10;
+    for _ in 0..FLOOD_COUNT {
+        let pkt = build_initial_packet(addr);
+        send_udp(addr, &pkt);
+        listener.poll();
+    }
+
+    // With burst=1 only the very first packet can create a connection.
+    // All subsequent ones are dropped by the rate limiter.
+    assert!(
+        listener.connections.len() <= 1,
+        "rate limiter must cap connections at burst=1, got {}",
+        listener.connections.len()
+    );
+}
+
+/// Normal traffic well below the rate limit must not be affected.
+/// With a generous burst and rate, all N connection attempts succeed.
+#[test]
+fn normal_traffic_below_rate_limit_is_unaffected() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_certs(&dir);
+    // burst=20, rate=10000/s: far above what we'll send.
+    let config =
+        make_config_with_rate_limit(0, cert, key, "127.0.0.1:1".to_string(), 10_000, 20);
+    let mut listener = QUICListener::new(config).expect("listener");
+    let addr = listener.socket.local_addr().unwrap();
+
+    const REQUEST_COUNT: usize = 5;
+    for _ in 0..REQUEST_COUNT {
+        let pkt = build_initial_packet(addr);
+        send_udp(addr, &pkt);
+        listener.poll();
+    }
+
+    assert_eq!(
+        listener.connections.len(),
+        REQUEST_COUNT,
+        "all {} connections should be accepted when below rate limit",
+        REQUEST_COUNT
+    );
+}

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -123,6 +123,11 @@ The following table lists all default configuration values used when properties 
 | `log.file.path` | `"/var/log/spooky/spooky.log"` | Log file path (used when `log.file.enabled` is true) |
 | `performance.new_connections_per_sec` | `2000` | Token-bucket refill rate for new QUIC connections (conns/sec) |
 | `performance.new_connections_burst` | `500` | Burst capacity for new QUIC connections |
+| `performance.quic_max_idle_timeout_ms` | `5000` | QUIC idle timeout — connection closed after this many ms of inactivity |
+| `performance.quic_initial_max_data` | `10000000` | Connection-level flow control window (bytes) |
+| `performance.quic_initial_max_stream_data` | `1000000` | Per-stream flow control window (bytes) |
+| `performance.quic_initial_max_streams_bidi` | `100` | Max concurrent bidirectional streams per connection |
+| `performance.quic_initial_max_streams_uni` | `100` | Max concurrent unidirectional streams per connection |
 
 ## Listen Configuration
 
@@ -498,6 +503,11 @@ Controls resource limits, tuning knobs, and connection-flood protection. All fie
 | `h2_pool_idle_timeout_ms` | integer | No | `90000` | How long an idle H2 connection is kept before being closed (ms) |
 | `new_connections_per_sec` | integer | No | `2000` | Steady-state rate at which new QUIC connections are accepted (token-bucket refill, connections/sec) |
 | `new_connections_burst` | integer | No | `500` | Burst capacity above the steady-state rate; the bucket starts full so the first burst of legitimate connections always succeeds |
+| `quic_max_idle_timeout_ms` | integer | No | `5000` | QUIC idle timeout in ms; connection is closed after this period of inactivity |
+| `quic_initial_max_data` | integer | No | `10000000` | Connection-level QUIC flow control window in bytes |
+| `quic_initial_max_stream_data` | integer | No | `1000000` | Per-stream QUIC flow control window in bytes; must be ≤ `quic_initial_max_data` |
+| `quic_initial_max_streams_bidi` | integer | No | `100` | Maximum concurrent bidirectional QUIC streams per connection |
+| `quic_initial_max_streams_uni` | integer | No | `100` | Maximum concurrent unidirectional QUIC streams per connection |
 
 ### Connection flood protection
 

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -121,6 +121,8 @@ The following table lists all default configuration values used when properties 
 | `log.level` | `"info"` | Logging verbosity level |
 | `log.file.enabled` | `false` | Write logs to file instead of stderr |
 | `log.file.path` | `"/var/log/spooky/spooky.log"` | Log file path (used when `log.file.enabled` is true) |
+| `performance.new_connections_per_sec` | `2000` | Token-bucket refill rate for new QUIC connections (conns/sec) |
+| `performance.new_connections_burst` | `500` | Burst capacity for new QUIC connections |
 
 ## Listen Configuration
 
@@ -468,6 +470,67 @@ log:
   file:
     enabled: true
     path: /tmp/spooky-trace.log
+```
+
+## Performance Configuration
+
+Controls resource limits, tuning knobs, and connection-flood protection. All fields are optional and fall back to sane defaults.
+
+### Properties
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `worker_threads` | integer | No | `1` | Number of polling worker threads |
+| `control_plane_threads` | integer | No | `2` | Threads for background tasks (health checks, metrics) |
+| `reuseport` | bool | No | `true` | Enable `SO_REUSEPORT`; required when `worker_threads > 1` |
+| `pin_workers` | bool | No | `false` | Pin each worker thread to a dedicated CPU core |
+| `global_inflight_limit` | integer | No | `4096` | Maximum concurrent in-flight requests across all upstreams |
+| `per_upstream_inflight_limit` | integer | No | `1024` | Maximum concurrent in-flight requests per upstream pool |
+| `per_backend_inflight_limit` | integer | No | `64` | Maximum concurrent in-flight requests per backend |
+| `backend_timeout_ms` | integer | No | `2000` | Initial backend response timeout (ms) |
+| `backend_connect_timeout_ms` | integer | No | `500` | Backend TCP/TLS handshake timeout (ms); must be ≤ `backend_timeout_ms` |
+| `backend_body_idle_timeout_ms` | integer | No | `2000` | Idle timeout while streaming response body (ms); must be ≥ `backend_timeout_ms` |
+| `backend_body_total_timeout_ms` | integer | No | `30000` | Maximum total time to receive the full response body (ms) |
+| `backend_total_request_timeout_ms` | integer | No | `35000` | Hard deadline for an entire request round-trip (ms); must be ≥ `backend_body_total_timeout_ms` |
+| `udp_recv_buffer_bytes` | integer | No | `8388608` | UDP socket receive buffer size (bytes) |
+| `udp_send_buffer_bytes` | integer | No | `8388608` | UDP socket send buffer size (bytes) |
+| `h2_pool_max_idle_per_backend` | integer | No | `256` | Maximum idle HTTP/2 connections kept open per backend |
+| `h2_pool_idle_timeout_ms` | integer | No | `90000` | How long an idle H2 connection is kept before being closed (ms) |
+| `new_connections_per_sec` | integer | No | `2000` | Steady-state rate at which new QUIC connections are accepted (token-bucket refill, connections/sec) |
+| `new_connections_burst` | integer | No | `500` | Burst capacity above the steady-state rate; the bucket starts full so the first burst of legitimate connections always succeeds |
+
+### Connection flood protection
+
+`new_connections_per_sec` and `new_connections_burst` implement a token-bucket rate limiter on new QUIC connection accepts. The bucket starts full so legitimate burst traffic at startup is never penalised. Packets for **existing** connections are never affected by this limit — only unknown `Initial` packets that would create a new connection state entry are gated.
+
+```yaml
+performance:
+  new_connections_per_sec: 2000   # refill rate: 2 k new conns/sec
+  new_connections_burst: 500      # allow a burst of up to 500 above the rate
+```
+
+Set `new_connections_burst` to `1` and `new_connections_per_sec` to a low value to aggressively throttle connection floods at the cost of rejecting legitimate concurrent handshakes.
+
+### Examples
+
+```yaml
+# Single-worker, conservative limits
+performance:
+  worker_threads: 1
+  global_inflight_limit: 1024
+  new_connections_per_sec: 500
+  new_connections_burst: 100
+
+# High-throughput multi-worker setup
+performance:
+  worker_threads: 8
+  reuseport: true
+  pin_workers: true
+  global_inflight_limit: 16384
+  per_upstream_inflight_limit: 4096
+  per_backend_inflight_limit: 256
+  new_connections_per_sec: 10000
+  new_connections_burst: 2000
 ```
 
 ## Configuration Validation


### PR DESCRIPTION
### Summary
This PR hardens the QUIC runtime in three areas:

- **Malformed packet safety**
  - Ensures malformed/unknown QUIC packets are dropped safely without panic.
  - Preserves listener map consistency (`connections`, `cid_routes`, `peer_routes`) under malformed traffic.

- **Connection flood protection**
  - Adds per-listener token-bucket rate limiting for new `Initial` connection attempts.
  - Introduces:
    - `performance.new_connections_per_sec`
    - `performance.new_connections_burst`
  - Enforces limiter before `quiche::accept`.
  - Adds validator checks for new fields.

- **Tunable QUIC transport limits**
  - Moves QUIC transport limits to config-backed performance fields:
    - `performance.quic_max_idle_timeout_ms`
    - `performance.quic_initial_max_data`
    - `performance.quic_initial_max_stream_data`
    - `performance.quic_initial_max_streams_bidi`
    - `performance.quic_initial_max_streams_uni`
  - Keeps defaults backward-compatible with prior behavior.
  - Adds validation and cross-field sanity check (`stream_data <= max_data`).

### Why
To improve runtime stability and predictability under malformed input and connection bursts, while making QUIC flow-control/stream limits operator-tunable without code changes.

### Validation
- Added/updated tests for malformed packet handling and map consistency.
- Added/updated tests for flood-rate limiting behavior (burst capped, normal traffic unaffected).
- Added/updated config validator tests for new QUIC and rate-limit fields.