### PR TITLE
Adaptive admission hardening: global queue caps and deterministic overload shedding

### DIFF
--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -98,6 +98,8 @@ resilience:
         high_latency_ms: 250
     route_queue:
         default_cap: 512
+        global_cap: 2048
+        shed_retry_after_seconds: 1
         caps: {}
     circuit_breaker:
         enabled: true

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -29,6 +29,8 @@ use crate::default::{
     resilience_default_cb_open_ms, resilience_default_hedging_delay_ms,
     resilience_default_hedging_enabled, resilience_default_retry_budget_enabled,
     resilience_default_retry_budget_ratio_percent, resilience_default_route_queue_default_cap,
+    resilience_default_route_queue_global_cap,
+    resilience_default_route_queue_shed_retry_after_seconds,
     resilience_default_watchdog_check_interval_ms, resilience_default_watchdog_drain_grace_ms,
     resilience_default_watchdog_enabled, resilience_default_watchdog_min_requests_per_window,
     resilience_default_watchdog_overload_inflight_percent,
@@ -357,6 +359,10 @@ impl Default for AdaptiveAdmission {
 pub struct RouteQueue {
     #[serde(default = "resilience_default_route_queue_default_cap")]
     pub default_cap: usize,
+    #[serde(default = "resilience_default_route_queue_global_cap")]
+    pub global_cap: usize,
+    #[serde(default = "resilience_default_route_queue_shed_retry_after_seconds")]
+    pub shed_retry_after_seconds: u32,
     #[serde(default)]
     pub caps: HashMap<String, usize>,
 }
@@ -365,6 +371,8 @@ impl Default for RouteQueue {
     fn default() -> Self {
         Self {
             default_cap: resilience_default_route_queue_default_cap(),
+            global_cap: resilience_default_route_queue_global_cap(),
+            shed_retry_after_seconds: resilience_default_route_queue_shed_retry_after_seconds(),
             caps: HashMap::new(),
         }
     }

--- a/crates/config/src/default.rs
+++ b/crates/config/src/default.rs
@@ -194,6 +194,14 @@ pub fn resilience_default_route_queue_default_cap() -> usize {
     512
 }
 
+pub fn resilience_default_route_queue_global_cap() -> usize {
+    2048
+}
+
+pub fn resilience_default_route_queue_shed_retry_after_seconds() -> u32 {
+    1
+}
+
 pub fn resilience_default_cb_enabled() -> bool {
     true
 }

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -255,6 +255,16 @@ pub fn validate(config: &Config) -> bool {
         return false;
     }
 
+    if config.resilience.route_queue.global_cap == 0 {
+        error!("resilience.route_queue.global_cap must be greater than 0");
+        return false;
+    }
+
+    if config.resilience.route_queue.shed_retry_after_seconds == 0 {
+        error!("resilience.route_queue.shed_retry_after_seconds must be greater than 0");
+        return false;
+    }
+
     if config
         .resilience
         .route_queue
@@ -679,6 +689,8 @@ upstream:
         assert_eq!(cfg.observability.metrics.path, "/metrics");
         assert!(cfg.resilience.adaptive_admission.enabled);
         assert_eq!(cfg.resilience.route_queue.default_cap, 512);
+        assert_eq!(cfg.resilience.route_queue.global_cap, 2048);
+        assert_eq!(cfg.resilience.route_queue.shed_retry_after_seconds, 1);
         assert!(!cfg.resilience.watchdog.enabled);
         assert_eq!(cfg.resilience.watchdog.check_interval_ms, 1_000);
     }
@@ -782,6 +794,14 @@ upstream:
         assert!(!validate(&cfg));
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.resilience.route_queue.global_cap = 0;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.resilience.route_queue.shed_retry_after_seconds = 0;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.resilience.retry_budget.ratio_percent = 101;
         assert!(!validate(&cfg));
 
@@ -837,6 +857,8 @@ upstream:
         cfg.performance.h2_pool_idle_timeout_ms = 120_000;
         cfg.performance.per_backend_inflight_limit = 32;
         cfg.resilience.route_queue.default_cap = 256;
+        cfg.resilience.route_queue.global_cap = 2048;
+        cfg.resilience.route_queue.shed_retry_after_seconds = 2;
         cfg.resilience.retry_budget.ratio_percent = 30;
         cfg.observability = Observability {
             metrics: MetricsEndpoint {

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -49,7 +49,7 @@ use crate::{
         scid_rotation_interval,
     },
     outcome_from_status,
-    resilience::RuntimeResilience,
+    resilience::{RouteQueueRejection, RuntimeResilience},
     route_index::RouteIndex,
     watchdog::{WatchdogCoordinator, WatchdogRuntimeConfig, now_millis},
 };
@@ -1215,12 +1215,12 @@ impl QUICListener {
                                     request_start.elapsed(),
                                     RouteOutcome::OverloadShed,
                                 );
-                                Self::send_simple_response(
+                                Self::send_overload_response(
                                     h3,
                                     &mut connection.quic,
                                     stream_id,
-                                    http::StatusCode::SERVICE_UNAVAILABLE,
                                     b"brownout active, non-core route shed\n",
+                                    resilience.shed_retry_after_seconds,
                                 )?;
                                 resilience
                                     .adaptive_admission
@@ -1239,12 +1239,12 @@ impl QUICListener {
                                         request_start.elapsed(),
                                         RouteOutcome::OverloadShed,
                                     );
-                                    Self::send_simple_response(
+                                    Self::send_overload_response(
                                         h3,
                                         &mut connection.quic,
                                         stream_id,
-                                        http::StatusCode::SERVICE_UNAVAILABLE,
                                         b"adaptive admission overload\n",
+                                        resilience.shed_retry_after_seconds,
                                     )?;
                                     resilience
                                         .adaptive_admission
@@ -1255,8 +1255,8 @@ impl QUICListener {
 
                             let route_queue_permit =
                                 match resilience.route_queue.try_acquire(&upstream_name) {
-                                    Some(permit) => permit,
-                                    None => {
+                                    Ok(permit) => permit,
+                                    Err(RouteQueueRejection::RouteCap) => {
                                         metrics.inc_failure();
                                         metrics.inc_overload_shed();
                                         metrics.record_route(
@@ -1264,12 +1264,32 @@ impl QUICListener {
                                             request_start.elapsed(),
                                             RouteOutcome::OverloadShed,
                                         );
-                                        Self::send_simple_response(
+                                        Self::send_overload_response(
                                             h3,
                                             &mut connection.quic,
                                             stream_id,
-                                            http::StatusCode::SERVICE_UNAVAILABLE,
                                             b"route queue cap exceeded\n",
+                                            resilience.shed_retry_after_seconds,
+                                        )?;
+                                        resilience
+                                            .adaptive_admission
+                                            .observe(request_start.elapsed(), true);
+                                        continue;
+                                    }
+                                    Err(RouteQueueRejection::GlobalCap) => {
+                                        metrics.inc_failure();
+                                        metrics.inc_overload_shed();
+                                        metrics.record_route(
+                                            &upstream_name,
+                                            request_start.elapsed(),
+                                            RouteOutcome::OverloadShed,
+                                        );
+                                        Self::send_overload_response(
+                                            h3,
+                                            &mut connection.quic,
+                                            stream_id,
+                                            b"global queue cap exceeded\n",
+                                            resilience.shed_retry_after_seconds,
                                         )?;
                                         resilience
                                             .adaptive_admission
@@ -1289,12 +1309,12 @@ impl QUICListener {
                                             request_start.elapsed(),
                                             RouteOutcome::OverloadShed,
                                         );
-                                        Self::send_simple_response(
+                                        Self::send_overload_response(
                                             h3,
                                             &mut connection.quic,
                                             stream_id,
-                                            http::StatusCode::SERVICE_UNAVAILABLE,
                                             b"overloaded, retry later\n",
+                                            resilience.shed_retry_after_seconds,
                                         )?;
                                         resilience
                                             .adaptive_admission
@@ -1316,12 +1336,12 @@ impl QUICListener {
                                                 request_start.elapsed(),
                                                 RouteOutcome::OverloadShed,
                                             );
-                                            Self::send_simple_response(
+                                            Self::send_overload_response(
                                                 h3,
                                                 &mut connection.quic,
                                                 stream_id,
-                                                http::StatusCode::SERVICE_UNAVAILABLE,
                                                 b"upstream overloaded, retry later\n",
+                                                resilience.shed_retry_after_seconds,
                                             )?;
                                             resilience
                                                 .adaptive_admission
@@ -1364,12 +1384,12 @@ impl QUICListener {
                                         request_start.elapsed(),
                                         RouteOutcome::OverloadShed,
                                     );
-                                    Self::send_simple_response(
+                                    Self::send_overload_response(
                                         h3,
                                         &mut connection.quic,
                                         stream_id,
-                                        http::StatusCode::SERVICE_UNAVAILABLE,
                                         b"backend overloaded, retry later\n",
+                                        resilience.shed_retry_after_seconds,
                                     )?;
                                     resilience
                                         .adaptive_admission
@@ -1775,12 +1795,12 @@ impl QUICListener {
                                     req.start.elapsed(),
                                     RouteOutcome::OverloadShed,
                                 );
-                                Self::send_simple_response(
+                                Self::send_overload_response(
                                     h3,
                                     &mut connection.quic,
                                     stream_id,
-                                    http::StatusCode::SERVICE_UNAVAILABLE,
                                     b"request body backpressure overload\n",
+                                    resilience.shed_retry_after_seconds,
                                 )?;
                                 resilience
                                     .adaptive_admission
@@ -1907,6 +1927,7 @@ impl QUICListener {
                     upstream_pools,
                     routing_index,
                     metrics,
+                    resilience.shed_retry_after_seconds,
                 ) {
                     error!(
                         "failed to emit timeout response for stream {}: {:?}",
@@ -2045,6 +2066,7 @@ impl QUICListener {
                                         upstream_pools,
                                         routing_index,
                                         metrics,
+                                        resilience.shed_retry_after_seconds,
                                     ) {
                                         error!(
                                             "failed to emit protocol recovery response on stream {}: {:?}",
@@ -2244,6 +2266,7 @@ impl QUICListener {
                                 upstream_pools,
                                 routing_index,
                                 metrics,
+                                resilience.shed_retry_after_seconds,
                             ) {
                                 error!(
                                     "failed to emit recoverable forward error response on stream {}: {:?}",
@@ -2555,6 +2578,7 @@ impl QUICListener {
         upstream_pools: &HashMap<String, Arc<Mutex<UpstreamPool>>>,
         routing_index: &RouteIndex,
         metrics: &Metrics,
+        overload_retry_after_seconds: u32,
     ) -> Result<(), quiche::h3::Error> {
         let start = req.start;
         let route_label = req.upstream_name.as_deref().unwrap_or("unrouted");
@@ -2624,12 +2648,12 @@ impl QUICListener {
                     backend_addr,
                     start.elapsed().as_millis()
                 );
-                Self::send_simple_response(
+                Self::send_overload_response(
                     h3,
                     quic,
                     stream_id,
-                    http::StatusCode::SERVICE_UNAVAILABLE,
                     b"backend overloaded, retry later\n",
+                    overload_retry_after_seconds,
                 )
             }
             Err(ProxyError::Pool(PoolError::CircuitOpen(_))) => {
@@ -2642,12 +2666,12 @@ impl QUICListener {
                     backend_addr,
                     start.elapsed().as_millis()
                 );
-                Self::send_simple_response(
+                Self::send_overload_response(
                     h3,
                     quic,
                     stream_id,
-                    http::StatusCode::SERVICE_UNAVAILABLE,
                     b"backend circuit open, retry later\n",
+                    overload_retry_after_seconds,
                 )
             }
             Err(ProxyError::Transport(_))
@@ -2748,6 +2772,29 @@ impl QUICListener {
         let resp_headers = vec![
             quiche::h3::Header::new(b":status", status.as_str().as_bytes()),
             quiche::h3::Header::new(b"content-type", b"text/plain"),
+            quiche::h3::Header::new(b"content-length", body.len().to_string().as_bytes()),
+        ];
+
+        h3.send_response(quic, stream_id, &resp_headers, false)?;
+        h3.send_body(quic, stream_id, body, true)?;
+        Ok(())
+    }
+
+    fn send_overload_response(
+        h3: &mut quiche::h3::Connection,
+        quic: &mut quiche::Connection,
+        stream_id: u64,
+        body: &[u8],
+        retry_after_seconds: u32,
+    ) -> Result<(), quiche::h3::Error> {
+        let retry_after = retry_after_seconds.max(1).to_string();
+        let resp_headers = vec![
+            quiche::h3::Header::new(
+                b":status",
+                http::StatusCode::SERVICE_UNAVAILABLE.as_str().as_bytes(),
+            ),
+            quiche::h3::Header::new(b"content-type", b"text/plain"),
+            quiche::h3::Header::new(b"retry-after", retry_after.as_bytes()),
             quiche::h3::Header::new(b"content-length", body.len().to_string().as_bytes()),
         ];
 

--- a/crates/edge/src/resilience.rs
+++ b/crates/edge/src/resilience.rs
@@ -105,33 +105,57 @@ impl Drop for AdaptivePermit {
 
 pub struct RouteQueueLimiter {
     default_cap: usize,
+    global_cap: usize,
     caps: HashMap<String, usize>,
-    inflight: Mutex<HashMap<String, usize>>,
+    inflight: Mutex<RouteQueueState>,
+}
+
+#[derive(Default)]
+struct RouteQueueState {
+    total: usize,
+    by_route: HashMap<String, usize>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum RouteQueueRejection {
+    GlobalCap,
+    RouteCap,
 }
 
 impl RouteQueueLimiter {
-    pub fn new(default_cap: usize, caps: HashMap<String, usize>) -> Self {
+    pub fn new(default_cap: usize, global_cap: usize, caps: HashMap<String, usize>) -> Self {
         Self {
             default_cap: default_cap.max(1),
+            global_cap: global_cap.max(1),
             caps,
-            inflight: Mutex::new(HashMap::new()),
+            inflight: Mutex::new(RouteQueueState::default()),
         }
     }
 
-    pub fn try_acquire(self: &Arc<Self>, route: &str) -> Option<RouteQueuePermit> {
+    pub fn try_acquire(
+        self: &Arc<Self>,
+        route: &str,
+    ) -> Result<RouteQueuePermit, RouteQueueRejection> {
         let cap = self
             .caps
             .get(route)
             .copied()
             .unwrap_or(self.default_cap)
             .max(1);
-        let mut guard = self.inflight.lock().ok()?;
-        let current = guard.get(route).copied().unwrap_or(0);
-        if current >= cap {
-            return None;
+        let mut guard = self
+            .inflight
+            .lock()
+            .map_err(|_| RouteQueueRejection::GlobalCap)?;
+        if guard.total >= self.global_cap {
+            return Err(RouteQueueRejection::GlobalCap);
         }
-        guard.insert(route.to_string(), current + 1);
-        Some(RouteQueuePermit {
+        let current = guard.by_route.get(route).copied().unwrap_or(0);
+        if current >= cap {
+            return Err(RouteQueueRejection::RouteCap);
+        }
+        guard.total = guard.total.saturating_add(1);
+        guard.by_route.insert(route.to_string(), current + 1);
+        Ok(RouteQueuePermit {
             limiter: Arc::clone(self),
             route: route.to_string(),
         })
@@ -146,12 +170,13 @@ pub struct RouteQueuePermit {
 impl Drop for RouteQueuePermit {
     fn drop(&mut self) {
         if let Ok(mut guard) = self.limiter.inflight.lock()
-            && let Some(current) = guard.get_mut(&self.route)
+            && let Some(current) = guard.by_route.get_mut(&self.route)
         {
             *current = current.saturating_sub(1);
             if *current == 0 {
-                guard.remove(&self.route);
+                guard.by_route.remove(&self.route);
             }
+            guard.total = guard.total.saturating_sub(1);
         }
     }
 }
@@ -395,6 +420,7 @@ pub struct RuntimeResilience {
     pub circuit_breakers: Arc<CircuitBreakers>,
     pub retry_budget: Arc<RetryBudget>,
     pub brownout: Arc<BrownoutController>,
+    pub shed_retry_after_seconds: u32,
     pub hedging_enabled: bool,
     pub hedging_delay: Duration,
     safe_methods: HashSet<String>,
@@ -414,6 +440,7 @@ impl RuntimeResilience {
         ));
         let route_queue = Arc::new(RouteQueueLimiter::new(
             config.route_queue.default_cap,
+            config.route_queue.global_cap,
             config.route_queue.caps.clone(),
         ));
         let cb = &config.circuit_breaker;
@@ -454,6 +481,7 @@ impl RuntimeResilience {
             circuit_breakers,
             retry_budget,
             brownout,
+            shed_retry_after_seconds: config.route_queue.shed_retry_after_seconds.max(1),
             hedging_enabled: config.hedging.enabled,
             hedging_delay: Duration::from_millis(config.hedging.delay_ms.max(1)),
             safe_methods,
@@ -489,9 +517,23 @@ mod tests {
 
     #[test]
     fn route_queue_cap_enforced() {
-        let limiter = Arc::new(RouteQueueLimiter::new(1, HashMap::new()));
+        let limiter = Arc::new(RouteQueueLimiter::new(1, 10, HashMap::new()));
         let _p1 = limiter.try_acquire("api").expect("first permit");
-        assert!(limiter.try_acquire("api").is_none());
+        assert!(matches!(
+            limiter.try_acquire("api"),
+            Err(RouteQueueRejection::RouteCap)
+        ));
+    }
+
+    #[test]
+    fn route_queue_global_cap_enforced() {
+        let limiter = Arc::new(RouteQueueLimiter::new(10, 2, HashMap::new()));
+        let _p1 = limiter.try_acquire("api").expect("first permit");
+        let _p2 = limiter.try_acquire("admin").expect("second permit");
+        assert!(matches!(
+            limiter.try_acquire("api"),
+            Err(RouteQueueRejection::GlobalCap)
+        ));
     }
 
     #[test]

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -2090,6 +2090,52 @@ fn global_inflight_limit_sheds_excess_requests() {
 }
 
 #[test]
+fn route_queue_global_cap_sheds_excess_requests() {
+    let dir = tempdir().expect("failed to create temp dir");
+    let (cert, key) = write_test_certs(&dir);
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+
+    let backend_addr = rt.block_on(start_h2_backend_with_regression_routes());
+    let mut config = make_config(0, backend_addr.to_string(), cert, key);
+    config.performance.global_inflight_limit = 64;
+    config.performance.per_upstream_inflight_limit = 64;
+    config.resilience.route_queue.default_cap = 64;
+    config.resilience.route_queue.global_cap = 1;
+
+    let listener = QUICListener::new(config).expect("failed to create listener");
+    let listen_addr = listener.socket.local_addr().unwrap();
+    let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
+
+    let observations = run_h3_client_concurrent_get(
+        listen_addr,
+        &["/slow", "/slow"],
+        Duration::from_secs(REQUEST_TIMEOUT_SECS + 4),
+    )
+    .expect("concurrent requests should complete");
+
+    let mut status_200 = 0usize;
+    let mut status_503 = 0usize;
+    let mut shed_body = String::new();
+    for obs in &observations {
+        match obs.status.as_deref() {
+            Some("200") => status_200 += 1,
+            Some("503") => {
+                status_503 += 1;
+                shed_body = String::from_utf8_lossy(&obs.body).to_string();
+            }
+            other => panic!("unexpected status: {:?}", other),
+        }
+    }
+
+    assert_eq!(status_200, 1, "expected one successful request");
+    assert_eq!(status_503, 1, "expected one shed request");
+    assert!(
+        shed_body.contains("global queue cap exceeded"),
+        "shed body should mention global queue cap, got: {shed_body}"
+    );
+}
+
+#[test]
 fn upstream_inflight_limit_sheds_excess_requests() {
     let dir = tempdir().expect("failed to create temp dir");
     let (cert, key) = write_test_certs(&dir);


### PR DESCRIPTION
## Summary
This PR strengthens overload protection so traffic spikes do not turn into timeout storms.

## What changed
- Added a **global route-queue cap** on top of per-route caps.
- Added explicit queue rejection reasons (`global` vs `route`) for deterministic behavior.
- Standardized overload responses to **503 + Retry-After** so clients get clear retry guidance.
- Wired overload handling through admission and forward-error paths for consistent shedding behavior.
- Added unit and integration coverage for global-cap and concurrent shed scenarios.

## Impact
- Better graceful degradation under burst traffic.
- Lower risk of cascading latency and retry amplification.
- More predictable admission behavior for production workloads.