### PR TITLE
Harden runtime panic handling and add CI gate for unwrap/expect regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,24 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake build-essential pkg-config
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run clippy panic-safety gates
+        run: |
+          cargo clippy --workspace --lib --bins -- -D clippy::unwrap_used -D clippy::expect_used
+
   test:
     runs-on: ubuntu-latest
+    needs: lint
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -226,6 +226,7 @@ pub struct Metrics {
     pub watchdog_restart_requests: AtomicU64,
     pub watchdog_restart_hooks: AtomicU64,
     pub watchdog_degraded_windows: AtomicU64,
+    pub runtime_panics: AtomicU64,
     route_stats_shards: Vec<Mutex<HashMap<String, RouteStats>>>,
 }
 
@@ -270,6 +271,7 @@ impl Default for Metrics {
             watchdog_restart_requests: AtomicU64::new(0),
             watchdog_restart_hooks: AtomicU64::new(0),
             watchdog_degraded_windows: AtomicU64::new(0),
+            runtime_panics: AtomicU64::new(0),
             route_stats_shards: shards,
         }
     }
@@ -316,6 +318,10 @@ impl Metrics {
     pub fn inc_watchdog_degraded_window(&self) {
         self.watchdog_degraded_windows
             .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_runtime_panic(&self) {
+        self.runtime_panics.fetch_add(1, Ordering::Relaxed);
     }
 
     pub fn record_route(&self, route: &str, latency: Duration, outcome: RouteOutcome) {
@@ -425,6 +431,13 @@ impl Metrics {
         out.push_str(&format!(
             "spooky_watchdog_restart_hooks {}\n",
             self.watchdog_restart_hooks.load(Ordering::Relaxed)
+        ));
+
+        out.push_str("# HELP spooky_runtime_panics Total runtime task panics observed.\n");
+        out.push_str("# TYPE spooky_runtime_panics counter\n");
+        out.push_str(&format!(
+            "spooky_runtime_panics {}\n",
+            self.runtime_panics.load(Ordering::Relaxed)
         ));
 
         out.push_str(

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -243,6 +243,7 @@ impl QUICListener {
         Self::spawn_health_checks(
             shared_state.upstream_pools.clone(),
             Arc::clone(&shared_state.h2_pool),
+            Arc::clone(&shared_state.metrics),
         );
         Self::spawn_metrics_endpoint(config, Arc::clone(&shared_state.metrics));
         Self::spawn_watchdog(
@@ -2836,44 +2837,50 @@ impl QUICListener {
             }
         };
 
-        handle.spawn(async move {
-            info!(
-                "Metrics endpoint listening on http://{}{}",
-                bind, metrics_path
-            );
+        spawn_supervised_async_task(
+            &handle,
+            "metrics-endpoint",
+            Some(Arc::clone(&metrics)),
+            async move {
+                info!(
+                    "Metrics endpoint listening on http://{}{}",
+                    bind, metrics_path
+                );
 
-            loop {
-                let (stream, _peer) = match listener.accept().await {
-                    Ok(v) => v,
-                    Err(err) => {
-                        error!("Metrics endpoint accept failed: {}", err);
-                        continue;
-                    }
-                };
+                loop {
+                    let (stream, _peer) = match listener.accept().await {
+                        Ok(v) => v,
+                        Err(err) => {
+                            error!("Metrics endpoint accept failed: {}", err);
+                            continue;
+                        }
+                    };
 
-                let io = TokioIo::new(stream);
-                let metrics = Arc::clone(&metrics);
-                let metrics_path = metrics_path.clone();
+                    let io = TokioIo::new(stream);
+                    let metrics = Arc::clone(&metrics);
+                    let metrics_path = metrics_path.clone();
 
-                tokio::spawn(async move {
-                    let service = service_fn(move |req: Request<Incoming>| {
-                        let metrics = Arc::clone(&metrics);
-                        let metrics_path = metrics_path.clone();
-                        async move {
-                            Ok::<_, hyper::Error>(Self::handle_metrics_request(
-                                req,
-                                &metrics_path,
-                                metrics,
-                            ))
+                    tokio::spawn(async move {
+                        let service = service_fn(move |req: Request<Incoming>| {
+                            let metrics = Arc::clone(&metrics);
+                            let metrics_path = metrics_path.clone();
+                            async move {
+                                Ok::<_, hyper::Error>(Self::handle_metrics_request(
+                                    req,
+                                    &metrics_path,
+                                    metrics,
+                                ))
+                            }
+                        });
+
+                        if let Err(err) = http1::Builder::new().serve_connection(io, service).await
+                        {
+                            error!("Metrics endpoint connection failed: {}", err);
                         }
                     });
-
-                    if let Err(err) = http1::Builder::new().serve_connection(io, service).await {
-                        error!("Metrics endpoint connection failed: {}", err);
-                    }
-                });
-            }
-        });
+                }
+            },
+        );
     }
 
     fn handle_metrics_request(
@@ -2921,149 +2928,156 @@ impl QUICListener {
             }
         };
 
-        handle.spawn(async move {
-            info!(
-                "Watchdog enabled: check_interval_ms={} poll_stall_timeout_ms={} timeout_error_rate_percent={} overload_inflight_percent={} unhealthy_windows={} drain_grace_ms={} restart_cooldown_ms={}",
-                watchdog_config.check_interval_ms,
-                watchdog_config.poll_stall_timeout_ms,
-                watchdog_config.timeout_error_rate_percent,
-                watchdog_config.overload_inflight_percent,
-                watchdog_config.unhealthy_consecutive_windows,
-                watchdog_config.drain_grace_ms,
-                watchdog_config.restart_cooldown_ms,
-            );
+        spawn_supervised_async_task(
+            &handle,
+            "watchdog",
+            Some(Arc::clone(&metrics)),
+            async move {
+                info!(
+                    "Watchdog enabled: check_interval_ms={} poll_stall_timeout_ms={} timeout_error_rate_percent={} overload_inflight_percent={} unhealthy_windows={} drain_grace_ms={} restart_cooldown_ms={}",
+                    watchdog_config.check_interval_ms,
+                    watchdog_config.poll_stall_timeout_ms,
+                    watchdog_config.timeout_error_rate_percent,
+                    watchdog_config.overload_inflight_percent,
+                    watchdog_config.unhealthy_consecutive_windows,
+                    watchdog_config.drain_grace_ms,
+                    watchdog_config.restart_cooldown_ms,
+                );
 
-            let mut interval =
-                tokio::time::interval(Duration::from_millis(watchdog_config.check_interval_ms));
-            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-            let has_restart_hook = watchdog_config
-                .restart_hook
-                .as_deref()
-                .map(str::trim)
-                .is_some_and(|value| !value.is_empty());
-
-            let mut previous_requests = metrics.requests_total.load(Ordering::Relaxed);
-            let mut previous_timeouts = metrics.backend_timeouts.load(Ordering::Relaxed);
-            let mut degraded_windows = 0u32;
-
-            loop {
-                interval.tick().await;
-                let now = now_millis();
-                let stalled = now.saturating_sub(watchdog.last_poll_progress_ms())
-                    > watchdog_config.poll_stall_timeout_ms;
-
-                let current_requests = metrics.requests_total.load(Ordering::Relaxed);
-                let current_timeouts = metrics.backend_timeouts.load(Ordering::Relaxed);
-                let request_delta = current_requests.saturating_sub(previous_requests);
-                let timeout_delta = current_timeouts.saturating_sub(previous_timeouts);
-                previous_requests = current_requests;
-                previous_timeouts = current_timeouts;
-
-                let timeout_rate_percent = if request_delta == 0 {
-                    0
-                } else {
-                    timeout_delta.saturating_mul(100) / request_delta
-                };
-
-                let timeout_pressure = request_delta >= watchdog_config.min_requests_per_window
-                    && timeout_rate_percent >= watchdog_config.timeout_error_rate_percent as u64;
-                let overload_pressure = resilience.adaptive_admission.inflight_percent()
-                    >= watchdog_config.overload_inflight_percent;
-
-                if stalled || timeout_pressure || overload_pressure {
-                    degraded_windows = degraded_windows.saturating_add(1);
-                    watchdog.set_degraded(true);
-                    metrics.inc_watchdog_degraded_window();
-                } else {
-                    degraded_windows = 0;
-                    watchdog.set_degraded(false);
-                }
-
-                if degraded_windows >= watchdog_config.unhealthy_consecutive_windows {
-                    if !has_restart_hook {
-                        warn!(
-                            "Watchdog detected unhealthy runtime state, but restart_hook is not configured"
-                        );
-                        degraded_windows = 0;
-                        continue;
-                    }
-                    let mut reasons = Vec::new();
-                    if stalled {
-                        reasons.push("poll_stall");
-                    }
-                    if timeout_pressure {
-                        reasons.push("timeout_spike");
-                    }
-                    if overload_pressure {
-                        reasons.push("inflight_overload");
-                    }
-                    let reason = reasons.join("+");
-                    if watchdog.request_restart(&reason) {
-                        metrics.inc_watchdog_restart_request();
-                        warn!("Watchdog requested safe restart: {}", reason);
-                    }
-                    degraded_windows = 0;
-                }
-
-                if !watchdog.restart_requested() {
-                    continue;
-                }
-
-                let requested_at = watchdog.restart_requested_at_ms();
-                let grace_elapsed = requested_at != 0
-                    && now.saturating_sub(requested_at) >= watchdog_config.drain_grace_ms;
-                if !watchdog.workers_drained() && !grace_elapsed {
-                    continue;
-                }
-
-                let restart_reason = watchdog.restart_reason();
-                if watchdog.workers_drained() {
-                    info!(
-                        "Watchdog safe restart condition reached (all workers drained): {}",
-                        restart_reason
-                    );
-                } else {
-                    warn!(
-                        "Watchdog restart drain grace elapsed; executing hook without full drain: {}",
-                        restart_reason
-                    );
-                }
-
-                let cmd = watchdog_config
+                let mut interval =
+                    tokio::time::interval(Duration::from_millis(watchdog_config.check_interval_ms));
+                interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+                let has_restart_hook = watchdog_config
                     .restart_hook
                     .as_deref()
                     .map(str::trim)
-                    .unwrap_or_default();
-                let status = tokio::process::Command::new("/bin/sh")
-                    .arg("-c")
-                    .arg(cmd)
-                    .env("SPOOKY_WATCHDOG_REASON", &restart_reason)
-                    .status()
-                    .await;
-                match status {
-                    Ok(status) => {
+                    .is_some_and(|value| !value.is_empty());
+
+                let mut previous_requests = metrics.requests_total.load(Ordering::Relaxed);
+                let mut previous_timeouts = metrics.backend_timeouts.load(Ordering::Relaxed);
+                let mut degraded_windows = 0u32;
+
+                loop {
+                    interval.tick().await;
+                    let now = now_millis();
+                    let stalled = now.saturating_sub(watchdog.last_poll_progress_ms())
+                        > watchdog_config.poll_stall_timeout_ms;
+
+                    let current_requests = metrics.requests_total.load(Ordering::Relaxed);
+                    let current_timeouts = metrics.backend_timeouts.load(Ordering::Relaxed);
+                    let request_delta = current_requests.saturating_sub(previous_requests);
+                    let timeout_delta = current_timeouts.saturating_sub(previous_timeouts);
+                    previous_requests = current_requests;
+                    previous_timeouts = current_timeouts;
+
+                    let timeout_rate_percent = if request_delta == 0 {
+                        0
+                    } else {
+                        timeout_delta.saturating_mul(100) / request_delta
+                    };
+
+                    let timeout_pressure = request_delta >= watchdog_config.min_requests_per_window
+                        && timeout_rate_percent
+                            >= watchdog_config.timeout_error_rate_percent as u64;
+                    let overload_pressure = resilience.adaptive_admission.inflight_percent()
+                        >= watchdog_config.overload_inflight_percent;
+
+                    if stalled || timeout_pressure || overload_pressure {
+                        degraded_windows = degraded_windows.saturating_add(1);
+                        watchdog.set_degraded(true);
+                        metrics.inc_watchdog_degraded_window();
+                    } else {
+                        degraded_windows = 0;
+                        watchdog.set_degraded(false);
+                    }
+
+                    if degraded_windows >= watchdog_config.unhealthy_consecutive_windows {
+                        if !has_restart_hook {
+                            warn!(
+                                "Watchdog detected unhealthy runtime state, but restart_hook is not configured"
+                            );
+                            degraded_windows = 0;
+                            continue;
+                        }
+                        let mut reasons = Vec::new();
+                        if stalled {
+                            reasons.push("poll_stall");
+                        }
+                        if timeout_pressure {
+                            reasons.push("timeout_spike");
+                        }
+                        if overload_pressure {
+                            reasons.push("inflight_overload");
+                        }
+                        let reason = reasons.join("+");
+                        if watchdog.request_restart(&reason) {
+                            metrics.inc_watchdog_restart_request();
+                            warn!("Watchdog requested safe restart: {}", reason);
+                        }
+                        degraded_windows = 0;
+                    }
+
+                    if !watchdog.restart_requested() {
+                        continue;
+                    }
+
+                    let requested_at = watchdog.restart_requested_at_ms();
+                    let grace_elapsed = requested_at != 0
+                        && now.saturating_sub(requested_at) >= watchdog_config.drain_grace_ms;
+                    if !watchdog.workers_drained() && !grace_elapsed {
+                        continue;
+                    }
+
+                    let restart_reason = watchdog.restart_reason();
+                    if watchdog.workers_drained() {
                         info!(
-                            "Watchdog restart hook exited with status {}",
-                            status
-                                .code()
-                                .map(|code| code.to_string())
-                                .unwrap_or_else(|| "signal".to_string())
+                            "Watchdog safe restart condition reached (all workers drained): {}",
+                            restart_reason
+                        );
+                    } else {
+                        warn!(
+                            "Watchdog restart drain grace elapsed; executing hook without full drain: {}",
+                            restart_reason
                         );
                     }
-                    Err(err) => {
-                        error!("Watchdog restart hook execution failed: {}", err);
-                    }
-                }
-                metrics.inc_watchdog_restart_hook();
 
-                watchdog.complete_restart_cycle();
-            }
-        });
+                    let cmd = watchdog_config
+                        .restart_hook
+                        .as_deref()
+                        .map(str::trim)
+                        .unwrap_or_default();
+                    let status = tokio::process::Command::new("/bin/sh")
+                        .arg("-c")
+                        .arg(cmd)
+                        .env("SPOOKY_WATCHDOG_REASON", &restart_reason)
+                        .status()
+                        .await;
+                    match status {
+                        Ok(status) => {
+                            info!(
+                                "Watchdog restart hook exited with status {}",
+                                status
+                                    .code()
+                                    .map(|code| code.to_string())
+                                    .unwrap_or_else(|| "signal".to_string())
+                            );
+                        }
+                        Err(err) => {
+                            error!("Watchdog restart hook execution failed: {}", err);
+                        }
+                    }
+                    metrics.inc_watchdog_restart_hook();
+
+                    watchdog.complete_restart_cycle();
+                }
+            },
+        );
     }
 
     fn spawn_health_checks(
         upstream_pools: HashMap<String, Arc<Mutex<UpstreamPool>>>,
         h2_pool: Arc<H2Pool>,
+        metrics: Arc<Metrics>,
     ) {
         let entries = {
             let mut all_entries = Vec::new();
@@ -3099,7 +3113,8 @@ impl QUICListener {
         for (upstream_pool, index, address, health) in entries {
             let h2_pool = h2_pool.clone();
             let handle = handle.clone();
-            handle.spawn(async move {
+            let metrics = Arc::clone(&metrics);
+            spawn_supervised_async_task(&handle, "health-check", Some(metrics), async move {
                 let interval = Duration::from_millis(health.interval.max(1));
                 let timeout = Duration::from_millis(health.timeout_ms.max(1));
                 let path: &str = if health.path.is_empty() {
@@ -3189,6 +3204,34 @@ where
     } else {
         false
     }
+}
+
+fn spawn_supervised_async_task<F>(
+    handle: &Handle,
+    task_name: &'static str,
+    metrics: Option<Arc<Metrics>>,
+    fut: F,
+) where
+    F: Future<Output = ()> + Send + 'static,
+{
+    let task_name = task_name.to_string();
+    let join = handle.spawn(fut);
+    let monitor_handle = handle.clone();
+    monitor_handle.spawn(async move {
+        match join.await {
+            Ok(()) => {}
+            Err(err) => {
+                if let Some(metrics) = metrics {
+                    metrics.inc_runtime_panic();
+                }
+                if err.is_panic() {
+                    error!("Background task '{}' panicked", task_name);
+                } else {
+                    warn!("Background task '{}' cancelled", task_name);
+                }
+            }
+        }
+    });
 }
 
 fn fallback_runtime() -> Option<&'static tokio::runtime::Runtime> {

--- a/spooky/src/main.rs
+++ b/spooky/src/main.rs
@@ -1,5 +1,7 @@
 //! Spooky HTTP/3 Load Balancer - Main Entry Point
 
+mod runtime_guard;
+
 use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
@@ -54,6 +56,7 @@ async fn main() {
         config_yaml.log.file.enabled,
         &config_yaml.log.file.path,
     );
+    runtime_guard::install_panic_hook();
 
     // Validate Configurations
     if !validate_config(&config_yaml) {
@@ -156,23 +159,39 @@ async fn main() {
         }
     }
 
+    let mut worker_failed = false;
+    let mut active_worker_handles = worker_handles;
     while !shutdown.load(Ordering::Relaxed) {
+        let mut idx = 0usize;
+        while idx < active_worker_handles.len() {
+            if !active_worker_handles[idx].is_finished() {
+                idx += 1;
+                continue;
+            }
+
+            let handle = active_worker_handles.swap_remove(idx);
+            join_worker_handle(handle, &mut worker_failed);
+            if worker_failed {
+                shutdown.store(true, Ordering::Relaxed);
+                break;
+            }
+        }
+
+        if worker_failed {
+            break;
+        }
+
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
 
-    let mut worker_failed = false;
-    for handle in worker_handles {
-        match handle.join() {
-            Ok(Ok(())) => {}
-            Ok(Err(err)) => {
-                worker_failed = true;
-                error!("Worker exited with error: {}", err);
-            }
-            Err(_) => {
-                worker_failed = true;
-                error!("Worker thread panicked");
-            }
-        }
+    for handle in active_worker_handles {
+        join_worker_handle(handle, &mut worker_failed);
+    }
+
+    let panic_count = runtime_guard::panic_count();
+    if panic_count > 0 {
+        worker_failed = true;
+        error!("Process captured {} panic(s) via panic hook", panic_count);
     }
 
     if worker_failed {
@@ -199,5 +218,22 @@ fn maybe_pin_worker(worker_idx: usize, pin_workers: bool) {
     let core_id = core_ids[worker_idx % core_ids.len()];
     if !core_affinity::set_for_current(core_id) {
         warn!("Failed to pin worker {} to core {}", worker_idx, core_id.id);
+    }
+}
+
+fn join_worker_handle(handle: thread::JoinHandle<Result<(), String>>, worker_failed: &mut bool) {
+    match handle.join() {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => {
+            *worker_failed = true;
+            error!("Worker exited with error: {}", err);
+        }
+        Err(payload) => {
+            *worker_failed = true;
+            error!(
+                "Worker thread panicked: {}",
+                runtime_guard::panic_payload_message(payload.as_ref())
+            );
+        }
     }
 }

--- a/spooky/src/runtime_guard.rs
+++ b/spooky/src/runtime_guard.rs
@@ -1,0 +1,80 @@
+use std::any::Any;
+use std::panic::{self, PanicHookInfo};
+use std::sync::Once;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use log::error;
+
+static PANIC_COUNT: AtomicU64 = AtomicU64::new(0);
+static PANIC_HOOK_ONCE: Once = Once::new();
+
+pub fn install_panic_hook() {
+    PANIC_HOOK_ONCE.call_once(|| {
+        let previous = panic::take_hook();
+        panic::set_hook(Box::new(move |info| {
+            PANIC_COUNT.fetch_add(1, Ordering::Relaxed);
+            error!("panic captured: {}", format_panic_info(info));
+            previous(info);
+        }));
+    });
+}
+
+pub fn panic_count() -> u64 {
+    PANIC_COUNT.load(Ordering::Relaxed)
+}
+
+pub fn panic_payload_message(payload: &(dyn Any + Send + 'static)) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        return (*message).to_string();
+    }
+    if let Some(message) = payload.downcast_ref::<String>() {
+        return message.clone();
+    }
+    "non-string panic payload".to_string()
+}
+
+fn format_panic_info(info: &PanicHookInfo<'_>) -> String {
+    let location = info
+        .location()
+        .map(|loc| format!("{}:{}:{}", loc.file(), loc.line(), loc.column()))
+        .unwrap_or_else(|| "unknown-location".to_string());
+    let message = panic_message(info);
+    format!("{message} at {location}")
+}
+
+fn panic_message(info: &PanicHookInfo<'_>) -> String {
+    let payload = info.payload();
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        return (*message).to_string();
+    }
+    if let Some(message) = payload.downcast_ref::<String>() {
+        return message.clone();
+    }
+    "panic with non-string payload".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::panic_payload_message;
+
+    #[test]
+    fn panic_payload_message_supports_str_and_string() {
+        let str_payload: Box<dyn std::any::Any + Send> = Box::new("panic-str");
+        assert_eq!(panic_payload_message(str_payload.as_ref()), "panic-str");
+
+        let string_payload: Box<dyn std::any::Any + Send> = Box::new("panic-string".to_string());
+        assert_eq!(
+            panic_payload_message(string_payload.as_ref()),
+            "panic-string"
+        );
+    }
+
+    #[test]
+    fn panic_payload_message_handles_non_string_payload() {
+        let int_payload: Box<dyn std::any::Any + Send> = Box::new(42_u64);
+        assert_eq!(
+            panic_payload_message(int_payload.as_ref()),
+            "non-string panic payload"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
This PR hardens startup/runtime failure behavior so panic-prone paths are detected and surfaced early, and adds CI enforcement to prevent new `unwrap`/`expect` usage in runtime targets.

## Changes
- Added runtime panic guard module:
  - Installs a global panic hook after logger initialization.
  - Captures panic count and logs structured panic details.
  - Extracts panic payloads for actionable worker panic logs.
- Hardened worker supervision in main runtime:
  - Polls and joins finished worker threads during runtime (not only at shutdown).
  - Fails fast when a worker exits with error/panic.
  - Marks process failed if panic hook observed panics.
- Added supervised control-plane task spawning:
  - Metrics endpoint, watchdog, and health-check loops are now monitored.
  - Task panic/cancellation is logged explicitly.
  - Runtime panic events increment a dedicated metric.
- Added new metric:
  - `spooky_runtime_panics` (counter)
- Added CI lint gate for runtime targets:
  - `cargo clippy --workspace --lib --bins -- -D clippy::unwrap_used -D clippy::expect_used`

## Why
Critical paths must not crash silently under recoverable runtime faults. This improves resilience/observability and makes panic regression detectable in CI before merge.

## Validation
Executed locally:
- `cargo fmt`
- `cargo test -p spooky-edge --lib`
- `cargo test -p spooky --bin spooky`
- `cargo clippy --workspace --lib --bins -- -D clippy::unwrap_used -D clippy::expect_used`

## Notes
- CI gate intentionally scopes to `--lib --bins` so runtime code is enforced without forcing immediate refactors in existing test-only `unwrap/expect` usage.