### PR TITLE
Runtime operability hardening: adaptive streaming timeouts, global LB fallback, isolated health probes, and metrics clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ curl --http3-only -k \
 
 - **Rust**: 1.85 or later (edition 2024)
 - **OS**: Linux
-- **Permissions**: Must run as root (required for QUIC/UDP socket binding)
+- **Permissions**: Root is only required for privileged ports (`<1024`); non-privileged ports run unprivileged
 - **Network**: UDP port access for QUIC traffic
 - **Memory**: 256MB minimum, 1GB recommended
 

--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -1,12 +1,103 @@
 use crate::config::Config;
+use serde_yaml::{Mapping, Value};
 use std::fs;
 
 pub fn read_config(filename: &str) -> Result<Config, String> {
     let text = fs::read_to_string(filename)
         .map_err(|err| format!("Failed to read config file '{}': {}", filename, err))?;
 
-    let data: Config = serde_yaml::from_str(&text)
-        .map_err(|err| format!("Could not parse YAML file '{}': {}", filename, err))?;
+    parse_config_text(&text)
+        .map_err(|err| format!("Could not parse YAML file '{}': {}", filename, err))
+}
 
-    Ok(data)
+fn parse_config_text(text: &str) -> Result<Config, serde_yaml::Error> {
+    let mut root: Value = serde_yaml::from_str(text)?;
+    apply_global_lb_fallback(&mut root);
+    serde_yaml::from_value(root)
+}
+
+fn apply_global_lb_fallback(root: &mut Value) {
+    let Some(root_map) = root.as_mapping_mut() else {
+        return;
+    };
+
+    let lb_key = Value::String("load_balancing".to_string());
+    let upstream_key = Value::String("upstream".to_string());
+
+    let Some(global_lb) = root_map.get(&lb_key).cloned() else {
+        return;
+    };
+    let Some(upstreams) = root_map
+        .get_mut(&upstream_key)
+        .and_then(Value::as_mapping_mut)
+    else {
+        return;
+    };
+
+    for upstream_value in upstreams.values_mut() {
+        let Some(upstream_map) = upstream_value.as_mapping_mut() else {
+            continue;
+        };
+        ensure_mapping_has_lb(upstream_map, &lb_key, global_lb.clone());
+    }
+}
+
+fn ensure_mapping_has_lb(map: &mut Mapping, lb_key: &Value, global_lb: Value) {
+    if !map.contains_key(lb_key) {
+        map.insert(lb_key.clone(), global_lb);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_config_text;
+
+    #[test]
+    fn applies_global_lb_to_upstream_without_override() {
+        let yaml = r#"
+version: 1
+listen:
+  protocol: http3
+  address: "127.0.0.1"
+  port: 9889
+  tls:
+    cert: "certs/cert.pem"
+    key: "certs/key.pem"
+load_balancing:
+  type: consistent-hash
+upstream:
+  inherited:
+    route:
+      path_prefix: "/"
+    backends:
+      - id: b1
+        address: "http://127.0.0.1:7001"
+        weight: 1
+        health_check: {}
+  explicit:
+    load_balancing:
+      type: random
+    route:
+      path_prefix: "/api"
+    backends:
+      - id: b2
+        address: "http://127.0.0.1:7002"
+        weight: 1
+        health_check: {}
+"#;
+
+        let cfg = parse_config_text(yaml).expect("config should parse");
+        assert_eq!(
+            cfg.upstream
+                .get("inherited")
+                .map(|u| u.load_balancing.lb_type.as_str()),
+            Some("consistent-hash")
+        );
+        assert_eq!(
+            cfg.upstream
+                .get("explicit")
+                .map(|u| u.load_balancing.lb_type.as_str()),
+            Some("random")
+        );
+    }
 }

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -219,6 +219,9 @@ pub struct Metrics {
     pub requests_total: AtomicU64,
     pub requests_success: AtomicU64,
     pub requests_failure: AtomicU64,
+    pub health_checks_total: AtomicU64,
+    pub health_checks_success: AtomicU64,
+    pub health_checks_failure: AtomicU64,
     pub backend_timeouts: AtomicU64,
     pub backend_errors: AtomicU64,
     pub overload_shed: AtomicU64,
@@ -263,6 +266,9 @@ impl Default for Metrics {
             requests_total: AtomicU64::new(0),
             requests_success: AtomicU64::new(0),
             requests_failure: AtomicU64::new(0),
+            health_checks_total: AtomicU64::new(0),
+            health_checks_success: AtomicU64::new(0),
+            health_checks_failure: AtomicU64::new(0),
             backend_timeouts: AtomicU64::new(0),
             backend_errors: AtomicU64::new(0),
             overload_shed: AtomicU64::new(0),
@@ -286,6 +292,16 @@ impl Metrics {
 
     pub fn inc_failure(&self) {
         self.requests_failure.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_health_check_success(&self) {
+        self.health_checks_total.fetch_add(1, Ordering::Relaxed);
+        self.health_checks_success.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_health_check_failure(&self) {
+        self.health_checks_total.fetch_add(1, Ordering::Relaxed);
+        self.health_checks_failure.fetch_add(1, Ordering::Relaxed);
     }
 
     pub fn inc_timeout(&self) {
@@ -379,6 +395,29 @@ impl Metrics {
         out.push_str(&format!(
             "spooky_requests_failure {}\n",
             self.requests_failure.load(Ordering::Relaxed)
+        ));
+
+        out.push_str("# HELP spooky_health_checks_total Total active health checks executed.\n");
+        out.push_str("# TYPE spooky_health_checks_total counter\n");
+        out.push_str(&format!(
+            "spooky_health_checks_total {}\n",
+            self.health_checks_total.load(Ordering::Relaxed)
+        ));
+
+        out.push_str(
+            "# HELP spooky_health_checks_success Total successful active health checks.\n",
+        );
+        out.push_str("# TYPE spooky_health_checks_success counter\n");
+        out.push_str(&format!(
+            "spooky_health_checks_success {}\n",
+            self.health_checks_success.load(Ordering::Relaxed)
+        ));
+
+        out.push_str("# HELP spooky_health_checks_failure Total failed active health checks.\n");
+        out.push_str("# TYPE spooky_health_checks_failure counter\n");
+        out.push_str(&format!(
+            "spooky_health_checks_failure {}\n",
+            self.health_checks_failure.load(Ordering::Relaxed)
         ));
 
         out.push_str("# HELP spooky_backend_timeouts Total backend timeout events.\n");

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -26,6 +26,7 @@ use socket2::{Domain, Protocol, Socket, Type};
 use spooky_bridge::h3_to_h2::build_h2_request;
 use spooky_errors::{PoolError, ProxyError};
 use spooky_lb::{HealthTransition, UpstreamPool};
+use spooky_transport::h2_client::H2Client;
 use spooky_transport::h2_pool::H2Pool;
 use tokio::runtime::Handle;
 use tokio::sync::{
@@ -242,7 +243,12 @@ impl QUICListener {
             .set_expected_workers(worker_count.max(1));
         Self::spawn_health_checks(
             shared_state.upstream_pools.clone(),
-            Arc::clone(&shared_state.h2_pool),
+            Arc::new(H2Client::new(
+                config.performance.h2_pool_max_idle_per_backend.max(1),
+                Duration::from_millis(config.performance.h2_pool_idle_timeout_ms.max(1)),
+                Duration::from_millis(config.performance.backend_connect_timeout_ms.max(1)),
+            )),
+            Arc::clone(&shared_state.metrics),
         );
         Self::spawn_metrics_endpoint(config, Arc::clone(&shared_state.metrics));
         Self::spawn_watchdog(
@@ -2066,7 +2072,10 @@ impl QUICListener {
                         let (chunk_tx, chunk_rx) =
                             mpsc::channel::<ResponseChunk>(RESPONSE_CHUNK_CHANNEL_CAPACITY);
                         let fail_tx = chunk_tx.clone();
-                        let total_deadline =
+                        // `backend_body_total_timeout` is used as a pre-first-byte guard:
+                        // once the upstream starts making body progress, the idle timeout
+                        // governs pacing and the stream may continue until request deadline.
+                        let first_byte_deadline =
                             tokio::time::Instant::now() + backend_body_total_timeout;
                         let deferred_status = status;
                         let deferred_headers = owned_h3_headers.clone();
@@ -2075,17 +2084,23 @@ impl QUICListener {
                             let mut body: hyper::body::Incoming = body;
                             let mut response_bytes_received: usize = 0;
                             let mut buffered_chunks: Vec<Bytes> = Vec::new();
+                            let mut saw_body_progress = false;
                             loop {
                                 let frame_fut = BodyExt::frame(&mut body);
                                 let now = tokio::time::Instant::now();
-                                if now >= total_deadline {
+                                if !saw_body_progress && now >= first_byte_deadline {
                                     let _ = chunk_tx
                                         .send(ResponseChunk::Error(ProxyError::Timeout))
                                         .await;
                                     return;
                                 }
-                                let remaining_total = total_deadline.saturating_duration_since(now);
-                                let wait_timeout = remaining_total.min(backend_body_idle_timeout);
+                                let wait_timeout = if saw_body_progress {
+                                    backend_body_idle_timeout
+                                } else {
+                                    first_byte_deadline
+                                        .saturating_duration_since(now)
+                                        .min(backend_body_idle_timeout)
+                                };
                                 let result = tokio::time::timeout(wait_timeout, frame_fut).await;
                                 match result {
                                     Err(_elapsed) => {
@@ -2097,6 +2112,9 @@ impl QUICListener {
                                     }
                                     Ok(Some(Ok(f))) => {
                                         if let Ok(data) = f.into_data() {
+                                            if !data.is_empty() {
+                                                saw_body_progress = true;
+                                            }
                                             if defer_headers_until_body_validated {
                                                 response_bytes_received = response_bytes_received
                                                     .saturating_add(data.len());
@@ -3063,7 +3081,8 @@ impl QUICListener {
 
     fn spawn_health_checks(
         upstream_pools: HashMap<String, Arc<Mutex<UpstreamPool>>>,
-        h2_pool: Arc<H2Pool>,
+        health_client: Arc<H2Client>,
+        metrics: Arc<Metrics>,
     ) {
         let entries = {
             let mut all_entries = Vec::new();
@@ -3097,7 +3116,8 @@ impl QUICListener {
         };
 
         for (upstream_pool, index, address, health) in entries {
-            let h2_pool = h2_pool.clone();
+            let health_client = Arc::clone(&health_client);
+            let metrics = Arc::clone(&metrics);
             let handle = handle.clone();
             handle.spawn(async move {
                 let interval = Duration::from_millis(health.interval.max(1));
@@ -3131,13 +3151,17 @@ impl QUICListener {
                         Err(_) => continue,
                     };
 
-                    let result =
-                        tokio::time::timeout(timeout, h2_pool.send(&address, request)).await;
+                    let result = tokio::time::timeout(timeout, health_client.send(request)).await;
 
                     let healthy = match result {
                         Ok(Ok(response)) => response.status().is_success(),
                         _ => false,
                     };
+                    if healthy {
+                        metrics.inc_health_check_success();
+                    } else {
+                        metrics.inc_health_check_failure();
+                    }
 
                     let transition = match upstream_pool.lock() {
                         Ok(mut pool) => {

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -248,7 +248,6 @@ impl QUICListener {
                 Duration::from_millis(config.performance.h2_pool_idle_timeout_ms.max(1)),
                 Duration::from_millis(config.performance.backend_connect_timeout_ms.max(1)),
             )),
-            Arc::clone(&shared_state.h2_pool),
             Arc::clone(&shared_state.metrics),
         );
         Self::spawn_metrics_endpoint(config, Arc::clone(&shared_state.metrics));
@@ -3168,7 +3167,6 @@ impl QUICListener {
     fn spawn_health_checks(
         upstream_pools: HashMap<String, Arc<Mutex<UpstreamPool>>>,
         health_client: Arc<H2Client>,
-        h2_pool: Arc<H2Pool>,
         metrics: Arc<Metrics>,
     ) {
         let entries = {
@@ -3204,10 +3202,10 @@ impl QUICListener {
 
         for (upstream_pool, index, address, health) in entries {
             let health_client = Arc::clone(&health_client);
-            let metrics = Arc::clone(&metrics);
+            let task_metrics = Arc::clone(&metrics);
             let handle = handle.clone();
-            let metrics = Arc::clone(&metrics);
-            spawn_supervised_async_task(&handle, "health-check", Some(metrics), async move {
+            let supervise_metrics = Arc::clone(&task_metrics);
+            spawn_supervised_async_task(&handle, "health-check", Some(supervise_metrics), async move {
                 let interval = Duration::from_millis(health.interval.max(1));
                 let timeout = Duration::from_millis(health.timeout_ms.max(1));
                 let path: &str = if health.path.is_empty() {
@@ -3246,9 +3244,9 @@ impl QUICListener {
                         _ => false,
                     };
                     if healthy {
-                        metrics.inc_health_check_success();
+                        task_metrics.inc_health_check_success();
                     } else {
-                        metrics.inc_health_check_failure();
+                        task_metrics.inc_health_check_failure();
                     }
 
                     let transition = match upstream_pool.lock() {

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -1022,6 +1022,19 @@ async fn start_h2_backend_with_regression_routes() -> SocketAddr {
                             .insert(CONTENT_LENGTH, HeaderValue::from_static("21"));
                         response
                     }
+                    "/long-stream" => {
+                        let (tx, body) = DelayedChunkBody::channel(8);
+                        tokio::spawn(async move {
+                            let _ = tx.send(Bytes::from_static(b"part-1")).await;
+                            tokio::time::sleep(Duration::from_millis(220)).await;
+                            let _ = tx.send(Bytes::from_static(b"part-2")).await;
+                            tokio::time::sleep(Duration::from_millis(220)).await;
+                            let _ = tx.send(Bytes::from_static(b"part-3")).await;
+                            tokio::time::sleep(Duration::from_millis(220)).await;
+                            let _ = tx.send(Bytes::from_static(b"part-4")).await;
+                        });
+                        Response::new(body.boxed())
+                    }
                     _ => Response::new(Full::new(Bytes::from_static(b"default\n")).boxed()),
                 };
                 Ok::<_, hyper::Error>(response)
@@ -1934,6 +1947,34 @@ fn response_body_is_streamed_progressively() {
     assert!(
         span >= Duration::from_millis(200),
         "expected delayed progressive delivery across chunks, got span {span:?}"
+    );
+}
+
+#[test]
+fn long_stream_survives_body_total_timeout_after_progress() {
+    let dir = tempdir().expect("failed to create temp dir");
+    let (cert, key) = write_test_certs(&dir);
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let backend_addr = rt.block_on(start_h2_backend_with_regression_routes());
+    let mut config = make_config(0, backend_addr.to_string(), cert, key);
+    config.performance.backend_body_total_timeout_ms = 250;
+    config.performance.backend_body_idle_timeout_ms = 500;
+    config.performance.backend_total_request_timeout_ms = 5_000;
+    let listener = QUICListener::new(config).expect("failed to create listener");
+    let listen_addr = listener.socket.local_addr().unwrap();
+    let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
+
+    let observations = run_h3_client_concurrent_get(
+        listen_addr,
+        &["/long-stream"],
+        Duration::from_secs(REQUEST_TIMEOUT_SECS + 6),
+    )
+    .expect("long stream request failed");
+    let stream = observation_for(&observations, "/long-stream");
+    assert_eq!(stream.status.as_deref(), Some("200"));
+    assert_eq!(
+        String::from_utf8_lossy(&stream.body),
+        "part-1part-2part-3part-4"
     );
 }
 

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -167,23 +167,21 @@ All metrics use atomic operations with relaxed ordering for high-performance loc
 - `inc_timeout()` - Increment backend timeout counter
 - `inc_backend_error()` - Increment backend error counter
 
-### Future: Metrics API Endpoint
+### Metrics API Endpoint
 
-**Status**: Planned feature
+**Status**: Available
 
-A metrics exposition endpoint is planned for future implementation that will expose collected metrics for monitoring and observability systems.
+Spooky exposes a Prometheus-compatible metrics endpoint in the runtime control plane when metrics are enabled in configuration.
 
-#### Planned Endpoint
+#### Endpoint
 
 ```
 GET /metrics
 ```
 
-The endpoint will provide Prometheus-compatible metric exposition format, making Spooky metrics accessible to standard monitoring and alerting infrastructure.
+The metrics path is configurable (`observability.metrics.path`) and defaults to `/metrics`.
 
-#### Planned Metric Categories
-
-Future implementations may include:
+#### Metric Categories
 
 - **Request metrics**: Total requests, success/failure rates, request duration histograms
 - **Connection metrics**: Active QUIC connections, HTTP/2 connection pool statistics

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -91,7 +91,7 @@ Named upstream pool definitions. Each key represents a unique upstream pool with
 
 ### load_balancing
 
-**Deprecated.** This top-level field is accepted by the parser for backward compatibility but has no effect at runtime. Configure load balancing strategy per upstream pool via `upstream.<name>.load_balancing` instead.
+Optional global fallback for upstream load balancing. If an upstream omits `upstream.<name>.load_balancing`, the top-level `load_balancing` value is applied to that upstream during config load.
 
 ### log
 
@@ -216,7 +216,7 @@ Route matching rules:
 2. If `path_prefix` is specified, the request path must start with the prefix
 3. If both are specified, both conditions must match
 4. Routes are evaluated by longest-prefix matching - the route with the most specific (longest) path prefix is selected
-5. For routes with equal-length prefixes, selection depends on HashMap iteration order (not deterministic by configuration order)
+5. For equal-length prefixes, ties are deterministic: host-specific routes win over host-agnostic routes, then lexicographically smaller upstream name wins
 
 #### Route Examples
 
@@ -496,7 +496,7 @@ Controls resource limits, tuning knobs, and connection-flood protection. All fie
 | `backend_timeout_ms` | integer | No | `2000` | Initial backend response timeout (ms) |
 | `backend_connect_timeout_ms` | integer | No | `500` | Backend TCP/TLS handshake timeout (ms); must be ≤ `backend_timeout_ms` |
 | `backend_body_idle_timeout_ms` | integer | No | `2000` | Idle timeout while streaming response body (ms); must be ≥ `backend_timeout_ms` |
-| `backend_body_total_timeout_ms` | integer | No | `30000` | Maximum total time to receive the full response body (ms) |
+| `backend_body_total_timeout_ms` | integer | No | `30000` | Maximum wait for first upstream body bytes (ms); after body progress, idle timeout governs chunk pacing |
 | `backend_total_request_timeout_ms` | integer | No | `35000` | Hard deadline for an entire request round-trip (ms); must be ≥ `backend_body_total_timeout_ms` |
 | `shutdown_drain_timeout_ms` | integer | No | `5000` | Graceful-shutdown drain timeout in ms; active connections are force-closed once this deadline is reached |
 | `udp_recv_buffer_bytes` | integer | No | `8388608` | UDP socket receive buffer size (bytes) |

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -14,7 +14,8 @@
 - Build tools: CMake, pkg-config, C compiler toolchain
 
 **Permissions:**
-- Spooky must run as root (required for QUIC/UDP socket binding)
+- Root is only required when binding privileged ports (`<1024`).
+- For typical deployments, run Spooky as an unprivileged user on a non-privileged port.
 
 ## Installation Methods
 

--- a/docs/user-guide/load-balancing.md
+++ b/docs/user-guide/load-balancing.md
@@ -599,7 +599,7 @@ done
 
 ```yaml
 # Global load balancing strategy (applies to all upstream pools)
-# Per-upstream load_balancing is planned but not currently active
+# Upstream pools can override this with upstream.<name>.load_balancing
 load_balancing:
   type: "round-robin"
 

--- a/spooky/src/main.rs
+++ b/spooky/src/main.rs
@@ -42,8 +42,9 @@ async fn main() {
     let uid = unsafe { libc::getuid() };
     if uid != 0 && config_yaml.listen.port < 1024 {
         eprintln!(
-            "Binding port {} requires root privileges.",
-            config_yaml.listen.port
+            "Binding privileged port {} requires root or CAP_NET_BIND_SERVICE. \
+Use a port >= 1024 for unprivileged startup.",
+            config_yaml.listen.port,
         );
         std::process::exit(1);
     }


### PR DESCRIPTION
## Summary
This PR hardens runtime behavior for production operations and removes several reliability/operability gaps that can cause confusion or degraded behavior under load.

## What changed
- Fixed upstream streaming timeout behavior so long but actively progressing responses are not cut off by an absolute body timer.
- Applied global load-balancing fallback semantics when an upstream does not declare its own strategy, while preserving upstream overrides.
- Kept route-match tie handling deterministic and aligned documentation with actual deterministic precedence.
- Isolated active health-check traffic from request-plane transport resources to reduce contention during incidents.
- Improved privileged-port startup UX by clarifying root/capability requirements and unprivileged operation expectations.
- Clarified and updated observability guidance to reflect the available runtime metrics endpoint.
- Added coverage for global LB fallback semantics and long-stream timeout resilience.

## Operational impact
- Better resilience for long-lived streaming responses.
- Lower risk of probe traffic interfering with serving traffic.
- More predictable operator behavior from config fallback and clearer startup/metrics guidance.
- Improved production readiness for constrained and containerized environments.