### PR TITLE
Configurable shutdown drain timeout + drain behavior hardening

### DIFF
--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -67,6 +67,7 @@ performance:
     backend_body_idle_timeout_ms: 2000
     backend_body_total_timeout_ms: 30000
     backend_total_request_timeout_ms: 35000
+    shutdown_drain_timeout_ms: 5000
     udp_recv_buffer_bytes: 8388608
     udp_send_buffer_bytes: 8388608
     h2_pool_max_idle_per_backend: 256

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -12,13 +12,13 @@ use crate::default::{
     perf_default_backend_connect_timeout_ms, perf_default_backend_timeout_ms,
     perf_default_backend_total_request_timeout_ms, perf_default_control_plane_threads,
     perf_default_global_inflight_limit, perf_default_h2_pool_idle_timeout_ms,
-    perf_default_h2_pool_max_idle_per_backend, perf_default_new_connections_burst,
-    perf_default_new_connections_per_sec, perf_default_per_backend_inflight_limit,
-    perf_default_per_upstream_inflight_limit, perf_default_pin_workers,
-    perf_default_quic_initial_max_data, perf_default_quic_initial_max_stream_data,
-    perf_default_max_response_body_bytes, perf_default_quic_initial_max_streams_bidi,
+    perf_default_h2_pool_max_idle_per_backend, perf_default_max_response_body_bytes,
+    perf_default_new_connections_burst, perf_default_new_connections_per_sec,
+    perf_default_per_backend_inflight_limit, perf_default_per_upstream_inflight_limit,
+    perf_default_pin_workers, perf_default_quic_initial_max_data,
+    perf_default_quic_initial_max_stream_data, perf_default_quic_initial_max_streams_bidi,
     perf_default_quic_initial_max_streams_uni, perf_default_quic_max_idle_timeout_ms,
-    perf_default_reuseport,
+    perf_default_reuseport, perf_default_shutdown_drain_timeout_ms,
     perf_default_udp_recv_buffer_bytes, perf_default_udp_send_buffer_bytes,
     perf_default_worker_threads, resilience_default_adaptive_decrease_step,
     resilience_default_adaptive_enabled, resilience_default_adaptive_high_latency_ms,
@@ -203,6 +203,9 @@ pub struct Performance {
     #[serde(default = "perf_default_backend_total_request_timeout_ms")]
     pub backend_total_request_timeout_ms: u64,
 
+    #[serde(default = "perf_default_shutdown_drain_timeout_ms")]
+    pub shutdown_drain_timeout_ms: u64,
+
     #[serde(default = "perf_default_udp_recv_buffer_bytes")]
     pub udp_recv_buffer_bytes: usize,
 
@@ -270,6 +273,7 @@ impl Default for Performance {
             backend_body_idle_timeout_ms: perf_default_backend_body_idle_timeout_ms(),
             backend_body_total_timeout_ms: perf_default_backend_body_total_timeout_ms(),
             backend_total_request_timeout_ms: perf_default_backend_total_request_timeout_ms(),
+            shutdown_drain_timeout_ms: perf_default_shutdown_drain_timeout_ms(),
             udp_recv_buffer_bytes: perf_default_udp_recv_buffer_bytes(),
             udp_send_buffer_bytes: perf_default_udp_send_buffer_bytes(),
             h2_pool_max_idle_per_backend: perf_default_h2_pool_max_idle_per_backend(),

--- a/crates/config/src/default.rs
+++ b/crates/config/src/default.rs
@@ -114,6 +114,10 @@ pub fn perf_default_backend_total_request_timeout_ms() -> u64 {
     35_000
 }
 
+pub fn perf_default_shutdown_drain_timeout_ms() -> u64 {
+    5_000
+}
+
 pub fn perf_default_udp_recv_buffer_bytes() -> usize {
     8 * 1024 * 1024
 }

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -129,6 +129,11 @@ pub fn validate(config: &Config) -> bool {
         return false;
     }
 
+    if config.performance.shutdown_drain_timeout_ms == 0 {
+        error!("performance.shutdown_drain_timeout_ms must be greater than 0");
+        return false;
+    }
+
     if config.performance.udp_recv_buffer_bytes == 0 {
         error!("performance.udp_recv_buffer_bytes must be greater than 0");
         return false;
@@ -673,6 +678,7 @@ upstream:
         assert_eq!(cfg.performance.backend_body_idle_timeout_ms, 2000);
         assert_eq!(cfg.performance.backend_body_total_timeout_ms, 30000);
         assert_eq!(cfg.performance.backend_total_request_timeout_ms, 35_000);
+        assert_eq!(cfg.performance.shutdown_drain_timeout_ms, 5_000);
         assert_eq!(cfg.performance.udp_recv_buffer_bytes, 8 * 1024 * 1024);
         assert_eq!(cfg.performance.udp_send_buffer_bytes, 8 * 1024 * 1024);
         assert_eq!(cfg.performance.h2_pool_max_idle_per_backend, 256);
@@ -716,6 +722,10 @@ upstream:
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.performance.backend_body_total_timeout_ms = 100;
         cfg.performance.backend_body_idle_timeout_ms = 200;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.performance.shutdown_drain_timeout_ms = 0;
         assert!(!validate(&cfg));
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
@@ -829,6 +839,7 @@ upstream:
         cfg.performance.backend_body_idle_timeout_ms = 2_500;
         cfg.performance.backend_body_total_timeout_ms = 10_000;
         cfg.performance.backend_total_request_timeout_ms = 15_000;
+        cfg.performance.shutdown_drain_timeout_ms = 7_500;
         cfg.performance.udp_recv_buffer_bytes = 4 * 1024 * 1024;
         cfg.performance.udp_send_buffer_bytes = 4 * 1024 * 1024;
         cfg.performance.h2_pool_max_idle_per_backend = 128;

--- a/crates/edge/src/constants.rs
+++ b/crates/edge/src/constants.rs
@@ -30,7 +30,6 @@ pub const MAX_UDP_PAYLOAD_BYTES: usize = 1_350;
 
 pub const UDP_READ_TIMEOUT_MS: u64 = 50;
 pub const BACKEND_TIMEOUT_SECS: u64 = 2;
-pub const DRAIN_TIMEOUT_SECS: u64 = 5;
 pub const REQUEST_TIMEOUT_SECS: u64 = 5;
 
 pub const QUIC_IDLE_TIMEOUT_MS: u64 = 5_000;
@@ -81,10 +80,6 @@ pub const BENCH_CONN_MISS_PORT: u16 = u16::MAX;
 
 pub fn backend_timeout() -> Duration {
     Duration::from_secs(BACKEND_TIMEOUT_SECS)
-}
-
-pub fn drain_timeout() -> Duration {
-    Duration::from_secs(DRAIN_TIMEOUT_SECS)
 }
 
 pub fn request_timeout() -> Duration {

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -93,6 +93,7 @@ pub struct QUICListener {
     pub draining: bool,
     pub drain_start: Option<Instant>,
     pub watchdog_worker_drained: bool,
+    pub drain_timeout: Duration,
     pub backend_timeout: Duration,
     pub backend_body_idle_timeout: Duration,
     pub backend_body_total_timeout: Duration,

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -42,11 +42,11 @@ use crate::{
     cid_radix::CidRadix,
     constants::{
         DEFAULT_SCID_LEN_BYTES, MAX_DATAGRAM_SIZE_BYTES, MAX_REQUEST_BODY_BYTES,
-        MAX_STREAMS_PER_CONNECTION, MAX_UDP_PAYLOAD_BYTES,
-        MIN_SCID_LEN_BYTES, REQUEST_BUFFERED_CHUNK_BYTES_LIMIT, REQUEST_CHUNK_BYTES_LIMIT,
+        MAX_STREAMS_PER_CONNECTION, MAX_UDP_PAYLOAD_BYTES, MIN_SCID_LEN_BYTES,
+        REQUEST_BUFFERED_CHUNK_BYTES_LIMIT, REQUEST_CHUNK_BYTES_LIMIT,
         REQUEST_CHUNK_CHANNEL_CAPACITY, RESET_TOKEN_LEN_BYTES, RESPONSE_CHUNK_BYTES_LIMIT,
         RESPONSE_CHUNK_CHANNEL_CAPACITY, SCID_ROTATION_PACKET_THRESHOLD, UDP_READ_TIMEOUT_MS,
-        drain_timeout, scid_rotation_interval,
+        scid_rotation_interval,
     },
     outcome_from_status,
     resilience::RuntimeResilience,
@@ -303,6 +303,7 @@ impl QUICListener {
             Duration::from_millis(config.performance.backend_body_total_timeout_ms);
         let backend_total_request_timeout =
             Duration::from_millis(config.performance.backend_total_request_timeout_ms);
+        let drain_timeout = Duration::from_millis(config.performance.shutdown_drain_timeout_ms);
         let max_response_body_bytes = config.performance.max_response_body_bytes;
         let conn_rate_limiter = TokenBucket::new(
             config.performance.new_connections_per_sec,
@@ -325,6 +326,7 @@ impl QUICListener {
             draining: false,
             drain_start: None,
             watchdog_worker_drained: false,
+            drain_timeout,
             backend_timeout,
             backend_body_idle_timeout,
             backend_body_total_timeout,
@@ -465,9 +467,14 @@ impl QUICListener {
         quic_config.set_max_recv_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
         quic_config.set_max_send_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
         quic_config.set_initial_max_data(config.performance.quic_initial_max_data);
-        quic_config.set_initial_max_stream_data_bidi_local(config.performance.quic_initial_max_stream_data);
-        quic_config.set_initial_max_stream_data_bidi_remote(config.performance.quic_initial_max_stream_data);
-        quic_config.set_initial_max_stream_data_uni(config.performance.quic_initial_max_stream_data);
+        quic_config.set_initial_max_stream_data_bidi_local(
+            config.performance.quic_initial_max_stream_data,
+        );
+        quic_config.set_initial_max_stream_data_bidi_remote(
+            config.performance.quic_initial_max_stream_data,
+        );
+        quic_config
+            .set_initial_max_stream_data_uni(config.performance.quic_initial_max_stream_data);
         quic_config.set_initial_max_streams_bidi(config.performance.quic_initial_max_streams_bidi);
         quic_config.set_initial_max_streams_uni(config.performance.quic_initial_max_streams_uni);
         quic_config.set_disable_active_migration(true);
@@ -494,8 +501,19 @@ impl QUICListener {
             return true;
         }
 
+        // Once all in-flight streams are terminal, drain can complete without
+        // waiting for clients to idle-close their QUIC connections.
+        let has_active_streams = self
+            .connections
+            .values()
+            .any(|conn| !conn.streams.is_empty());
+        if !has_active_streams {
+            self.close_all();
+            return true;
+        }
+
         if let Some(start) = self.drain_start
-            && start.elapsed() >= drain_timeout()
+            && start.elapsed() >= self.drain_timeout
         {
             self.close_all();
             return true;
@@ -590,7 +608,10 @@ impl QUICListener {
         // Rate-limit new connection creation to prevent unbounded memory growth
         // under connection floods. Existing connections are never affected.
         if !self.conn_rate_limiter.try_consume() {
-            debug!("New connection rate limit exceeded, dropping Initial packet from {}", peer);
+            debug!(
+                "New connection rate limit exceeded, dropping Initial packet from {}",
+                peer
+            );
             return None;
         }
 
@@ -1948,8 +1969,7 @@ impl QUICListener {
                             .get(http::header::CONTENT_LENGTH)
                             .and_then(|v| v.to_str().ok())
                             .and_then(|v| v.parse::<usize>().ok());
-                        if upstream_content_length
-                            .is_some_and(|len| len > max_response_body_bytes)
+                        if upstream_content_length.is_some_and(|len| len > max_response_body_bytes)
                         {
                             if let Some(req) = streams.get(&stream_id) {
                                 metrics.inc_failure();
@@ -1988,8 +2008,10 @@ impl QUICListener {
                             {
                                 continue;
                             }
-                            owned_h3_headers
-                                .push((name.as_str().as_bytes().to_vec(), value.as_bytes().to_vec()));
+                            owned_h3_headers.push((
+                                name.as_str().as_bytes().to_vec(),
+                                value.as_bytes().to_vec(),
+                            ));
                         }
 
                         let defer_headers_until_body_validated = upstream_content_length.is_none();
@@ -2076,7 +2098,8 @@ impl QUICListener {
                                             if defer_headers_until_body_validated {
                                                 response_bytes_received = response_bytes_received
                                                     .saturating_add(data.len());
-                                                if response_bytes_received > max_response_body_bytes {
+                                                if response_bytes_received > max_response_body_bytes
+                                                {
                                                     let _ = chunk_tx
                                                         .send(ResponseChunk::Error(ProxyError::Pool(
                                                             PoolError::BackendOverloaded(
@@ -2086,16 +2109,16 @@ impl QUICListener {
                                                         .await;
                                                     return;
                                                 }
-                                                for start in
-                                                    (0..data.len()).step_by(RESPONSE_CHUNK_BYTES_LIMIT)
+                                                for start in (0..data.len())
+                                                    .step_by(RESPONSE_CHUNK_BYTES_LIMIT)
                                                 {
                                                     let end = (start + RESPONSE_CHUNK_BYTES_LIMIT)
                                                         .min(data.len());
                                                     buffered_chunks.push(data.slice(start..end));
                                                 }
                                             } else {
-                                                for start in
-                                                    (0..data.len()).step_by(RESPONSE_CHUNK_BYTES_LIMIT)
+                                                for start in (0..data.len())
+                                                    .step_by(RESPONSE_CHUNK_BYTES_LIMIT)
                                                 {
                                                     let end = (start + RESPONSE_CHUNK_BYTES_LIMIT)
                                                         .min(data.len());
@@ -2134,7 +2157,10 @@ impl QUICListener {
                                                 return;
                                             }
                                             for chunk in buffered_chunks {
-                                                if chunk_tx.send(ResponseChunk::Data(chunk)).await.is_err()
+                                                if chunk_tx
+                                                    .send(ResponseChunk::Data(chunk))
+                                                    .await
+                                                    .is_err()
                                                 {
                                                     return;
                                                 }
@@ -2267,7 +2293,8 @@ impl QUICListener {
                                     req.response_headers_sent = true;
                                 }
                                 Err(quiche::h3::Error::StreamBlocked) => {
-                                    req.pending_chunk = Some(ResponseChunk::Start { status, headers });
+                                    req.pending_chunk =
+                                        Some(ResponseChunk::Start { status, headers });
                                     break;
                                 }
                                 Err(err) => {
@@ -2369,12 +2396,10 @@ impl QUICListener {
                                         http::StatusCode::SERVICE_UNAVAILABLE,
                                         b"upstream response body too large\n",
                                     ),
-                                    _ => (
-                                        http::StatusCode::BAD_GATEWAY,
-                                        b"upstream error\n",
-                                    ),
+                                    _ => (http::StatusCode::BAD_GATEWAY, b"upstream error\n"),
                                 };
-                                let _ = Self::send_simple_response(h3, quic, stream_id, status, body);
+                                let _ =
+                                    Self::send_simple_response(h3, quic, stream_id, status, body);
                             } else {
                                 // Best-effort: close the stream.
                                 let _ = h3.send_body(quic, stream_id, b"", true);
@@ -3251,10 +3276,17 @@ mod tests {
         let mut tb = TokenBucket::new(100, 5);
         // Bucket starts full; first 5 tokens should all succeed.
         for i in 0..5 {
-            assert!(tb.try_consume(), "token {} should be available (burst=5)", i);
+            assert!(
+                tb.try_consume(),
+                "token {} should be available (burst=5)",
+                i
+            );
         }
         // 6th token must fail — bucket is empty.
-        assert!(!tb.try_consume(), "6th token must be denied when burst exhausted");
+        assert!(
+            !tb.try_consume(),
+            "6th token must be denied when burst exhausted"
+        );
     }
 
     #[test]
@@ -3280,7 +3312,10 @@ mod tests {
         // rate=0 is clamped to 1; burst=0 is clamped to 1.
         let mut tb = TokenBucket::new(0, 0);
         // Starts with 1 token (burst=1).
-        assert!(tb.try_consume(), "first token should succeed with clamped burst=1");
+        assert!(
+            tb.try_consume(),
+            "first token should succeed with clamped burst=1"
+        );
         assert!(!tb.try_consume(), "second token must fail when burst=1");
     }
 

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -4,16 +4,17 @@ use std::{
     net::SocketAddr,
     pin::Pin,
     sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     task::{Context, Poll},
+    thread,
     time::{Duration, Instant},
 };
 
 use bytes::Bytes;
-use http_body_util::{BodyExt, Empty, Full, combinators::BoxBody};
 use http::header::{CONTENT_LENGTH, HeaderValue};
+use http_body_util::{BodyExt, Empty, Full, combinators::BoxBody};
 use hyper::{
     Request, Response, Uri,
     body::{Body, Frame, Incoming},
@@ -33,10 +34,9 @@ use spooky_config::config::{Backend, Config, HealthCheck, Listen, LoadBalancing,
 use spooky_edge::QUICListener;
 use spooky_edge::constants::{
     BACKEND_TIMEOUT_SECS, MAX_DATAGRAM_SIZE_BYTES, MAX_REQUEST_BODY_BYTES,
-    MAX_STREAMS_PER_CONNECTION, MAX_UDP_PAYLOAD_BYTES,
-    QUIC_IDLE_TIMEOUT_MS, QUIC_INITIAL_MAX_DATA, QUIC_INITIAL_MAX_STREAMS_BIDI,
-    QUIC_INITIAL_MAX_STREAMS_UNI, QUIC_INITIAL_STREAM_DATA, REQUEST_TIMEOUT_SECS,
-    UDP_READ_TIMEOUT_MS,
+    MAX_STREAMS_PER_CONNECTION, MAX_UDP_PAYLOAD_BYTES, QUIC_IDLE_TIMEOUT_MS, QUIC_INITIAL_MAX_DATA,
+    QUIC_INITIAL_MAX_STREAMS_BIDI, QUIC_INITIAL_MAX_STREAMS_UNI, QUIC_INITIAL_STREAM_DATA,
+    REQUEST_TIMEOUT_SECS, UDP_READ_TIMEOUT_MS,
 };
 
 fn write_test_certs(dir: &TempDir) -> (String, String) {
@@ -1009,15 +1009,54 @@ async fn start_h2_backend_with_regression_routes() -> SocketAddr {
                             let _ = tx.send(Bytes::from_static(b"chunk-3")).await;
                         });
                         let mut response = Response::new(body.boxed());
-                        response.headers_mut().insert(
-                            CONTENT_LENGTH,
-                            HeaderValue::from_static("21"),
-                        );
+                        response
+                            .headers_mut()
+                            .insert(CONTENT_LENGTH, HeaderValue::from_static("21"));
                         response
                     }
                     _ => Response::new(Full::new(Bytes::from_static(b"default\n")).boxed()),
                 };
                 Ok::<_, hyper::Error>(response)
+            });
+
+            tokio::spawn(async move {
+                let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
+                    .serve_connection(io, service)
+                    .await;
+            });
+        }
+    });
+
+    addr
+}
+
+async fn start_h2_backend_with_drain_probe(inflight_seen: Arc<AtomicBool>) -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = match listener.accept().await {
+                Ok(v) => v,
+                Err(_) => break,
+            };
+
+            let io = TokioIo::new(stream);
+            let inflight_seen = Arc::clone(&inflight_seen);
+            let service = service_fn(move |req: Request<Incoming>| {
+                let path = req.uri().path().to_string();
+                let inflight_seen = Arc::clone(&inflight_seen);
+                async move {
+                    let response: Response<TestBody> = match path.as_str() {
+                        "/drain-slow" => {
+                            inflight_seen.store(true, Ordering::Relaxed);
+                            tokio::time::sleep(Duration::from_millis(700)).await;
+                            Response::new(Full::new(Bytes::from_static(b"drain-ok\n")).boxed())
+                        }
+                        _ => Response::new(Full::new(Bytes::from_static(b"default\n")).boxed()),
+                    };
+                    Ok::<_, hyper::Error>(response)
+                }
             });
 
             tokio::spawn(async move {
@@ -1180,6 +1219,270 @@ fn http3_to_http2_roundtrip() {
     let body = run_h3_client(listen_addr).expect("client request failed");
 
     assert!(!body.is_empty(), "expected non-empty response from backend");
+}
+
+#[test]
+fn in_flight_request_completes_during_drain_window() {
+    let dir = tempdir().expect("failed to create temp dir");
+    let (cert, key) = write_test_certs(&dir);
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let inflight_seen = Arc::new(AtomicBool::new(false));
+    let backend_addr = rt.block_on(start_h2_backend_with_drain_probe(Arc::clone(
+        &inflight_seen,
+    )));
+    let config = make_config(0, backend_addr.to_string(), cert, key);
+    let listener = QUICListener::new(config).expect("failed to create listener");
+    let listen_addr = listener.socket.local_addr().unwrap();
+
+    let listener = Arc::new(Mutex::new(listener));
+    let stop = Arc::new(AtomicBool::new(false));
+    let listener_thread = {
+        let listener = Arc::clone(&listener);
+        let stop = Arc::clone(&stop);
+        thread::spawn(move || {
+            while !stop.load(Ordering::Relaxed) {
+                if let Ok(mut guard) = listener.lock() {
+                    guard.poll();
+                } else {
+                    break;
+                }
+            }
+        })
+    };
+
+    let client_thread = thread::spawn(move || {
+        run_h3_client_concurrent_get(
+            listen_addr,
+            &["/drain-slow"],
+            Duration::from_secs(REQUEST_TIMEOUT_SECS + 6),
+        )
+    });
+
+    let wait_start = Instant::now();
+    while !inflight_seen.load(Ordering::Relaxed) {
+        assert!(
+            wait_start.elapsed() < Duration::from_secs(3),
+            "backend never observed the in-flight request before drain"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    if let Ok(mut guard) = listener.lock() {
+        guard.start_draining();
+    }
+
+    let observations = client_thread
+        .join()
+        .expect("client thread join failed")
+        .expect("request should complete while draining");
+    let drained = observation_for(&observations, "/drain-slow");
+    assert_eq!(drained.status.as_deref(), Some("200"));
+    assert_eq!(drained.body, b"drain-ok\n");
+
+    let drain_wait_start = Instant::now();
+    loop {
+        let done = if let Ok(mut guard) = listener.lock() {
+            guard.drain_complete()
+        } else {
+            false
+        };
+        if done {
+            break;
+        }
+        assert!(
+            drain_wait_start.elapsed() < Duration::from_secs(2),
+            "drain should complete promptly once in-flight streams finish"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    stop.store(true, Ordering::Relaxed);
+    let _ = listener_thread.join();
+}
+
+/// While draining, new QUIC Initial packets must be silently dropped so no new
+/// connection state is allocated.  The test starts draining before any client
+/// connects, then confirms a fresh QUIC connection attempt never reaches the
+/// Established state within a short window (the handshake packets are dropped).
+#[test]
+fn draining_rejects_new_connections() {
+    let dir = tempdir().expect("failed to create temp dir");
+    let (cert, key) = write_test_certs(&dir);
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let backend_addr = rt.block_on(start_h2_backend());
+    let config = make_config(0, backend_addr.to_string(), cert, key);
+    let listener = QUICListener::new(config).expect("failed to create listener");
+    let listen_addr = listener.socket.local_addr().unwrap();
+
+    let listener = Arc::new(Mutex::new(listener));
+
+    // Start draining immediately — before any client connects.
+    listener.lock().unwrap().start_draining();
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let listener_thread = {
+        let listener = Arc::clone(&listener);
+        let stop = Arc::clone(&stop);
+        thread::spawn(move || {
+            while !stop.load(Ordering::Relaxed) {
+                if let Ok(mut guard) = listener.lock() {
+                    guard.poll();
+                }
+            }
+        })
+    };
+
+    // Attempt a fresh QUIC connection.  Initial packets are silently dropped,
+    // so the handshake never completes; the connection stays in Initial state.
+    let established = {
+        let socket = std::net::UdpSocket::bind("0.0.0.0:0").unwrap();
+        let local_addr = socket.local_addr().unwrap();
+
+        let mut qconfig = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
+        qconfig.verify_peer(false);
+        qconfig
+            .set_application_protos(quiche::h3::APPLICATION_PROTOCOL)
+            .unwrap();
+        qconfig.set_max_idle_timeout(QUIC_IDLE_TIMEOUT_MS);
+        qconfig.set_max_recv_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+        qconfig.set_max_send_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+        qconfig.set_initial_max_data(QUIC_INITIAL_MAX_DATA);
+        qconfig.set_initial_max_stream_data_bidi_local(QUIC_INITIAL_STREAM_DATA);
+        qconfig.set_initial_max_stream_data_bidi_remote(QUIC_INITIAL_STREAM_DATA);
+        qconfig.set_initial_max_stream_data_uni(QUIC_INITIAL_STREAM_DATA);
+        qconfig.set_initial_max_streams_bidi(QUIC_INITIAL_MAX_STREAMS_BIDI);
+        qconfig.set_initial_max_streams_uni(QUIC_INITIAL_MAX_STREAMS_UNI);
+        qconfig.set_disable_active_migration(true);
+
+        let mut scid_bytes = [0u8; quiche::MAX_CONN_ID_LEN];
+        rand::thread_rng().fill_bytes(&mut scid_bytes);
+        let scid = quiche::ConnectionId::from_ref(&scid_bytes);
+        let mut conn =
+            quiche::connect(Some("localhost"), &scid, local_addr, listen_addr, &mut qconfig)
+                .unwrap();
+
+        let mut out = [0u8; MAX_UDP_PAYLOAD_BYTES];
+        let mut buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
+
+        // Send the Initial packet.
+        let (w, si) = conn.send(&mut out).unwrap();
+        socket.send_to(&out[..w], si.to).unwrap();
+
+        // Poll for up to 500 ms; the handshake should never complete.
+        let deadline = Instant::now() + Duration::from_millis(500);
+        let mut established = false;
+        while Instant::now() < deadline {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            socket
+                .set_read_timeout(Some(remaining.min(Duration::from_millis(50))))
+                .unwrap();
+            match socket.recv_from(&mut buf) {
+                Ok((len, from)) => {
+                    let _ = conn.recv(
+                        &mut buf[..len],
+                        quiche::RecvInfo {
+                            from,
+                            to: local_addr,
+                        },
+                    );
+                }
+                Err(ref e)
+                    if e.kind() == std::io::ErrorKind::WouldBlock
+                        || e.kind() == std::io::ErrorKind::TimedOut =>
+                {
+                    conn.on_timeout();
+                }
+                Err(_) => break,
+            }
+            // Flush any retransmits.
+            loop {
+                match conn.send(&mut out) {
+                    Ok((w, si)) => {
+                        let _ = socket.send_to(&out[..w], si.to);
+                    }
+                    Err(quiche::Error::Done) => break,
+                    Err(_) => break,
+                }
+            }
+            if conn.is_established() {
+                established = true;
+                break;
+            }
+        }
+        established
+    };
+
+    stop.store(true, Ordering::Relaxed);
+    let _ = listener_thread.join();
+
+    assert!(
+        !established,
+        "new QUIC connection must not be established while listener is draining"
+    );
+}
+
+#[test]
+fn draining_forces_close_after_configured_timeout() {
+    let dir = tempdir().expect("failed to create temp dir");
+    let (cert, key) = write_test_certs(&dir);
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let inflight_seen = Arc::new(AtomicBool::new(false));
+    let backend_addr = rt.block_on(start_h2_backend_with_drain_probe(Arc::clone(
+        &inflight_seen,
+    )));
+    let mut config = make_config(0, backend_addr.to_string(), cert, key);
+    config.performance.shutdown_drain_timeout_ms = 120;
+    let mut listener = QUICListener::new(config).expect("failed to create listener");
+    let listen_addr = listener.socket.local_addr().unwrap();
+
+    let client_thread = thread::spawn(move || {
+        run_h3_client_concurrent_get(
+            listen_addr,
+            &["/drain-slow"],
+            Duration::from_secs(REQUEST_TIMEOUT_SECS + 6),
+        )
+    });
+
+    let mut drain_started: Option<Instant> = None;
+    let drive_start = Instant::now();
+    loop {
+        listener.poll();
+
+        if drain_started.is_none() && inflight_seen.load(Ordering::Relaxed) {
+            listener.start_draining();
+            drain_started = Some(Instant::now());
+        }
+
+        if drain_started.is_some() && listener.drain_complete() {
+            break;
+        }
+
+        assert!(
+            drive_start.elapsed() < Duration::from_secs(3),
+            "drain test did not converge in expected time"
+        );
+    }
+    let drain_elapsed = drain_started
+        .expect("drain should start once in-flight request is observed")
+        .elapsed();
+    assert!(
+        drain_elapsed < Duration::from_millis(600),
+        "forced close should complete before slow backend success path (elapsed={drain_elapsed:?})"
+    );
+
+    let client_result = client_thread.join().expect("client thread join failed");
+    if let Ok(observations) = client_result {
+        let drained = observation_for(&observations, "/drain-slow");
+        let got_full_success =
+            drained.status.as_deref() == Some("200") && drained.body == b"drain-ok\n";
+        assert!(
+            !got_full_success,
+            "forced close should prevent full slow-backend success before timeout"
+        );
+    }
 }
 
 /// A request body exceeding MAX_REQUEST_BODY_BYTES must be rejected with 413
@@ -1424,7 +1727,10 @@ fn slow_request_producer_over_cap_returns_413() {
     )
     .expect("slow over-cap request producer should complete");
 
-    assert_eq!(status, "413", "slow over-cap producer should get bounded failure");
+    assert_eq!(
+        status, "413",
+        "slow over-cap producer should get bounded failure"
+    );
     assert!(!got_reset, "slow request producer should not reset stream");
 }
 
@@ -2080,8 +2386,7 @@ fn stream_cap_rejects_excess_concurrent_streams() {
     // Raise the QUIC transport stream limit above the app-level cap so the N+1th
     // stream reaches the application guard (rather than being dropped at the
     // QUIC layer with StreamLimit).
-    config.performance.quic_initial_max_streams_bidi =
-        (MAX_STREAMS_PER_CONNECTION as u64) + 10;
+    config.performance.quic_initial_max_streams_bidi = (MAX_STREAMS_PER_CONNECTION as u64) + 10;
     let listener = QUICListener::new(config).expect("failed to create listener");
     let listen_addr = listener.socket.local_addr().unwrap();
     let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
@@ -2196,8 +2501,14 @@ fn response_body_cap_returns_503_on_declared_length_breach() {
     let mut scid_bytes = [0u8; quiche::MAX_CONN_ID_LEN];
     rand::thread_rng().fill_bytes(&mut scid_bytes);
     let scid = quiche::ConnectionId::from_ref(&scid_bytes);
-    let mut conn =
-        quiche::connect(Some("localhost"), &scid, local_addr, listen_addr, &mut qconfig).unwrap();
+    let mut conn = quiche::connect(
+        Some("localhost"),
+        &scid,
+        local_addr,
+        listen_addr,
+        &mut qconfig,
+    )
+    .unwrap();
     let h3_config = quiche::h3::Config::new().unwrap();
 
     let mut out = [0u8; MAX_UDP_PAYLOAD_BYTES];
@@ -2248,9 +2559,7 @@ fn response_body_cap_returns_503_on_declared_length_breach() {
         }
 
         if conn.is_established() && h3.is_none() {
-            h3 = Some(
-                quiche::h3::Connection::with_transport(&mut conn, &h3_config).unwrap(),
-            );
+            h3 = Some(quiche::h3::Connection::with_transport(&mut conn, &h3_config).unwrap());
         }
 
         if let Some(h3c) = h3.as_mut() {
@@ -2376,8 +2685,14 @@ fn response_body_cap_returns_503_on_unknown_length_breach() {
     let mut scid_bytes = [0u8; quiche::MAX_CONN_ID_LEN];
     rand::thread_rng().fill_bytes(&mut scid_bytes);
     let scid = quiche::ConnectionId::from_ref(&scid_bytes);
-    let mut conn =
-        quiche::connect(Some("localhost"), &scid, local_addr, listen_addr, &mut qconfig).unwrap();
+    let mut conn = quiche::connect(
+        Some("localhost"),
+        &scid,
+        local_addr,
+        listen_addr,
+        &mut qconfig,
+    )
+    .unwrap();
     let h3_config = quiche::h3::Config::new().unwrap();
 
     let mut out = [0u8; MAX_UDP_PAYLOAD_BYTES];
@@ -2428,9 +2743,7 @@ fn response_body_cap_returns_503_on_unknown_length_breach() {
         }
 
         if conn.is_established() && h3.is_none() {
-            h3 = Some(
-                quiche::h3::Connection::with_transport(&mut conn, &h3_config).unwrap(),
-            );
+            h3 = Some(quiche::h3::Connection::with_transport(&mut conn, &h3_config).unwrap());
         }
 
         if let Some(h3c) = h3.as_mut() {

--- a/crates/edge/tests/h3_edge.rs
+++ b/crates/edge/tests/h3_edge.rs
@@ -630,9 +630,10 @@ fn malformed_truncated_long_header_is_dropped() {
     // Long-header first byte: version-specific Initial packet marker (0xC0 | 0x00)
     // followed by the QUIC version, then truncated before DCIL/SCIL fields.
     let truncated: &[u8] = &[
-        0xC0,       // long-header flag + Initial type bits
-        0x00, 0x00, 0x00, 0x01, // QUIC v1
-        // deliberately truncated here (no DCIL/SCIL/lengths)
+        0xC0, // long-header flag + Initial type bits
+        0x00, 0x00, 0x00,
+        0x01, // QUIC v1
+              // deliberately truncated here (no DCIL/SCIL/lengths)
     ];
     send_udp(addr, truncated);
     listener.poll();
@@ -647,9 +648,9 @@ fn malformed_dcid_length_overflow_is_dropped() {
     // Craft a packet whose DCID length field claims 255 bytes but the packet
     // ends immediately after.
     let mut pkt = vec![
-        0xC0,                   // long-header Initial
+        0xC0, // long-header Initial
         0x00, 0x00, 0x00, 0x01, // QUIC v1
-        0xFF,                   // DCID length = 255 (but no bytes follow)
+        0xFF, // DCID length = 255 (but no bytes follow)
     ];
     // pad with some bytes but far fewer than 255
     pkt.extend_from_slice(&[0xAB; 8]);
@@ -666,9 +667,10 @@ fn short_header_unknown_connection_is_dropped() {
     // Short header: first bit 0, remaining bits arbitrary. Use a 20-byte DCID
     // that does not correspond to any established connection.
     let mut pkt = vec![0x40u8]; // short-header flag (bit 7 = 0, bit 6 = 1 for fixed bit)
-    pkt.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0x00, 0x01,
-                             0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
-                             0x0A, 0x0B, 0x0C, 0x0D]);
+    pkt.extend_from_slice(&[
+        0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        0x09, 0x0A, 0x0B, 0x0C, 0x0D,
+    ]);
     send_udp(addr, &pkt);
     listener.poll();
     assert_maps_empty(&listener);
@@ -681,12 +683,12 @@ fn retry_packet_for_unknown_connection_is_dropped() {
     // Long-header Retry type: bits 0xF0 with version and minimal fields.
     // quiche will parse the header but the listener should not create a conn.
     let mut pkt = vec![
-        0xF0,                   // long-header, Retry type bits
+        0xF0, // long-header, Retry type bits
         0x00, 0x00, 0x00, 0x01, // QUIC v1
-        0x08,                   // DCID len = 8
+        0x08, // DCID len = 8
     ];
     pkt.extend_from_slice(&[0x11; 8]); // DCID
-    pkt.push(0x08);                    // SCID len = 8
+    pkt.push(0x08); // SCID len = 8
     pkt.extend_from_slice(&[0x22; 8]); // SCID
     // Retry token (arbitrary, no integrity tag)
     pkt.extend_from_slice(&[0x99; 16]);
@@ -701,12 +703,12 @@ fn handshake_packet_unknown_connection_is_dropped() {
     let (mut listener, addr) = make_listener();
     // Long-header Handshake type: 0xE0
     let mut pkt = vec![
-        0xE0,                   // long-header, Handshake type bits
+        0xE0, // long-header, Handshake type bits
         0x00, 0x00, 0x00, 0x01, // QUIC v1
-        0x08,                   // DCID len = 8
+        0x08, // DCID len = 8
     ];
     pkt.extend_from_slice(&[0x33; 8]); // DCID
-    pkt.push(0x08);                    // SCID len = 8
+    pkt.push(0x08); // SCID len = 8
     pkt.extend_from_slice(&[0x44; 8]); // SCID
     // Packet number + payload (garbage)
     pkt.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
@@ -722,12 +724,12 @@ fn repeated_malformed_packets_leave_maps_consistent() {
     let (mut listener, addr) = make_listener();
 
     let payloads: &[&[u8]] = &[
-        &[],                                      // zero-length
-        &[0xFF],                                  // single byte
-        &[0x00; 16],                              // all-zero short
-        &[0xFF; 64],                              // all-ones garbage
-        &[0xC0, 0x00, 0x00, 0x00, 0x01, 0xFF],   // truncated long header
-        &[0x40, 0xDE, 0xAD, 0xBE, 0xEF, 0x00],   // short header, unknown DCID
+        &[],                                   // zero-length
+        &[0xFF],                               // single byte
+        &[0x00; 16],                           // all-zero short
+        &[0xFF; 64],                           // all-ones garbage
+        &[0xC0, 0x00, 0x00, 0x00, 0x01, 0xFF], // truncated long header
+        &[0x40, 0xDE, 0xAD, 0xBE, 0xEF, 0x00], // short header, unknown DCID
     ];
 
     for payload in payloads {
@@ -813,8 +815,7 @@ fn make_config_with_rate_limit(
 fn build_initial_packet(dest_addr: std::net::SocketAddr) -> Vec<u8> {
     let local_addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
 
-    let mut config =
-        quiche::Config::new(quiche::PROTOCOL_VERSION).expect("quiche config");
+    let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION).expect("quiche config");
     config.verify_peer(false);
     config
         .set_application_protos(quiche::h3::APPLICATION_PROTOCOL)
@@ -872,6 +873,72 @@ fn connection_flood_is_rate_limited() {
     );
 }
 
+/// Once draining starts, unknown/new Initial packets must not create a
+/// connection, even if admission limits would otherwise allow it.
+#[test]
+fn draining_mode_rejects_initial_when_no_connections_exist() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_certs(&dir);
+    let config = make_config_with_rate_limit(0, cert, key, "127.0.0.1:1".to_string(), 10_000, 20);
+    let mut listener = QUICListener::new(config).expect("listener");
+    let addr = listener.socket.local_addr().unwrap();
+
+    listener.start_draining();
+
+    let pkt = build_initial_packet(addr);
+    send_udp(addr, &pkt);
+    listener.poll();
+
+    assert_eq!(
+        listener.connections.len(),
+        0,
+        "no new connection should be admitted after drain starts"
+    );
+}
+
+/// Draining should preserve existing connection processing but reject any new
+/// connection admission from unknown Initial packets.
+#[test]
+fn draining_mode_rejects_new_initial_after_existing_connection() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_certs(&dir);
+    let config = make_config_with_rate_limit(0, cert, key, "127.0.0.1:1".to_string(), 10_000, 20);
+    let mut listener = QUICListener::new(config).expect("listener");
+    let addr = listener.socket.local_addr().unwrap();
+
+    let first = build_initial_packet(addr);
+    send_udp(addr, &first);
+    listener.poll();
+    assert_eq!(
+        listener.connections.len(),
+        1,
+        "first Initial should create a baseline connection before drain"
+    );
+    let known_connection_ids: std::collections::HashSet<Vec<u8>> = listener
+        .connections
+        .keys()
+        .map(|cid| cid.to_vec())
+        .collect();
+
+    listener.start_draining();
+
+    for _ in 0..5 {
+        let pkt = build_initial_packet(addr);
+        send_udp(addr, &pkt);
+        listener.poll();
+    }
+
+    let post_drain_ids: std::collections::HashSet<Vec<u8>> = listener
+        .connections
+        .keys()
+        .map(|cid| cid.to_vec())
+        .collect();
+    assert!(
+        post_drain_ids.is_subset(&known_connection_ids),
+        "draining mode must reject unknown/new Initial packets (before={known_connection_ids:?}, after={post_drain_ids:?})"
+    );
+}
+
 /// Normal traffic well below the rate limit must not be affected.
 /// With a generous burst and rate, all N connection attempts succeed.
 #[test]
@@ -879,8 +946,7 @@ fn normal_traffic_below_rate_limit_is_unaffected() {
     let dir = tempdir().expect("tempdir");
     let (cert, key) = write_test_certs(&dir);
     // burst=20, rate=10000/s: far above what we'll send.
-    let config =
-        make_config_with_rate_limit(0, cert, key, "127.0.0.1:1".to_string(), 10_000, 20);
+    let config = make_config_with_rate_limit(0, cert, key, "127.0.0.1:1".to_string(), 10_000, 20);
     let mut listener = QUICListener::new(config).expect("listener");
     let addr = listener.socket.local_addr().unwrap();
 

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -498,6 +498,7 @@ Controls resource limits, tuning knobs, and connection-flood protection. All fie
 | `backend_body_idle_timeout_ms` | integer | No | `2000` | Idle timeout while streaming response body (ms); must be ≥ `backend_timeout_ms` |
 | `backend_body_total_timeout_ms` | integer | No | `30000` | Maximum total time to receive the full response body (ms) |
 | `backend_total_request_timeout_ms` | integer | No | `35000` | Hard deadline for an entire request round-trip (ms); must be ≥ `backend_body_total_timeout_ms` |
+| `shutdown_drain_timeout_ms` | integer | No | `5000` | Graceful-shutdown drain timeout in ms; active connections are force-closed once this deadline is reached |
 | `udp_recv_buffer_bytes` | integer | No | `8388608` | UDP socket receive buffer size (bytes) |
 | `udp_send_buffer_bytes` | integer | No | `8388608` | UDP socket send buffer size (bytes) |
 | `h2_pool_max_idle_per_backend` | integer | No | `256` | Maximum idle HTTP/2 connections kept open per backend |


### PR DESCRIPTION
## Summary
- Added configurable shutdown drain timeout via `performance.shutdown_drain_timeout_ms`
- Replaced fixed drain timeout logic with config-driven enforcement
- Hardened drain behavior:
  - in-flight streams continue during drain and complete when possible
  - unknown/new `Initial` packets are rejected once draining starts
- Added validation and tests for drain semantics and timeout enforcement

## Changes
- Config:
  - new `performance.shutdown_drain_timeout_ms` (default `5000`)
  - validator enforces `> 0`
  - sample config + docs updated
- Edge runtime:
  - listener stores per-instance drain timeout from config
  - drain completion uses configured timeout for forced close
- Tests:
  - in-flight request completes during drain window
  - no new connection admission after drain starts
  - forced close occurs after configured drain timeout

## Why
This makes graceful shutdown behavior explicit and tunable per deployment while ensuring deterministic drain semantics under both normal and timeout paths.