### PR TITLE
Runtime hardening: reduce hot-path log noise, improve operator messages, and enforce protocol policy controls

### DIFF
--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -103,6 +103,14 @@ resilience:
         global_cap: 2048
         shed_retry_after_seconds: 1
         caps: {}
+    protocol:
+        allow_0rtt: false
+        early_data_safe_methods: ["GET", "HEAD"]
+        max_headers_count: 128
+        max_headers_bytes: 16384
+        enforce_authority_host_match: true
+        allowed_methods: []
+        denied_path_prefixes: []
     circuit_breaker:
         enabled: true
         failure_threshold: 5

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -28,9 +28,11 @@ use crate::default::{
     resilience_default_brownout_trigger_inflight_percent, resilience_default_cb_enabled,
     resilience_default_cb_failure_threshold, resilience_default_cb_half_open_max_probes,
     resilience_default_cb_open_ms, resilience_default_hedging_delay_ms,
-    resilience_default_hedging_enabled, resilience_default_retry_budget_enabled,
-    resilience_default_retry_budget_ratio_percent, resilience_default_route_queue_default_cap,
-    resilience_default_route_queue_global_cap,
+    resilience_default_hedging_enabled, resilience_default_protocol_allow_0rtt,
+    resilience_default_protocol_enforce_authority_host_match,
+    resilience_default_protocol_max_headers_bytes, resilience_default_protocol_max_headers_count,
+    resilience_default_retry_budget_enabled, resilience_default_retry_budget_ratio_percent,
+    resilience_default_route_queue_default_cap, resilience_default_route_queue_global_cap,
     resilience_default_route_queue_shed_retry_after_seconds,
     resilience_default_watchdog_check_interval_ms, resilience_default_watchdog_drain_grace_ms,
     resilience_default_watchdog_enabled, resilience_default_watchdog_min_requests_per_window,
@@ -316,6 +318,8 @@ pub struct Resilience {
     #[serde(default)]
     pub route_queue: RouteQueue,
     #[serde(default)]
+    pub protocol: ProtocolPolicy,
+    #[serde(default)]
     pub circuit_breaker: CircuitBreaker,
     #[serde(default)]
     pub hedging: Hedging,
@@ -332,6 +336,7 @@ impl Default for Resilience {
         Self {
             adaptive_admission: AdaptiveAdmission::default(),
             route_queue: RouteQueue::default(),
+            protocol: ProtocolPolicy::default(),
             circuit_breaker: CircuitBreaker::default(),
             hedging: Hedging::default(),
             retry_budget: RetryBudget::default(),
@@ -386,6 +391,39 @@ impl Default for RouteQueue {
             global_cap: resilience_default_route_queue_global_cap(),
             shed_retry_after_seconds: resilience_default_route_queue_shed_retry_after_seconds(),
             caps: HashMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct ProtocolPolicy {
+    #[serde(default = "resilience_default_protocol_allow_0rtt")]
+    pub allow_0rtt: bool,
+    #[serde(default)]
+    pub early_data_safe_methods: Vec<String>,
+    #[serde(default = "resilience_default_protocol_max_headers_count")]
+    pub max_headers_count: usize,
+    #[serde(default = "resilience_default_protocol_max_headers_bytes")]
+    pub max_headers_bytes: usize,
+    #[serde(default = "resilience_default_protocol_enforce_authority_host_match")]
+    pub enforce_authority_host_match: bool,
+    #[serde(default)]
+    pub allowed_methods: Vec<String>,
+    #[serde(default)]
+    pub denied_path_prefixes: Vec<String>,
+}
+
+impl Default for ProtocolPolicy {
+    fn default() -> Self {
+        Self {
+            allow_0rtt: resilience_default_protocol_allow_0rtt(),
+            early_data_safe_methods: vec!["GET".to_string(), "HEAD".to_string()],
+            max_headers_count: resilience_default_protocol_max_headers_count(),
+            max_headers_bytes: resilience_default_protocol_max_headers_bytes(),
+            enforce_authority_host_match: resilience_default_protocol_enforce_authority_host_match(
+            ),
+            allowed_methods: Vec::new(),
+            denied_path_prefixes: Vec::new(),
         }
     }
 }

--- a/crates/config/src/default.rs
+++ b/crates/config/src/default.rs
@@ -210,6 +210,22 @@ pub fn resilience_default_route_queue_shed_retry_after_seconds() -> u32 {
     1
 }
 
+pub fn resilience_default_protocol_allow_0rtt() -> bool {
+    false
+}
+
+pub fn resilience_default_protocol_max_headers_count() -> usize {
+    128
+}
+
+pub fn resilience_default_protocol_max_headers_bytes() -> usize {
+    16 * 1024
+}
+
+pub fn resilience_default_protocol_enforce_authority_host_match() -> bool {
+    true
+}
+
 pub fn resilience_default_cb_enabled() -> bool {
     true
 }

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -286,6 +286,62 @@ pub fn validate(config: &Config) -> bool {
         return false;
     }
 
+    if config.resilience.protocol.max_headers_count == 0 {
+        error!("resilience.protocol.max_headers_count must be greater than 0");
+        return false;
+    }
+
+    if config.resilience.protocol.max_headers_bytes == 0 {
+        error!("resilience.protocol.max_headers_bytes must be greater than 0");
+        return false;
+    }
+
+    if config
+        .resilience
+        .protocol
+        .early_data_safe_methods
+        .iter()
+        .any(|method| method.trim().is_empty())
+    {
+        error!("resilience.protocol.early_data_safe_methods must not contain empty values");
+        return false;
+    }
+
+    if config
+        .resilience
+        .protocol
+        .allowed_methods
+        .iter()
+        .any(|method| method.trim().is_empty())
+    {
+        error!("resilience.protocol.allowed_methods must not contain empty values");
+        return false;
+    }
+
+    if config
+        .resilience
+        .protocol
+        .denied_path_prefixes
+        .iter()
+        .any(|prefix| prefix.is_empty() || !prefix.starts_with('/'))
+    {
+        error!("resilience.protocol.denied_path_prefixes must contain '/'-prefixed paths");
+        return false;
+    }
+
+    if config.resilience.protocol.allow_0rtt
+        && config
+            .resilience
+            .protocol
+            .early_data_safe_methods
+            .is_empty()
+    {
+        error!(
+            "resilience.protocol.early_data_safe_methods must be non-empty when allow_0rtt=true"
+        );
+        return false;
+    }
+
     if config.resilience.circuit_breaker.failure_threshold == 0 {
         error!("resilience.circuit_breaker.failure_threshold must be greater than 0");
         return false;
@@ -703,6 +759,10 @@ upstream:
         assert_eq!(cfg.resilience.route_queue.default_cap, 512);
         assert_eq!(cfg.resilience.route_queue.global_cap, 2048);
         assert_eq!(cfg.resilience.route_queue.shed_retry_after_seconds, 1);
+        assert!(!cfg.resilience.protocol.allow_0rtt);
+        assert_eq!(cfg.resilience.protocol.max_headers_count, 128);
+        assert_eq!(cfg.resilience.protocol.max_headers_bytes, 16 * 1024);
+        assert!(cfg.resilience.protocol.enforce_authority_host_match);
         assert!(!cfg.resilience.watchdog.enabled);
         assert_eq!(cfg.resilience.watchdog.check_interval_ms, 1_000);
     }
@@ -822,6 +882,27 @@ upstream:
         assert!(!validate(&cfg));
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.resilience.protocol.max_headers_count = 0;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.resilience.protocol.max_headers_bytes = 0;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.resilience.protocol.allow_0rtt = true;
+        cfg.resilience.protocol.early_data_safe_methods.clear();
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.resilience.protocol.denied_path_prefixes = vec!["admin".to_string()];
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.resilience.protocol.allowed_methods = vec!["".to_string()];
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.resilience.retry_budget.ratio_percent = 101;
         assert!(!validate(&cfg));
 
@@ -881,6 +962,12 @@ upstream:
         cfg.resilience.route_queue.default_cap = 256;
         cfg.resilience.route_queue.global_cap = 2048;
         cfg.resilience.route_queue.shed_retry_after_seconds = 2;
+        cfg.resilience.protocol.allow_0rtt = true;
+        cfg.resilience.protocol.early_data_safe_methods = vec!["GET".to_string()];
+        cfg.resilience.protocol.max_headers_count = 64;
+        cfg.resilience.protocol.max_headers_bytes = 8 * 1024;
+        cfg.resilience.protocol.allowed_methods = vec!["GET".to_string(), "POST".to_string()];
+        cfg.resilience.protocol.denied_path_prefixes = vec!["/admin".to_string()];
         cfg.resilience.retry_budget.ratio_percent = 30;
         cfg.observability = Observability {
             metrics: MetricsEndpoint {

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -225,6 +225,10 @@ pub struct Metrics {
     pub requests_total: AtomicU64,
     pub requests_success: AtomicU64,
     pub requests_failure: AtomicU64,
+    pub request_validation_rejects: AtomicU64,
+    pub policy_denied: AtomicU64,
+    pub early_data_accepted: AtomicU64,
+    pub early_data_rejected: AtomicU64,
     pub health_checks_total: AtomicU64,
     pub health_checks_success: AtomicU64,
     pub health_checks_failure: AtomicU64,
@@ -275,6 +279,10 @@ impl Default for Metrics {
             requests_total: AtomicU64::new(0),
             requests_success: AtomicU64::new(0),
             requests_failure: AtomicU64::new(0),
+            request_validation_rejects: AtomicU64::new(0),
+            policy_denied: AtomicU64::new(0),
+            early_data_accepted: AtomicU64::new(0),
+            early_data_rejected: AtomicU64::new(0),
             health_checks_total: AtomicU64::new(0),
             health_checks_success: AtomicU64::new(0),
             health_checks_failure: AtomicU64::new(0),
@@ -304,6 +312,23 @@ impl Metrics {
 
     pub fn inc_failure(&self) {
         self.requests_failure.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_request_validation_reject(&self) {
+        self.request_validation_rejects
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_policy_denied(&self) {
+        self.policy_denied.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_early_data_accepted(&self) {
+        self.early_data_accepted.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_early_data_rejected(&self) {
+        self.early_data_rejected.fetch_add(1, Ordering::Relaxed);
     }
 
     pub fn inc_health_check_success(&self) {
@@ -419,6 +444,38 @@ impl Metrics {
         out.push_str(&format!(
             "spooky_requests_failure {}\n",
             self.requests_failure.load(Ordering::Relaxed)
+        ));
+
+        out.push_str(
+            "# HELP spooky_request_validation_rejects Total requests rejected by protocol validation.\n",
+        );
+        out.push_str("# TYPE spooky_request_validation_rejects counter\n");
+        out.push_str(&format!(
+            "spooky_request_validation_rejects {}\n",
+            self.request_validation_rejects.load(Ordering::Relaxed)
+        ));
+
+        out.push_str(
+            "# HELP spooky_policy_denied Total requests denied by runtime method/path policies.\n",
+        );
+        out.push_str("# TYPE spooky_policy_denied counter\n");
+        out.push_str(&format!(
+            "spooky_policy_denied {}\n",
+            self.policy_denied.load(Ordering::Relaxed)
+        ));
+
+        out.push_str("# HELP spooky_early_data_accepted Total requests accepted in early data.\n");
+        out.push_str("# TYPE spooky_early_data_accepted counter\n");
+        out.push_str(&format!(
+            "spooky_early_data_accepted {}\n",
+            self.early_data_accepted.load(Ordering::Relaxed)
+        ));
+
+        out.push_str("# HELP spooky_early_data_rejected Total requests rejected in early data.\n");
+        out.push_str("# TYPE spooky_early_data_rejected counter\n");
+        out.push_str(&format!(
+            "spooky_early_data_rejected {}\n",
+            self.early_data_rejected.load(Ordering::Relaxed)
         ));
 
         out.push_str("# HELP spooky_health_checks_total Total active health checks executed.\n");

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -108,6 +108,12 @@ fn is_hop_header(name: &str) -> bool {
 
 type ResolvedBackend = (String, String, usize, Arc<Mutex<UpstreamPool>>);
 
+struct RequestValidationResult {
+    method: String,
+    path: String,
+    authority: Option<String>,
+}
+
 fn request_content_length(headers: &[quiche::h3::Header]) -> Option<usize> {
     for header in headers {
         if !header.name().eq_ignore_ascii_case(b"content-length") {
@@ -118,6 +124,168 @@ fn request_content_length(headers: &[quiche::h3::Header]) -> Option<usize> {
         return Some(parsed);
     }
     None
+}
+
+fn validate_request_headers(
+    list: &[quiche::h3::Header],
+    resilience: &RuntimeResilience,
+) -> Result<RequestValidationResult, (http::StatusCode, &'static [u8], bool)> {
+    if list.len() > resilience.max_headers_count {
+        return Err((
+            http::StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE,
+            b"too many request headers\n",
+            false,
+        ));
+    }
+
+    let mut header_bytes = 0usize;
+    let mut method = None::<String>;
+    let mut path = None::<String>;
+    let mut authority = None::<String>;
+    let mut host = None::<String>;
+    let mut scheme_seen = false;
+
+    for header in list {
+        header_bytes = header_bytes.saturating_add(header.name().len() + header.value().len());
+        if header_bytes > resilience.max_headers_bytes {
+            return Err((
+                http::StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE,
+                b"request headers exceed size limit\n",
+                false,
+            ));
+        }
+
+        match header.name() {
+            b":method" => {
+                if method.is_some() {
+                    return Err((
+                        http::StatusCode::BAD_REQUEST,
+                        b"duplicate :method header\n",
+                        false,
+                    ));
+                }
+                method = Some(String::from_utf8_lossy(header.value()).to_string());
+            }
+            b":path" => {
+                if path.is_some() {
+                    return Err((
+                        http::StatusCode::BAD_REQUEST,
+                        b"duplicate :path header\n",
+                        false,
+                    ));
+                }
+                path = Some(String::from_utf8_lossy(header.value()).to_string());
+            }
+            b":authority" => {
+                if authority.is_some() {
+                    return Err((
+                        http::StatusCode::BAD_REQUEST,
+                        b"duplicate :authority header\n",
+                        false,
+                    ));
+                }
+                authority = Some(String::from_utf8_lossy(header.value()).to_string());
+            }
+            b"host" => {
+                if host.is_some() {
+                    return Err((
+                        http::StatusCode::BAD_REQUEST,
+                        b"duplicate host header\n",
+                        false,
+                    ));
+                }
+                host = Some(String::from_utf8_lossy(header.value()).to_string());
+            }
+            b":scheme" => {
+                if scheme_seen {
+                    return Err((
+                        http::StatusCode::BAD_REQUEST,
+                        b"duplicate :scheme header\n",
+                        false,
+                    ));
+                }
+                scheme_seen = true;
+            }
+            name if name.starts_with(b":") => {
+                return Err((
+                    http::StatusCode::BAD_REQUEST,
+                    b"unsupported pseudo-header\n",
+                    false,
+                ));
+            }
+            _ => {}
+        }
+    }
+
+    let method = match method {
+        Some(method) => method,
+        None => {
+            return Err((
+                http::StatusCode::BAD_REQUEST,
+                b"missing :method header\n",
+                false,
+            ));
+        }
+    };
+    let path = match path {
+        Some(path) => path,
+        None => {
+            return Err((
+                http::StatusCode::BAD_REQUEST,
+                b"missing :path header\n",
+                false,
+            ));
+        }
+    };
+
+    if method.trim().is_empty() || method.as_bytes().iter().any(|b| b.is_ascii_whitespace()) {
+        return Err((
+            http::StatusCode::BAD_REQUEST,
+            b"invalid :method header\n",
+            false,
+        ));
+    }
+
+    if path.is_empty() || !path.starts_with('/') {
+        return Err((
+            http::StatusCode::BAD_REQUEST,
+            b"invalid :path header\n",
+            false,
+        ));
+    }
+
+    if resilience.enforce_authority_host_match
+        && let (Some(authority_value), Some(host_value)) = (authority.as_deref(), host.as_deref())
+        && !authority_value.eq_ignore_ascii_case(host_value)
+    {
+        return Err((
+            http::StatusCode::BAD_REQUEST,
+            b":authority and host headers must match\n",
+            false,
+        ));
+    }
+
+    if !resilience.method_allowed(&method) {
+        return Err((
+            http::StatusCode::METHOD_NOT_ALLOWED,
+            b"request method blocked by policy\n",
+            true,
+        ));
+    }
+
+    if resilience.path_denied(&path) {
+        return Err((
+            http::StatusCode::FORBIDDEN,
+            b"request path blocked by policy\n",
+            true,
+        ));
+    }
+
+    Ok(RequestValidationResult {
+        method,
+        path,
+        authority: authority.or(host),
+    })
 }
 
 fn resolve_primary_from_radix_prefix<T>(
@@ -553,7 +721,7 @@ impl QUICListener {
         let header = match quiche::Header::from_slice(&mut buf, quiche::MAX_CONN_ID_LEN) {
             Ok(hdr) => hdr,
             Err(_) => {
-                error!("Wrong QUIC HEADER");
+                error!("Failed to parse QUIC packet header");
                 return None;
             }
         };
@@ -843,7 +1011,7 @@ impl QUICListener {
         let header = match quiche::Header::from_slice(&mut recv_data, quiche::MAX_CONN_ID_LEN) {
             Ok(hdr) => hdr,
             Err(_) => {
-                error!("Wrong QUIC HEADER");
+                error!("Failed to parse QUIC packet header");
                 return;
             }
         };
@@ -964,11 +1132,11 @@ impl QUICListener {
         }
 
         if let Some(err) = connection.quic.peer_error() {
-            error!("🔴 Peer error: {:?}", err);
+            error!("QUIC peer error: {:?}", err);
         }
 
         if let Some(err) = connection.quic.local_error() {
-            error!("🔴 Local error: {:?}", err);
+            error!("QUIC local error: {:?}", err);
         }
 
         connection.last_activity = Instant::now();
@@ -1188,30 +1356,60 @@ impl QUICListener {
         loop {
             match h3.poll(&mut connection.quic) {
                 Ok((stream_id, quiche::h3::Event::Headers { list, .. })) => {
-                    let mut method = String::new();
-                    let mut path = String::new();
-                    let mut authority = None;
-
-                    for header in &list {
-                        match header.name() {
-                            b":method" => {
-                                method = String::from_utf8_lossy(header.value()).to_string()
+                    let request = match validate_request_headers(&list, resilience) {
+                        Ok(request) => request,
+                        Err((status, body, is_policy)) => {
+                            metrics.inc_failure();
+                            metrics.inc_request_validation_reject();
+                            if is_policy {
+                                metrics.inc_policy_denied();
                             }
-                            b":path" => path = String::from_utf8_lossy(header.value()).to_string(),
-                            b":authority" | b"host" => {
-                                authority =
-                                    Some(String::from_utf8_lossy(header.value()).to_string())
-                            }
-                            _ => {}
+                            metrics.record_route(
+                                "unrouted",
+                                Duration::from_millis(0),
+                                RouteOutcome::Failure,
+                            );
+                            let _ = Self::send_simple_response(
+                                h3,
+                                &mut connection.quic,
+                                stream_id,
+                                status,
+                                body,
+                            );
+                            continue;
                         }
-                    }
+                    };
+                    let method = request.method;
+                    let path = request.path;
+                    let authority = request.authority;
 
-                    if !method.is_empty() && !path.is_empty() {
-                        info!("HTTP/3 request {} {}", method, path);
-                    }
+                    debug!("HTTP/3 request {} {}", method, path);
 
                     metrics.inc_total();
                     let request_start = Instant::now();
+
+                    if connection.quic.is_in_early_data() {
+                        if resilience.early_data_allowed_for(&method) {
+                            metrics.inc_early_data_accepted();
+                        } else {
+                            metrics.inc_failure();
+                            metrics.inc_early_data_rejected();
+                            metrics.inc_policy_denied();
+                            metrics.record_route(
+                                "unrouted",
+                                request_start.elapsed(),
+                                RouteOutcome::Failure,
+                            );
+                            Self::send_simple_response(
+                                h3,
+                                &mut connection.quic,
+                                stream_id,
+                                http::StatusCode::TOO_EARLY,
+                                b"request blocked by early-data policy\n",
+                            )?;
+                            continue;
+                        }
+                    }
 
                     // Route lookup — needed to start the H2 request immediately.
                     let resolved = Self::resolve_backend(
@@ -1395,7 +1593,7 @@ impl QUICListener {
                                             &mut connection.quic,
                                             stream_id,
                                             http::StatusCode::SERVICE_UNAVAILABLE,
-                                            b"no upstream throttle configured\n",
+                                            b"upstream admission limiter unavailable\n",
                                         )?;
                                         resilience
                                             .adaptive_admission
@@ -2289,7 +2487,7 @@ impl QUICListener {
                             resilience
                                 .adaptive_admission
                                 .observe(req.start.elapsed(), false);
-                            info!(
+                            debug!(
                                 "Upstream {} status {} latency_ms {}",
                                 req.backend_addr.as_deref().unwrap_or("?"),
                                 status,
@@ -2501,7 +2699,7 @@ impl QUICListener {
                                     resilience
                                         .adaptive_admission
                                         .observe(req.start.elapsed(), true);
-                                    info!(
+                                    debug!(
                                         "Upstream {} body timeout latency_ms {}",
                                         req.backend_addr.as_deref().unwrap_or("?"),
                                         req.start.elapsed().as_millis()
@@ -2584,7 +2782,7 @@ impl QUICListener {
             (idx, lb_type, backend_addr)
         };
 
-        info!("Selected backend {} via {}", backend_addr, lb_type);
+        debug!("Selected backend {} via {}", backend_addr, lb_type);
         Ok((
             upstream_name.to_string(),
             backend_addr,
@@ -2669,7 +2867,7 @@ impl QUICListener {
                 error!("Bridge error: {:?}", err);
                 metrics.inc_failure();
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::Failure);
-                info!(
+                debug!(
                     "Upstream {} status 400 latency_ms {}",
                     backend_addr,
                     start.elapsed().as_millis()
@@ -2683,11 +2881,11 @@ impl QUICListener {
                 )
             }
             Err(ProxyError::Pool(PoolError::BackendOverloaded(_))) => {
-                info!("Backend overloaded");
+                debug!("Backend overloaded");
                 metrics.inc_failure();
                 metrics.inc_overload_shed();
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::OverloadShed);
-                info!(
+                debug!(
                     "Upstream {} status 503 latency_ms {}",
                     backend_addr,
                     start.elapsed().as_millis()
@@ -2701,11 +2899,11 @@ impl QUICListener {
                 )
             }
             Err(ProxyError::Pool(PoolError::CircuitOpen(_))) => {
-                info!("Backend circuit open");
+                debug!("Backend circuit open");
                 metrics.inc_failure();
                 metrics.inc_overload_shed();
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::OverloadShed);
-                info!(
+                debug!(
                     "Upstream {} status 503 latency_ms {}",
                     backend_addr,
                     start.elapsed().as_millis()
@@ -2722,7 +2920,7 @@ impl QUICListener {
             | Err(ProxyError::Pool(PoolError::Send(_)))
             | Err(ProxyError::Pool(PoolError::InflightLimiterClosed))
             | Err(ProxyError::Pool(PoolError::UnknownBackend(_))) => {
-                error!("Transport error");
+                error!("Upstream transport error");
                 if let Some(pool) = &upstream_pool
                     && let Some(t) = pool
                         .lock()
@@ -2734,7 +2932,7 @@ impl QUICListener {
                 metrics.inc_failure();
                 metrics.inc_backend_error();
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::BackendError);
-                info!(
+                debug!(
                     "Upstream {} status 502 latency_ms {}",
                     backend_addr,
                     start.elapsed().as_millis()
@@ -2761,7 +2959,7 @@ impl QUICListener {
                 )
             }
             Err(ProxyError::Timeout) => {
-                error!("Server timeout");
+                error!("Upstream request timed out");
                 if let Some(pool) = &upstream_pool
                     && let Some(t) = pool
                         .lock()
@@ -2773,7 +2971,7 @@ impl QUICListener {
                 metrics.inc_failure();
                 metrics.inc_timeout();
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::Timeout);
-                info!(
+                debug!(
                     "Upstream {} status 503 latency_ms {}",
                     backend_addr,
                     start.elapsed().as_millis()
@@ -2790,7 +2988,7 @@ impl QUICListener {
                 error!("TLS error: {}", err);
                 metrics.inc_failure();
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::Failure);
-                info!(
+                debug!(
                     "TLS error for stream {} latency_ms {}",
                     stream_id,
                     start.elapsed().as_millis()
@@ -3205,66 +3403,72 @@ impl QUICListener {
             let task_metrics = Arc::clone(&metrics);
             let handle = handle.clone();
             let supervise_metrics = Arc::clone(&task_metrics);
-            spawn_supervised_async_task(&handle, "health-check", Some(supervise_metrics), async move {
-                let interval = Duration::from_millis(health.interval.max(1));
-                let timeout = Duration::from_millis(health.timeout_ms.max(1));
-                let path: &str = if health.path.is_empty() {
-                    "/"
-                } else {
-                    &health.path
-                };
-                let endpoint = match BackendEndpoint::parse(&address) {
-                    Ok(endpoint) => endpoint,
-                    Err(err) => {
-                        error!(
-                            "disabling health checks for backend '{}' due to invalid endpoint: {}",
-                            address, err
-                        );
-                        return;
-                    }
-                };
-                let health_uri = endpoint.uri_for_path(path);
-
-                loop {
-                    tokio::time::sleep(interval).await;
-
-                    let request = match http::Request::builder()
-                        .method("GET")
-                        .uri(&health_uri)
-                        .body(BoxBody::new(Full::new(Bytes::new())))
-                    {
-                        Ok(req) => req,
-                        Err(_) => continue,
-                    };
-
-                    let result = tokio::time::timeout(timeout, health_client.send(request)).await;
-
-                    let healthy = match result {
-                        Ok(Ok(response)) => response.status().is_success(),
-                        _ => false,
-                    };
-                    if healthy {
-                        task_metrics.inc_health_check_success();
+            spawn_supervised_async_task(
+                &handle,
+                "health-check",
+                Some(supervise_metrics),
+                async move {
+                    let interval = Duration::from_millis(health.interval.max(1));
+                    let timeout = Duration::from_millis(health.timeout_ms.max(1));
+                    let path: &str = if health.path.is_empty() {
+                        "/"
                     } else {
-                        task_metrics.inc_health_check_failure();
-                    }
-
-                    let transition = match upstream_pool.lock() {
-                        Ok(mut pool) => {
-                            if healthy {
-                                pool.pool.mark_success(index)
-                            } else {
-                                pool.pool.mark_failure(index)
-                            }
-                        }
-                        Err(_) => None,
+                        &health.path
                     };
+                    let endpoint = match BackendEndpoint::parse(&address) {
+                        Ok(endpoint) => endpoint,
+                        Err(err) => {
+                            error!(
+                                "disabling health checks for backend '{}' due to invalid endpoint: {}",
+                                address, err
+                            );
+                            return;
+                        }
+                    };
+                    let health_uri = endpoint.uri_for_path(path);
 
-                    if let Some(transition) = transition {
-                        Self::log_health_transition(&address, transition);
+                    loop {
+                        tokio::time::sleep(interval).await;
+
+                        let request = match http::Request::builder()
+                            .method("GET")
+                            .uri(&health_uri)
+                            .body(BoxBody::new(Full::new(Bytes::new())))
+                        {
+                            Ok(req) => req,
+                            Err(_) => continue,
+                        };
+
+                        let result =
+                            tokio::time::timeout(timeout, health_client.send(request)).await;
+
+                        let healthy = match result {
+                            Ok(Ok(response)) => response.status().is_success(),
+                            _ => false,
+                        };
+                        if healthy {
+                            task_metrics.inc_health_check_success();
+                        } else {
+                            task_metrics.inc_health_check_failure();
+                        }
+
+                        let transition = match upstream_pool.lock() {
+                            Ok(mut pool) => {
+                                if healthy {
+                                    pool.pool.mark_success(index)
+                                } else {
+                                    pool.pool.mark_failure(index)
+                                }
+                            }
+                            Err(_) => None,
+                        };
+
+                        if let Some(transition) = transition {
+                            Self::log_health_transition(&address, transition);
+                        }
                     }
-                }
-            });
+                },
+            );
         }
     }
 }

--- a/crates/edge/src/resilience.rs
+++ b/crates/edge/src/resilience.rs
@@ -421,9 +421,16 @@ pub struct RuntimeResilience {
     pub retry_budget: Arc<RetryBudget>,
     pub brownout: Arc<BrownoutController>,
     pub shed_retry_after_seconds: u32,
+    pub allow_0rtt: bool,
+    pub max_headers_count: usize,
+    pub max_headers_bytes: usize,
+    pub enforce_authority_host_match: bool,
     pub hedging_enabled: bool,
     pub hedging_delay: Duration,
-    safe_methods: HashSet<String>,
+    hedge_safe_methods: HashSet<String>,
+    early_data_safe_methods: HashSet<String>,
+    allowed_methods: HashSet<String>,
+    denied_path_prefixes: Vec<String>,
     route_allowlist: HashSet<String>,
 }
 
@@ -462,9 +469,21 @@ impl RuntimeResilience {
             config.brownout.core_routes.clone(),
         ));
 
-        let safe_methods = config
+        let hedge_safe_methods = config
             .hedging
             .safe_methods
+            .iter()
+            .map(|method| method.to_ascii_uppercase())
+            .collect::<HashSet<_>>();
+        let early_data_safe_methods = config
+            .protocol
+            .early_data_safe_methods
+            .iter()
+            .map(|method| method.to_ascii_uppercase())
+            .collect::<HashSet<_>>();
+        let allowed_methods = config
+            .protocol
+            .allowed_methods
             .iter()
             .map(|method| method.to_ascii_uppercase())
             .collect::<HashSet<_>>();
@@ -482,9 +501,16 @@ impl RuntimeResilience {
             retry_budget,
             brownout,
             shed_retry_after_seconds: config.route_queue.shed_retry_after_seconds.max(1),
+            allow_0rtt: config.protocol.allow_0rtt,
+            max_headers_count: config.protocol.max_headers_count.max(1),
+            max_headers_bytes: config.protocol.max_headers_bytes.max(1),
+            enforce_authority_host_match: config.protocol.enforce_authority_host_match,
             hedging_enabled: config.hedging.enabled,
             hedging_delay: Duration::from_millis(config.hedging.delay_ms.max(1)),
-            safe_methods,
+            hedge_safe_methods,
+            early_data_safe_methods,
+            allowed_methods,
+            denied_path_prefixes: config.protocol.denied_path_prefixes.clone(),
             route_allowlist,
         }
     }
@@ -493,11 +519,31 @@ impl RuntimeResilience {
         if !self.hedging_enabled || self.brownout.is_active() || !bodyless {
             return false;
         }
-        let safe_method = self.safe_methods.contains(&method.to_ascii_uppercase());
+        let safe_method = self
+            .hedge_safe_methods
+            .contains(&method.to_ascii_uppercase());
         if !safe_method {
             return false;
         }
         self.route_allowlist.is_empty() || self.route_allowlist.contains(route)
+    }
+
+    pub fn early_data_allowed_for(&self, method: &str) -> bool {
+        self.allow_0rtt
+            && self
+                .early_data_safe_methods
+                .contains(&method.to_ascii_uppercase())
+    }
+
+    pub fn method_allowed(&self, method: &str) -> bool {
+        self.allowed_methods.is_empty()
+            || self.allowed_methods.contains(&method.to_ascii_uppercase())
+    }
+
+    pub fn path_denied(&self, path: &str) -> bool {
+        self.denied_path_prefixes
+            .iter()
+            .any(|prefix| path.starts_with(prefix))
     }
 }
 
@@ -561,5 +607,22 @@ mod tests {
         assert!(controller.is_active());
         assert!(controller.route_allowed("core"));
         assert!(!controller.route_allowed("non_core"));
+    }
+
+    #[test]
+    fn runtime_resilience_method_and_path_policy_checks() {
+        let mut cfg = ResilienceConfig::default();
+        cfg.protocol.allowed_methods = vec!["GET".to_string()];
+        cfg.protocol.denied_path_prefixes = vec!["/admin".to_string()];
+        cfg.protocol.allow_0rtt = true;
+        cfg.protocol.early_data_safe_methods = vec!["GET".to_string()];
+
+        let runtime = RuntimeResilience::from_config(&cfg, 64);
+        assert!(runtime.method_allowed("GET"));
+        assert!(!runtime.method_allowed("POST"));
+        assert!(runtime.path_denied("/admin/secret"));
+        assert!(!runtime.path_denied("/api"));
+        assert!(runtime.early_data_allowed_for("GET"));
+        assert!(!runtime.early_data_allowed_for("POST"));
     }
 }

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -2177,6 +2177,65 @@ fn route_queue_global_cap_sheds_excess_requests() {
 }
 
 #[test]
+fn protocol_policy_denies_disallowed_method() {
+    let dir = tempdir().expect("failed to create temp dir");
+    let (cert, key) = write_test_certs(&dir);
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+
+    let backend_addr = rt.block_on(start_h2_backend_with_regression_routes());
+    let mut config = make_config(0, backend_addr.to_string(), cert, key);
+    config.resilience.protocol.allowed_methods = vec!["GET".to_string()];
+
+    let listener = QUICListener::new(config).expect("failed to create listener");
+    let listen_addr = listener.socket.local_addr().unwrap();
+    let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
+
+    let (status, body, _got_reset) = run_h3_client_chunked_post(
+        listen_addr,
+        "/fast",
+        0,
+        1,
+        Duration::ZERO,
+        Duration::ZERO,
+        Duration::from_secs(REQUEST_TIMEOUT_SECS + 4),
+    )
+    .expect("method policy request should complete");
+    assert_eq!(status, "405");
+    assert!(
+        String::from_utf8_lossy(&body).contains("method blocked"),
+        "expected policy body in response"
+    );
+}
+
+#[test]
+fn protocol_policy_denies_blocked_path_prefix() {
+    let dir = tempdir().expect("failed to create temp dir");
+    let (cert, key) = write_test_certs(&dir);
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+
+    let backend_addr = rt.block_on(start_h2_backend_with_regression_routes());
+    let mut config = make_config(0, backend_addr.to_string(), cert, key);
+    config.resilience.protocol.denied_path_prefixes = vec!["/admin".to_string()];
+
+    let listener = QUICListener::new(config).expect("failed to create listener");
+    let listen_addr = listener.socket.local_addr().unwrap();
+    let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
+
+    let observations = run_h3_client_concurrent_get(
+        listen_addr,
+        &["/admin/secrets"],
+        Duration::from_secs(REQUEST_TIMEOUT_SECS + 4),
+    )
+    .expect("path policy request should complete");
+    let denied = observation_for(&observations, "/admin/secrets");
+    assert_eq!(denied.status.as_deref(), Some("403"));
+    assert!(
+        String::from_utf8_lossy(&denied.body).contains("path blocked"),
+        "expected policy body in response"
+    );
+}
+
+#[test]
 fn upstream_inflight_limit_sheds_excess_requests() {
     let dir = tempdir().expect("failed to create temp dir");
     let (cert, key) = write_test_certs(&dir);


### PR DESCRIPTION
## Summary
This PR improves production runtime clarity and protocol safety by reducing noisy hot-path logging, cleaning up operator-facing messages, and implementing configurable request/early-data policy enforcement.

## What changed
- Reduced high-frequency log noise in request/forwarding paths by moving per-request success/status logs out of `info` level and keeping `info` for lifecycle/control-plane events.
- Replaced unclear or placeholder error/log messages with clearer operator-focused wording.
- Added protocol hardening policy configuration:
  - early-data (0-RTT) control and safe-method gating
  - header count and total header-bytes limits
  - authority/host consistency enforcement
  - method allowlist
  - denied path-prefix policy
- Enforced the above policy controls in the HTTP/3 request handling path with deterministic responses (`400/403/405/425/431` as appropriate).
- Added new metrics for protocol and policy outcomes:
  - request validation rejects
  - policy denials
  - early-data accepted/rejected
- Added/updated unit and integration tests for protocol policy behavior and config validation.

## Impact
- Cleaner logs under high throughput and better signal-to-noise for operations.
- More predictable and auditable request rejection behavior.
- Stronger protocol guardrails and better production hardening for enterprise traffic policies.