### PR TITLE
Enforce verified upstream TLS by default and make cleartext backend transport explicit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ http = "1.3.1"
 http-body-util = "0.1"
 hyper = "1"
 hyper-util = { version = "0.1", features = ["full"] }
+hyper-rustls = { version = "0.27", features = ["http2", "webpki-roots"] }
 log = "0.4.28"
 quiche = "0.24.6"
 rand = "0.8"

--- a/config/config.minimal.yaml
+++ b/config/config.minimal.yaml
@@ -11,6 +11,6 @@ upstream:
       path_prefix: "/"
     backends:
       - id: "backend1"
-        address: "127.0.0.1:8080"
+        address: "http://127.0.0.1:8080"  # explicit cleartext for local/dev; omit scheme for verified HTTPS default
         health_check:
           path: "/health"

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -18,14 +18,14 @@ upstream:
 
     backends:
       - id: "backend1"
-        address: "127.0.0.1:7001"
+        address: "http://127.0.0.1:7001"   # explicit cleartext for local/dev; omit scheme for verified HTTPS default
         weight: 100  # relative traffic share; must be 1–1000 (higher = more traffic)
         health_check:
           path: "/health"
           interval: 5000
 
       - id: "backend2"
-        address: "127.0.0.1:7002"
+        address: "http://127.0.0.1:7002"   # explicit cleartext for local/dev; omit scheme for verified HTTPS default
         weight: 50   # receives ~33% of traffic vs backend1's ~67%
         health_check:
           path: "/status"
@@ -40,7 +40,7 @@ upstream:
 
     backends:
       - id: "auth1"
-        address: "127.0.0.1:8001"
+        address: "http://127.0.0.1:8001"   # explicit cleartext for local/dev; omit scheme for verified HTTPS default
         weight: 100  # relative traffic share; must be 1–1000
         health_check:
           path: "/health"

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -10,3 +10,4 @@ quiche.workspace = true
 bytes.workspace = true
 http-body-util.workspace = true
 spooky-errors = { path = "../errors" }
+spooky-config = { path = "../config" }

--- a/crates/bridge/src/h3_to_h2.rs
+++ b/crates/bridge/src/h3_to_h2.rs
@@ -4,6 +4,7 @@ use bytes::Bytes;
 use http::{HeaderName, HeaderValue, Method, Request, Uri};
 use http_body_util::combinators::BoxBody;
 use quiche::h3::NameValue;
+use spooky_config::backend_endpoint::BackendEndpoint;
 
 pub use spooky_errors::BridgeError;
 
@@ -19,9 +20,10 @@ pub fn build_h2_request(
     content_length: Option<usize>,
 ) -> Result<Request<BoxBody<Bytes, Infallible>>, BridgeError> {
     let method = Method::from_bytes(method.as_bytes()).map_err(|_| BridgeError::InvalidMethod)?;
+    let endpoint = BackendEndpoint::parse(backend).map_err(|_| BridgeError::InvalidUri)?;
 
     let request_path = if path.is_empty() { "/" } else { path };
-    let uri = format!("http://{backend}{request_path}");
+    let uri = endpoint.uri_for_path(request_path);
     let uri = Uri::try_from(uri).map_err(|_| BridgeError::InvalidUri)?;
 
     let mut builder = Request::builder().method(method).uri(uri);
@@ -48,7 +50,7 @@ pub fn build_h2_request(
     }
 
     if !saw_host {
-        builder = builder.header(http::header::HOST, backend);
+        builder = builder.header(http::header::HOST, endpoint.authority());
     }
 
     if let Some(len) = content_length
@@ -58,4 +60,66 @@ pub fn build_h2_request(
     }
 
     builder.body(body).map_err(BridgeError::Build)
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use http::header::HOST;
+    use http_body_util::{BodyExt, Empty};
+
+    use super::build_h2_request;
+
+    #[test]
+    fn defaults_to_https_origin_for_host_port_backend() {
+        let req = build_h2_request(
+            "backend.internal:443",
+            "GET",
+            "/health",
+            &[],
+            Empty::<Bytes>::new().boxed(),
+            None,
+        )
+        .expect("request");
+
+        assert_eq!(req.uri().to_string(), "https://backend.internal:443/health");
+        assert_eq!(
+            req.headers().get(HOST).and_then(|h| h.to_str().ok()),
+            Some("backend.internal:443")
+        );
+    }
+
+    #[test]
+    fn keeps_explicit_http_scheme() {
+        let req = build_h2_request(
+            "http://127.0.0.1:8080",
+            "GET",
+            "/",
+            &[],
+            Empty::<Bytes>::new().boxed(),
+            None,
+        )
+        .expect("request");
+
+        assert_eq!(req.uri().to_string(), "http://127.0.0.1:8080/");
+        assert_eq!(
+            req.headers().get(HOST).and_then(|h| h.to_str().ok()),
+            Some("127.0.0.1:8080")
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_backend_endpoint() {
+        let err = build_h2_request(
+            "https://backend.internal:443/path",
+            "GET",
+            "/",
+            &[],
+            Empty::<Bytes>::new().boxed(),
+            None,
+        )
+        .expect_err("invalid backend endpoint should fail");
+
+        assert!(matches!(err, crate::h3_to_h2::BridgeError::InvalidUri));
+    }
 }

--- a/crates/config/src/backend_endpoint.rs
+++ b/crates/config/src/backend_endpoint.rs
@@ -1,0 +1,192 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackendScheme {
+    Http,
+    Https,
+}
+
+impl BackendScheme {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Http => "http",
+            Self::Https => "https",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackendEndpoint {
+    scheme: BackendScheme,
+    authority: String,
+}
+
+impl BackendEndpoint {
+    /// Parse backend endpoint policy from config.
+    ///
+    /// Accepted forms:
+    /// - `host:port` => defaults to `https://host:port`
+    /// - `https://host:port`
+    /// - `http://host:port` (explicit insecure opt-out)
+    pub fn parse(raw: &str) -> Result<Self, String> {
+        let raw = raw.trim();
+        if raw.is_empty() {
+            return Err("backend address is empty".to_string());
+        }
+
+        let lower = raw.to_ascii_lowercase();
+        let (scheme, authority) = if lower.starts_with("http://") {
+            (BackendScheme::Http, &raw[7..])
+        } else if lower.starts_with("https://") {
+            (BackendScheme::Https, &raw[8..])
+        } else if raw.contains("://") {
+            return Err("unsupported URL scheme; use http:// or https://".to_string());
+        } else {
+            (BackendScheme::Https, raw)
+        };
+
+        if authority.is_empty() {
+            return Err("backend authority is empty".to_string());
+        }
+
+        if authority.contains('/') || authority.contains('?') || authority.contains('#') {
+            return Err("backend address must not include path, query, or fragment".to_string());
+        }
+
+        validate_authority(authority)?;
+
+        Ok(Self {
+            scheme,
+            authority: authority.to_string(),
+        })
+    }
+
+    pub fn scheme(&self) -> BackendScheme {
+        self.scheme
+    }
+
+    pub fn authority(&self) -> &str {
+        &self.authority
+    }
+
+    pub fn origin(&self) -> String {
+        format!("{}://{}", self.scheme.as_str(), self.authority)
+    }
+
+    pub fn uri_for_path(&self, path: &str) -> String {
+        let normalized = if path.is_empty() {
+            "/"
+        } else if path.starts_with('/') {
+            path
+        } else {
+            return format!("{}/{}", self.origin(), path);
+        };
+        format!("{}{}", self.origin(), normalized)
+    }
+}
+
+fn validate_authority(authority: &str) -> Result<(), String> {
+    if authority.chars().any(|ch| ch.is_ascii_whitespace()) {
+        return Err("backend authority must not contain whitespace".to_string());
+    }
+
+    let (host, port_str) = if authority.starts_with('[') {
+        let bracket_end = authority
+            .find(']')
+            .ok_or_else(|| "invalid IPv6 authority; missing closing ']'".to_string())?;
+        let host = &authority[1..bracket_end];
+        if host.is_empty() {
+            return Err("backend host is empty".to_string());
+        }
+
+        let suffix = &authority[bracket_end + 1..];
+        if !suffix.starts_with(':') {
+            return Err("backend authority must include ':port'".to_string());
+        }
+        (host, &suffix[1..])
+    } else {
+        let (host, port) = authority
+            .rsplit_once(':')
+            .ok_or_else(|| "backend authority must be host:port".to_string())?;
+        if host.is_empty() {
+            return Err("backend host is empty".to_string());
+        }
+        if host.contains(':') {
+            return Err("IPv6 authorities must use brackets, e.g. [::1]:443".to_string());
+        }
+        (host, port)
+    };
+
+    if host.is_empty() {
+        return Err("backend host is empty".to_string());
+    }
+
+    if port_str.is_empty() {
+        return Err("backend port is empty".to_string());
+    }
+    if !port_str.chars().all(|c| c.is_ascii_digit()) {
+        return Err("backend port must be numeric".to_string());
+    }
+    let port = port_str
+        .parse::<u16>()
+        .map_err(|_| "backend port must be in range 1-65535".to_string())?;
+    if port == 0 {
+        return Err("backend port must be in range 1-65535".to_string());
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BackendEndpoint, BackendScheme};
+
+    #[test]
+    fn parse_host_port_defaults_to_https() {
+        let endpoint = BackendEndpoint::parse("example.com:443").expect("endpoint");
+        assert_eq!(endpoint.scheme(), BackendScheme::Https);
+        assert_eq!(endpoint.authority(), "example.com:443");
+        assert_eq!(endpoint.origin(), "https://example.com:443");
+    }
+
+    #[test]
+    fn parse_explicit_http_is_supported() {
+        let endpoint = BackendEndpoint::parse("http://127.0.0.1:8080").expect("endpoint");
+        assert_eq!(endpoint.scheme(), BackendScheme::Http);
+        assert_eq!(endpoint.authority(), "127.0.0.1:8080");
+    }
+
+    #[test]
+    fn parse_bracketed_ipv6() {
+        let endpoint = BackendEndpoint::parse("https://[::1]:8443").expect("endpoint");
+        assert_eq!(endpoint.scheme(), BackendScheme::Https);
+        assert_eq!(endpoint.authority(), "[::1]:8443");
+    }
+
+    #[test]
+    fn parse_rejects_path_query_and_fragment() {
+        assert!(BackendEndpoint::parse("https://example.com:443/api").is_err());
+        assert!(BackendEndpoint::parse("https://example.com:443?a=1").is_err());
+        assert!(BackendEndpoint::parse("https://example.com:443#frag").is_err());
+    }
+
+    #[test]
+    fn parse_rejects_invalid_authority() {
+        assert!(BackendEndpoint::parse("127.0.0.1").is_err());
+        assert!(BackendEndpoint::parse("127.0.0.1:abc").is_err());
+        assert!(BackendEndpoint::parse("::1:443").is_err());
+        assert!(BackendEndpoint::parse("https://:443").is_err());
+    }
+
+    #[test]
+    fn uri_for_path_normalizes_empty_and_relative_paths() {
+        let endpoint = BackendEndpoint::parse("backend.local:443").expect("endpoint");
+        assert_eq!(endpoint.uri_for_path(""), "https://backend.local:443/");
+        assert_eq!(
+            endpoint.uri_for_path("/health"),
+            "https://backend.local:443/health"
+        );
+        assert_eq!(
+            endpoint.uri_for_path("health"),
+            "https://backend.local:443/health"
+        );
+    }
+}

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -94,8 +94,12 @@ pub struct Upstream {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Backend {
-    pub id: String,      // "backend1"
-    pub address: String, // "10.0.1.100:8080"
+    pub id: String, // "backend1"
+    /// Backend endpoint.
+    /// - `host:port` (defaults to verified HTTPS)
+    /// - `https://host:port` (verified HTTPS)
+    /// - `http://host:port` (explicit insecure opt-out)
+    pub address: String,
 
     #[serde(default = "get_default_weight")]
     pub weight: u32, // 100

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod backend_endpoint;
 pub mod config;
 pub mod default;
 pub mod loader;

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -1,5 +1,6 @@
+use crate::backend_endpoint::{BackendEndpoint, BackendScheme};
 use crate::config::Config;
-use log::{error, info};
+use log::{error, info, warn};
 
 pub const VALID_LOG_LEVELS: &[&str] = &[
     "whisper",
@@ -481,31 +482,21 @@ pub fn validate(config: &Config) -> bool {
                 return false;
             }
 
-            // Validate backend address: must be parseable as host:port with a
-            // numeric port in [1, 65535]. Rejects URLs (contain "://"), bare
-            // hostnames, non-numeric ports, and out-of-range port numbers.
-            {
-                let addr = &backend.address;
-                let valid = if addr.contains("://") {
-                    false
-                } else if let Some(colon) = addr.rfind(':') {
-                    let host = &addr[..colon];
-                    let port_str = &addr[colon + 1..];
-                    !host.is_empty()
-                        && !port_str.is_empty()
-                        && port_str.chars().all(|c| c.is_ascii_digit())
-                        && port_str.parse::<u16>().map_or(false, |p| p >= 1)
-                } else {
-                    false
-                };
-                if !valid {
+            let endpoint = match BackendEndpoint::parse(&backend.address) {
+                Ok(endpoint) => endpoint,
+                Err(reason) => {
                     error!(
-                        "Backend address '{}' in upstream '{}' must be host:port \
-                         with a numeric port in 1-65535",
-                        addr, upstream_name
+                        "Backend address '{}' in upstream '{}' is invalid: {}",
+                        backend.address, upstream_name, reason
                     );
                     return false;
                 }
+            };
+            if endpoint.scheme() == BackendScheme::Http {
+                warn!(
+                    "Backend '{}' in upstream '{}' uses explicit insecure cleartext transport ({})",
+                    backend.id, upstream_name, backend.address
+                );
             }
 
             // Validate weight
@@ -857,5 +848,55 @@ upstream:
         };
 
         assert!(validate(&cfg));
+    }
+
+    #[test]
+    fn backend_address_validation_supports_secure_default_and_explicit_http() {
+        let dir = tempdir().expect("tempdir");
+        let cert = dir.path().join("cert.pem");
+        let key = dir.path().join("key.pem");
+        std::fs::write(&cert, "cert").expect("write cert");
+        std::fs::write(&key, "key").expect("write key");
+
+        // Bare host:port defaults to HTTPS policy.
+        let mut cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.upstream
+            .get_mut("test_upstream")
+            .expect("upstream")
+            .backends[0]
+            .address = "api.example.internal:443".to_string();
+        assert!(validate(&cfg));
+
+        // Explicit HTTP remains allowed as an opt-out.
+        cfg.upstream
+            .get_mut("test_upstream")
+            .expect("upstream")
+            .backends[0]
+            .address = "http://127.0.0.1:8080".to_string();
+        assert!(validate(&cfg));
+    }
+
+    #[test]
+    fn backend_address_validation_rejects_invalid_urls() {
+        let dir = tempdir().expect("tempdir");
+        let cert = dir.path().join("cert.pem");
+        let key = dir.path().join("key.pem");
+        std::fs::write(&cert, "cert").expect("write cert");
+        std::fs::write(&key, "key").expect("write key");
+
+        let mut cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.upstream
+            .get_mut("test_upstream")
+            .expect("upstream")
+            .backends[0]
+            .address = "https://127.0.0.1:8443/path".to_string();
+        assert!(!validate(&cfg));
+
+        cfg.upstream
+            .get_mut("test_upstream")
+            .expect("upstream")
+            .backends[0]
+            .address = "ftp://127.0.0.1:21".to_string();
+        assert!(!validate(&cfg));
     }
 }

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -34,7 +34,7 @@ use tokio::sync::{
     oneshot,
 };
 
-use spooky_config::config::Config as SpookyConfig;
+use spooky_config::{backend_endpoint::BackendEndpoint, config::Config as SpookyConfig};
 
 use crate::{
     ChannelBody, ForwardResult, Metrics, QUICListener, QuicConnection, RequestEnvelope,
@@ -181,16 +181,18 @@ impl QUICListener {
             config.performance.h2_pool_idle_timeout_ms
         );
 
-        let backend_addresses = config
-            .upstream
-            .values()
-            .flat_map(|upstream| {
-                upstream
-                    .backends
-                    .iter()
-                    .map(|backend| backend.address.clone())
-            })
-            .collect::<Vec<_>>();
+        let mut backend_addresses = Vec::new();
+        for (upstream_name, upstream) in &config.upstream {
+            for backend in &upstream.backends {
+                if let Err(err) = BackendEndpoint::parse(&backend.address) {
+                    return Err(ProxyError::Transport(format!(
+                        "invalid backend address '{}' in upstream '{}' (backend '{}'): {}",
+                        backend.address, upstream_name, backend.id, err
+                    )));
+                }
+                backend_addresses.push(backend.address.clone());
+            }
+        }
 
         let h2_pool = Arc::new(H2Pool::new(
             backend_addresses,
@@ -3105,13 +3107,24 @@ impl QUICListener {
                 } else {
                     &health.path
                 };
+                let endpoint = match BackendEndpoint::parse(&address) {
+                    Ok(endpoint) => endpoint,
+                    Err(err) => {
+                        error!(
+                            "disabling health checks for backend '{}' due to invalid endpoint: {}",
+                            address, err
+                        );
+                        return;
+                    }
+                };
+                let health_uri = endpoint.uri_for_path(path);
 
                 loop {
                     tokio::time::sleep(interval).await;
 
                     let request = match http::Request::builder()
                         .method("GET")
-                        .uri(format!("http://{address}{path}"))
+                        .uri(&health_uri)
                         .body(BoxBody::new(Full::new(Bytes::new())))
                     {
                         Ok(req) => req,

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -76,7 +76,7 @@ fn make_config(port: u32, backend_addr: String, cert: String, key: String) -> Co
             },
             backends: vec![Backend {
                 id: "backend1".to_string(),
-                address: backend_addr,
+                address: normalize_backend_address(backend_addr),
                 weight: 1,
                 health_check: HealthCheck {
                     path: "/health".to_string(),
@@ -110,6 +110,14 @@ fn make_config(port: u32, backend_addr: String, cert: String, key: String) -> Co
         performance: spooky_config::config::Performance::default(),
         observability: spooky_config::config::Observability::default(),
         resilience: spooky_config::config::Resilience::default(),
+    }
+}
+
+fn normalize_backend_address(address: String) -> String {
+    if address.contains("://") {
+        address
+    } else {
+        format!("http://{address}")
     }
 }
 
@@ -1198,7 +1206,13 @@ fn make_config_with_backends(
         key,
     );
     if let Some(upstream) = config.upstream.get_mut("test_pool") {
-        upstream.backends = backends;
+        upstream.backends = backends
+            .into_iter()
+            .map(|mut backend| {
+                backend.address = normalize_backend_address(backend.address);
+                backend
+            })
+            .collect();
         upstream.load_balancing.lb_type = lb_type.to_string();
     }
     config
@@ -1359,9 +1373,14 @@ fn draining_rejects_new_connections() {
         let mut scid_bytes = [0u8; quiche::MAX_CONN_ID_LEN];
         rand::thread_rng().fill_bytes(&mut scid_bytes);
         let scid = quiche::ConnectionId::from_ref(&scid_bytes);
-        let mut conn =
-            quiche::connect(Some("localhost"), &scid, local_addr, listen_addr, &mut qconfig)
-                .unwrap();
+        let mut conn = quiche::connect(
+            Some("localhost"),
+            &scid,
+            local_addr,
+            listen_addr,
+            &mut qconfig,
+        )
+        .unwrap();
 
         let mut out = [0u8; MAX_UDP_PAYLOAD_BYTES];
         let mut buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];

--- a/crates/edge/tests/h3_edge.rs
+++ b/crates/edge/tests/h3_edge.rs
@@ -62,7 +62,7 @@ fn make_config(port: u32, cert: String, key: String, backend_address: String) ->
             },
             backends: vec![Backend {
                 id: "backend1".to_string(),
-                address: backend_address,
+                address: normalize_backend_address(backend_address),
                 weight: 1,
                 health_check: HealthCheck {
                     path: "/health".to_string(),
@@ -96,6 +96,14 @@ fn make_config(port: u32, cert: String, key: String, backend_address: String) ->
         performance: spooky_config::config::Performance::default(),
         observability: spooky_config::config::Observability::default(),
         resilience: spooky_config::config::Resilience::default(),
+    }
+}
+
+fn normalize_backend_address(address: String) -> String {
+    if address.contains("://") {
+        address
+    } else {
+        format!("http://{address}")
     }
 }
 
@@ -497,6 +505,22 @@ fn http3_request_is_accepted_and_parsed() {
 }
 
 #[test]
+fn invalid_backend_scheme_is_rejected_at_startup() {
+    let dir = tempdir().expect("failed to create temp dir");
+    let (cert, key) = write_test_certs(&dir);
+    let config = make_config(0, cert, key, "ftp://127.0.0.1:8080".to_string());
+    match QUICListener::new(config) {
+        Ok(_) => panic!("invalid backend scheme should fail startup"),
+        Err(err) => {
+            assert!(
+                err.to_string().contains("invalid backend address"),
+                "unexpected startup error: {err}"
+            );
+        }
+    }
+}
+
+#[test]
 fn server_rotates_scids_for_active_connection() {
     let dir = tempdir().expect("failed to create temp dir");
     let (cert, key) = write_test_certs(&dir);
@@ -769,7 +793,7 @@ fn make_config_with_rate_limit(
             },
             backends: vec![Backend {
                 id: "backend1".to_string(),
-                address: backend_address,
+                address: normalize_backend_address(backend_address),
                 weight: 1,
                 health_check: HealthCheck {
                     path: "/health".to_string(),

--- a/crates/edge/tests/lb_integration.rs
+++ b/crates/edge/tests/lb_integration.rs
@@ -92,7 +92,13 @@ fn make_config(
                 path_prefix: Some("/".to_string()),
                 ..Default::default()
             },
-            backends,
+            backends: backends
+                .into_iter()
+                .map(|mut backend| {
+                    backend.address = normalize_backend_address(backend.address);
+                    backend
+                })
+                .collect(),
         },
     );
 
@@ -116,6 +122,14 @@ fn make_config(
         performance: spooky_config::config::Performance::default(),
         observability: spooky_config::config::Observability::default(),
         resilience: spooky_config::config::Resilience::default(),
+    }
+}
+
+fn normalize_backend_address(address: String) -> String {
+    if address.contains("://") {
+        address
+    } else {
+        format!("http://{address}")
     }
 }
 

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -9,5 +9,6 @@ bytes.workspace = true
 http-body-util.workspace = true
 hyper.workspace = true
 hyper-util.workspace = true
+hyper-rustls.workspace = true
 tokio.workspace = true
 spooky-errors = { path = "../errors" }

--- a/crates/transport/src/h2_client.rs
+++ b/crates/transport/src/h2_client.rs
@@ -5,10 +5,11 @@ use std::time::Duration;
 use http_body_util::combinators::BoxBody;
 use hyper::body::Bytes;
 use hyper::{Request, rt::Executor};
+use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
 use hyper_util::client::legacy::{Client, connect::HttpConnector};
 
 pub struct H2Client {
-    client: Client<HttpConnector, BoxBody<Bytes, Infallible>>,
+    client: Client<HttpsConnector<HttpConnector>, BoxBody<Bytes, Infallible>>,
 }
 
 #[derive(Clone, Copy)]
@@ -33,12 +34,17 @@ impl H2Client {
         let mut http = HttpConnector::new();
         http.enforce_http(false);
         http.set_connect_timeout(Some(connect_timeout));
+        let https = HttpsConnectorBuilder::new()
+            .with_webpki_roots()
+            .https_or_http()
+            .enable_http2()
+            .wrap_connector(http);
 
         let client = Client::builder(TokioExecutor)
             .http2_only(true)
             .pool_max_idle_per_host(max_idle_per_host)
             .pool_idle_timeout(pool_idle_timeout)
-            .build(http);
+            .build(https);
 
         Self { client }
     }


### PR DESCRIPTION
## Why
Upstream backend transport previously allowed insecure posture by default (`host:port` effectively cleartext). That is not acceptable for enterprise production.

## What changed
- Added backend endpoint parsing/validation with secure defaults:
  - `host:port` => treated as `https://host:port` (verified TLS)
  - `https://host:port` => verified TLS
  - `http://host:port` => explicit insecure opt-out
- Updated config validation to reject malformed backend endpoints and warn on explicit `http://`.
- Switched transport client to TLS-capable HTTP/2 (`hyper-rustls`) with certificate verification.
- Updated H3->H2 request building to derive backend URI from endpoint policy (no hardcoded `http://`).
- Updated backend health checks to use scheme-aware backend URIs.
- Added fail-fast startup checks for invalid backend endpoint config.
- Updated sample/minimal configs to use explicit `http://` for local dev backends.
- Updated integration test config helpers to normalize local test backends to explicit `http://`.

## Backward compatibility / migration
- **Behavior change:** bare `host:port` backend addresses are now secure-by-default (HTTPS).
- If you need cleartext backend transport (local/dev only), set backend address explicitly as:
  - `http://127.0.0.1:8080`
