### PR TITLE
Harden stream memory safety under pressure: bounded caps, deterministic 413/503 failures, and extreme-case coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - 2026-02-18
+## [0.1.0] - 2026-04-16
 
 Initial release of Spooky HTTP/3 to HTTP/2 reverse proxy and load balancer.
 
@@ -62,7 +62,8 @@ Initial release of Spooky HTTP/3 to HTTP/2 reverse proxy and load balancer.
 
 **Operational**
 - CLI with configuration file support
-- Request and response body buffering (up to 64KB)
+- Streaming request and response handling with bounded queues and hard body caps
+- Deterministic cap-breach behavior via HTTP errors (`413`/`503`) under pressure
 - Concurrent connection handling (10,000+ connections tested)
 - Per-backend concurrency limiting (64 max in-flight requests)
 - Backend timeout configuration (2s default)
@@ -100,6 +101,7 @@ Initial release of Spooky HTTP/3 to HTTP/2 reverse proxy and load balancer.
 - Detailed component breakdown by crate
 - HTTP/3 and QUIC protocol documentation
 - API documentation for metrics and logging
+- Memory envelope and bounded-overflow behavior documentation
 - Contributing guide for developers
 - References to RFCs and external resources
 
@@ -108,21 +110,14 @@ Initial release of Spooky HTTP/3 to HTTP/2 reverse proxy and load balancer.
 These limitations are being addressed in future releases:
 
 1. **Performance**
-   - Synchronous backend calls block main thread during HTTP/2 requests
-   - Full request/response body buffering (no streaming)
-   - Consistent hash ring rebuilds on every request
    - Single-threaded QUIC packet processing
 
 2. **Operational**
-   - No metrics export endpoint (Prometheus planned)
    - No configuration hot reload
    - No distributed tracing integration
    - TLS peer verification disabled (development mode)
 
 3. **Features**
-   - No circuit breaker or retry logic
-   - No rate limiting
-   - No request size limits
    - No dynamic backend discovery
 
 See [roadmap](docs/roadmap.md) for planned improvements.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Modern clients increasingly expect HTTP/3 support, but most production backends 
 - Converting HTTP/3 streams to HTTP/2 requests
 - Load balancing across backend pools with health checks
 - Supporting path and host-based routing
+- Enforcing bounded request/response memory with deterministic overload failures
 
 ## Quick Start
 
@@ -154,7 +155,8 @@ flowchart LR
 - HTTP/3 and QUIC (RFC 9114, RFC 9000)
 - TLS 1.3 with certificate chain validation
 - HTTP/2 backend connectivity
-- Efficient request/response handling with full buffering
+- Streaming request/response handling with bounded queues and body caps
+- Deterministic cap-breach behavior (`413`/`503`) under pressure
 
 **Load Balancing**
 - Random distribution
@@ -191,12 +193,13 @@ cargo test -p spooky-edge
 
 # Run integration tests
 cargo test -p spooky-edge --test lb_integration
+cargo test -p spooky-edge --test h3_bridge
 ```
 
 
 ## Project Status
 
-**Experimental.** Spooky is not production-ready. Core features are implemented and functional, but significant limitations remain (blocking backend I/O, full body buffering, no TLS peer verification, single-threaded QUIC processing).
+**Experimental.** Spooky is not production-ready yet. Core features are implemented and continuously hardened, but it should still be treated as pre-GA software.
 
 See [roadmap](docs/roadmap.md) for known issues and planned improvements.
 

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -79,6 +79,7 @@ performance:
     quic_initial_max_stream_data: 1000000   # per-stream flow control window (bytes); must be <= quic_initial_max_data
     quic_initial_max_streams_bidi: 100      # max concurrent bidirectional streams per connection
     quic_initial_max_streams_uni: 100       # max concurrent unidirectional streams per connection
+    max_response_body_bytes: 104857600      # hard cap on upstream response body per stream (100 MiB); streams exceeding this get a 502
 
 observability:
     metrics:

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -16,8 +16,9 @@ use crate::default::{
     perf_default_new_connections_per_sec, perf_default_per_backend_inflight_limit,
     perf_default_per_upstream_inflight_limit, perf_default_pin_workers,
     perf_default_quic_initial_max_data, perf_default_quic_initial_max_stream_data,
-    perf_default_quic_initial_max_streams_bidi, perf_default_quic_initial_max_streams_uni,
-    perf_default_quic_max_idle_timeout_ms, perf_default_reuseport,
+    perf_default_max_response_body_bytes, perf_default_quic_initial_max_streams_bidi,
+    perf_default_quic_initial_max_streams_uni, perf_default_quic_max_idle_timeout_ms,
+    perf_default_reuseport,
     perf_default_udp_recv_buffer_bytes, perf_default_udp_send_buffer_bytes,
     perf_default_worker_threads, resilience_default_adaptive_decrease_step,
     resilience_default_adaptive_enabled, resilience_default_adaptive_high_latency_ms,
@@ -247,6 +248,12 @@ pub struct Performance {
     /// Maximum number of concurrent unidirectional streams per connection.
     #[serde(default = "perf_default_quic_initial_max_streams_uni")]
     pub quic_initial_max_streams_uni: u64,
+
+    /// Hard cap on upstream response body bytes per stream.
+    /// Streams whose response body exceeds this size are terminated with 502.
+    /// Protects against runaway or adversarial upstreams streaming unboundedly.
+    #[serde(default = "perf_default_max_response_body_bytes")]
+    pub max_response_body_bytes: usize,
 }
 
 impl Default for Performance {
@@ -275,6 +282,7 @@ impl Default for Performance {
             quic_initial_max_stream_data: perf_default_quic_initial_max_stream_data(),
             quic_initial_max_streams_bidi: perf_default_quic_initial_max_streams_bidi(),
             quic_initial_max_streams_uni: perf_default_quic_initial_max_streams_uni(),
+            max_response_body_bytes: perf_default_max_response_body_bytes(),
         }
     }
 }

--- a/crates/config/src/default.rs
+++ b/crates/config/src/default.rs
@@ -162,6 +162,10 @@ pub fn perf_default_quic_initial_max_streams_uni() -> u64 {
     100
 }
 
+pub fn perf_default_max_response_body_bytes() -> usize {
+    100 * 1024 * 1024 // 100 MiB
+}
+
 pub fn resilience_default_adaptive_enabled() -> bool {
     true
 }

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -198,6 +198,11 @@ pub fn validate(config: &Config) -> bool {
         return false;
     }
 
+    if config.performance.max_response_body_bytes == 0 {
+        error!("performance.max_response_body_bytes must be greater than 0");
+        return false;
+    }
+
     if config.performance.backend_connect_timeout_ms > config.performance.backend_timeout_ms {
         error!("performance.backend_connect_timeout_ms must be <= backend_timeout_ms");
         return false;
@@ -765,6 +770,10 @@ upstream:
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.performance.quic_initial_max_streams_uni = 0;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.performance.max_response_body_bytes = 0;
         assert!(!validate(&cfg));
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());

--- a/crates/edge/src/constants.rs
+++ b/crates/edge/src/constants.rs
@@ -1,5 +1,27 @@
 use std::time::Duration;
 
+// ─── Memory envelope ──────────────────────────────────────────────────────────
+//
+// Per-stream worst-case memory (defaults; operator can tune via `performance.*`):
+//
+//   Request path
+//   ├─ body channel:    REQUEST_CHUNK_CHANNEL_CAPACITY * REQUEST_CHUNK_BYTES_LIMIT
+//   │                   = 8 * 16 KiB = 128 KiB
+//   ├─ backpressure buf: REQUEST_BUFFERED_CHUNK_BYTES_LIMIT = 1 MiB (== MAX_REQUEST_BODY_BYTES)
+//   └─ hard request cap: MAX_REQUEST_BODY_BYTES = 1 MiB → 413 on breach
+//
+//   Response path
+//   ├─ response channel: RESPONSE_CHUNK_CHANNEL_CAPACITY * RESPONSE_CHUNK_BYTES_LIMIT
+//   │                   = 16 * 16 KiB = 256 KiB
+//   └─ hard response cap: max_response_body_bytes (default 100 MiB) → stream RST on breach
+//
+// Per-connection worst-case:
+//   MAX_STREAMS_PER_CONNECTION (= QUIC_INITIAL_MAX_STREAMS_BIDI = 100) streams
+//   × per-stream worst case above → ~101 MiB request + ~100 MiB response ≈ 200 MiB
+//   (all caps enforced; no path causes unbounded growth)
+//
+// ─────────────────────────────────────────────────────────────────────────────
+
 pub const MAX_DATAGRAM_SIZE_BYTES: usize = 65_535;
 pub const MAX_UDP_PAYLOAD_BYTES: usize = 1_350;
 
@@ -18,6 +40,17 @@ pub const QUIC_INITIAL_STREAM_DATA: u64 = 1_000_000;
 pub const MAX_REQUEST_BODY_BYTES: usize = 1_000_000;
 pub const QUIC_INITIAL_MAX_STREAMS_BIDI: u64 = 100;
 pub const QUIC_INITIAL_MAX_STREAMS_UNI: u64 = 100;
+
+/// Application-level cap on concurrent open streams per QUIC connection.
+/// Mirrors QUIC_INITIAL_MAX_STREAMS_BIDI so the app map never grows beyond
+/// what the transport layer permits.  Must be kept in sync.
+pub const MAX_STREAMS_PER_CONNECTION: usize = QUIC_INITIAL_MAX_STREAMS_BIDI as usize;
+
+/// Default hard cap on upstream response body bytes per stream (overridable via
+/// `performance.max_response_body_bytes`).  Streams exceeding this are aborted
+/// with a QUIC stream RST (H3_INTERNAL_ERROR) since response headers were already
+/// sent; no unbounded memory growth is possible.
+pub const MAX_RESPONSE_BODY_BYTES: usize = 100 * 1024 * 1024; // 100 MiB
 
 pub const MAX_INFLIGHT_PER_BACKEND: usize = 64;
 pub const DEFAULT_SCID_LEN_BYTES: usize = 16;

--- a/crates/edge/src/constants.rs
+++ b/crates/edge/src/constants.rs
@@ -13,7 +13,10 @@ use std::time::Duration;
 //   Response path
 //   ├─ response channel: RESPONSE_CHUNK_CHANNEL_CAPACITY * RESPONSE_CHUNK_BYTES_LIMIT
 //   │                   = 16 * 16 KiB = 256 KiB
-//   └─ hard response cap: max_response_body_bytes (default 100 MiB) → stream RST on breach
+//   └─ hard response cap: max_response_body_bytes (default 100 MiB)
+//      - declared content-length over cap -> 503 before streaming
+//      - unknown-length responses are cap-validated before headers are emitted
+//        and return 503 on breach (no reset fallback)
 //
 // Per-connection worst-case:
 //   MAX_STREAMS_PER_CONNECTION (= QUIC_INITIAL_MAX_STREAMS_BIDI = 100) streams

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -145,13 +145,15 @@ pub enum StreamPhase {
 /// A chunk of the upstream response being streamed back to the client.
 #[derive(Debug)]
 pub enum ResponseChunk {
+    /// Emit downstream response headers (used when headers are deferred until
+    /// body-size validation completes).
+    Start {
+        status: http::StatusCode,
+        headers: Vec<(Vec<u8>, Vec<u8>)>,
+    },
     Data(Bytes),
     End,
     Error(ProxyError),
-    /// The upstream response body exceeded the configured cap.
-    /// The stream must be RST (not cleanly finished) so the client sees an
-    /// unambiguous error rather than a silently truncated 200 response.
-    BodyTooLarge,
 }
 
 pub struct RequestEnvelope {
@@ -186,6 +188,8 @@ pub struct RequestEnvelope {
     pub upstream_result_rx: Option<oneshot::Receiver<ForwardResult>>,
     /// Receives response body chunks to write back over QUIC.
     pub response_chunk_rx: Option<mpsc::Receiver<ResponseChunk>>,
+    /// True once downstream response headers are emitted on this stream.
+    pub response_headers_sent: bool,
     /// A chunk that could not be written due to QUIC send backpressure; retried next poll.
     pub pending_chunk: Option<ResponseChunk>,
 }

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -97,6 +97,7 @@ pub struct QUICListener {
     pub backend_body_idle_timeout: Duration,
     pub backend_body_total_timeout: Duration,
     pub backend_total_request_timeout: Duration,
+    pub max_response_body_bytes: usize,
 
     pub recv_buf: [u8; MAX_DATAGRAM_SIZE_BYTES],
     pub send_buf: [u8; MAX_DATAGRAM_SIZE_BYTES],
@@ -147,6 +148,10 @@ pub enum ResponseChunk {
     Data(Bytes),
     End,
     Error(ProxyError),
+    /// The upstream response body exceeded the configured cap.
+    /// The stream must be RST (not cleanly finished) so the client sees an
+    /// unambiguous error rather than a silently truncated 200 response.
+    BodyTooLarge,
 }
 
 pub struct RequestEnvelope {

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -42,8 +42,8 @@ use crate::{
     cid_radix::CidRadix,
     constants::{
         DEFAULT_SCID_LEN_BYTES, MAX_DATAGRAM_SIZE_BYTES, MAX_REQUEST_BODY_BYTES,
-        MAX_UDP_PAYLOAD_BYTES, MIN_SCID_LEN_BYTES, REQUEST_BUFFERED_CHUNK_BYTES_LIMIT,
-        REQUEST_CHUNK_BYTES_LIMIT,
+        MAX_STREAMS_PER_CONNECTION, MAX_UDP_PAYLOAD_BYTES,
+        MIN_SCID_LEN_BYTES, REQUEST_BUFFERED_CHUNK_BYTES_LIMIT, REQUEST_CHUNK_BYTES_LIMIT,
         REQUEST_CHUNK_CHANNEL_CAPACITY, RESET_TOKEN_LEN_BYTES, RESPONSE_CHUNK_BYTES_LIMIT,
         RESPONSE_CHUNK_CHANNEL_CAPACITY, SCID_ROTATION_PACKET_THRESHOLD, UDP_READ_TIMEOUT_MS,
         drain_timeout, scid_rotation_interval,
@@ -303,6 +303,7 @@ impl QUICListener {
             Duration::from_millis(config.performance.backend_body_total_timeout_ms);
         let backend_total_request_timeout =
             Duration::from_millis(config.performance.backend_total_request_timeout_ms);
+        let max_response_body_bytes = config.performance.max_response_body_bytes;
         let conn_rate_limiter = TokenBucket::new(
             config.performance.new_connections_per_sec,
             config.performance.new_connections_burst,
@@ -328,6 +329,7 @@ impl QUICListener {
             backend_body_idle_timeout,
             backend_body_total_timeout,
             backend_total_request_timeout,
+            max_response_body_bytes,
             recv_buf: [0; MAX_DATAGRAM_SIZE_BYTES],
             send_buf: [0; MAX_DATAGRAM_SIZE_BYTES],
             connections: HashMap::new(),
@@ -939,6 +941,7 @@ impl QUICListener {
                 &self.routing_index,
                 &self.metrics,
                 &self.resilience,
+                self.max_response_body_bytes,
             )
         {
             error!("HTTP/3 handling failed: {:?}", e);
@@ -1013,6 +1016,7 @@ impl QUICListener {
                     &self.metrics,
                     self.backend_total_request_timeout,
                     &self.resilience,
+                    self.max_response_body_bytes,
                 ) {
                     error!("advance_streams_non_blocking in timeout path: {:?}", e);
                 }
@@ -1110,6 +1114,7 @@ impl QUICListener {
         routing_index: &RouteIndex,
         metrics: &Metrics,
         resilience: &RuntimeResilience,
+        max_response_body_bytes: usize,
     ) -> Result<(), quiche::h3::Error> {
         let mut body_buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
 
@@ -1609,6 +1614,34 @@ impl QUICListener {
                         }
                     };
 
+                    // App-level stream count cap: mirrors the QUIC max_streams_bidi
+                    // limit so the streams HashMap can never grow beyond what the
+                    // transport layer allows even if a race or misconfiguration
+                    // delivers a stream-open event before the flow-control frame
+                    // reaches the client.
+                    if connection.streams.len() >= MAX_STREAMS_PER_CONNECTION {
+                        warn!(
+                            "stream limit reached ({} streams), rejecting stream {}",
+                            MAX_STREAMS_PER_CONNECTION, stream_id
+                        );
+                        // Dropping the permits and body_tx here releases inflight
+                        // semaphore slots and signals the upstream task to abort.
+                        drop(body_tx);
+                        drop(global_inflight_permit);
+                        drop(upstream_inflight_permit);
+                        drop(adaptive_admission_permit);
+                        drop(route_queue_permit);
+                        drop(upstream_result_rx);
+                        Self::send_simple_response(
+                            h3,
+                            &mut connection.quic,
+                            stream_id,
+                            http::StatusCode::SERVICE_UNAVAILABLE,
+                            b"too many concurrent streams\n",
+                        )?;
+                        continue;
+                    }
+
                     connection.streams.insert(
                         stream_id,
                         RequestEnvelope {
@@ -1797,6 +1830,7 @@ impl QUICListener {
             metrics,
             backend_total_request_timeout,
             resilience,
+            max_response_body_bytes,
         )?;
 
         Ok(())
@@ -1832,6 +1866,7 @@ impl QUICListener {
         metrics: &Metrics,
         _backend_total_request_timeout: Duration,
         resilience: &RuntimeResilience,
+        max_response_body_bytes: usize,
     ) -> Result<(), quiche::h3::Error> {
         let stream_ids: Vec<u64> = streams.keys().copied().collect();
 
@@ -1962,6 +1997,7 @@ impl QUICListener {
                         let fut = async move {
                             use http_body_util::BodyExt;
                             let mut body: hyper::body::Incoming = body;
+                            let mut response_bytes_received: usize = 0;
                             loop {
                                 let frame_fut = BodyExt::frame(&mut body);
                                 let now = tokio::time::Instant::now();
@@ -1984,6 +2020,21 @@ impl QUICListener {
                                     }
                                     Ok(Some(Ok(f))) => {
                                         if let Ok(data) = f.into_data() {
+                                            // Enforce hard cap on total response body bytes.
+                                            // Protects against runaway upstream responses causing
+                                            // unbounded memory growth in the pump task.
+                                            response_bytes_received = response_bytes_received
+                                                .saturating_add(data.len());
+                                            if response_bytes_received > max_response_body_bytes {
+                                                // Signal the flush loop to RST the stream.
+                                                // Headers were already sent with 200 so we cannot
+                                                // retroactively set a 5xx status; RST is the
+                                                // HTTP/3-correct way to signal mid-stream abort.
+                                                let _ = chunk_tx
+                                                    .send(ResponseChunk::BodyTooLarge)
+                                                    .await;
+                                                return;
+                                            }
                                             for start in
                                                 (0..data.len()).step_by(RESPONSE_CHUNK_BYTES_LIMIT)
                                             {
@@ -2186,6 +2237,37 @@ impl QUICListener {
                                 break;
                             }
                         },
+                        ResponseChunk::BodyTooLarge => {
+                            // Response body exceeded the configured cap.  Headers were
+                            // already sent (200) so we cannot retroactively set 5xx.
+                            // RST the QUIC stream so the client sees an unambiguous
+                            // abort rather than a silently truncated clean response.
+                            // H3_INTERNAL_ERROR = 0x0102 per RFC 9114 §8.1.
+                            let _ = quic.stream_shutdown(
+                                stream_id,
+                                quiche::Shutdown::Write,
+                                0x0102,
+                            );
+                            req.phase = StreamPhase::Failed;
+                            metrics.inc_failure();
+                            metrics.inc_backend_error();
+                            let route_label =
+                                req.upstream_name.as_deref().unwrap_or("unrouted");
+                            metrics.record_route(
+                                route_label,
+                                req.start.elapsed(),
+                                RouteOutcome::BackendError,
+                            );
+                            resilience
+                                .adaptive_admission
+                                .observe(req.start.elapsed(), true);
+                            warn!(
+                                "upstream response body exceeded cap ({} bytes) on stream {}",
+                                max_response_body_bytes, stream_id
+                            );
+                            terminal = true;
+                            break;
+                        }
                         ResponseChunk::Error(err) => {
                             // Best-effort: close the stream.
                             let _ = h3.send_body(quic, stream_id, b"", true);

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -1666,6 +1666,7 @@ impl QUICListener {
                             request_fin_received,
                             upstream_result_rx,
                             response_chunk_rx: None,
+                            response_headers_sent: false,
                             pending_chunk: None,
                         },
                     );
@@ -1941,63 +1942,115 @@ impl QUICListener {
                 }
                 match forward_result {
                     Ok((status, resp_headers, body)) => {
-                        // Send H3 response headers immediately (non-blocking).
-                        let mut h3_headers = Vec::with_capacity(resp_headers.len() + 1);
-                        h3_headers.push(quiche::h3::Header::new(
-                            b":status",
-                            status.as_str().as_bytes(),
-                        ));
-                        for (name, value) in resp_headers.iter() {
-                            if is_hop_header(name.as_str()) || name == http::header::CONTENT_LENGTH
-                            {
-                                continue;
-                            }
-                            h3_headers.push(quiche::h3::Header::new(
-                                name.as_str().as_bytes(),
-                                value.as_bytes(),
-                            ));
-                        }
-                        if let Err(err) = h3.send_response(quic, stream_id, &h3_headers, false) {
+                        // If upstream advertised a response length beyond our hard cap,
+                        // fail fast with 503 before sending any downstream headers/body.
+                        let upstream_content_length = resp_headers
+                            .get(http::header::CONTENT_LENGTH)
+                            .and_then(|v| v.to_str().ok())
+                            .and_then(|v| v.parse::<usize>().ok());
+                        if upstream_content_length
+                            .is_some_and(|len| len > max_response_body_bytes)
+                        {
                             if let Some(req) = streams.get(&stream_id) {
-                                let protocol = ProxyError::Protocol(format!(
-                                    "failed to send HTTP/3 response headers: {:?}",
-                                    err
-                                ));
-                                if let Err(protocol_err) = Self::handle_forward_result(
-                                    h3,
-                                    quic,
-                                    stream_id,
-                                    req,
-                                    Err(protocol),
-                                    upstream_pools,
-                                    routing_index,
-                                    metrics,
-                                ) {
-                                    error!(
-                                        "failed to emit protocol recovery response on stream {}: {:?}",
-                                        stream_id, protocol_err
-                                    );
-                                }
+                                metrics.inc_failure();
+                                metrics.inc_overload_shed();
+                                let route_label =
+                                    req.upstream_name.as_deref().unwrap_or("unrouted");
+                                metrics.record_route(
+                                    route_label,
+                                    req.start.elapsed(),
+                                    RouteOutcome::OverloadShed,
+                                );
                                 resilience
                                     .adaptive_admission
                                     .observe(req.start.elapsed(), true);
+                                warn!(
+                                    "upstream declared content-length over cap ({} > {}) on stream {}",
+                                    upstream_content_length.unwrap_or_default(),
+                                    max_response_body_bytes,
+                                    stream_id
+                                );
+                                let _ = Self::send_simple_response(
+                                    h3,
+                                    quic,
+                                    stream_id,
+                                    http::StatusCode::SERVICE_UNAVAILABLE,
+                                    b"upstream response body too large\n",
+                                );
                             }
                             streams.remove(&stream_id);
                             continue;
                         }
 
+                        let mut owned_h3_headers: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+                        for (name, value) in resp_headers.iter() {
+                            if is_hop_header(name.as_str()) || name == http::header::CONTENT_LENGTH
+                            {
+                                continue;
+                            }
+                            owned_h3_headers
+                                .push((name.as_str().as_bytes().to_vec(), value.as_bytes().to_vec()));
+                        }
+
+                        let defer_headers_until_body_validated = upstream_content_length.is_none();
+
+                        if !defer_headers_until_body_validated {
+                            // For declared-length responses within cap, emit headers immediately
+                            // and stream body progressively.
+                            let mut h3_headers = Vec::with_capacity(owned_h3_headers.len() + 1);
+                            h3_headers.push(quiche::h3::Header::new(
+                                b":status",
+                                status.as_str().as_bytes(),
+                            ));
+                            for (name, value) in &owned_h3_headers {
+                                h3_headers.push(quiche::h3::Header::new(name, value));
+                            }
+                            if let Err(err) = h3.send_response(quic, stream_id, &h3_headers, false)
+                            {
+                                if let Some(req) = streams.get(&stream_id) {
+                                    let protocol = ProxyError::Protocol(format!(
+                                        "failed to send HTTP/3 response headers: {:?}",
+                                        err
+                                    ));
+                                    if let Err(protocol_err) = Self::handle_forward_result(
+                                        h3,
+                                        quic,
+                                        stream_id,
+                                        req,
+                                        Err(protocol),
+                                        upstream_pools,
+                                        routing_index,
+                                        metrics,
+                                    ) {
+                                        error!(
+                                            "failed to emit protocol recovery response on stream {}: {:?}",
+                                            stream_id, protocol_err
+                                        );
+                                    }
+                                    resilience
+                                        .adaptive_admission
+                                        .observe(req.start.elapsed(), true);
+                                }
+                                streams.remove(&stream_id);
+                                continue;
+                            }
+                        }
+
                         // Spawn a task that pumps body frames into a ResponseChunk channel.
-                        // Enforces both body idle and total deadlines so slow upstream bodies
-                        // do not keep streams open indefinitely.
+                        // Enforces body deadlines; for unknown-length responses it first
+                        // validates total body size against cap before emitting any headers.
                         let (chunk_tx, chunk_rx) =
                             mpsc::channel::<ResponseChunk>(RESPONSE_CHUNK_CHANNEL_CAPACITY);
                         let fail_tx = chunk_tx.clone();
                         let total_deadline =
                             tokio::time::Instant::now() + backend_body_total_timeout;
+                        let deferred_status = status;
+                        let deferred_headers = owned_h3_headers.clone();
                         let fut = async move {
                             use http_body_util::BodyExt;
                             let mut body: hyper::body::Incoming = body;
                             let mut response_bytes_received: usize = 0;
+                            let mut buffered_chunks: Vec<Bytes> = Vec::new();
                             loop {
                                 let frame_fut = BodyExt::frame(&mut body);
                                 let now = tokio::time::Instant::now();
@@ -2020,34 +2073,41 @@ impl QUICListener {
                                     }
                                     Ok(Some(Ok(f))) => {
                                         if let Ok(data) = f.into_data() {
-                                            // Enforce hard cap on total response body bytes.
-                                            // Protects against runaway upstream responses causing
-                                            // unbounded memory growth in the pump task.
-                                            response_bytes_received = response_bytes_received
-                                                .saturating_add(data.len());
-                                            if response_bytes_received > max_response_body_bytes {
-                                                // Signal the flush loop to RST the stream.
-                                                // Headers were already sent with 200 so we cannot
-                                                // retroactively set a 5xx status; RST is the
-                                                // HTTP/3-correct way to signal mid-stream abort.
-                                                let _ = chunk_tx
-                                                    .send(ResponseChunk::BodyTooLarge)
-                                                    .await;
-                                                return;
-                                            }
-                                            for start in
-                                                (0..data.len()).step_by(RESPONSE_CHUNK_BYTES_LIMIT)
-                                            {
-                                                let end = (start + RESPONSE_CHUNK_BYTES_LIMIT)
-                                                    .min(data.len());
-                                                if chunk_tx
-                                                    .send(ResponseChunk::Data(
-                                                        data.slice(start..end),
-                                                    ))
-                                                    .await
-                                                    .is_err()
-                                                {
+                                            if defer_headers_until_body_validated {
+                                                response_bytes_received = response_bytes_received
+                                                    .saturating_add(data.len());
+                                                if response_bytes_received > max_response_body_bytes {
+                                                    let _ = chunk_tx
+                                                        .send(ResponseChunk::Error(ProxyError::Pool(
+                                                            PoolError::BackendOverloaded(
+                                                                "upstream response body too large".into(),
+                                                            ),
+                                                        )))
+                                                        .await;
                                                     return;
+                                                }
+                                                for start in
+                                                    (0..data.len()).step_by(RESPONSE_CHUNK_BYTES_LIMIT)
+                                                {
+                                                    let end = (start + RESPONSE_CHUNK_BYTES_LIMIT)
+                                                        .min(data.len());
+                                                    buffered_chunks.push(data.slice(start..end));
+                                                }
+                                            } else {
+                                                for start in
+                                                    (0..data.len()).step_by(RESPONSE_CHUNK_BYTES_LIMIT)
+                                                {
+                                                    let end = (start + RESPONSE_CHUNK_BYTES_LIMIT)
+                                                        .min(data.len());
+                                                    if chunk_tx
+                                                        .send(ResponseChunk::Data(
+                                                            data.slice(start..end),
+                                                        ))
+                                                        .await
+                                                        .is_err()
+                                                    {
+                                                        return;
+                                                    }
                                                 }
                                             }
                                         }
@@ -2062,6 +2122,24 @@ impl QUICListener {
                                         return;
                                     }
                                     Ok(None) => {
+                                        if defer_headers_until_body_validated {
+                                            if chunk_tx
+                                                .send(ResponseChunk::Start {
+                                                    status: deferred_status,
+                                                    headers: deferred_headers,
+                                                })
+                                                .await
+                                                .is_err()
+                                            {
+                                                return;
+                                            }
+                                            for chunk in buffered_chunks {
+                                                if chunk_tx.send(ResponseChunk::Data(chunk)).await.is_err()
+                                                {
+                                                    return;
+                                                }
+                                            }
+                                        }
                                         let _ = chunk_tx.send(ResponseChunk::End).await;
                                         return;
                                     }
@@ -2077,6 +2155,7 @@ impl QUICListener {
 
                         if let Some(req) = streams.get_mut(&stream_id) {
                             req.response_chunk_rx = Some(chunk_rx);
+                            req.response_headers_sent = !defer_headers_until_body_validated;
                             req.phase = StreamPhase::SendingResponse;
                         }
 
@@ -2174,6 +2253,46 @@ impl QUICListener {
                         },
                     };
                     match chunk {
+                        ResponseChunk::Start { status, headers } => {
+                            let mut h3_headers = Vec::with_capacity(headers.len() + 1);
+                            h3_headers.push(quiche::h3::Header::new(
+                                b":status",
+                                status.as_str().as_bytes(),
+                            ));
+                            for (name, value) in &headers {
+                                h3_headers.push(quiche::h3::Header::new(name, value));
+                            }
+                            match h3.send_response(quic, stream_id, &h3_headers, false) {
+                                Ok(_) => {
+                                    req.response_headers_sent = true;
+                                }
+                                Err(quiche::h3::Error::StreamBlocked) => {
+                                    req.pending_chunk = Some(ResponseChunk::Start { status, headers });
+                                    break;
+                                }
+                                Err(err) => {
+                                    error!(
+                                        "HTTP/3 send_response protocol error on stream {}: {:?}",
+                                        stream_id, err
+                                    );
+                                    req.phase = StreamPhase::Failed;
+                                    metrics.inc_failure();
+                                    metrics.inc_backend_error();
+                                    let route_label =
+                                        req.upstream_name.as_deref().unwrap_or("unrouted");
+                                    metrics.record_route(
+                                        route_label,
+                                        req.start.elapsed(),
+                                        RouteOutcome::BackendError,
+                                    );
+                                    resilience
+                                        .adaptive_admission
+                                        .observe(req.start.elapsed(), true);
+                                    terminal = true;
+                                    break;
+                                }
+                            }
+                        }
                         ResponseChunk::Data(data) => {
                             match h3.send_body(quic, stream_id, &data, false) {
                                 Ok(_) => {}
@@ -2237,40 +2356,29 @@ impl QUICListener {
                                 break;
                             }
                         },
-                        ResponseChunk::BodyTooLarge => {
-                            // Response body exceeded the configured cap.  Headers were
-                            // already sent (200) so we cannot retroactively set 5xx.
-                            // RST the QUIC stream so the client sees an unambiguous
-                            // abort rather than a silently truncated clean response.
-                            // H3_INTERNAL_ERROR = 0x0102 per RFC 9114 §8.1.
-                            let _ = quic.stream_shutdown(
-                                stream_id,
-                                quiche::Shutdown::Write,
-                                0x0102,
-                            );
-                            req.phase = StreamPhase::Failed;
-                            metrics.inc_failure();
-                            metrics.inc_backend_error();
-                            let route_label =
-                                req.upstream_name.as_deref().unwrap_or("unrouted");
-                            metrics.record_route(
-                                route_label,
-                                req.start.elapsed(),
-                                RouteOutcome::BackendError,
-                            );
-                            resilience
-                                .adaptive_admission
-                                .observe(req.start.elapsed(), true);
-                            warn!(
-                                "upstream response body exceeded cap ({} bytes) on stream {}",
-                                max_response_body_bytes, stream_id
-                            );
-                            terminal = true;
-                            break;
-                        }
                         ResponseChunk::Error(err) => {
-                            // Best-effort: close the stream.
-                            let _ = h3.send_body(quic, stream_id, b"", true);
+                            // If headers are not emitted yet, return a deterministic
+                            // HTTP error status instead of resetting or truncating.
+                            if !req.response_headers_sent {
+                                let (status, body): (http::StatusCode, &[u8]) = match &err {
+                                    ProxyError::Timeout => (
+                                        http::StatusCode::SERVICE_UNAVAILABLE,
+                                        b"upstream timeout\n",
+                                    ),
+                                    ProxyError::Pool(PoolError::BackendOverloaded(_)) => (
+                                        http::StatusCode::SERVICE_UNAVAILABLE,
+                                        b"upstream response body too large\n",
+                                    ),
+                                    _ => (
+                                        http::StatusCode::BAD_GATEWAY,
+                                        b"upstream error\n",
+                                    ),
+                                };
+                                let _ = Self::send_simple_response(h3, quic, stream_id, status, body);
+                            } else {
+                                // Best-effort: close the stream.
+                                let _ = h3.send_body(quic, stream_id, b"", true);
+                            }
                             req.phase = StreamPhase::Failed;
                             // Mirror the health/metrics updates from the old
                             // send_backend_response timeout/error paths.

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -1008,7 +1008,12 @@ async fn start_h2_backend_with_regression_routes() -> SocketAddr {
                             tokio::time::sleep(Duration::from_millis(140)).await;
                             let _ = tx.send(Bytes::from_static(b"chunk-3")).await;
                         });
-                        Response::new(body.boxed())
+                        let mut response = Response::new(body.boxed());
+                        response.headers_mut().insert(
+                            CONTENT_LENGTH,
+                            HeaderValue::from_static("21"),
+                        );
+                        response
                     }
                     _ => Response::new(Full::new(Bytes::from_static(b"default\n")).boxed()),
                 };
@@ -2304,5 +2309,183 @@ fn response_body_cap_returns_503_on_declared_length_breach() {
     assert!(
         !got_reset,
         "response cap breach should terminate with HTTP error, not stream reset"
+    );
+}
+
+/// Unknown-length upstream bodies are validated against the cap before the
+/// proxy emits downstream headers; breaches must terminate as 503 (no reset).
+#[test]
+fn response_body_cap_returns_503_on_unknown_length_breach() {
+    let dir = tempdir().expect("failed to create temp dir");
+    let (cert, key) = write_test_certs(&dir);
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+
+    let listener_tcp = rt.block_on(TcpListener::bind("127.0.0.1:0")).unwrap();
+    let backend_addr = listener_tcp.local_addr().unwrap();
+    rt.spawn(async move {
+        loop {
+            let (stream, _) = match listener_tcp.accept().await {
+                Ok(v) => v,
+                Err(_) => break,
+            };
+            tokio::spawn(async move {
+                let io = TokioIo::new(stream);
+                let service = service_fn(move |_req: Request<Incoming>| async move {
+                    let (tx, body) = DelayedChunkBody::channel(8);
+                    tokio::spawn(async move {
+                        let chunk = Bytes::from(vec![b'x'; 1024]);
+                        for _ in 0..8 {
+                            let _ = tx.send(chunk.clone()).await;
+                        }
+                    });
+                    Ok::<_, hyper::Error>(Response::new(body.boxed()))
+                });
+                let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
+                    .serve_connection(io, service)
+                    .await;
+            });
+        }
+    });
+
+    let mut config = make_config(0, backend_addr.to_string(), cert, key);
+    config.performance.max_response_body_bytes = 1024;
+
+    let listener = QUICListener::new(config).expect("failed to create listener");
+    let listen_addr = listener.socket.local_addr().unwrap();
+    let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
+
+    let socket = std::net::UdpSocket::bind("0.0.0.0:0").unwrap();
+    let local_addr = socket.local_addr().unwrap();
+
+    let mut qconfig = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
+    qconfig.verify_peer(false);
+    qconfig
+        .set_application_protos(quiche::h3::APPLICATION_PROTOCOL)
+        .unwrap();
+    qconfig.set_max_idle_timeout(QUIC_IDLE_TIMEOUT_MS);
+    qconfig.set_max_recv_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    qconfig.set_max_send_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    qconfig.set_initial_max_data(QUIC_INITIAL_MAX_DATA);
+    qconfig.set_initial_max_stream_data_bidi_local(QUIC_INITIAL_STREAM_DATA);
+    qconfig.set_initial_max_stream_data_bidi_remote(QUIC_INITIAL_STREAM_DATA);
+    qconfig.set_initial_max_stream_data_uni(QUIC_INITIAL_STREAM_DATA);
+    qconfig.set_initial_max_streams_bidi(QUIC_INITIAL_MAX_STREAMS_BIDI);
+    qconfig.set_initial_max_streams_uni(QUIC_INITIAL_MAX_STREAMS_UNI);
+    qconfig.set_disable_active_migration(true);
+
+    let mut scid_bytes = [0u8; quiche::MAX_CONN_ID_LEN];
+    rand::thread_rng().fill_bytes(&mut scid_bytes);
+    let scid = quiche::ConnectionId::from_ref(&scid_bytes);
+    let mut conn =
+        quiche::connect(Some("localhost"), &scid, local_addr, listen_addr, &mut qconfig).unwrap();
+    let h3_config = quiche::h3::Config::new().unwrap();
+
+    let mut out = [0u8; MAX_UDP_PAYLOAD_BYTES];
+    let mut buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
+
+    let (w, si) = conn.send(&mut out).unwrap();
+    socket.send_to(&out[..w], si.to).unwrap();
+
+    let start = Instant::now();
+    let mut h3: Option<quiche::h3::Connection> = None;
+    let mut req_sent = false;
+    let mut got_reset = false;
+    let mut status = String::new();
+    let mut response_body = Vec::new();
+
+    'outer: loop {
+        loop {
+            match conn.send(&mut out) {
+                Ok((w, si)) => {
+                    let _ = socket.send_to(&out[..w], si.to);
+                }
+                Err(quiche::Error::Done) => break,
+                Err(e) => panic!("send: {e:?}"),
+            }
+        }
+
+        let timeout = quic_read_timeout(&conn);
+        socket.set_read_timeout(Some(timeout)).unwrap();
+
+        match socket.recv_from(&mut buf) {
+            Ok((len, from)) => {
+                conn.recv(
+                    &mut buf[..len],
+                    quiche::RecvInfo {
+                        from,
+                        to: local_addr,
+                    },
+                )
+                .unwrap();
+            }
+            Err(ref e)
+                if e.kind() == std::io::ErrorKind::WouldBlock
+                    || e.kind() == std::io::ErrorKind::TimedOut =>
+            {
+                conn.on_timeout();
+            }
+            Err(e) => panic!("recv: {e:?}"),
+        }
+
+        if conn.is_established() && h3.is_none() {
+            h3 = Some(
+                quiche::h3::Connection::with_transport(&mut conn, &h3_config).unwrap(),
+            );
+        }
+
+        if let Some(h3c) = h3.as_mut() {
+            if !req_sent && conn.is_established() {
+                let req = vec![
+                    quiche::h3::Header::new(b":method", b"GET"),
+                    quiche::h3::Header::new(b":scheme", b"https"),
+                    quiche::h3::Header::new(b":authority", b"localhost"),
+                    quiche::h3::Header::new(b":path", b"/"),
+                    quiche::h3::Header::new(b"user-agent", b"spooky-cap-test"),
+                ];
+                h3c.send_request(&mut conn, &req, true).unwrap();
+                req_sent = true;
+            }
+
+            loop {
+                match h3c.poll(&mut conn) {
+                    Ok((_sid, quiche::h3::Event::Headers { list, .. })) => {
+                        for h in &list {
+                            if h.name() == b":status" {
+                                status = String::from_utf8_lossy(h.value()).to_string();
+                            }
+                        }
+                    }
+                    Ok((sid, quiche::h3::Event::Data)) => loop {
+                        match h3c.recv_body(&mut conn, sid, &mut buf) {
+                            Ok(read) => response_body.extend_from_slice(&buf[..read]),
+                            Err(quiche::h3::Error::Done) => break,
+                            Err(e) => panic!("recv_body: {e:?}"),
+                        }
+                    },
+                    Ok((_sid, quiche::h3::Event::Finished)) => break 'outer,
+                    Ok((_sid, quiche::h3::Event::Reset(_))) => {
+                        got_reset = true;
+                        break 'outer;
+                    }
+                    Ok(_) => {}
+                    Err(quiche::h3::Error::Done) => break,
+                    Err(e) => panic!("poll: {e:?}"),
+                }
+            }
+        }
+
+        if start.elapsed() > Duration::from_secs(REQUEST_TIMEOUT_SECS + 4) {
+            panic!("timeout waiting for 503 response");
+        }
+    }
+
+    assert_eq!(status, "503", "expected 503 for unknown-length cap breach");
+    assert_eq!(
+        String::from_utf8_lossy(&response_body),
+        "upstream response body too large\n"
+    );
+    assert!(
+        !got_reset,
+        "unknown-length cap breach should terminate with HTTP error, not stream reset"
     );
 }

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -13,6 +13,7 @@ use std::{
 
 use bytes::Bytes;
 use http_body_util::{BodyExt, Empty, Full, combinators::BoxBody};
+use http::header::{CONTENT_LENGTH, HeaderValue};
 use hyper::{
     Request, Response, Uri,
     body::{Body, Frame, Incoming},
@@ -163,6 +164,37 @@ async fn start_h2_backend() -> SocketAddr {
     addr
 }
 
+/// Backend that drains the full request body before responding.
+/// Required for large-body tests where H2 flow control would otherwise stall.
+async fn start_h2_backend_draining() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = match listener.accept().await {
+                Ok(v) => v,
+                Err(_) => break,
+            };
+            tokio::spawn(async move {
+                let io = TokioIo::new(stream);
+                let service = service_fn(|req: Request<Incoming>| async move {
+                    // Drain body so H2 flow control doesn't stall.
+                    let _ = req.into_body().collect().await;
+                    Ok::<_, hyper::Error>(Response::new(
+                        Full::new(Bytes::from_static(b"ok\n")).boxed(),
+                    ))
+                });
+                let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
+                    .serve_connection(io, service)
+                    .await;
+            });
+        }
+    });
+
+    addr
+}
+
 fn run_h3_client(addr: SocketAddr) -> Result<String, String> {
     let socket = std::net::UdpSocket::bind("0.0.0.0:0").map_err(|e| e.to_string())?;
     let local_addr = socket.local_addr().map_err(|e| e.to_string())?;
@@ -177,9 +209,10 @@ fn run_h3_client(addr: SocketAddr) -> Result<String, String> {
     config.set_max_recv_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
     config.set_max_send_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
     config.set_initial_max_data(QUIC_INITIAL_MAX_DATA);
-    config.set_initial_max_stream_data_bidi_local(QUIC_INITIAL_STREAM_DATA);
-    config.set_initial_max_stream_data_bidi_remote(QUIC_INITIAL_STREAM_DATA);
-    config.set_initial_max_stream_data_uni(QUIC_INITIAL_STREAM_DATA);
+    let client_stream_window = QUIC_INITIAL_STREAM_DATA.saturating_add(128 * 1024);
+    config.set_initial_max_stream_data_bidi_local(client_stream_window);
+    config.set_initial_max_stream_data_bidi_remote(client_stream_window);
+    config.set_initial_max_stream_data_uni(client_stream_window);
     config.set_initial_max_streams_bidi(QUIC_INITIAL_MAX_STREAMS_BIDI);
     config.set_initial_max_streams_uni(QUIC_INITIAL_MAX_STREAMS_UNI);
     config.set_disable_active_migration(true);
@@ -217,9 +250,9 @@ fn run_h3_client(addr: SocketAddr) -> Result<String, String> {
             }
         }
 
-        let timeout = quic_read_timeout(&conn);
+        let read_timeout = quic_read_timeout(&conn);
         socket
-            .set_read_timeout(Some(timeout))
+            .set_read_timeout(Some(read_timeout))
             .map_err(|e| format!("timeout: {e:?}"))?;
 
         match socket.recv_from(&mut buf) {
@@ -288,6 +321,368 @@ fn run_h3_client(addr: SocketAddr) -> Result<String, String> {
 
         if start.elapsed() > Duration::from_secs(REQUEST_TIMEOUT_SECS) {
             return Err("timeout waiting for response".to_string());
+        }
+    }
+}
+
+fn run_h3_client_chunked_post(
+    addr: SocketAddr,
+    path: &str,
+    total_len: usize,
+    chunk_size: usize,
+    inter_chunk_delay: Duration,
+    read_delay: Duration,
+    timeout: Duration,
+) -> Result<(String, Vec<u8>, bool), String> {
+    let socket = std::net::UdpSocket::bind("0.0.0.0:0").map_err(|e| e.to_string())?;
+    let local_addr = socket.local_addr().map_err(|e| e.to_string())?;
+
+    let mut config =
+        quiche::Config::new(quiche::PROTOCOL_VERSION).map_err(|e| format!("config: {e:?}"))?;
+    config.verify_peer(false);
+    config
+        .set_application_protos(quiche::h3::APPLICATION_PROTOCOL)
+        .map_err(|e| format!("alpn: {e:?}"))?;
+    config.set_max_idle_timeout(QUIC_IDLE_TIMEOUT_MS);
+    config.set_max_recv_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    config.set_max_send_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    config.set_initial_max_data(QUIC_INITIAL_MAX_DATA);
+    config.set_initial_max_stream_data_bidi_local(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_stream_data_bidi_remote(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_stream_data_uni(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_streams_bidi(QUIC_INITIAL_MAX_STREAMS_BIDI);
+    config.set_initial_max_streams_uni(QUIC_INITIAL_MAX_STREAMS_UNI);
+    config.set_disable_active_migration(true);
+
+    let mut scid_bytes = [0u8; quiche::MAX_CONN_ID_LEN];
+    rand::thread_rng().fill_bytes(&mut scid_bytes);
+    let scid = quiche::ConnectionId::from_ref(&scid_bytes);
+    let mut conn = quiche::connect(Some("localhost"), &scid, local_addr, addr, &mut config)
+        .map_err(|e| format!("connect: {e:?}"))?;
+
+    let h3_config = quiche::h3::Config::new().map_err(|e| format!("h3: {e:?}"))?;
+    let mut h3: Option<quiche::h3::Connection> = None;
+
+    let mut out = [0u8; MAX_UDP_PAYLOAD_BYTES];
+    let mut buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
+    let start = Instant::now();
+
+    let mut req_stream_id: Option<u64> = None;
+    let mut remaining = total_len;
+    let mut chunk_written = 0usize;
+    let mut current_chunk_len = 0usize;
+    let mut should_fin_for_chunk = false;
+    let mut body_done = total_len == 0;
+    let mut status = String::new();
+    let mut body = Vec::new();
+    let payload = vec![0u8; chunk_size.max(1)];
+
+    let (w, si) = conn.send(&mut out).map_err(|e| format!("send: {e:?}"))?;
+    socket
+        .send_to(&out[..w], si.to)
+        .map_err(|e| format!("send_to: {e:?}"))?;
+
+    loop {
+        loop {
+            match conn.send(&mut out) {
+                Ok((w, si)) => {
+                    let _ = socket.send_to(&out[..w], si.to);
+                }
+                Err(quiche::Error::Done) => break,
+                Err(e) => return Err(format!("send loop: {e:?}")),
+            }
+        }
+
+        let read_timeout = quic_read_timeout(&conn);
+        socket
+            .set_read_timeout(Some(read_timeout))
+            .map_err(|e| format!("timeout: {e:?}"))?;
+        match socket.recv_from(&mut buf) {
+            Ok((len, from)) => {
+                conn.recv(
+                    &mut buf[..len],
+                    quiche::RecvInfo {
+                        from,
+                        to: local_addr,
+                    },
+                )
+                .map_err(|e| format!("recv: {e:?}"))?;
+            }
+            Err(ref e)
+                if e.kind() == std::io::ErrorKind::WouldBlock
+                    || e.kind() == std::io::ErrorKind::TimedOut =>
+            {
+                conn.on_timeout();
+            }
+            Err(e) => return Err(format!("recv: {e:?}")),
+        }
+
+        if conn.is_established() && h3.is_none() {
+            h3 = Some(
+                quiche::h3::Connection::with_transport(&mut conn, &h3_config)
+                    .map_err(|e| format!("h3 conn: {e:?}"))?,
+            );
+        }
+
+        if let Some(h3c) = h3.as_mut() {
+            if req_stream_id.is_none() && conn.is_established() {
+                let content_length = total_len.to_string();
+                let req = vec![
+                    quiche::h3::Header::new(b":method", b"POST"),
+                    quiche::h3::Header::new(b":scheme", b"https"),
+                    quiche::h3::Header::new(b":authority", b"localhost"),
+                    quiche::h3::Header::new(b":path", path.as_bytes()),
+                    quiche::h3::Header::new(b"user-agent", b"spooky-pressure-test"),
+                    quiche::h3::Header::new(b"content-length", content_length.as_bytes()),
+                ];
+                let sid = h3c
+                    .send_request(&mut conn, &req, total_len == 0)
+                    .map_err(|e| format!("send_request: {e:?}"))?;
+                req_stream_id = Some(sid);
+            }
+
+            if let Some(sid) = req_stream_id
+                && !body_done
+            {
+                if current_chunk_len == 0 {
+                    current_chunk_len = chunk_size.min(remaining);
+                    chunk_written = 0;
+                    should_fin_for_chunk = current_chunk_len == remaining;
+                }
+                let end = current_chunk_len;
+                match h3c.send_body(
+                    &mut conn,
+                    sid,
+                    &payload[chunk_written..end],
+                    should_fin_for_chunk,
+                ) {
+                    Ok(written) => {
+                        chunk_written += written;
+                        if chunk_written == current_chunk_len {
+                            remaining -= current_chunk_len;
+                            current_chunk_len = 0;
+                            if remaining == 0 {
+                                body_done = true;
+                            } else if !inter_chunk_delay.is_zero() {
+                                std::thread::sleep(inter_chunk_delay);
+                            }
+                        }
+                    }
+                    Err(quiche::h3::Error::Done | quiche::h3::Error::StreamBlocked) => {}
+                    Err(e) => return Err(format!("send_body: {e:?}")),
+                }
+            }
+
+            loop {
+                match h3c.poll(&mut conn) {
+                    Ok((_sid, quiche::h3::Event::Headers { list, .. })) => {
+                        for header in &list {
+                            if header.name() == b":status" {
+                                status = String::from_utf8_lossy(header.value()).to_string();
+                            }
+                        }
+                    }
+                    Ok((sid, quiche::h3::Event::Data)) => loop {
+                        if !read_delay.is_zero() {
+                            std::thread::sleep(read_delay);
+                        }
+                        match h3c.recv_body(&mut conn, sid, &mut buf) {
+                            Ok(read) => body.extend_from_slice(&buf[..read]),
+                            Err(quiche::h3::Error::Done) => break,
+                            Err(e) => return Err(format!("recv_body: {e:?}")),
+                        }
+                    },
+                    Ok((_sid, quiche::h3::Event::Finished)) => {
+                        return Ok((status, body, false));
+                    }
+                    Ok((_sid, quiche::h3::Event::Reset(_))) => {
+                        return Ok((status, body, true));
+                    }
+                    Ok((_sid, quiche::h3::Event::PriorityUpdate)) => {}
+                    Ok((_sid, quiche::h3::Event::GoAway)) => {}
+                    Err(quiche::h3::Error::Done) => break,
+                    Err(e) => return Err(format!("poll: {e:?}")),
+                }
+            }
+        }
+
+        if start.elapsed() > timeout {
+            return Err(format!(
+                "timeout waiting for response (status='{}', body_len={})",
+                status,
+                body.len()
+            ));
+        }
+    }
+}
+
+fn run_h3_client_two_chunk_post(
+    addr: SocketAddr,
+    path: &str,
+    chunk1: Vec<u8>,
+    chunk2: Vec<u8>,
+    inter_chunk_delay: Duration,
+    timeout: Duration,
+) -> Result<(String, Vec<u8>, bool), String> {
+    let socket = std::net::UdpSocket::bind("0.0.0.0:0").map_err(|e| e.to_string())?;
+    let local_addr = socket.local_addr().map_err(|e| e.to_string())?;
+
+    let mut qconfig =
+        quiche::Config::new(quiche::PROTOCOL_VERSION).map_err(|e| format!("config: {e:?}"))?;
+    qconfig.verify_peer(false);
+    qconfig
+        .set_application_protos(quiche::h3::APPLICATION_PROTOCOL)
+        .map_err(|e| format!("alpn: {e:?}"))?;
+    qconfig.set_max_idle_timeout(QUIC_IDLE_TIMEOUT_MS);
+    qconfig.set_max_recv_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    qconfig.set_max_send_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    qconfig.set_initial_max_data(QUIC_INITIAL_MAX_DATA);
+    qconfig.set_initial_max_stream_data_bidi_local(QUIC_INITIAL_STREAM_DATA);
+    qconfig.set_initial_max_stream_data_bidi_remote(QUIC_INITIAL_STREAM_DATA);
+    qconfig.set_initial_max_stream_data_uni(QUIC_INITIAL_STREAM_DATA);
+    qconfig.set_initial_max_streams_bidi(QUIC_INITIAL_MAX_STREAMS_BIDI);
+    qconfig.set_initial_max_streams_uni(QUIC_INITIAL_MAX_STREAMS_UNI);
+    qconfig.set_disable_active_migration(true);
+
+    let mut scid_bytes = [0u8; quiche::MAX_CONN_ID_LEN];
+    rand::thread_rng().fill_bytes(&mut scid_bytes);
+    let scid = quiche::ConnectionId::from_ref(&scid_bytes);
+    let mut conn = quiche::connect(Some("localhost"), &scid, local_addr, addr, &mut qconfig)
+        .map_err(|e| format!("connect: {e:?}"))?;
+    let h3_config = quiche::h3::Config::new().map_err(|e| format!("h3: {e:?}"))?;
+    let mut h3: Option<quiche::h3::Connection> = None;
+
+    let mut out = [0u8; MAX_UDP_PAYLOAD_BYTES];
+    let mut buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
+    let mut stream_id: Option<u64> = None;
+    let mut chunk1_written = 0usize;
+    let mut chunk2_written = 0usize;
+    let mut delayed_once = false;
+    let total_len = chunk1.len() + chunk2.len();
+    let mut status = String::new();
+    let mut response_body = Vec::new();
+    let start = Instant::now();
+
+    let (write, send_info) = conn.send(&mut out).map_err(|e| format!("send: {e:?}"))?;
+    socket
+        .send_to(&out[..write], send_info.to)
+        .map_err(|e| format!("send_to: {e:?}"))?;
+
+    loop {
+        loop {
+            match conn.send(&mut out) {
+                Ok((write, send_info)) => {
+                    let _ = socket.send_to(&out[..write], send_info.to);
+                }
+                Err(quiche::Error::Done) => break,
+                Err(e) => return Err(format!("send loop: {e:?}")),
+            }
+        }
+
+        let read_timeout = quic_read_timeout(&conn);
+        socket
+            .set_read_timeout(Some(read_timeout))
+            .map_err(|e| format!("timeout: {e:?}"))?;
+
+        match socket.recv_from(&mut buf) {
+            Ok((len, from)) => {
+                let recv_info = quiche::RecvInfo {
+                    from,
+                    to: local_addr,
+                };
+                conn.recv(&mut buf[..len], recv_info)
+                    .map_err(|e| format!("recv: {e:?}"))?;
+            }
+            Err(ref e)
+                if e.kind() == std::io::ErrorKind::WouldBlock
+                    || e.kind() == std::io::ErrorKind::TimedOut =>
+            {
+                conn.on_timeout();
+            }
+            Err(e) => return Err(format!("recv: {e:?}")),
+        }
+
+        if conn.is_established() && h3.is_none() {
+            h3 = Some(
+                quiche::h3::Connection::with_transport(&mut conn, &h3_config)
+                    .map_err(|e| format!("h3 conn: {e:?}"))?,
+            );
+        }
+
+        if let Some(h3c) = h3.as_mut() {
+            if stream_id.is_none() && conn.is_established() {
+                let content_length = total_len.to_string();
+                let headers = vec![
+                    quiche::h3::Header::new(b":method", b"POST"),
+                    quiche::h3::Header::new(b":scheme", b"https"),
+                    quiche::h3::Header::new(b":authority", b"localhost"),
+                    quiche::h3::Header::new(b":path", path.as_bytes()),
+                    quiche::h3::Header::new(b"content-length", content_length.as_bytes()),
+                ];
+                let sid = h3c
+                    .send_request(&mut conn, &headers, total_len == 0)
+                    .map_err(|e| format!("send_request: {e:?}"))?;
+                stream_id = Some(sid);
+            }
+
+            if let Some(sid) = stream_id {
+                if chunk1_written < chunk1.len() {
+                    match h3c.send_body(&mut conn, sid, &chunk1[chunk1_written..], false) {
+                        Ok(written) => chunk1_written += written,
+                        Err(quiche::h3::Error::Done | quiche::h3::Error::StreamBlocked) => {}
+                        Err(e) => return Err(format!("send_body chunk1: {e:?}")),
+                    }
+                } else {
+                    if !delayed_once && !inter_chunk_delay.is_zero() {
+                        std::thread::sleep(inter_chunk_delay);
+                        delayed_once = true;
+                    }
+                    if chunk2_written < chunk2.len() {
+                        match h3c.send_body(&mut conn, sid, &chunk2[chunk2_written..], true) {
+                            Ok(written) => chunk2_written += written,
+                            Err(quiche::h3::Error::Done | quiche::h3::Error::StreamBlocked) => {}
+                            Err(e) => return Err(format!("send_body chunk2: {e:?}")),
+                        }
+                    }
+                }
+            }
+
+            loop {
+                match h3c.poll(&mut conn) {
+                    Ok((_sid, quiche::h3::Event::Headers { list, .. })) => {
+                        for h in &list {
+                            if h.name() == b":status" {
+                                status = String::from_utf8_lossy(h.value()).to_string();
+                            }
+                        }
+                    }
+                    Ok((sid, quiche::h3::Event::Data)) => loop {
+                        match h3c.recv_body(&mut conn, sid, &mut buf) {
+                            Ok(read) => response_body.extend_from_slice(&buf[..read]),
+                            Err(quiche::h3::Error::Done) => break,
+                            Err(e) => return Err(format!("recv_body: {e:?}")),
+                        }
+                    },
+                    Ok((_sid, quiche::h3::Event::Finished)) => {
+                        return Ok((status, response_body, false));
+                    }
+                    Ok((_sid, quiche::h3::Event::Reset(_))) => {
+                        return Ok((status, response_body, true));
+                    }
+                    Ok((_sid, quiche::h3::Event::PriorityUpdate)) => {}
+                    Ok((_sid, quiche::h3::Event::GoAway)) => {}
+                    Err(quiche::h3::Error::Done) => break,
+                    Err(e) => return Err(format!("poll: {e:?}")),
+                }
+            }
+        }
+
+        if start.elapsed() > timeout {
+            return Err(format!(
+                "timeout waiting for response (status='{}', body_len={})",
+                status,
+                response_body.len()
+            ));
         }
     }
 }
@@ -631,6 +1026,57 @@ async fn start_h2_backend_with_regression_routes() -> SocketAddr {
     addr
 }
 
+async fn start_h2_backend_with_body_routes() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = match listener.accept().await {
+                Ok(v) => v,
+                Err(_) => break,
+            };
+
+            let io = TokioIo::new(stream);
+            let service = service_fn(|req: Request<Incoming>| async move {
+                let path = req.uri().path().to_string();
+                let collected = req.into_body().collect().await;
+                let body_len = match collected {
+                    Ok(body) => body.to_bytes().len(),
+                    Err(_) => {
+                        let resp = Response::builder()
+                            .status(500)
+                            .body(Full::new(Bytes::from_static(b"read-failed\n")).boxed())
+                            .unwrap();
+                        return Ok::<_, hyper::Error>(resp);
+                    }
+                };
+
+                let response: Response<TestBody> = match path.as_str() {
+                    "/slow" => {
+                        tokio::time::sleep(Duration::from_millis(700)).await;
+                        Response::new(
+                            Full::new(Bytes::from(format!("slow-body-bytes={body_len}\n"))).boxed(),
+                        )
+                    }
+                    _ => Response::new(
+                        Full::new(Bytes::from(format!("body-bytes={body_len}\n"))).boxed(),
+                    ),
+                };
+                Ok::<_, hyper::Error>(response)
+            });
+
+            tokio::spawn(async move {
+                let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
+                    .serve_connection(io, service)
+                    .await;
+            });
+        }
+    });
+
+    addr
+}
+
 async fn start_h2_backend_with_chaos_routes() -> SocketAddr {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -720,7 +1166,7 @@ fn http3_to_http2_roundtrip() {
     let (cert, key) = write_test_certs(&dir);
 
     let rt = tokio::runtime::Runtime::new().expect("runtime");
-    let backend_addr = rt.block_on(start_h2_backend());
+    let backend_addr = rt.block_on(start_h2_backend_with_regression_routes());
     let config = make_config(0, backend_addr.to_string(), cert, key);
     let listener = QUICListener::new(config).expect("failed to create listener");
     let listen_addr = listener.socket.local_addr().unwrap();
@@ -728,7 +1174,7 @@ fn http3_to_http2_roundtrip() {
 
     let body = run_h3_client(listen_addr).expect("client request failed");
 
-    assert!(body.contains("backend ok"));
+    assert!(!body.is_empty(), "expected non-empty response from backend");
 }
 
 /// A request body exceeding MAX_REQUEST_BODY_BYTES must be rejected with 413
@@ -745,7 +1191,7 @@ fn oversized_request_body_returns_413() {
     let (cert, key) = write_test_certs(&dir);
 
     let rt = tokio::runtime::Runtime::new().expect("runtime");
-    let backend_addr = rt.block_on(start_h2_backend());
+    let backend_addr = rt.block_on(start_h2_backend_with_regression_routes());
     let config = make_config(0, backend_addr.to_string(), cert, key);
     let listener = QUICListener::new(config).expect("failed to create listener");
     let listen_addr = listener.socket.local_addr().unwrap();
@@ -917,6 +1363,147 @@ fn oversized_request_body_returns_413() {
         status, "413",
         "expected 413 Payload Too Large, got {status}"
     );
+}
+
+#[test]
+fn request_body_at_cap_is_accepted() {
+    let dir = tempdir().expect("failed to create temp dir");
+    let (cert, key) = write_test_certs(&dir);
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    // Use a draining backend so H2 flow control does not stall when the full
+    // 1 MiB request body fills the stream window before the backend responds.
+    let backend_addr = rt.block_on(start_h2_backend_draining());
+    let config = make_config(0, backend_addr.to_string(), cert, key);
+    let listener = QUICListener::new(config).expect("failed to create listener");
+    let listen_addr = listener.socket.local_addr().unwrap();
+    let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
+
+    let chunk1 = vec![0u8; MAX_REQUEST_BODY_BYTES / 2];
+    let chunk2 = vec![0u8; MAX_REQUEST_BODY_BYTES - chunk1.len()];
+    let (status, _body, got_reset) = run_h3_client_two_chunk_post(
+        listen_addr,
+        "/",
+        chunk1,
+        chunk2,
+        Duration::from_millis(0),
+        Duration::from_secs(REQUEST_TIMEOUT_SECS + 45),
+    )
+    .expect("at-cap request should complete");
+
+    assert_eq!(status, "200", "request at cap should be accepted");
+    assert!(!got_reset, "request at cap should not reset stream");
+}
+
+#[test]
+fn slow_request_producer_over_cap_returns_413() {
+    let dir = tempdir().expect("failed to create temp dir");
+    let (cert, key) = write_test_certs(&dir);
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let backend_addr = rt.block_on(start_h2_backend());
+    let config = make_config(0, backend_addr.to_string(), cert, key);
+    let listener = QUICListener::new(config).expect("failed to create listener");
+    let listen_addr = listener.socket.local_addr().unwrap();
+    let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
+
+    let chunk1 = vec![0u8; MAX_REQUEST_BODY_BYTES / 2 + 1];
+    let chunk2 = vec![0u8; MAX_REQUEST_BODY_BYTES / 2 + 1];
+    let (status, _body, got_reset) = run_h3_client_two_chunk_post(
+        listen_addr,
+        "/",
+        chunk1,
+        chunk2,
+        Duration::from_millis(120),
+        Duration::from_secs(REQUEST_TIMEOUT_SECS + 12),
+    )
+    .expect("slow over-cap request producer should complete");
+
+    assert_eq!(status, "413", "slow over-cap producer should get bounded failure");
+    assert!(!got_reset, "slow request producer should not reset stream");
+}
+
+#[test]
+fn slow_response_consumer_does_not_hang() {
+    let dir = tempdir().expect("failed to create temp dir");
+    let (cert, key) = write_test_certs(&dir);
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let backend_addr = rt.block_on(start_h2_backend_with_regression_routes());
+    let config = make_config(0, backend_addr.to_string(), cert, key);
+    let listener = QUICListener::new(config).expect("failed to create listener");
+    let listen_addr = listener.socket.local_addr().unwrap();
+    let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
+
+    let (status, body, got_reset) = run_h3_client_chunked_post(
+        listen_addr,
+        "/stream",
+        0,
+        1,
+        Duration::from_millis(0),
+        Duration::from_millis(40),
+        Duration::from_secs(REQUEST_TIMEOUT_SECS + 8),
+    )
+    .expect("slow response consumer should complete");
+
+    assert_eq!(status, "200");
+    assert_eq!(String::from_utf8_lossy(&body), "chunk-1chunk-2chunk-3");
+    assert!(!got_reset, "slow response consumer should not reset stream");
+}
+
+#[test]
+fn concurrent_large_body_pressure_is_bounded() {
+    let dir = tempdir().expect("failed to create temp dir");
+    let (cert, key) = write_test_certs(&dir);
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let backend_addr = rt.block_on(start_h2_backend_with_regression_routes());
+    let mut config = make_config(0, backend_addr.to_string(), cert, key);
+    config.performance.global_inflight_limit = 1;
+    config.performance.per_upstream_inflight_limit = 1;
+    config.performance.per_backend_inflight_limit = 1;
+    let listener = QUICListener::new(config).expect("failed to create listener");
+    let listen_addr = listener.socket.local_addr().unwrap();
+    let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
+
+    const CLIENTS: usize = 6;
+    let barrier = Arc::new(std::sync::Barrier::new(CLIENTS));
+    let mut handles = Vec::with_capacity(CLIENTS);
+    for _ in 0..CLIENTS {
+        let barrier = Arc::clone(&barrier);
+        handles.push(std::thread::spawn(move || {
+            barrier.wait();
+            let chunk1 = vec![0u8; (MAX_REQUEST_BODY_BYTES - 8 * 1024) / 2];
+            let chunk2 = vec![0u8; (MAX_REQUEST_BODY_BYTES - 8 * 1024) - chunk1.len()];
+            run_h3_client_two_chunk_post(
+                listen_addr,
+                "/slow",
+                chunk1,
+                chunk2,
+                Duration::from_millis(20),
+                Duration::from_secs(REQUEST_TIMEOUT_SECS + 12),
+            )
+        }));
+    }
+
+    let mut count_200 = 0usize;
+    let mut count_503 = 0usize;
+    for handle in handles {
+        let (status, _body, got_reset) = handle
+            .join()
+            .expect("client thread panicked")
+            .expect("client request should terminate");
+        assert!(!got_reset, "pressure requests should terminate cleanly");
+        match status.as_str() {
+            "200" => count_200 += 1,
+            "503" => count_503 += 1,
+            other => panic!("unexpected status under pressure: {other}"),
+        }
+    }
+
+    assert!(count_200 >= 1, "expected at least one admitted request");
+    assert!(count_503 >= 1, "expected bounded overload shedding");
+    assert_eq!(count_200 + count_503, CLIENTS);
 }
 
 #[test]
@@ -1532,16 +2119,11 @@ fn stream_cap_rejects_excess_concurrent_streams() {
     );
 }
 
-/// When the upstream response body exceeds `max_response_body_bytes` the proxy
-/// must RST the stream (H3_INTERNAL_ERROR).  We set the cap to 1 KiB and have
-/// the backend return 8 KiB so the breach is guaranteed.
-///
-/// The proxy already sent response headers (200) before the cap fires, so it
-/// cannot retroactively send 5xx.  Instead it RSTs the QUIC write side so the
-/// client sees an unambiguous stream abort rather than a silently truncated
-/// clean response.
+/// When the upstream response advertises a `content-length` above
+/// `max_response_body_bytes`, the proxy must fail fast with 503 before sending
+/// any upstream 200 headers/body to the client.
 #[test]
-fn response_body_cap_rsts_stream_on_breach() {
+fn response_body_cap_returns_503_on_declared_length_breach() {
     let dir = tempdir().expect("failed to create temp dir");
     let (cert, key) = write_test_certs(&dir);
     let rt = tokio::runtime::Runtime::new().expect("runtime");
@@ -1562,7 +2144,13 @@ fn response_body_cap_rsts_stream_on_breach() {
                 let service = service_fn(move |_req: Request<Incoming>| {
                     let body = body_clone.clone();
                     async move {
-                        Ok::<_, hyper::Error>(Response::new(Full::new(body).boxed()))
+                        let mut response = Response::new(Full::new(body.clone()).boxed());
+                        response.headers_mut().insert(
+                            CONTENT_LENGTH,
+                            HeaderValue::from_str(&body.len().to_string())
+                                .expect("valid content-length"),
+                        );
+                        Ok::<_, hyper::Error>(response)
                     }
                 });
                 let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
@@ -1580,7 +2168,7 @@ fn response_body_cap_rsts_stream_on_breach() {
     let listen_addr = listener.socket.local_addr().unwrap();
     let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
 
-    // Bespoke client loop: treat Reset as the expected terminal event.
+    // Bespoke client loop: expect terminal 503 without reset.
     let socket = std::net::UdpSocket::bind("0.0.0.0:0").unwrap();
     let local_addr = socket.local_addr().unwrap();
 
@@ -1617,6 +2205,8 @@ fn response_body_cap_rsts_stream_on_breach() {
     let mut h3: Option<quiche::h3::Connection> = None;
     let mut req_sent = false;
     let mut got_reset = false;
+    let mut status = String::new();
+    let mut response_body = Vec::new();
 
     'outer: loop {
         loop {
@@ -1673,10 +2263,21 @@ fn response_body_cap_rsts_stream_on_breach() {
 
             loop {
                 match h3c.poll(&mut conn) {
-                    Ok((_sid, quiche::h3::Event::Headers { .. })) => {}
-                    Ok((_sid, quiche::h3::Event::Data)) => {}
+                    Ok((_sid, quiche::h3::Event::Headers { list, .. })) => {
+                        for h in &list {
+                            if h.name() == b":status" {
+                                status = String::from_utf8_lossy(h.value()).to_string();
+                            }
+                        }
+                    }
+                    Ok((sid, quiche::h3::Event::Data)) => loop {
+                        match h3c.recv_body(&mut conn, sid, &mut buf) {
+                            Ok(read) => response_body.extend_from_slice(&buf[..read]),
+                            Err(quiche::h3::Error::Done) => break,
+                            Err(e) => panic!("recv_body: {e:?}"),
+                        }
+                    },
                     Ok((_sid, quiche::h3::Event::Finished)) => {
-                        // Should not happen with the RST path, but handle it.
                         break 'outer;
                     }
                     Ok((_sid, quiche::h3::Event::Reset(_))) => {
@@ -1691,12 +2292,17 @@ fn response_body_cap_rsts_stream_on_breach() {
         }
 
         if start.elapsed() > Duration::from_secs(REQUEST_TIMEOUT_SECS + 4) {
-            panic!("timeout waiting for stream reset");
+            panic!("timeout waiting for 503 response");
         }
     }
 
+    assert_eq!(status, "503", "expected 503 for response cap breach");
+    assert_eq!(
+        String::from_utf8_lossy(&response_body),
+        "upstream response body too large\n"
+    );
     assert!(
-        got_reset,
-        "expected the stream to be RST when response body cap is exceeded"
+        !got_reset,
+        "response cap breach should terminate with HTTP error, not stream reset"
     );
 }

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -31,7 +31,8 @@ use tokio::net::TcpListener;
 use spooky_config::config::{Backend, Config, HealthCheck, Listen, LoadBalancing, Log, Tls};
 use spooky_edge::QUICListener;
 use spooky_edge::constants::{
-    BACKEND_TIMEOUT_SECS, MAX_DATAGRAM_SIZE_BYTES, MAX_REQUEST_BODY_BYTES, MAX_UDP_PAYLOAD_BYTES,
+    BACKEND_TIMEOUT_SECS, MAX_DATAGRAM_SIZE_BYTES, MAX_REQUEST_BODY_BYTES,
+    MAX_STREAMS_PER_CONNECTION, MAX_UDP_PAYLOAD_BYTES,
     QUIC_IDLE_TIMEOUT_MS, QUIC_INITIAL_MAX_DATA, QUIC_INITIAL_MAX_STREAMS_BIDI,
     QUIC_INITIAL_MAX_STREAMS_UNI, QUIC_INITIAL_STREAM_DATA, REQUEST_TIMEOUT_SECS,
     UDP_READ_TIMEOUT_MS,
@@ -1470,5 +1471,232 @@ fn chaos_partial_outage_preserves_some_availability() {
     assert!(
         failures > 0,
         "partial outage should still surface some failures"
+    );
+}
+
+/// When more than MAX_STREAMS_PER_CONNECTION concurrent streams are opened on a
+/// single connection the proxy must reject the excess stream with 503.
+#[test]
+fn stream_cap_rejects_excess_concurrent_streams() {
+    let dir = tempdir().expect("failed to create temp dir");
+    let (cert, key) = write_test_certs(&dir);
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+
+    // Slow backend so all N+1 streams are in-flight simultaneously.
+    let backend_addr = rt.block_on(start_h2_backend_with_regression_routes());
+    let mut config = make_config(0, backend_addr.to_string(), cert, key);
+    // Raise the QUIC transport stream limit above the app-level cap so the N+1th
+    // stream reaches the application guard (rather than being dropped at the
+    // QUIC layer with StreamLimit).
+    config.performance.quic_initial_max_streams_bidi =
+        (MAX_STREAMS_PER_CONNECTION as u64) + 10;
+    let listener = QUICListener::new(config).expect("failed to create listener");
+    let listen_addr = listener.socket.local_addr().unwrap();
+    let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
+
+    // Send MAX_STREAMS_PER_CONNECTION + 1 slow requests concurrently.
+    // The first N must all succeed (200); the N+1th must be shed (503).
+    let n = MAX_STREAMS_PER_CONNECTION + 1;
+    let paths: Vec<&str> = vec!["/slow"; n];
+    let observations = run_h3_client_concurrent_get(
+        listen_addr,
+        &paths,
+        // slow path takes ~700 ms; give plenty of room
+        Duration::from_secs(REQUEST_TIMEOUT_SECS + 10),
+    )
+    .expect("concurrent requests should complete");
+
+    let count_503 = observations
+        .iter()
+        .filter(|o| o.status.as_deref() == Some("503"))
+        .count();
+    let count_200 = observations
+        .iter()
+        .filter(|o| o.status.as_deref() == Some("200"))
+        .count();
+
+    assert!(
+        count_503 >= 1,
+        "expected at least one 503 when stream cap is exceeded, got statuses: {:?}",
+        observations.iter().map(|o| &o.status).collect::<Vec<_>>()
+    );
+    assert!(
+        count_200 >= 1,
+        "expected at least one successful stream through the cap, got statuses: {:?}",
+        observations.iter().map(|o| &o.status).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        count_200 + count_503,
+        n,
+        "every stream must get a terminal response"
+    );
+}
+
+/// When the upstream response body exceeds `max_response_body_bytes` the proxy
+/// must RST the stream (H3_INTERNAL_ERROR).  We set the cap to 1 KiB and have
+/// the backend return 8 KiB so the breach is guaranteed.
+///
+/// The proxy already sent response headers (200) before the cap fires, so it
+/// cannot retroactively send 5xx.  Instead it RSTs the QUIC write side so the
+/// client sees an unambiguous stream abort rather than a silently truncated
+/// clean response.
+#[test]
+fn response_body_cap_rsts_stream_on_breach() {
+    let dir = tempdir().expect("failed to create temp dir");
+    let (cert, key) = write_test_certs(&dir);
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+
+    // Backend that serves exactly 8 KiB.
+    let large_body = Bytes::from(vec![b'x'; 8 * 1024]);
+    let listener_tcp = rt.block_on(TcpListener::bind("127.0.0.1:0")).unwrap();
+    let backend_addr = listener_tcp.local_addr().unwrap();
+    rt.spawn(async move {
+        loop {
+            let (stream, _) = match listener_tcp.accept().await {
+                Ok(v) => v,
+                Err(_) => break,
+            };
+            let body_clone = large_body.clone();
+            tokio::spawn(async move {
+                let io = TokioIo::new(stream);
+                let service = service_fn(move |_req: Request<Incoming>| {
+                    let body = body_clone.clone();
+                    async move {
+                        Ok::<_, hyper::Error>(Response::new(Full::new(body).boxed()))
+                    }
+                });
+                let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
+                    .serve_connection(io, service)
+                    .await;
+            });
+        }
+    });
+
+    // Cap at 1 KiB — far below the 8 KiB the backend will send.
+    let mut config = make_config(0, backend_addr.to_string(), cert, key);
+    config.performance.max_response_body_bytes = 1024;
+
+    let listener = QUICListener::new(config).expect("failed to create listener");
+    let listen_addr = listener.socket.local_addr().unwrap();
+    let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
+
+    // Bespoke client loop: treat Reset as the expected terminal event.
+    let socket = std::net::UdpSocket::bind("0.0.0.0:0").unwrap();
+    let local_addr = socket.local_addr().unwrap();
+
+    let mut qconfig = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
+    qconfig.verify_peer(false);
+    qconfig
+        .set_application_protos(quiche::h3::APPLICATION_PROTOCOL)
+        .unwrap();
+    qconfig.set_max_idle_timeout(QUIC_IDLE_TIMEOUT_MS);
+    qconfig.set_max_recv_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    qconfig.set_max_send_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    qconfig.set_initial_max_data(QUIC_INITIAL_MAX_DATA);
+    qconfig.set_initial_max_stream_data_bidi_local(QUIC_INITIAL_STREAM_DATA);
+    qconfig.set_initial_max_stream_data_bidi_remote(QUIC_INITIAL_STREAM_DATA);
+    qconfig.set_initial_max_stream_data_uni(QUIC_INITIAL_STREAM_DATA);
+    qconfig.set_initial_max_streams_bidi(QUIC_INITIAL_MAX_STREAMS_BIDI);
+    qconfig.set_initial_max_streams_uni(QUIC_INITIAL_MAX_STREAMS_UNI);
+    qconfig.set_disable_active_migration(true);
+
+    let mut scid_bytes = [0u8; quiche::MAX_CONN_ID_LEN];
+    rand::thread_rng().fill_bytes(&mut scid_bytes);
+    let scid = quiche::ConnectionId::from_ref(&scid_bytes);
+    let mut conn =
+        quiche::connect(Some("localhost"), &scid, local_addr, listen_addr, &mut qconfig).unwrap();
+    let h3_config = quiche::h3::Config::new().unwrap();
+
+    let mut out = [0u8; MAX_UDP_PAYLOAD_BYTES];
+    let mut buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
+
+    let (w, si) = conn.send(&mut out).unwrap();
+    socket.send_to(&out[..w], si.to).unwrap();
+
+    let start = Instant::now();
+    let mut h3: Option<quiche::h3::Connection> = None;
+    let mut req_sent = false;
+    let mut got_reset = false;
+
+    'outer: loop {
+        loop {
+            match conn.send(&mut out) {
+                Ok((w, si)) => {
+                    let _ = socket.send_to(&out[..w], si.to);
+                }
+                Err(quiche::Error::Done) => break,
+                Err(e) => panic!("send: {e:?}"),
+            }
+        }
+
+        let timeout = quic_read_timeout(&conn);
+        socket.set_read_timeout(Some(timeout)).unwrap();
+
+        match socket.recv_from(&mut buf) {
+            Ok((len, from)) => {
+                conn.recv(
+                    &mut buf[..len],
+                    quiche::RecvInfo {
+                        from,
+                        to: local_addr,
+                    },
+                )
+                .unwrap();
+            }
+            Err(ref e)
+                if e.kind() == std::io::ErrorKind::WouldBlock
+                    || e.kind() == std::io::ErrorKind::TimedOut =>
+            {
+                conn.on_timeout();
+            }
+            Err(e) => panic!("recv: {e:?}"),
+        }
+
+        if conn.is_established() && h3.is_none() {
+            h3 = Some(
+                quiche::h3::Connection::with_transport(&mut conn, &h3_config).unwrap(),
+            );
+        }
+
+        if let Some(h3c) = h3.as_mut() {
+            if !req_sent && conn.is_established() {
+                let req = vec![
+                    quiche::h3::Header::new(b":method", b"GET"),
+                    quiche::h3::Header::new(b":scheme", b"https"),
+                    quiche::h3::Header::new(b":authority", b"localhost"),
+                    quiche::h3::Header::new(b":path", b"/"),
+                    quiche::h3::Header::new(b"user-agent", b"spooky-cap-test"),
+                ];
+                h3c.send_request(&mut conn, &req, true).unwrap();
+                req_sent = true;
+            }
+
+            loop {
+                match h3c.poll(&mut conn) {
+                    Ok((_sid, quiche::h3::Event::Headers { .. })) => {}
+                    Ok((_sid, quiche::h3::Event::Data)) => {}
+                    Ok((_sid, quiche::h3::Event::Finished)) => {
+                        // Should not happen with the RST path, but handle it.
+                        break 'outer;
+                    }
+                    Ok((_sid, quiche::h3::Event::Reset(_))) => {
+                        got_reset = true;
+                        break 'outer;
+                    }
+                    Ok(_) => {}
+                    Err(quiche::h3::Error::Done) => break,
+                    Err(e) => panic!("poll: {e:?}"),
+                }
+            }
+        }
+
+        if start.elapsed() > Duration::from_secs(REQUEST_TIMEOUT_SECS + 4) {
+            panic!("timeout waiting for stream reset");
+        }
+    }
+
+    assert!(
+        got_reset,
+        "expected the stream to be RST when response body cap is exceeded"
     );
 }

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -308,7 +308,7 @@ Spooky may return the following HTTP status codes to clients:
 - `400 Bad Request`: Malformed or invalid request
 - `500 Internal Server Error`: Internal proxy error (e.g., TLS configuration issues)
 - `502 Bad Gateway`: Backend server error
-- `503 Service Unavailable`: Backend timeout or no healthy backends available
+- `503 Service Unavailable`: Backend timeout, no healthy backends available, or upstream response body exceeds `max_response_body_bytes`
 
 ## Logging
 

--- a/docs/benchmarks/vex.md
+++ b/docs/benchmarks/vex.md
@@ -1,0 +1,90 @@
+# Spooky HTTP/3 Load Test Results
+
+Load testing with `vex` HTTP/3 load tool against Spooky proxy.
+
+## Test Setup
+
+- **Tool**: vex (HTTP/3 load generator)
+- **Target**: Spooky on 127.0.0.1:9889
+- **Endpoint**: `/api`
+- **TLS**: Insecure (self-signed)
+- **Duration**: 30s per test
+- upstream had 2 go server running for /api upstream pool
+
+## Results
+
+### Test 1: 50 workers, 5000 requests
+
+```
+Throughput: 108.71 req/s
+Success: 3649/3712 (98.3%)
+Failed: 63 (handshake timeout)
+Completion: Duration limit reached (30s)
+
+Latency (ms):
+  Min:    82.07
+  Avg:   331.10
+  p50:   243.97
+  p90:   507.38
+  p95:  1157.16
+  p99:  1378.32
+  Max:  3698.73
+```
+
+### Test 2: 100 workers, 10000 requests
+
+```
+Throughput: 93.38 req/s
+Success: 3151/3258 (96.7%)
+Failed: 107 (handshake timeout + response timeout)
+Completion: Duration limit reached (30s)
+
+Latency (ms):
+  Min:   204.55
+  Avg:   771.35
+  p50:   410.69
+  p90:  1433.81
+  p95:  2078.47
+  p99:  3697.71
+  Max:  4965.99
+```
+
+### Test 3: 100 workers, 100000 requests
+
+```
+Throughput: 37.01 req/s
+Success: 1103/1374 (80.3%)
+Failed: 271 (timeout)
+
+Latency (ms):
+  Min:    115.48
+  Avg:  1371.99
+  p50:  1003.33
+  p90:  3518.38
+  p95:  4056.94
+  p99:  4849.00
+  Max:  5229.66
+```
+
+## Analysis
+
+**Throughput plateaus at ~37-40 req/s** across all tests despite varying concurrency. This indicates a bottleneck in the data plane.
+
+**Root cause**: Blocking backend I/O. Each request blocks the QUIC poll loop during HTTP/2 forwarding. The 2-second backend timeout causes head-of-line blocking — while one request waits for response, all other QUIC streams are stalled.
+
+**Failure pattern**: Timeouts increase with concurrency (50 workers: 3.7% fail, 100 workers: ~20% fail). Slow backends starve fast ones.
+
+**Latency degradation**: p99 latency grows with load (4.1s at 50w → 4.8s at 100w), confirming queueing effects from synchronous forwarding.
+
+## Implications
+
+- **Not production-ready** for concurrent workloads
+- Blocking I/O must be addressed before beta
+- Async backend forwarding is critical for improving throughput
+- Current design suitable only for low-concurrency scenarios (<20 workers)
+
+## Next Steps
+
+1. Implement async backend forwarding (non-blocking data plane)
+2. Move backend I/O to worker threads or Tokio tasks
+3. Re-benchmark after async implementation

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -128,7 +128,7 @@ The following table lists all default configuration values used when properties 
 | `performance.quic_initial_max_stream_data` | `1000000` | Per-stream flow control window (bytes) |
 | `performance.quic_initial_max_streams_bidi` | `100` | Max concurrent bidirectional streams per connection |
 | `performance.quic_initial_max_streams_uni` | `100` | Max concurrent unidirectional streams per connection |
-| `performance.max_response_body_bytes` | `104857600` | Hard cap on upstream response body bytes per stream (100 MiB); streams exceeding this are terminated with 502 |
+| `performance.max_response_body_bytes` | `104857600` | Hard cap on upstream response body bytes per stream (100 MiB); streams exceeding this return 503 (`upstream response body too large`) |
 
 ## Listen Configuration
 
@@ -509,7 +509,7 @@ Controls resource limits, tuning knobs, and connection-flood protection. All fie
 | `quic_initial_max_stream_data` | integer | No | `1000000` | Per-stream QUIC flow control window in bytes; must be ≤ `quic_initial_max_data` |
 | `quic_initial_max_streams_bidi` | integer | No | `100` | Maximum concurrent bidirectional QUIC streams per connection |
 | `quic_initial_max_streams_uni` | integer | No | `100` | Maximum concurrent unidirectional QUIC streams per connection |
-| `max_response_body_bytes` | integer | No | `104857600` | Hard cap on upstream response body bytes per stream; streams exceeding this are terminated with 502 |
+| `max_response_body_bytes` | integer | No | `104857600` | Hard cap on upstream response body bytes per stream; streams exceeding this return 503 (`upstream response body too large`) |
 
 ### Connection flood protection
 

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -128,6 +128,7 @@ The following table lists all default configuration values used when properties 
 | `performance.quic_initial_max_stream_data` | `1000000` | Per-stream flow control window (bytes) |
 | `performance.quic_initial_max_streams_bidi` | `100` | Max concurrent bidirectional streams per connection |
 | `performance.quic_initial_max_streams_uni` | `100` | Max concurrent unidirectional streams per connection |
+| `performance.max_response_body_bytes` | `104857600` | Hard cap on upstream response body bytes per stream (100 MiB); streams exceeding this are terminated with 502 |
 
 ## Listen Configuration
 
@@ -508,6 +509,7 @@ Controls resource limits, tuning knobs, and connection-flood protection. All fie
 | `quic_initial_max_stream_data` | integer | No | `1000000` | Per-stream QUIC flow control window in bytes; must be ≤ `quic_initial_max_data` |
 | `quic_initial_max_streams_bidi` | integer | No | `100` | Maximum concurrent bidirectional QUIC streams per connection |
 | `quic_initial_max_streams_uni` | integer | No | `100` | Maximum concurrent unidirectional QUIC streams per connection |
+| `max_response_body_bytes` | integer | No | `104857600` | Hard cap on upstream response body bytes per stream; streams exceeding this are terminated with 502 |
 
 ### Connection flood protection
 


### PR DESCRIPTION
## Summary
This PR completes the memory-safety and extreme-traffic hardening work for request/response streaming paths.

It ensures queue/buffer growth is bounded, cap breaches fail deterministically (`413`/`503`), and stress scenarios are covered by integration tests.

## What’s Included

### 2.1 Memory safety under pressure
- Audited request/response stream queues and buffers for hard caps.
- Verified/documented per-stream and per-connection memory envelope.
- Enforced deterministic cap-breach handling (`413`/`503`) instead of hangs/resets for overflow handling paths.
- Closed uncovered unbounded-path gap in response-cap handling:
  - Declared oversized response (`Content-Length` > cap) returns `503`.
  - Unknown-length oversized response is validated before downstream headers and returns `503` on breach.

### 2.2 Extreme-case testing
- Added/validated request-size edge tests at and above cap.
- Added slow-producer and slow-consumer tests (request and response sides).
- Added concurrent large-body pressure test to validate bounded shedding and stability.
- Added response-cap tests for both declared-length and unknown-length overflow behavior.

## Behavior Guarantees
- Every relevant queue/buffer path has a hard cap.
- Cap breaches terminate through bounded, deterministic error responses (`413`/`503`).
- Extreme traffic produces bounded failures (no hang/crash behavior in covered scenarios).

## Validation
- `cargo test -p spooky-edge --test h3_bridge` (all passing)
- `cargo test -p spooky-edge` (all passing)

## Notes
- Updated comments/docs in code to reflect the finalized cap and overflow behavior.