### PR TITLE
Connection lifecycle hardening: drain, teardown, and churn cleanup

### DIFF
--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -384,6 +384,37 @@ pub(crate) fn sweep_closed_connections<C, F>(
     }
 }
 
+/// Deterministically tear down a single stream's in-flight resources.
+///
+/// Drops resources in an order that minimises wasted work:
+/// 1. `body_tx` — signals EOF/cancellation to the upstream H2 task so it
+///    stops reading the request body and exits promptly.
+/// 2. `upstream_result_rx` — dropping the oneshot receiver tells the
+///    upstream task that nobody is listening; `result_tx.send()` in the
+///    spawned task returns `Err` and the task exits.
+/// 3. `response_chunk_rx` — dropping the mpsc receiver causes the
+///    body-pump task's next `chunk_tx.send().await` to return `Err`
+///    and the task exits.
+/// 4. `pending_chunk` — discard any backpressured chunk.
+/// 5. All permits (`global`, `upstream`, `adaptive`, `route_queue`) —
+///    released last so the concurrency slots open up only after we know
+///    no more work is queued.
+///
+/// Returns the phase the stream was in at the time of abort (useful for
+/// logging and metrics at the call site).
+pub(crate) fn abort_stream(req: &mut RequestEnvelope) -> StreamPhase {
+    let phase = req.phase.clone();
+    req.body_tx = None;
+    req.upstream_result_rx = None;
+    req.response_chunk_rx = None;
+    req.pending_chunk = None;
+    req.global_inflight_permit = None;
+    req.upstream_inflight_permit = None;
+    req.adaptive_admission_permit = None;
+    req.route_queue_permit = None;
+    phase
+}
+
 impl QUICListener {
     pub fn new(config: SpookyConfig) -> Result<Self, ProxyError> {
         let shared_state = Arc::new(Self::build_shared_state(&config)?);
@@ -2161,7 +2192,14 @@ impl QUICListener {
                         // by advance_streams_non_blocking, called unconditionally below.
                     }
                 }
-                Ok((stream_id, quiche::h3::Event::Reset(_))) => {
+                Ok((stream_id, quiche::h3::Event::Reset(error_code))) => {
+                    if let Some(req) = connection.streams.get_mut(&stream_id) {
+                        let phase = abort_stream(req);
+                        debug!(
+                            "stream {} reset by client (error_code={}, phase={:?}): resources released",
+                            stream_id, error_code, phase
+                        );
+                    }
                     connection.streams.remove(&stream_id);
                 }
                 Ok((_stream_id, quiche::h3::Event::PriorityUpdate)) => {}
@@ -2245,6 +2283,9 @@ impl QUICListener {
                 resilience
                     .adaptive_admission
                     .observe(req.start.elapsed(), true);
+                if let Some(req) = streams.get_mut(&stream_id) {
+                    abort_stream(req);
+                }
                 streams.remove(&stream_id);
                 continue;
             }
@@ -2597,6 +2638,9 @@ impl QUICListener {
                                 .adaptive_admission
                                 .observe(req.start.elapsed(), true);
                         }
+                        if let Some(req) = streams.get_mut(&stream_id) {
+                            abort_stream(req);
+                        }
                         streams.remove(&stream_id);
                         continue;
                     }
@@ -2812,6 +2856,9 @@ impl QUICListener {
 
             // ── 5: remove terminal streams ────────────────────────────────────
             if terminal {
+                if let Some(req) = streams.get_mut(&stream_id) {
+                    abort_stream(req);
+                }
                 streams.remove(&stream_id);
             }
         }
@@ -3637,7 +3684,7 @@ mod tests {
     use std::net::SocketAddr;
 
     use super::{
-        ConnectionRoutes, TokenBucket, purge_connection_routes,
+        ConnectionRoutes, TokenBucket, abort_stream, purge_connection_routes,
         resolve_primary_from_radix_prefix, sweep_closed_connections,
     };
 
@@ -4149,5 +4196,194 @@ mod tests {
             cid_radix.longest_prefix_match(p1.as_ref()).is_none(),
             "timed-out connection must be removed from radix"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // abort_stream / stream teardown path tests (4.2)
+    //
+    // These tests exercise the three teardown paths defined in the
+    // connection-lifecycle spec:
+    //   (A) client reset before upstream response  (ReceivingRequest /
+    //       AwaitingUpstream phase)
+    //   (B) client reset during upstream body streaming (SendingResponse)
+    //   (C) upstream timeout / error
+    //
+    // Each test asserts that abort_stream releases all held resources
+    // deterministically: permits are dropped, channels are closed, and
+    // pending chunks are discarded.
+    // -----------------------------------------------------------------------
+
+    use crate::{RequestEnvelope, StreamPhase};
+    use crate::resilience::{AdaptiveAdmission, RouteQueueLimiter};
+    use std::time::Instant;
+    use tokio::sync::{Semaphore, mpsc, oneshot};
+
+    fn make_envelope(phase: StreamPhase) -> RequestEnvelope {
+        RequestEnvelope {
+            method: "GET".into(),
+            path: "/".into(),
+            authority: None,
+            body_tx: None,
+            body_buf: std::collections::VecDeque::new(),
+            body_buf_bytes: 0,
+            body_bytes_received: 0,
+            backend_addr: None,
+            backend_index: None,
+            upstream_name: None,
+            global_inflight_permit: None,
+            upstream_inflight_permit: None,
+            adaptive_admission_permit: None,
+            route_queue_permit: None,
+            start: Instant::now(),
+            total_request_deadline: Instant::now() + std::time::Duration::from_secs(30),
+            bodyless_mode: false,
+            phase,
+            request_fin_received: false,
+            upstream_result_rx: None,
+            response_chunk_rx: None,
+            response_headers_sent: false,
+            pending_chunk: None,
+        }
+    }
+
+    /// Path A: client reset before upstream response (ReceivingRequest phase).
+    /// Verifies permits are released and body_tx is dropped.
+    #[test]
+    fn abort_stream_receiving_request_releases_permits() {
+        let global_sem = Arc::new(Semaphore::new(1));
+        let upstream_sem = Arc::new(Semaphore::new(1));
+        let adaptive = Arc::new(AdaptiveAdmission::new(false, 1, 100, 1, 1, 1000));
+        let route_limiter = Arc::new(RouteQueueLimiter::new(100, 1000, Default::default()));
+
+        let global_permit = global_sem.clone().try_acquire_owned().unwrap();
+        let upstream_permit = upstream_sem.clone().try_acquire_owned().unwrap();
+        let adaptive_permit = adaptive.try_acquire().unwrap();
+        let route_permit = route_limiter.try_acquire("test").unwrap();
+
+        let (body_tx, body_rx) = mpsc::channel::<bytes::Bytes>(4);
+
+        let mut req = make_envelope(StreamPhase::ReceivingRequest);
+        req.global_inflight_permit = Some(global_permit);
+        req.upstream_inflight_permit = Some(upstream_permit);
+        req.adaptive_admission_permit = Some(adaptive_permit);
+        req.route_queue_permit = Some(route_permit);
+        req.body_tx = Some(body_tx);
+
+        let phase = abort_stream(&mut req);
+
+        assert_eq!(phase, StreamPhase::ReceivingRequest);
+
+        // Permits released: semaphores should be available again.
+        assert_eq!(global_sem.available_permits(), 1, "global semaphore must be freed");
+        assert_eq!(upstream_sem.available_permits(), 1, "upstream semaphore must be freed");
+
+        // body_tx dropped: body_rx should see the channel as disconnected.
+        drop(body_rx); // safe to drop receiver — just checking channel is closed
+
+        // All option fields cleared.
+        assert!(req.global_inflight_permit.is_none());
+        assert!(req.upstream_inflight_permit.is_none());
+        assert!(req.adaptive_admission_permit.is_none());
+        assert!(req.route_queue_permit.is_none());
+        assert!(req.body_tx.is_none());
+    }
+
+    /// Path A (variant): client reset while awaiting upstream response.
+    /// Dropping upstream_result_rx cancels the oneshot — the upstream task's
+    /// send will return Err and it will exit.
+    #[test]
+    fn abort_stream_awaiting_upstream_cancels_oneshot() {
+        let (result_tx, result_rx) = oneshot::channel::<crate::ForwardResult>();
+
+        let mut req = make_envelope(StreamPhase::AwaitingUpstream);
+        req.upstream_result_rx = Some(result_rx);
+
+        let phase = abort_stream(&mut req);
+
+        assert_eq!(phase, StreamPhase::AwaitingUpstream);
+        assert!(req.upstream_result_rx.is_none(), "oneshot receiver must be cleared");
+
+        // Sending on the now-orphaned sender should return Err (closed).
+        let send_result = result_tx.send(Err(spooky_errors::ProxyError::Transport(
+            "test".into(),
+        )));
+        assert!(
+            send_result.is_err(),
+            "upstream task send must fail after receiver dropped"
+        );
+    }
+
+    /// Path B: client reset during body streaming (SendingResponse phase).
+    /// Dropping response_chunk_rx causes the body-pump task's next send to
+    /// return Err, making the task exit promptly.
+    #[test]
+    fn abort_stream_sending_response_closes_chunk_channel() {
+        let (chunk_tx, chunk_rx) = mpsc::channel::<crate::ResponseChunk>(4);
+
+        let mut req = make_envelope(StreamPhase::SendingResponse);
+        req.response_chunk_rx = Some(chunk_rx);
+        req.pending_chunk = Some(crate::ResponseChunk::End);
+
+        let phase = abort_stream(&mut req);
+
+        assert_eq!(phase, StreamPhase::SendingResponse);
+        assert!(req.response_chunk_rx.is_none(), "chunk receiver must be cleared");
+        assert!(req.pending_chunk.is_none(), "pending chunk must be discarded");
+
+        // The body-pump task's sender should observe a closed channel.
+        let send_result = chunk_tx.try_send(crate::ResponseChunk::End);
+        assert!(
+            send_result.is_err(),
+            "body-pump task send must fail after receiver dropped"
+        );
+    }
+
+    /// Path C: upstream timeout / error tears down all resources regardless
+    /// of which fields are populated.
+    #[test]
+    fn abort_stream_upstream_error_releases_all_resources() {
+        let global_sem = Arc::new(Semaphore::new(2));
+        let upstream_sem = Arc::new(Semaphore::new(2));
+
+        let global_permit = global_sem.clone().try_acquire_owned().unwrap();
+        let upstream_permit = upstream_sem.clone().try_acquire_owned().unwrap();
+
+        let (_result_tx, result_rx) = oneshot::channel::<crate::ForwardResult>();
+        let (chunk_tx, chunk_rx) = mpsc::channel::<crate::ResponseChunk>(4);
+
+        let mut req = make_envelope(StreamPhase::SendingResponse);
+        req.global_inflight_permit = Some(global_permit);
+        req.upstream_inflight_permit = Some(upstream_permit);
+        req.upstream_result_rx = Some(result_rx);
+        req.response_chunk_rx = Some(chunk_rx);
+        req.pending_chunk = Some(crate::ResponseChunk::End);
+
+        let phase = abort_stream(&mut req);
+
+        assert_eq!(phase, StreamPhase::SendingResponse);
+        assert_eq!(global_sem.available_permits(), 2, "global semaphore must be fully freed");
+        assert_eq!(upstream_sem.available_permits(), 2, "upstream semaphore must be fully freed");
+        assert!(req.upstream_result_rx.is_none());
+        assert!(req.response_chunk_rx.is_none());
+        assert!(req.pending_chunk.is_none());
+
+        // Body-pump task sender sees closed channel.
+        assert!(chunk_tx.try_send(crate::ResponseChunk::End).is_err());
+    }
+
+    /// Verify abort_stream is idempotent: calling it twice must not panic or
+    /// double-decrement any semaphore.
+    #[test]
+    fn abort_stream_is_idempotent() {
+        let global_sem = Arc::new(Semaphore::new(1));
+        let permit = global_sem.clone().try_acquire_owned().unwrap();
+
+        let mut req = make_envelope(StreamPhase::ReceivingRequest);
+        req.global_inflight_permit = Some(permit);
+
+        abort_stream(&mut req);
+        abort_stream(&mut req); // second call must be a no-op
+
+        assert_eq!(global_sem.available_permits(), 1, "must not double-release permit");
     }
 }

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -313,6 +313,77 @@ fn resolve_primary_from_radix_prefix<T>(
     None
 }
 
+/// Remove all routing index entries for a connection that is being torn down.
+///
+/// Cleans `cid_routes`, `cid_radix`, and `peer_routes` for both the primary
+/// SCID and every alias SCID in `routing_scids`.  Extracted as a free
+/// function so it can be exercised in unit tests without a full
+/// `QUICListener` instance.
+pub(crate) fn purge_connection_routes(
+    cid_routes: &mut HashMap<Arc<[u8]>, Arc<[u8]>>,
+    cid_radix: &mut CidRadix,
+    peer_routes: &mut HashMap<std::net::SocketAddr, Arc<[u8]>>,
+    primary_scid: &Arc<[u8]>,
+    routing_scids: &std::collections::HashSet<Arc<[u8]>>,
+    peer_address: &std::net::SocketAddr,
+) {
+    cid_radix.remove(primary_scid.as_ref());
+    cid_routes.remove(primary_scid.as_ref());
+    for cid in routing_scids {
+        cid_radix.remove(cid.as_ref());
+        cid_routes.remove(cid.as_ref());
+    }
+    peer_routes.remove(peer_address);
+}
+
+/// Routing metadata extracted from a connection for use during cleanup.
+/// Kept as a plain struct so `sweep_closed_connections` is testable without
+/// a real `quiche::Connection`.
+pub(crate) struct ConnectionRoutes {
+    pub primary_scid: Arc<[u8]>,
+    pub routing_scids: std::collections::HashSet<Arc<[u8]>>,
+    pub peer_address: std::net::SocketAddr,
+}
+
+impl From<&crate::QuicConnection> for ConnectionRoutes {
+    fn from(c: &crate::QuicConnection) -> Self {
+        Self {
+            primary_scid: Arc::clone(&c.primary_scid),
+            routing_scids: c.routing_scids.clone(),
+            peer_address: c.peer_address,
+        }
+    }
+}
+
+/// Remove every SCID in `to_remove` from `connections` and all routing
+/// indexes.  Called from `handle_timeouts` after the closed-connection scan
+/// and extracted here so the removal sweep can be tested without a live
+/// `QUICListener`.
+pub(crate) fn sweep_closed_connections<C, F>(
+    connections: &mut HashMap<Arc<[u8]>, C>,
+    cid_routes: &mut HashMap<Arc<[u8]>, Arc<[u8]>>,
+    cid_radix: &mut CidRadix,
+    peer_routes: &mut HashMap<std::net::SocketAddr, Arc<[u8]>>,
+    to_remove: Vec<Arc<[u8]>>,
+    routes_of: F,
+) where
+    F: Fn(&C) -> ConnectionRoutes,
+{
+    for scid in to_remove {
+        if let Some(connection) = connections.remove(&scid) {
+            let routes = routes_of(&connection);
+            purge_connection_routes(
+                cid_routes,
+                cid_radix,
+                peer_routes,
+                &routes.primary_scid,
+                &routes.routing_scids,
+                &routes.peer_address,
+            );
+        }
+    }
+}
+
 impl QUICListener {
     pub fn new(config: SpookyConfig) -> Result<Self, ProxyError> {
         let shared_state = Arc::new(Self::build_shared_state(&config)?);
@@ -874,13 +945,14 @@ impl QUICListener {
     }
 
     fn remove_connection_routes(&mut self, connection: &QuicConnection) {
-        self.cid_radix.remove(connection.primary_scid.as_ref());
-        self.cid_routes.remove(connection.primary_scid.as_ref());
-        for cid in &connection.routing_scids {
-            self.cid_radix.remove(cid.as_ref());
-            self.cid_routes.remove(cid.as_ref());
-        }
-        self.peer_routes.remove(&connection.peer_address);
+        purge_connection_routes(
+            &mut self.cid_routes,
+            &mut self.cid_radix,
+            &mut self.peer_routes,
+            &connection.primary_scid,
+            &connection.routing_scids,
+            &connection.peer_address,
+        );
     }
 
     fn sync_connection_routes(&mut self, connection: &mut QuicConnection) -> Arc<[u8]> {
@@ -1217,7 +1289,10 @@ impl QUICListener {
 
             if connection.last_activity.elapsed() >= timeout {
                 connection.quic.on_timeout();
-                connection.last_activity = Instant::now();
+                // Do NOT reset last_activity here: only real packet I/O
+                // resets it.  Resetting on timeout would prevent quiche
+                // from receiving on_timeout() again during the drain
+                // period, causing draining connections to linger.
                 Self::flush_send(&self.socket, &mut send_buf, connection);
             }
 
@@ -1248,11 +1323,14 @@ impl QUICListener {
             }
         }
 
-        for scid in to_remove {
-            if let Some(connection) = self.connections.remove(&scid) {
-                self.remove_connection_routes(&connection);
-            }
-        }
+        sweep_closed_connections(
+            &mut self.connections,
+            &mut self.cid_routes,
+            &mut self.cid_radix,
+            &mut self.peer_routes,
+            to_remove,
+            |c| ConnectionRoutes::from(c),
+        );
     }
 
     fn handle_timeout(socket: &UdpSocket, send_buf: &mut [u8], connection: &mut QuicConnection) {
@@ -3555,7 +3633,13 @@ mod tests {
 
     use crate::cid_radix::CidRadix;
 
-    use super::{TokenBucket, resolve_primary_from_radix_prefix};
+    use std::collections::HashSet;
+    use std::net::SocketAddr;
+
+    use super::{
+        ConnectionRoutes, TokenBucket, purge_connection_routes,
+        resolve_primary_from_radix_prefix, sweep_closed_connections,
+    };
 
     fn cid(bytes: &[u8]) -> Arc<[u8]> {
         Arc::from(bytes)
@@ -3691,6 +3775,379 @@ mod tests {
             consumed, burst as usize,
             "fresh bucket must yield exactly burst={} tokens in a tight loop, got {}",
             burst, consumed
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // purge_connection_routes / idle-timeout cleanup regression tests
+    // -----------------------------------------------------------------------
+
+    fn peer(port: u16) -> SocketAddr {
+        format!("127.0.0.1:{}", port).parse().unwrap()
+    }
+
+    fn populated_routing_maps(
+        primary: &Arc<[u8]>,
+        aliases: &[Arc<[u8]>],
+        addr: SocketAddr,
+    ) -> (
+        HashMap<Arc<[u8]>, Arc<[u8]>>,
+        CidRadix,
+        HashMap<SocketAddr, Arc<[u8]>>,
+    ) {
+        let mut cid_routes: HashMap<Arc<[u8]>, Arc<[u8]>> = HashMap::new();
+        let mut cid_radix = CidRadix::new();
+        let mut peer_routes: HashMap<SocketAddr, Arc<[u8]>> = HashMap::new();
+
+        cid_radix.insert(Arc::clone(primary));
+        for alias in aliases {
+            cid_routes.insert(Arc::clone(alias), Arc::clone(primary));
+            cid_radix.insert(Arc::clone(alias));
+        }
+        peer_routes.insert(addr, Arc::clone(primary));
+
+        (cid_routes, cid_radix, peer_routes)
+    }
+
+    #[test]
+    fn purge_removes_primary_radix_entry() {
+        let primary = cid(&[1, 2, 3, 4, 5, 6, 7, 8]);
+        let addr = peer(4433);
+        let (mut cid_routes, mut cid_radix, mut peer_routes) =
+            populated_routing_maps(&primary, &[], addr);
+
+        purge_connection_routes(
+            &mut cid_routes,
+            &mut cid_radix,
+            &mut peer_routes,
+            &primary,
+            &HashSet::new(),
+            &addr,
+        );
+
+        assert!(
+            cid_radix.longest_prefix_match(primary.as_ref()).is_none(),
+            "primary SCID must be removed from radix after cleanup"
+        );
+        assert!(
+            peer_routes.get(&addr).is_none(),
+            "peer_routes entry must be removed after cleanup"
+        );
+    }
+
+    #[test]
+    fn purge_removes_all_alias_entries() {
+        let primary = cid(&[0xAA; 8]);
+        let alias1 = cid(&[0xBB; 8]);
+        let alias2 = cid(&[0xCC; 8]);
+        let addr = peer(4434);
+
+        let aliases = [Arc::clone(&alias1), Arc::clone(&alias2)];
+        let (mut cid_routes, mut cid_radix, mut peer_routes) =
+            populated_routing_maps(&primary, &aliases, addr);
+
+        let routing_scids: HashSet<Arc<[u8]>> = aliases.iter().cloned().collect();
+        purge_connection_routes(
+            &mut cid_routes,
+            &mut cid_radix,
+            &mut peer_routes,
+            &primary,
+            &routing_scids,
+            &addr,
+        );
+
+        assert!(
+            cid_routes.get(alias1.as_ref()).is_none(),
+            "alias1 must be removed from cid_routes"
+        );
+        assert!(
+            cid_routes.get(alias2.as_ref()).is_none(),
+            "alias2 must be removed from cid_routes"
+        );
+        assert!(
+            cid_radix.longest_prefix_match(alias1.as_ref()).is_none(),
+            "alias1 must be removed from radix"
+        );
+        assert!(
+            cid_radix.longest_prefix_match(alias2.as_ref()).is_none(),
+            "alias2 must be removed from radix"
+        );
+        assert!(
+            peer_routes.get(&addr).is_none(),
+            "peer_routes entry must be removed"
+        );
+    }
+
+    #[test]
+    fn repeated_purge_churn_leaves_no_stale_entries() {
+        // Simulate repeated connect/timeout/disconnect cycles on distinct
+        // connections to verify no entries from prior connections bleed
+        // across cycles.
+        let mut cid_routes: HashMap<Arc<[u8]>, Arc<[u8]>> = HashMap::new();
+        let mut cid_radix = CidRadix::new();
+        let mut peer_routes: HashMap<SocketAddr, Arc<[u8]>> = HashMap::new();
+
+        for i in 0u8..20 {
+            let primary = cid(&[i, i, i, i, i, i, i, i]);
+            let alias = cid(&[i | 0x80, i | 0x80, i | 0x80, i | 0x80,
+                               i | 0x80, i | 0x80, i | 0x80, i | 0x80]);
+            let addr = peer(5000 + u16::from(i));
+
+            // Register
+            cid_radix.insert(Arc::clone(&primary));
+            cid_radix.insert(Arc::clone(&alias));
+            cid_routes.insert(Arc::clone(&alias), Arc::clone(&primary));
+            peer_routes.insert(addr, Arc::clone(&primary));
+
+            // Tear down
+            let routing_scids: HashSet<Arc<[u8]>> = [Arc::clone(&alias)].into_iter().collect();
+            purge_connection_routes(
+                &mut cid_routes,
+                &mut cid_radix,
+                &mut peer_routes,
+                &primary,
+                &routing_scids,
+                &addr,
+            );
+        }
+
+        assert!(cid_routes.is_empty(), "cid_routes must be empty after all connections torn down");
+        assert!(peer_routes.is_empty(), "peer_routes must be empty after all connections torn down");
+    }
+
+    #[test]
+    fn purge_is_idempotent() {
+        // Calling purge twice for the same connection must not panic or leave
+        // phantom entries.
+        let primary = cid(&[0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80]);
+        let alias = cid(&[0x11, 0x21, 0x31, 0x41, 0x51, 0x61, 0x71, 0x81]);
+        let addr = peer(4440);
+
+        let (mut cid_routes, mut cid_radix, mut peer_routes) =
+            populated_routing_maps(&primary, &[Arc::clone(&alias)], addr);
+
+        let routing_scids: HashSet<Arc<[u8]>> = [Arc::clone(&alias)].into_iter().collect();
+
+        for _ in 0..2 {
+            purge_connection_routes(
+                &mut cid_routes,
+                &mut cid_radix,
+                &mut peer_routes,
+                &primary,
+                &routing_scids,
+                &addr,
+            );
+        }
+
+        assert!(cid_routes.is_empty(), "cid_routes must be empty after double purge");
+        assert!(peer_routes.is_empty(), "peer_routes must be empty after double purge");
+    }
+
+    // -----------------------------------------------------------------------
+    // sweep_closed_connections churn tests
+    //
+    // These tests simulate the handle_timeouts removal sweep end-to-end:
+    // connections are registered in all routing maps, marked as timed-out
+    // (placed in to_remove), and swept via sweep_closed_connections.  After
+    // each cycle the invariant is that no stale entries remain in any map.
+    // -----------------------------------------------------------------------
+
+    /// Minimal stand-in for QuicConnection — holds only the routing fields
+    /// that sweep_closed_connections needs.
+    struct StubConn {
+        primary_scid: Arc<[u8]>,
+        routing_scids: HashSet<Arc<[u8]>>,
+        peer_address: SocketAddr,
+    }
+
+    fn stub_routes(c: &StubConn) -> ConnectionRoutes {
+        ConnectionRoutes {
+            primary_scid: Arc::clone(&c.primary_scid),
+            routing_scids: c.routing_scids.clone(),
+            peer_address: c.peer_address,
+        }
+    }
+
+    fn register_stub(
+        conn: &StubConn,
+        connections: &mut HashMap<Arc<[u8]>, StubConn>,
+        cid_routes: &mut HashMap<Arc<[u8]>, Arc<[u8]>>,
+        cid_radix: &mut CidRadix,
+        peer_routes: &mut HashMap<SocketAddr, Arc<[u8]>>,
+    ) {
+        cid_radix.insert(Arc::clone(&conn.primary_scid));
+        for alias in &conn.routing_scids {
+            if alias.as_ref() != conn.primary_scid.as_ref() {
+                cid_routes.insert(Arc::clone(alias), Arc::clone(&conn.primary_scid));
+                cid_radix.insert(Arc::clone(alias));
+            }
+        }
+        peer_routes.insert(conn.peer_address, Arc::clone(&conn.primary_scid));
+    }
+
+    fn assert_maps_empty(
+        label: &str,
+        connections: &HashMap<Arc<[u8]>, StubConn>,
+        cid_routes: &HashMap<Arc<[u8]>, Arc<[u8]>>,
+        peer_routes: &HashMap<SocketAddr, Arc<[u8]>>,
+    ) {
+        assert!(connections.is_empty(), "{}: connections must be empty", label);
+        assert!(cid_routes.is_empty(), "{}: cid_routes must be empty", label);
+        assert!(peer_routes.is_empty(), "{}: peer_routes must be empty", label);
+    }
+
+    #[test]
+    fn sweep_removes_timed_out_connection_and_all_routes() {
+        let primary = cid(&[0x01; 8]);
+        let alias = cid(&[0x02; 8]);
+        let addr = peer(6000);
+
+        let conn = StubConn {
+            primary_scid: Arc::clone(&primary),
+            routing_scids: [Arc::clone(&primary), Arc::clone(&alias)].into_iter().collect(),
+            peer_address: addr,
+        };
+
+        let mut connections: HashMap<Arc<[u8]>, StubConn> = HashMap::new();
+        let mut cid_routes = HashMap::new();
+        let mut cid_radix = CidRadix::new();
+        let mut peer_routes = HashMap::new();
+
+        register_stub(&conn, &mut connections, &mut cid_routes, &mut cid_radix, &mut peer_routes);
+        connections.insert(Arc::clone(&primary), conn);
+
+        sweep_closed_connections(
+            &mut connections,
+            &mut cid_routes,
+            &mut cid_radix,
+            &mut peer_routes,
+            vec![Arc::clone(&primary)],
+            stub_routes,
+        );
+
+        assert_maps_empty("after single sweep", &connections, &cid_routes, &peer_routes);
+        assert!(
+            cid_radix.longest_prefix_match(primary.as_ref()).is_none(),
+            "primary must be removed from radix"
+        );
+        assert!(
+            cid_radix.longest_prefix_match(alias.as_ref()).is_none(),
+            "alias must be removed from radix"
+        );
+    }
+
+    #[test]
+    fn sweep_repeated_timeout_churn_leaves_no_stale_entries() {
+        // Simulate N rounds of: connect → timeout → sweep.  After every round
+        // all four routing maps must be fully empty — no entries from prior
+        // connections bleed into subsequent rounds.
+        let rounds = 30usize;
+
+        let mut connections: HashMap<Arc<[u8]>, StubConn> = HashMap::new();
+        let mut cid_routes: HashMap<Arc<[u8]>, Arc<[u8]>> = HashMap::new();
+        let mut cid_radix = CidRadix::new();
+        let mut peer_routes: HashMap<SocketAddr, Arc<[u8]>> = HashMap::new();
+
+        for i in 0..rounds {
+            let b = i as u8;
+            let primary = cid(&[b, b, b, b, b, b, b, b]);
+            let alias1 = cid(&[b | 0x80, b | 0x80, b | 0x80, b | 0x80,
+                                b | 0x80, b | 0x80, b | 0x80, b | 0x80]);
+            let addr = peer(7000 + i as u16);
+
+            let conn = StubConn {
+                primary_scid: Arc::clone(&primary),
+                routing_scids: [Arc::clone(&primary), Arc::clone(&alias1)]
+                    .into_iter()
+                    .collect(),
+                peer_address: addr,
+            };
+
+            register_stub(&conn, &mut connections, &mut cid_routes, &mut cid_radix, &mut peer_routes);
+            connections.insert(Arc::clone(&primary), conn);
+
+            // Simulate handle_timeouts detecting this connection as closed.
+            sweep_closed_connections(
+                &mut connections,
+                &mut cid_routes,
+                &mut cid_radix,
+                &mut peer_routes,
+                vec![Arc::clone(&primary)],
+                stub_routes,
+            );
+
+            assert_maps_empty(
+                &format!("round {}", i),
+                &connections,
+                &cid_routes,
+                &peer_routes,
+            );
+        }
+    }
+
+    #[test]
+    fn sweep_partial_batch_clears_only_removed_entries() {
+        // Two connections registered; only one timed out.  After sweep the
+        // surviving connection's entries must remain intact.
+        let p1 = cid(&[0xA1; 8]);
+        let p2 = cid(&[0xB1; 8]);
+        let addr1 = peer(8001);
+        let addr2 = peer(8002);
+
+        let conn1 = StubConn {
+            primary_scid: Arc::clone(&p1),
+            routing_scids: [Arc::clone(&p1)].into_iter().collect(),
+            peer_address: addr1,
+        };
+        let conn2 = StubConn {
+            primary_scid: Arc::clone(&p2),
+            routing_scids: [Arc::clone(&p2)].into_iter().collect(),
+            peer_address: addr2,
+        };
+
+        let mut connections: HashMap<Arc<[u8]>, StubConn> = HashMap::new();
+        let mut cid_routes = HashMap::new();
+        let mut cid_radix = CidRadix::new();
+        let mut peer_routes = HashMap::new();
+
+        register_stub(&conn1, &mut connections, &mut cid_routes, &mut cid_radix, &mut peer_routes);
+        register_stub(&conn2, &mut connections, &mut cid_routes, &mut cid_radix, &mut peer_routes);
+        connections.insert(Arc::clone(&p1), conn1);
+        connections.insert(Arc::clone(&p2), conn2);
+
+        // Only p1 times out.
+        sweep_closed_connections(
+            &mut connections,
+            &mut cid_routes,
+            &mut cid_radix,
+            &mut peer_routes,
+            vec![Arc::clone(&p1)],
+            stub_routes,
+        );
+
+        assert!(
+            !connections.contains_key(p1.as_ref()),
+            "timed-out connection must be removed"
+        );
+        assert!(
+            connections.contains_key(p2.as_ref()),
+            "surviving connection must remain in connections"
+        );
+        assert!(
+            peer_routes.get(&addr2).is_some(),
+            "surviving connection peer_route must remain"
+        );
+        assert!(
+            peer_routes.get(&addr1).is_none(),
+            "timed-out connection peer_route must be removed"
+        );
+        assert!(
+            cid_radix.longest_prefix_match(p2.as_ref()).is_some(),
+            "surviving connection must remain in radix"
+        );
+        assert!(
+            cid_radix.longest_prefix_match(p1.as_ref()).is_none(),
+            "timed-out connection must be removed from radix"
         );
     }
 }

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -2967,3 +2967,460 @@ fn response_body_cap_returns_503_on_unknown_length_breach() {
         "unknown-length cap breach should terminate with HTTP error, not stream reset"
     );
 }
+
+// ── Teardown path integration tests (4.2) ───────────────────────────────────
+//
+// These tests exercise the three wire-level teardown paths at the real QUIC
+// protocol layer.  Each test sends a real QUIC+H3 request, triggers a reset
+// or error mid-stream, then verifies the server recovers cleanly by serving a
+// subsequent request on the same connection without any stuck-stream symptoms.
+
+/// Helper: build a minimal quiche QUIC client connected to `addr`.
+/// Returns (socket, quic conn, h3 conn).  The h3 layer is negotiated inside.
+fn make_quic_client(
+    addr: SocketAddr,
+) -> Result<
+    (
+        std::net::UdpSocket,
+        std::net::SocketAddr,
+        quiche::Connection,
+        quiche::h3::Connection,
+    ),
+    String,
+> {
+    let socket = std::net::UdpSocket::bind("0.0.0.0:0").map_err(|e| e.to_string())?;
+    let local_addr = socket.local_addr().map_err(|e| e.to_string())?;
+
+    let mut qconfig =
+        quiche::Config::new(quiche::PROTOCOL_VERSION).map_err(|e| format!("config: {e:?}"))?;
+    qconfig.verify_peer(false);
+    qconfig
+        .set_application_protos(quiche::h3::APPLICATION_PROTOCOL)
+        .map_err(|e| format!("alpn: {e:?}"))?;
+    qconfig.set_max_idle_timeout(QUIC_IDLE_TIMEOUT_MS);
+    qconfig.set_max_recv_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    qconfig.set_max_send_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    qconfig.set_initial_max_data(QUIC_INITIAL_MAX_DATA);
+    let stream_win = QUIC_INITIAL_STREAM_DATA.saturating_add(128 * 1024);
+    qconfig.set_initial_max_stream_data_bidi_local(stream_win);
+    qconfig.set_initial_max_stream_data_bidi_remote(stream_win);
+    qconfig.set_initial_max_stream_data_uni(stream_win);
+    qconfig.set_initial_max_streams_bidi(QUIC_INITIAL_MAX_STREAMS_BIDI);
+    qconfig.set_initial_max_streams_uni(QUIC_INITIAL_MAX_STREAMS_UNI);
+    qconfig.set_disable_active_migration(true);
+
+    let mut scid_bytes = [0u8; quiche::MAX_CONN_ID_LEN];
+    rand::thread_rng().fill_bytes(&mut scid_bytes);
+    let scid = quiche::ConnectionId::from_ref(&scid_bytes);
+    let mut conn = quiche::connect(Some("localhost"), &scid, local_addr, addr, &mut qconfig)
+        .map_err(|e| format!("connect: {e:?}"))?;
+
+    let h3_config = quiche::h3::Config::new().map_err(|e| format!("h3: {e:?}"))?;
+    let mut out = [0u8; MAX_UDP_PAYLOAD_BYTES];
+    let mut buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
+
+    // Initial packet.
+    let (w, si) = conn.send(&mut out).map_err(|e| format!("initial send: {e:?}"))?;
+    socket.send_to(&out[..w], si.to).map_err(|e| e.to_string())?;
+
+    let deadline = Instant::now() + Duration::from_secs(REQUEST_TIMEOUT_SECS);
+    loop {
+        loop {
+            match conn.send(&mut out) {
+                Ok((w, si)) => { let _ = socket.send_to(&out[..w], si.to); }
+                Err(quiche::Error::Done) => break,
+                Err(e) => return Err(format!("send: {e:?}")),
+            }
+        }
+        if conn.is_established() {
+            break;
+        }
+        socket.set_read_timeout(Some(quic_read_timeout(&conn))).ok();
+        match socket.recv_from(&mut buf) {
+            Ok((len, from)) => {
+                conn.recv(&mut buf[..len], quiche::RecvInfo { from, to: local_addr })
+                    .map_err(|e| format!("recv: {e:?}"))?;
+            }
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock
+                || e.kind() == std::io::ErrorKind::TimedOut =>
+            {
+                conn.on_timeout();
+            }
+            Err(e) => return Err(e.to_string()),
+        }
+        if Instant::now() > deadline {
+            return Err("handshake timeout".into());
+        }
+    }
+
+    let h3 = quiche::h3::Connection::with_transport(&mut conn, &h3_config)
+        .map_err(|e| format!("h3 layer: {e:?}"))?;
+    Ok((socket, local_addr, conn, h3))
+}
+
+/// Flush QUIC send buffer to the socket.
+fn flush_quic(
+    conn: &mut quiche::Connection,
+    socket: &std::net::UdpSocket,
+    out: &mut [u8],
+) {
+    loop {
+        match conn.send(out) {
+            Ok((w, si)) => { let _ = socket.send_to(&out[..w], si.to); }
+            Err(quiche::Error::Done) => break,
+            Err(_) => break,
+        }
+    }
+}
+
+/// Pump the QUIC event loop until `target_sid` finishes/resets OR `deadline`
+/// passes.  Collects H3 status/finished/reset events.  Returns true if done.
+fn pump_h3_until(
+    conn: &mut quiche::Connection,
+    h3: &mut quiche::h3::Connection,
+    socket: &std::net::UdpSocket,
+    local_addr: std::net::SocketAddr,
+    out: &mut [u8],
+    buf: &mut [u8],
+    target_sid: u64,
+    deadline: Instant,
+    events: &mut Vec<String>,
+) -> bool {
+    while Instant::now() < deadline {
+        flush_quic(conn, socket, out);
+        socket.set_read_timeout(Some(quic_read_timeout(conn))).ok();
+        match socket.recv_from(buf) {
+            Ok((len, from)) => {
+                let _ = conn.recv(&mut buf[..len], quiche::RecvInfo { from, to: local_addr });
+            }
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock
+                || e.kind() == std::io::ErrorKind::TimedOut =>
+            {
+                conn.on_timeout();
+            }
+            Err(_) => {}
+        }
+        loop {
+            match h3.poll(conn) {
+                Ok((sid, quiche::h3::Event::Headers { list, .. })) if sid == target_sid => {
+                    for h in &list {
+                        if h.name() == b":status" {
+                            events.push(format!("status:{}", String::from_utf8_lossy(h.value())));
+                        }
+                    }
+                }
+                Ok((sid, quiche::h3::Event::Data)) if sid == target_sid => {
+                    // consume body without storing
+                    let mut tmp = [0u8; 4096];
+                    while h3.recv_body(conn, sid, &mut tmp).is_ok() {}
+                    events.push("data".into());
+                }
+                Ok((sid, quiche::h3::Event::Finished)) if sid == target_sid => {
+                    events.push("finished".into());
+                    return true;
+                }
+                Ok((sid, quiche::h3::Event::Reset(_))) if sid == target_sid => {
+                    events.push("reset".into());
+                    return true;
+                }
+                Ok(_) => {}
+                Err(quiche::h3::Error::Done) => break,
+                Err(_) => break,
+            }
+        }
+    }
+    false
+}
+
+/// Teardown path A: client sends RESET_STREAM before the upstream has responded.
+///
+/// Uses `global_inflight_limit = 1` so the inflight permit is the only one
+/// available.  If `abort_stream` does not release it on reset, the follow-up
+/// `/fast` request on a fresh connection is rejected with 503 (inflight full)
+/// instead of 200. Passing means the wire-level reset propagated and resources
+/// were freed.
+#[test]
+fn teardown_client_reset_before_upstream_response() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_certs(&dir);
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+
+    let backend_addr = rt.block_on(start_h2_backend_with_regression_routes());
+    let mut config = make_config(0, backend_addr.to_string(), cert, key);
+    // Single inflight slot: a leaked permit means the follow-up is rejected.
+    config.performance.global_inflight_limit = 1;
+
+    let listener = QUICListener::new(config).expect("listener");
+    let listen_addr = listener.socket.local_addr().unwrap();
+    let _guard = ListenerTaskGuard::spawn(&rt, listener);
+
+    let (socket, local_addr, mut conn, mut h3) =
+        make_quic_client(listen_addr).expect("quic client");
+    let mut out = [0u8; MAX_UDP_PAYLOAD_BYTES];
+    let mut buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
+
+    // POST to /slow with fin=false so the write side stays open.
+    // Then immediately call stream_shutdown(Write) to send RESET_STREAM.
+    // The server is in ReceivingRequest at reset time (before it forwards to
+    // upstream), which exercises the AwaitingUpstream/ReceivingRequest teardown path.
+    let slow_headers = vec![
+        quiche::h3::Header::new(b":method", b"POST"),
+        quiche::h3::Header::new(b":scheme", b"https"),
+        quiche::h3::Header::new(b":authority", b"localhost"),
+        quiche::h3::Header::new(b":path", b"/slow"),
+        quiche::h3::Header::new(b"content-length", b"100"),
+    ];
+    let slow_sid = h3
+        .send_request(&mut conn, &slow_headers, false) // fin=false: write side stays open
+        .expect("send_request /slow");
+
+    // Flush so headers reach the server, then shut down the write side.
+    // This sends RESET_STREAM while the server is still in ReceivingRequest.
+    flush_quic(&mut conn, &socket, &mut out);
+    conn.stream_shutdown(slow_sid, quiche::Shutdown::Write, 0)
+        .expect("stream_shutdown");
+    flush_quic(&mut conn, &socket, &mut out);
+
+    // Pump briefly so the listener processes the reset and calls abort_stream.
+    let pump_end = Instant::now() + Duration::from_millis(200);
+    let mut discard = Vec::new();
+    pump_h3_until(
+        &mut conn, &mut h3, &socket, local_addr,
+        &mut out, &mut buf, slow_sid, pump_end, &mut discard,
+    );
+
+    // Follow-up /fast on a fresh connection. This avoids coupling the assertion
+    // to the original stream state machine on the same connection while still
+    // proving the inflight permit was released.
+    let followup = run_h3_client_concurrent_get(
+        listen_addr,
+        &["/fast"],
+        Duration::from_secs(REQUEST_TIMEOUT_SECS + 4),
+    )
+    .expect("follow-up /fast request failed");
+    let fast = observation_for(&followup, "/fast");
+    assert!(
+        fast.status.as_deref() == Some("200"),
+        "expected 200 from /fast; 503/timeout means the inflight permit was not released on reset. \
+         observed status={:?}",
+        fast.status
+    );
+}
+
+/// Teardown path B: connection dropped while the server is streaming the
+/// response body (SendingResponse phase).
+///
+/// Uses `global_inflight_limit = 1` and `/long-stream` (4×220ms chunks).
+/// The first QUIC connection receives response headers (server now in
+/// SendingResponse) then drops abruptly — simulating the client disappearing
+/// mid-stream.  The server must release the inflight permit via the timeout/
+/// connection-close path so a *new* connection can immediately serve a request.
+/// If the permit leaks, the second connection's /fast request gets 503.
+#[test]
+fn teardown_client_reset_during_response_streaming() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_certs(&dir);
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+
+    let backend_addr = rt.block_on(start_h2_backend_with_regression_routes());
+    let mut config = make_config(0, backend_addr.to_string(), cert, key);
+    // Single inflight slot: a leaked permit means the follow-up is rejected.
+    config.performance.global_inflight_limit = 1;
+    // Short QUIC idle timeout so the server tears down the abandoned stream fast.
+    config.performance.quic_max_idle_timeout_ms = 300;
+
+    let listener = QUICListener::new(config).expect("listener");
+    let listen_addr = listener.socket.local_addr().unwrap();
+    let _guard = ListenerTaskGuard::spawn(&rt, listener);
+
+    // ── First connection: GET /stream, receive first body chunk, then drop ────
+    {
+        let (socket, local_addr, mut conn, mut h3) =
+            make_quic_client(listen_addr).expect("quic client");
+        let mut out = [0u8; MAX_UDP_PAYLOAD_BYTES];
+        let mut buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
+
+        let headers = vec![
+            quiche::h3::Header::new(b":method", b"GET"),
+            quiche::h3::Header::new(b":scheme", b"https"),
+            quiche::h3::Header::new(b":authority", b"localhost"),
+            quiche::h3::Header::new(b":path", b"/stream"),
+        ];
+        let stream_sid = h3
+            .send_request(&mut conn, &headers, true)
+            .expect("send_request /stream");
+        flush_quic(&mut conn, &socket, &mut out);
+
+        // Wait for first response data chunk — this guarantees the server is in
+        // SendingResponse and actively streaming.
+        let data_deadline = Instant::now() + Duration::from_secs(REQUEST_TIMEOUT_SECS);
+        let mut got_data = false;
+        'wait: loop {
+            flush_quic(&mut conn, &socket, &mut out);
+            socket.set_read_timeout(Some(quic_read_timeout(&conn))).ok();
+            match socket.recv_from(&mut buf) {
+                Ok((len, from)) => {
+                    let _ = conn.recv(
+                        &mut buf[..len],
+                        quiche::RecvInfo { from, to: local_addr },
+                    );
+                }
+                Err(ref e)
+                    if e.kind() == std::io::ErrorKind::WouldBlock
+                        || e.kind() == std::io::ErrorKind::TimedOut =>
+                {
+                    conn.on_timeout();
+                }
+                Err(_) => {}
+            }
+            loop {
+                match h3.poll(&mut conn) {
+                    Ok((sid, quiche::h3::Event::Data)) if sid == stream_sid => {
+                        let mut tmp = [0u8; 4096];
+                        while h3.recv_body(&mut conn, sid, &mut tmp).is_ok() {}
+                        got_data = true;
+                        break 'wait;
+                    }
+                    Ok((sid, quiche::h3::Event::Finished)) if sid == stream_sid => {
+                        panic!("stream finished before teardown point");
+                    }
+                    Ok(_) => {}
+                    Err(quiche::h3::Error::Done) => break,
+                    Err(_) => break,
+                }
+            }
+            if Instant::now() > data_deadline {
+                panic!("timed out waiting for /stream response data");
+            }
+        }
+        assert!(got_data, "must receive response data before dropping connection");
+        // Connection drops here (socket + conn out of scope) — server is left
+        // in SendingResponse with an orphaned body-pump task.
+    }
+
+    // Wait for the server to detect the idle timeout and tear down the stream.
+    // quic_max_idle_timeout_ms=300ms + some margin for the poll loop.
+    std::thread::sleep(Duration::from_millis(600));
+
+    // ── Second connection: /fast must succeed ──────────────────────────────
+    // If the inflight permit was not released, this request gets 503.
+    let (socket2, local_addr2, mut conn2, mut h3_2) =
+        make_quic_client(listen_addr).expect("second quic client");
+    let mut out2 = [0u8; MAX_UDP_PAYLOAD_BYTES];
+    let mut buf2 = [0u8; MAX_DATAGRAM_SIZE_BYTES];
+
+    let fast_headers = vec![
+        quiche::h3::Header::new(b":method", b"GET"),
+        quiche::h3::Header::new(b":scheme", b"https"),
+        quiche::h3::Header::new(b":authority", b"localhost"),
+        quiche::h3::Header::new(b":path", b"/fast"),
+    ];
+    let fast_sid = h3_2
+        .send_request(&mut conn2, &fast_headers, true)
+        .expect("send_request /fast on second connection");
+
+    let mut events = Vec::new();
+    let done = pump_h3_until(
+        &mut conn2, &mut h3_2, &socket2, local_addr2,
+        &mut out2, &mut buf2, fast_sid,
+        Instant::now() + Duration::from_secs(REQUEST_TIMEOUT_SECS + 2),
+        &mut events,
+    );
+
+    assert!(
+        done,
+        "second-connection /fast must complete; timeout means inflight permit leaked \
+         from the abandoned SendingResponse stream"
+    );
+    assert!(
+        events.iter().any(|e| e.starts_with("status:200")),
+        "expected 200; 503 means the global inflight permit was not released. \
+         events={events:?}"
+    );
+}
+
+/// Teardown path C: upstream connection times out.
+///
+/// The client requests `/timeout` which sleeps longer than the configured
+/// backend timeout.  The server must send a 503 and clean up all stream
+/// resources.  A subsequent /fast request on the same connection must succeed.
+#[test]
+fn teardown_upstream_timeout_cleans_up_stream() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_certs(&dir);
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+
+    let backend_addr = rt.block_on(start_h2_backend_with_regression_routes());
+    let mut config = make_config(0, backend_addr.to_string(), cert, key);
+    // Use a short timeout so the test doesn't wait long.
+    config.performance.backend_timeout_ms = 200;
+
+    let listener = QUICListener::new(config).expect("listener");
+    let listen_addr = listener.socket.local_addr().unwrap();
+    let _guard = ListenerTaskGuard::spawn(&rt, listener);
+
+    let (socket, local_addr, mut conn, mut h3) =
+        make_quic_client(listen_addr).expect("quic client");
+    let mut out = [0u8; MAX_UDP_PAYLOAD_BYTES];
+    let mut buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
+
+    // Step 1: send /timeout request and wait for the 503 error response.
+    let timeout_headers = vec![
+        quiche::h3::Header::new(b":method", b"GET"),
+        quiche::h3::Header::new(b":scheme", b"https"),
+        quiche::h3::Header::new(b":authority", b"localhost"),
+        quiche::h3::Header::new(b":path", b"/timeout"),
+    ];
+    let timeout_sid = h3
+        .send_request(&mut conn, &timeout_headers, true)
+        .expect("send_request /timeout");
+
+    let mut timeout_events = Vec::new();
+    // backend_timeout_ms=200ms + some margin for the listener to respond
+    let done = pump_h3_until(
+        &mut conn,
+        &mut h3,
+        &socket,
+        local_addr,
+        &mut out,
+        &mut buf,
+        timeout_sid,
+        Instant::now() + Duration::from_secs(5),
+        &mut timeout_events,
+    );
+    assert!(done, "timeout stream must finish (with 503)");
+    assert!(
+        timeout_events.iter().any(|e| e.starts_with("status:503")),
+        "timeout must produce 503, got: {timeout_events:?}"
+    );
+
+    // Step 2: follow-up /fast on the same connection — proves the timeout
+    // teardown released all resources and the connection is still alive.
+    let fast_headers = vec![
+        quiche::h3::Header::new(b":method", b"GET"),
+        quiche::h3::Header::new(b":scheme", b"https"),
+        quiche::h3::Header::new(b":authority", b"localhost"),
+        quiche::h3::Header::new(b":path", b"/fast"),
+    ];
+    let fast_sid = h3
+        .send_request(&mut conn, &fast_headers, true)
+        .expect("send_request /fast after timeout");
+
+    let mut fast_events = Vec::new();
+    let done = pump_h3_until(
+        &mut conn,
+        &mut h3,
+        &socket,
+        local_addr,
+        &mut out,
+        &mut buf,
+        fast_sid,
+        Instant::now() + Duration::from_secs(REQUEST_TIMEOUT_SECS + 2),
+        &mut fast_events,
+    );
+    assert!(done, "follow-up /fast request must complete after timeout teardown");
+    assert!(
+        fast_events.iter().any(|e| e.starts_with("status:200")),
+        "follow-up request must receive 200, got: {fast_events:?}"
+    );
+}

--- a/crates/edge/tests/h3_edge.rs
+++ b/crates/edge/tests/h3_edge.rs
@@ -988,3 +988,209 @@ fn normal_traffic_below_rate_limit_is_unaffected() {
         REQUEST_COUNT
     );
 }
+
+// ---------------------------------------------------------------------------
+// Connection-lifecycle churn stress test (task 4.3)
+//
+// Runs many connect/request/disconnect cycles and asserts that no orphaned
+// entries are left in connections, cid_routes, peer_routes, or the radix trie.
+// ---------------------------------------------------------------------------
+
+/// Build a QUIC client config suitable for stress rounds.
+fn make_quic_client_config() -> quiche::Config {
+    let mut cfg = quiche::Config::new(quiche::PROTOCOL_VERSION).expect("quiche config");
+    cfg.verify_peer(false);
+    cfg.set_application_protos(quiche::h3::APPLICATION_PROTOCOL)
+        .expect("alpn");
+    // Use a short idle timeout so dropped sockets get cleaned up quickly.
+    cfg.set_max_idle_timeout(500);
+    cfg.set_max_recv_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    cfg.set_max_send_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    cfg.set_initial_max_data(QUIC_INITIAL_MAX_DATA);
+    cfg.set_initial_max_stream_data_bidi_local(QUIC_INITIAL_STREAM_DATA);
+    cfg.set_initial_max_stream_data_bidi_remote(QUIC_INITIAL_STREAM_DATA);
+    cfg.set_initial_max_stream_data_uni(QUIC_INITIAL_STREAM_DATA);
+    cfg.set_initial_max_streams_bidi(QUIC_INITIAL_MAX_STREAMS_BIDI);
+    cfg.set_initial_max_streams_uni(QUIC_INITIAL_MAX_STREAMS_UNI);
+    cfg.set_disable_active_migration(true);
+    cfg
+}
+
+/// Connect to `server_addr` and drive the QUIC handshake until established.
+/// Returns `(socket, local_addr, conn, h3)` on success, or an error string.
+fn stress_connect(
+    server_addr: std::net::SocketAddr,
+) -> Result<
+    (
+        UdpSocket,
+        std::net::SocketAddr,
+        quiche::Connection,
+        quiche::h3::Connection,
+    ),
+    String,
+> {
+    let socket = UdpSocket::bind("0.0.0.0:0").map_err(|e| e.to_string())?;
+    let local_addr = socket.local_addr().map_err(|e| e.to_string())?;
+    socket
+        .set_read_timeout(Some(Duration::from_millis(100)))
+        .map_err(|e| e.to_string())?;
+
+    let mut cfg = make_quic_client_config();
+    let mut scid_bytes = [0u8; quiche::MAX_CONN_ID_LEN];
+    rand::thread_rng().fill_bytes(&mut scid_bytes);
+    let scid = quiche::ConnectionId::from_ref(&scid_bytes);
+
+    let mut conn =
+        quiche::connect(Some("localhost"), &scid, local_addr, server_addr, &mut cfg)
+            .map_err(|e| format!("connect: {e:?}"))?;
+
+    let mut out = [0u8; MAX_UDP_PAYLOAD_BYTES];
+    let mut buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
+
+    let (w, si) = conn.send(&mut out).map_err(|e| format!("send: {e:?}"))?;
+    socket
+        .send_to(&out[..w], si.to)
+        .map_err(|e| format!("send_to: {e:?}"))?;
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        loop {
+            match conn.send(&mut out) {
+                Ok((w, si)) => {
+                    let _ = socket.send_to(&out[..w], si.to);
+                }
+                Err(quiche::Error::Done) => break,
+                Err(e) => return Err(format!("send: {e:?}")),
+            }
+        }
+
+        if conn.is_established() {
+            break;
+        }
+
+        match socket.recv_from(&mut buf) {
+            Ok((len, from)) => {
+                conn.recv(&mut buf[..len], quiche::RecvInfo { from, to: local_addr })
+                    .map_err(|e| format!("recv: {e:?}"))?;
+            }
+            Err(ref e)
+                if e.kind() == std::io::ErrorKind::WouldBlock
+                    || e.kind() == std::io::ErrorKind::TimedOut =>
+            {
+                conn.on_timeout();
+            }
+            Err(e) => return Err(format!("recv: {e:?}")),
+        }
+
+        if Instant::now() > deadline {
+            return Err("handshake timeout".to_string());
+        }
+    }
+
+    let h3_cfg = quiche::h3::Config::new().map_err(|e| format!("h3 cfg: {e:?}"))?;
+    let h3 = quiche::h3::Connection::with_transport(&mut conn, &h3_cfg)
+        .map_err(|e| format!("h3 conn: {e:?}"))?;
+
+    Ok((socket, local_addr, conn, h3))
+}
+
+/// Send a graceful QUIC CONNECTION_CLOSE and flush.
+fn stress_close_gracefully(
+    socket: &UdpSocket,
+    conn: &mut quiche::Connection,
+) {
+    let _ = conn.close(false, 0, b"done");
+    let mut out = [0u8; MAX_UDP_PAYLOAD_BYTES];
+    loop {
+        match conn.send(&mut out) {
+            Ok((w, si)) => {
+                let _ = socket.send_to(&out[..w], si.to);
+            }
+            Err(_) => break,
+        }
+    }
+}
+
+/// Stress test: repeatedly connect, optionally complete a request, then close
+/// or abruptly drop.  After all rounds the listener maps must be fully empty.
+#[test]
+fn lifecycle_churn_leaves_no_orphaned_state() {
+    const ROUNDS: usize = 30;
+    // Idle timeout matches the client config (500 ms).
+    const IDLE_MS: u64 = 500;
+
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_certs(&dir);
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let backend_addr = rt.block_on(start_h2_backend("ok\n"));
+
+    let mut config = make_config(0, cert, key, backend_addr.to_string());
+    // Match the client-side idle timeout so both sides agree.
+    config.performance.quic_max_idle_timeout_ms = IDLE_MS;
+    // Generous limits so the stress loop is never rate-limited.
+    config.performance.new_connections_per_sec = 10_000;
+    config.performance.new_connections_burst = 1_000;
+
+    let listener = Arc::new(Mutex::new(
+        QUICListener::new(config).expect("failed to create listener"),
+    ));
+    let server_addr = listener.lock().unwrap().socket.local_addr().unwrap();
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_flag = stop.clone();
+    let listener_poll = listener.clone();
+    let poll_handle = thread::spawn(move || {
+        while !stop_flag.load(Ordering::Relaxed) {
+            if let Ok(mut g) = listener_poll.lock() {
+                g.poll();
+            }
+        }
+    });
+
+    for round in 0..ROUNDS {
+        let (socket, _local_addr, mut conn, _h3) =
+            stress_connect(server_addr).unwrap_or_else(|e| panic!("round {round}: connect: {e}"));
+
+        socket
+            .set_read_timeout(Some(Duration::from_millis(100)))
+            .expect("set_read_timeout");
+
+        // Even rounds close gracefully; odd rounds abruptly drop the socket.
+        if round % 2 == 0 {
+            stress_close_gracefully(&socket, &mut conn);
+        }
+        // Odd rounds: drop socket and conn; server detects via idle timeout.
+    }
+
+    // Allow the idle timeout (500 ms) to fire and the listener to sweep all
+    // timed-out connections.  We wait 3× idle timeout for safety margin.
+    thread::sleep(Duration::from_millis(IDLE_MS * 3));
+
+    stop.store(true, Ordering::Relaxed);
+    let _ = poll_handle.join();
+
+    // Drive one final poll to flush any remaining close/sweep work.
+    if let Ok(mut g) = listener.lock() {
+        for _ in 0..20 {
+            g.poll();
+        }
+    }
+
+    let guard = listener.lock().expect("listener lock");
+    assert_cid_sync_invariants(&guard);
+    assert!(
+        guard.connections.is_empty(),
+        "connections must be empty after churn, found {} entries",
+        guard.connections.len()
+    );
+    assert!(
+        guard.cid_routes.is_empty(),
+        "cid_routes must be empty after churn, found {} entries",
+        guard.cid_routes.len()
+    );
+    assert!(
+        guard.peer_routes.is_empty(),
+        "peer_routes must be empty after churn, found {} entries",
+        guard.peer_routes.len()
+    );
+}


### PR DESCRIPTION
## Summary
- Strengthened graceful shutdown/drain behavior for in-flight requests
- Added configurable `performance.shutdown_drain_timeout_ms` and enforced it
- Hardened stream teardown across reset/timeout/error paths with deterministic cleanup
- Expanded lifecycle regression coverage for stale-route cleanup and churn

## What changed
- Drain/shutdown:
  - drain continues active streams and enforces configurable force-close timeout
  - rejects new Initial connections during draining
- Stream teardown:
  - centralized abort logic releases permits, channels, and pending chunks
  - covers client reset (before upstream + during streaming) and upstream timeout/error paths
- Connection lifecycle/churn:
  - added repeated timeout/churn cleanup tests
  - validates invariants across `connections`, `cid_routes`, `peer_routes`, and radix
- Config/docs:
  - added `performance.shutdown_drain_timeout_ms` (default `5000`, validated `> 0`)
  - updated sample config and config reference docs

## Validation
- Targeted `spooky-config` validator tests passed
- Targeted `spooky-edge` drain/teardown/churn tests passed
- Confirms no stale/orphaned routing state after lifecycle churn