### PR TITLE
Add sharded QUIC ingress dispatch with bounded queues and ingress pressure metrics

### DIFF
--- a/config/config.minimal.yaml
+++ b/config/config.minimal.yaml
@@ -14,3 +14,7 @@ upstream:
         address: "http://127.0.0.1:8080"  # explicit cleartext for local/dev; omit scheme for verified HTTPS default
         health_check:
           path: "/health"
+
+performance:
+  packet_shards_per_worker: 1
+  packet_shard_queue_capacity: 2048

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -58,6 +58,8 @@ log:
 performance:
     worker_threads: 1
     control_plane_threads: 2
+    packet_shards_per_worker: 1
+    packet_shard_queue_capacity: 2048
     reuseport: true
     pin_workers: false
     global_inflight_limit: 4096

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -14,6 +14,7 @@ use crate::default::{
     perf_default_global_inflight_limit, perf_default_h2_pool_idle_timeout_ms,
     perf_default_h2_pool_max_idle_per_backend, perf_default_max_response_body_bytes,
     perf_default_new_connections_burst, perf_default_new_connections_per_sec,
+    perf_default_packet_shard_queue_capacity, perf_default_packet_shards_per_worker,
     perf_default_per_backend_inflight_limit, perf_default_per_upstream_inflight_limit,
     perf_default_pin_workers, perf_default_quic_initial_max_data,
     perf_default_quic_initial_max_stream_data, perf_default_quic_initial_max_streams_bidi,
@@ -180,6 +181,15 @@ pub struct Performance {
     #[serde(default = "perf_default_control_plane_threads")]
     pub control_plane_threads: usize,
 
+    /// Number of packet-processing shards per bound UDP worker socket.
+    /// `1` preserves single-loop behavior; values >1 enable parallel shard workers.
+    #[serde(default = "perf_default_packet_shards_per_worker")]
+    pub packet_shards_per_worker: usize,
+
+    /// Capacity of bounded ingress queue per shard.
+    #[serde(default = "perf_default_packet_shard_queue_capacity")]
+    pub packet_shard_queue_capacity: usize,
+
     #[serde(default = "perf_default_reuseport")]
     pub reuseport: bool,
 
@@ -268,6 +278,8 @@ impl Default for Performance {
         Self {
             worker_threads: perf_default_worker_threads(),
             control_plane_threads: perf_default_control_plane_threads(),
+            packet_shards_per_worker: perf_default_packet_shards_per_worker(),
+            packet_shard_queue_capacity: perf_default_packet_shard_queue_capacity(),
             reuseport: perf_default_reuseport(),
             pin_workers: perf_default_pin_workers(),
             global_inflight_limit: perf_default_global_inflight_limit(),

--- a/crates/config/src/default.rs
+++ b/crates/config/src/default.rs
@@ -78,6 +78,14 @@ pub fn perf_default_control_plane_threads() -> usize {
     2
 }
 
+pub fn perf_default_packet_shards_per_worker() -> usize {
+    1
+}
+
+pub fn perf_default_packet_shard_queue_capacity() -> usize {
+    2048
+}
+
 pub fn perf_default_reuseport() -> bool {
     true
 }

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -90,6 +90,16 @@ pub fn validate(config: &Config) -> bool {
         return false;
     }
 
+    if config.performance.packet_shards_per_worker == 0 {
+        error!("performance.packet_shards_per_worker must be greater than 0");
+        return false;
+    }
+
+    if config.performance.packet_shard_queue_capacity == 0 {
+        error!("performance.packet_shard_queue_capacity must be greater than 0");
+        return false;
+    }
+
     if config.performance.worker_threads > 1 && !config.performance.reuseport {
         error!("performance.reuseport must be true when performance.worker_threads > 1");
         return false;
@@ -660,6 +670,8 @@ upstream:
         let cfg: Config = serde_yaml::from_str(&yaml).expect("parse");
         assert_eq!(cfg.performance.worker_threads, 1);
         assert_eq!(cfg.performance.control_plane_threads, 2);
+        assert_eq!(cfg.performance.packet_shards_per_worker, 1);
+        assert_eq!(cfg.performance.packet_shard_queue_capacity, 2048);
         assert!(cfg.performance.reuseport);
         assert!(!cfg.performance.pin_workers);
         assert_eq!(cfg.performance.global_inflight_limit, 4096);
@@ -698,6 +710,14 @@ upstream:
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.performance.worker_threads = 4;
         cfg.performance.reuseport = false;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.performance.packet_shards_per_worker = 0;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.performance.packet_shard_queue_capacity = 0;
         assert!(!validate(&cfg));
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
@@ -821,6 +841,8 @@ upstream:
         let mut cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.performance.worker_threads = 4;
         cfg.performance.control_plane_threads = 2;
+        cfg.performance.packet_shards_per_worker = 2;
+        cfg.performance.packet_shard_queue_capacity = 1024;
         cfg.performance.reuseport = true;
         cfg.performance.pin_workers = true;
         cfg.performance.global_inflight_limit = 10_000;

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -222,6 +222,8 @@ pub struct Metrics {
     pub backend_timeouts: AtomicU64,
     pub backend_errors: AtomicU64,
     pub overload_shed: AtomicU64,
+    pub ingress_packets_total: AtomicU64,
+    pub ingress_queue_drops: AtomicU64,
     pub scid_rotations: AtomicU64,
     pub watchdog_restart_requests: AtomicU64,
     pub watchdog_restart_hooks: AtomicU64,
@@ -266,6 +268,8 @@ impl Default for Metrics {
             backend_timeouts: AtomicU64::new(0),
             backend_errors: AtomicU64::new(0),
             overload_shed: AtomicU64::new(0),
+            ingress_packets_total: AtomicU64::new(0),
+            ingress_queue_drops: AtomicU64::new(0),
             scid_rotations: AtomicU64::new(0),
             watchdog_restart_requests: AtomicU64::new(0),
             watchdog_restart_hooks: AtomicU64::new(0),
@@ -298,6 +302,14 @@ impl Metrics {
 
     pub fn inc_overload_shed(&self) {
         self.overload_shed.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_ingress_packet(&self) {
+        self.ingress_packets_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_ingress_queue_drop(&self) {
+        self.ingress_queue_drops.fetch_add(1, Ordering::Relaxed);
     }
 
     pub fn inc_scid_rotation(&self) {
@@ -402,6 +414,22 @@ impl Metrics {
         out.push_str(&format!(
             "spooky_overload_shed {}\n",
             self.overload_shed.load(Ordering::Relaxed)
+        ));
+
+        out.push_str("# HELP spooky_ingress_packets_total Total UDP packets processed by ingress.\n");
+        out.push_str("# TYPE spooky_ingress_packets_total counter\n");
+        out.push_str(&format!(
+            "spooky_ingress_packets_total {}\n",
+            self.ingress_packets_total.load(Ordering::Relaxed)
+        ));
+
+        out.push_str(
+            "# HELP spooky_ingress_queue_drops Total ingress packets dropped due to full shard queues.\n",
+        );
+        out.push_str("# TYPE spooky_ingress_queue_drops counter\n");
+        out.push_str(&format!(
+            "spooky_ingress_queue_drops {}\n",
+            self.ingress_queue_drops.load(Ordering::Relaxed)
         ));
 
         out.push_str("# HELP spooky_scid_rotations Total SCID rotations.\n");

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -77,6 +77,12 @@ pub struct SharedRuntimeState {
     pub(crate) watchdog: Arc<WatchdogCoordinator>,
 }
 
+impl SharedRuntimeState {
+    pub fn inc_ingress_queue_drop(&self) {
+        self.metrics.inc_ingress_queue_drop();
+    }
+}
+
 pub struct QUICListener {
     pub socket: UdpSocket,
     pub config: Config,
@@ -416,7 +422,9 @@ impl Metrics {
             self.overload_shed.load(Ordering::Relaxed)
         ));
 
-        out.push_str("# HELP spooky_ingress_packets_total Total UDP packets processed by ingress.\n");
+        out.push_str(
+            "# HELP spooky_ingress_packets_total Total UDP packets processed by ingress.\n",
+        );
         out.push_str("# TYPE spooky_ingress_packets_total counter\n");
         out.push_str(&format!(
             "spooky_ingress_packets_total {}\n",

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -768,7 +768,7 @@ impl QUICListener {
         primary
     }
 
-    pub fn poll(&mut self) {
+    fn poll_preamble(&mut self) -> bool {
         self.watchdog.mark_poll_progress();
         if !self.watchdog.restart_requested() {
             self.watchdog_worker_drained = false;
@@ -782,6 +782,13 @@ impl QUICListener {
                 self.watchdog.mark_worker_drained();
                 self.watchdog_worker_drained = true;
             }
+            return false;
+        }
+        true
+    }
+
+    pub fn poll(&mut self) {
+        if !self.poll_preamble() {
             return;
         }
 
@@ -805,9 +812,28 @@ impl QUICListener {
             Err(_) => return,
         };
 
-        // let mut recv_data = self.recv_buf[..len].to_vec();
-        let mut recv_data = BytesMut::from(&self.recv_buf[..len]);
+        let packet = self.recv_buf[..len].to_vec();
+        self.process_datagram_inner(peer, local_addr, &packet);
+    }
 
+    pub fn poll_idle(&mut self) {
+        if !self.poll_preamble() {
+            return;
+        }
+        self.handle_timeouts();
+    }
+
+    pub fn process_datagram(&mut self, peer: SocketAddr, local_addr: SocketAddr, packet: &[u8]) {
+        if !self.poll_preamble() {
+            return;
+        }
+        self.process_datagram_inner(peer, local_addr, packet);
+    }
+
+    fn process_datagram_inner(&mut self, peer: SocketAddr, local_addr: SocketAddr, packet: &[u8]) {
+        self.metrics.inc_ingress_packet();
+
+        let mut recv_data = BytesMut::from(packet);
         let header = match quiche::Header::from_slice(&mut recv_data, quiche::MAX_CONN_ID_LEN) {
             Ok(hdr) => hdr,
             Err(_) => {

--- a/spooky/src/main.rs
+++ b/spooky/src/main.rs
@@ -1,5 +1,9 @@
 //! Spooky HTTP/3 Load Balancer - Main Entry Point
 
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::net::SocketAddr;
+use std::sync::mpsc::{self, RecvTimeoutError, SyncSender, TrySendError};
 use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
@@ -10,7 +14,7 @@ use clap::Parser;
 use log::{error, info, warn};
 
 use spooky_config::validator::validate as validate_config;
-use spooky_edge::{QUICListener, configure_async_runtime};
+use spooky_edge::{QUICListener, SharedRuntimeState, configure_async_runtime};
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
@@ -18,6 +22,12 @@ struct Cli {
     // Sets a custom config file
     #[arg(short, long)]
     config: Option<String>,
+}
+
+struct IngressPacket {
+    peer: SocketAddr,
+    local_addr: SocketAddr,
+    bytes: Vec<u8>,
 }
 
 #[tokio::main]
@@ -72,6 +82,7 @@ async fn main() {
     };
 
     let requested_workers = config_yaml.performance.worker_threads.max(1);
+    let shard_count = config_yaml.performance.packet_shards_per_worker.max(1);
     let worker_count = if requested_workers > 1 && !config_yaml.performance.reuseport {
         warn!(
             "reuseport disabled while worker_threads={} configured; running a single data-plane worker",
@@ -81,7 +92,8 @@ async fn main() {
     } else {
         requested_workers
     };
-    QUICListener::spawn_control_plane_tasks(&config_yaml, &shared_state, worker_count);
+    let effective_worker_count = worker_count.saturating_mul(shard_count);
+    QUICListener::spawn_control_plane_tasks(&config_yaml, &shared_state, effective_worker_count);
 
     let sockets = if worker_count > 1 {
         match QUICListener::bind_reuseport_sockets(&config_yaml, worker_count) {
@@ -103,8 +115,9 @@ async fn main() {
 
     info!("Spooky is starting");
     info!(
-        "Data-plane workers={} reuseport={} pin_workers={}",
+        "Data-plane workers={} packet_shards_per_worker={} reuseport={} pin_workers={}",
         sockets.len(),
+        shard_count,
         config_yaml.performance.reuseport,
         config_yaml.performance.pin_workers
     );
@@ -118,6 +131,7 @@ async fn main() {
     });
 
     let pin_workers = config_yaml.performance.pin_workers;
+    let shard_queue_capacity = config_yaml.performance.packet_shard_queue_capacity.max(1);
     let mut worker_handles = Vec::with_capacity(sockets.len());
     for (worker_idx, socket) in sockets.into_iter().enumerate() {
         let worker_config = config_yaml.clone();
@@ -126,23 +140,27 @@ async fn main() {
         let thread_name = format!("spooky-data-plane-{}", worker_idx);
         let handle = thread::Builder::new().name(thread_name.clone()).spawn(
             move || -> Result<(), String> {
-                maybe_pin_worker(worker_idx, pin_workers);
-                let mut listener = QUICListener::new_with_socket_and_shared_state(
+                if shard_count <= 1 {
+                    return run_single_listener_worker(
+                        worker_idx,
+                        pin_workers,
+                        worker_config,
+                        socket,
+                        worker_shared,
+                        worker_shutdown,
+                    );
+                }
+
+                run_sharded_listener_worker(
+                    worker_idx,
+                    shard_count,
+                    shard_queue_capacity,
+                    pin_workers,
                     worker_config,
                     socket,
                     worker_shared,
+                    worker_shutdown,
                 )
-                .map_err(|err| format!("worker {} listener init failed: {}", worker_idx, err))?;
-
-                while !worker_shutdown.load(Ordering::Relaxed) {
-                    listener.poll();
-                }
-
-                listener.start_draining();
-                while !listener.drain_complete() {
-                    listener.poll();
-                }
-                Ok(())
             },
         );
 
@@ -179,6 +197,206 @@ async fn main() {
         std::process::exit(1);
     }
     info!("Spooky shutdown complete");
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_sharded_listener_worker(
+    worker_idx: usize,
+    shard_count: usize,
+    shard_queue_capacity: usize,
+    pin_workers: bool,
+    worker_config: spooky_config::config::Config,
+    socket: std::net::UdpSocket,
+    worker_shared: Arc<SharedRuntimeState>,
+    worker_shutdown: Arc<AtomicBool>,
+) -> Result<(), String> {
+    maybe_pin_worker(worker_idx, pin_workers);
+
+    let local_addr = socket
+        .local_addr()
+        .map_err(|err| format!("worker {} local_addr failed: {}", worker_idx, err))?;
+
+    let mut shard_handles = Vec::with_capacity(shard_count);
+    let mut shard_txs: Vec<SyncSender<IngressPacket>> = Vec::with_capacity(shard_count);
+
+    for shard_idx in 0..shard_count {
+        let shard_socket = socket.try_clone().map_err(|err| {
+            format!(
+                "worker {} shard {} socket clone failed: {}",
+                worker_idx, shard_idx, err
+            )
+        })?;
+        let shard_config = worker_config.clone();
+        let shard_shared = Arc::clone(&worker_shared);
+        let shard_shutdown = Arc::clone(&worker_shutdown);
+        let shard_thread_idx = worker_idx
+            .saturating_mul(shard_count)
+            .saturating_add(shard_idx);
+
+        let (tx, rx) = mpsc::sync_channel::<IngressPacket>(shard_queue_capacity);
+        shard_txs.push(tx);
+
+        let shard_name = format!("spooky-data-plane-{}-shard-{}", worker_idx, shard_idx);
+        let shard_handle = thread::Builder::new()
+            .name(shard_name)
+            .spawn(move || -> Result<(), String> {
+                maybe_pin_worker(shard_thread_idx, pin_workers);
+                let mut listener = QUICListener::new_with_socket_and_shared_state(
+                    shard_config,
+                    shard_socket,
+                    shard_shared,
+                )
+                .map_err(|err| {
+                    format!(
+                        "worker {} shard {} listener init failed: {}",
+                        worker_idx, shard_idx, err
+                    )
+                })?;
+
+                let idle_timeout = Duration::from_millis(10);
+                while !shard_shutdown.load(Ordering::Relaxed) {
+                    match rx.recv_timeout(idle_timeout) {
+                        Ok(packet) => {
+                            listener.process_datagram(
+                                packet.peer,
+                                packet.local_addr,
+                                &packet.bytes,
+                            );
+                        }
+                        Err(RecvTimeoutError::Timeout) => {
+                            listener.poll_idle();
+                        }
+                        Err(RecvTimeoutError::Disconnected) => {
+                            break;
+                        }
+                    }
+                }
+
+                listener.start_draining();
+                while !listener.drain_complete() {
+                    listener.poll_idle();
+                }
+                Ok(())
+            })
+            .map_err(|err| {
+                format!(
+                    "failed to spawn worker {} shard {}: {}",
+                    worker_idx, shard_idx, err
+                )
+            })?;
+        shard_handles.push(shard_handle);
+    }
+
+    let mut recv_buf = [0u8; 65_535];
+    while !worker_shutdown.load(Ordering::Relaxed) {
+        match socket.recv_from(&mut recv_buf) {
+            Ok((len, peer)) => {
+                if len == 0 {
+                    continue;
+                }
+                let shard_idx = shard_index_for_peer(&peer, shard_count);
+                let packet = IngressPacket {
+                    peer,
+                    local_addr,
+                    bytes: recv_buf[..len].to_vec(),
+                };
+                match shard_txs[shard_idx].try_send(packet) {
+                    Ok(()) => {}
+                    Err(TrySendError::Full(_packet)) => {
+                        worker_shared.inc_ingress_queue_drop();
+                    }
+                    Err(TrySendError::Disconnected(_packet)) => {
+                        return Err(format!(
+                            "worker {} shard {} dispatch channel disconnected",
+                            worker_idx, shard_idx
+                        ));
+                    }
+                }
+            }
+            Err(ref e)
+                if e.kind() == std::io::ErrorKind::WouldBlock
+                    || e.kind() == std::io::ErrorKind::TimedOut => {}
+            Err(err) => {
+                return Err(format!(
+                    "worker {} ingress recv failed: {}",
+                    worker_idx, err
+                ));
+            }
+        }
+    }
+
+    drop(shard_txs);
+
+    let mut shard_failed = false;
+    for handle in shard_handles {
+        match handle.join() {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => {
+                shard_failed = true;
+                error!("Worker {} shard exited with error: {}", worker_idx, err);
+            }
+            Err(_) => {
+                shard_failed = true;
+                error!("Worker {} shard thread panicked", worker_idx);
+            }
+        }
+    }
+    if shard_failed {
+        Err(format!("worker {} had failing shard(s)", worker_idx))
+    } else {
+        Ok(())
+    }
+}
+
+fn run_single_listener_worker(
+    worker_idx: usize,
+    pin_workers: bool,
+    worker_config: spooky_config::config::Config,
+    socket: std::net::UdpSocket,
+    worker_shared: Arc<SharedRuntimeState>,
+    worker_shutdown: Arc<AtomicBool>,
+) -> Result<(), String> {
+    maybe_pin_worker(worker_idx, pin_workers);
+    let mut listener =
+        QUICListener::new_with_socket_and_shared_state(worker_config, socket, worker_shared)
+            .map_err(|err| format!("worker {} listener init failed: {}", worker_idx, err))?;
+
+    while !worker_shutdown.load(Ordering::Relaxed) {
+        listener.poll();
+    }
+
+    listener.start_draining();
+    while !listener.drain_complete() {
+        listener.poll();
+    }
+    Ok(())
+}
+
+fn shard_index_for_peer(peer: &SocketAddr, shard_count: usize) -> usize {
+    let mut hasher = DefaultHasher::new();
+    peer.hash(&mut hasher);
+    (hasher.finish() as usize) % shard_count.max(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::shard_index_for_peer;
+    use std::net::SocketAddr;
+
+    #[test]
+    fn shard_index_is_stable_for_same_peer() {
+        let peer: SocketAddr = "127.0.0.1:12345".parse().expect("peer addr");
+        let a = shard_index_for_peer(&peer, 8);
+        let b = shard_index_for_peer(&peer, 8);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn shard_index_is_within_bounds() {
+        let peer: SocketAddr = "10.1.2.3:443".parse().expect("peer addr");
+        let idx = shard_index_for_peer(&peer, 16);
+        assert!(idx < 16);
+    }
 }
 
 fn maybe_pin_worker(worker_idx: usize, pin_workers: bool) {


### PR DESCRIPTION
## Summary
This PR removes the single-loop UDP packet ingress bottleneck by introducing per-worker sharded ingress dispatch while preserving existing QUIC/H3 handling logic.

## What changed

### 1) Config + validation for ingress sharding
Added new performance controls:
- `performance.packet_shards_per_worker` (default `1`)
- `performance.packet_shard_queue_capacity` (default `2048`)

Validation now rejects `0` values for both fields.

### 2) Ingress visibility metrics
Added counters:
- `spooky_ingress_packets_total`
- `spooky_ingress_queue_drops`

These expose packet flow and queue-pressure drops in Prometheus output.

### 3) QUIC listener API refactor for external dispatch
Refactored listener to support externally fed datagrams:
- `process_datagram(peer, local_addr, packet)`
- `poll_idle()` (timeout/progress without socket recv)
- Shared internal packet processing path used by both `poll()` and external dispatch

### 4) Runtime sharded ingress model
For `packet_shards_per_worker > 1`, each UDP worker now:
- keeps a single ingress recv loop on its bound socket
- dispatches packets into bounded per-shard queues
- runs N shard threads, each with its own `QUICListener`
- tracks queue overflow as ingress drops

Current shard routing strategy: hash by peer `SocketAddr` (stable and cheap).

## Backward compatibility
- Default settings (`packet_shards_per_worker: 1`) preserve existing behavior.
- Sharded mode is opt-in via config.
