### PR TITLE
feat(runtime): harden memory caps and slow-client handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: run build build-spooky clean test test-edge test-transport certs certs-selfsigned certs-ca certs-clean certs-verify bench-micro bench-macro bench-gate bench-promote-baseline
+.PHONY: run build build-spooky clean test test-edge test-transport certs certs-selfsigned certs-ca certs-clean certs-verify certs-dir bench-micro bench-macro bench-gate bench-promote-baseline
+
+CERTS_DIR := certs
+SAN_CONF := $(CERTS_DIR)/san.conf
 
 run:
 	make build
@@ -20,7 +23,38 @@ test-transport:
 	sudo cargo test -p spooky-transport
 
 # Certificate generation targets
-certs-selfsigned:
+certs-dir:
+	mkdir -p $(CERTS_DIR)
+
+$(SAN_CONF): | certs-dir
+	@if [ ! -f "$(SAN_CONF)" ]; then \
+		echo "[req]" > "$(SAN_CONF)"; \
+		echo "default_bits = 2048" >> "$(SAN_CONF)"; \
+		echo "prompt = no" >> "$(SAN_CONF)"; \
+		echo "default_md = sha256" >> "$(SAN_CONF)"; \
+		echo "distinguished_name = req_distinguished_name" >> "$(SAN_CONF)"; \
+		echo "req_extensions = v3_req" >> "$(SAN_CONF)"; \
+		echo "" >> "$(SAN_CONF)"; \
+		echo "[req_distinguished_name]" >> "$(SAN_CONF)"; \
+		echo "C = US" >> "$(SAN_CONF)"; \
+		echo "ST = California" >> "$(SAN_CONF)"; \
+		echo "L = San Francisco" >> "$(SAN_CONF)"; \
+		echo "O = Spooky Proxy" >> "$(SAN_CONF)"; \
+		echo "OU = Development" >> "$(SAN_CONF)"; \
+		echo "CN = localhost" >> "$(SAN_CONF)"; \
+		echo "" >> "$(SAN_CONF)"; \
+		echo "[v3_req]" >> "$(SAN_CONF)"; \
+		echo "subjectAltName = @alt_names" >> "$(SAN_CONF)"; \
+		echo "" >> "$(SAN_CONF)"; \
+		echo "[alt_names]" >> "$(SAN_CONF)"; \
+		echo "DNS.1 = localhost" >> "$(SAN_CONF)"; \
+		echo "DNS.2 = proxy.spooky.local" >> "$(SAN_CONF)"; \
+		echo "IP.1 = 127.0.0.1" >> "$(SAN_CONF)"; \
+		echo "IP.2 = ::1" >> "$(SAN_CONF)"; \
+		echo "✅ Created default $(SAN_CONF)"; \
+	fi
+
+certs-selfsigned: $(SAN_CONF)
 	@echo "🔐 Generating ECC P-256 private key..."
 	openssl ecparam -name prime256v1 -genkey -noout -out certs/proxy-key.pem
 	@echo "🔄 Converting to PKCS#8 format for rustls compatibility..."
@@ -37,7 +71,7 @@ certs-selfsigned:
 	chmod 644 certs/proxy-cert.pem certs/proxy-cert.der
 	@echo "✅ Self-signed certificates created successfully!"
 
-certs-ca:
+certs-ca: $(SAN_CONF)
 	@echo "🏛️ Creating Certificate Authority..."
 	openssl ecparam -name prime256v1 -genkey -noout -out certs/ca-key.pem
 	openssl pkcs8 -topk8 -nocrypt -in certs/ca-key.pem -out certs/ca-key-pkcs8.pem

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -60,6 +60,7 @@ performance:
     control_plane_threads: 2
     packet_shards_per_worker: 1
     packet_shard_queue_capacity: 2048
+    packet_shard_queue_max_bytes: 67108864    # max queued UDP datagram bytes per shard dispatch queue (64 MiB)
     reuseport: true
     pin_workers: false
     global_inflight_limit: 4096
@@ -82,7 +83,11 @@ performance:
     quic_initial_max_stream_data: 1000000   # per-stream flow control window (bytes); must be <= quic_initial_max_data
     quic_initial_max_streams_bidi: 100      # max concurrent bidirectional streams per connection
     quic_initial_max_streams_uni: 100       # max concurrent unidirectional streams per connection
+    max_request_body_bytes: 1000000         # hard cap on client request body bytes per stream (413 on breach)
     max_response_body_bytes: 104857600      # hard cap on upstream response body per stream (100 MiB); streams exceeding this get a 502
+    request_buffer_global_cap_bytes: 67108864         # global cap for bytes buffered in request backpressure queues (64 MiB)
+    unknown_length_response_prebuffer_bytes: 2097152  # max bytes buffered for unknown-length upstream responses before emitting headers (2 MiB)
+    client_body_idle_timeout_ms: 10000                # fail request streams that stop sending body bytes for this long
 
 observability:
     metrics:

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -10,21 +10,24 @@ use crate::default::{
     observe_default_address, observe_default_metrics_path, observe_default_port,
     perf_default_backend_body_idle_timeout_ms, perf_default_backend_body_total_timeout_ms,
     perf_default_backend_connect_timeout_ms, perf_default_backend_timeout_ms,
-    perf_default_backend_total_request_timeout_ms, perf_default_control_plane_threads,
-    perf_default_global_inflight_limit, perf_default_h2_pool_idle_timeout_ms,
-    perf_default_h2_pool_max_idle_per_backend, perf_default_max_response_body_bytes,
+    perf_default_backend_total_request_timeout_ms, perf_default_client_body_idle_timeout_ms,
+    perf_default_control_plane_threads, perf_default_global_inflight_limit,
+    perf_default_h2_pool_idle_timeout_ms, perf_default_h2_pool_max_idle_per_backend,
+    perf_default_max_request_body_bytes, perf_default_max_response_body_bytes,
     perf_default_new_connections_burst, perf_default_new_connections_per_sec,
-    perf_default_packet_shard_queue_capacity, perf_default_packet_shards_per_worker,
-    perf_default_per_backend_inflight_limit, perf_default_per_upstream_inflight_limit,
-    perf_default_pin_workers, perf_default_quic_initial_max_data,
-    perf_default_quic_initial_max_stream_data, perf_default_quic_initial_max_streams_bidi,
-    perf_default_quic_initial_max_streams_uni, perf_default_quic_max_idle_timeout_ms,
+    perf_default_packet_shard_queue_capacity, perf_default_packet_shard_queue_max_bytes,
+    perf_default_packet_shards_per_worker, perf_default_per_backend_inflight_limit,
+    perf_default_per_upstream_inflight_limit, perf_default_pin_workers,
+    perf_default_quic_initial_max_data, perf_default_quic_initial_max_stream_data,
+    perf_default_quic_initial_max_streams_bidi, perf_default_quic_initial_max_streams_uni,
+    perf_default_quic_max_idle_timeout_ms, perf_default_request_buffer_global_cap_bytes,
     perf_default_reuseport, perf_default_shutdown_drain_timeout_ms,
     perf_default_udp_recv_buffer_bytes, perf_default_udp_send_buffer_bytes,
-    perf_default_worker_threads, resilience_default_adaptive_decrease_step,
-    resilience_default_adaptive_enabled, resilience_default_adaptive_high_latency_ms,
-    resilience_default_adaptive_increase_step, resilience_default_adaptive_min_limit,
-    resilience_default_brownout_enabled, resilience_default_brownout_recover_inflight_percent,
+    perf_default_unknown_length_response_prebuffer_bytes, perf_default_worker_threads,
+    resilience_default_adaptive_decrease_step, resilience_default_adaptive_enabled,
+    resilience_default_adaptive_high_latency_ms, resilience_default_adaptive_increase_step,
+    resilience_default_adaptive_min_limit, resilience_default_brownout_enabled,
+    resilience_default_brownout_recover_inflight_percent,
     resilience_default_brownout_trigger_inflight_percent, resilience_default_cb_enabled,
     resilience_default_cb_failure_threshold, resilience_default_cb_half_open_max_probes,
     resilience_default_cb_open_ms, resilience_default_hedging_delay_ms,
@@ -194,6 +197,10 @@ pub struct Performance {
     #[serde(default = "perf_default_packet_shard_queue_capacity")]
     pub packet_shard_queue_capacity: usize,
 
+    /// Memory-aware cap for queued datagram bytes per ingress shard dispatch queue.
+    #[serde(default = "perf_default_packet_shard_queue_max_bytes")]
+    pub packet_shard_queue_max_bytes: usize,
+
     #[serde(default = "perf_default_reuseport")]
     pub reuseport: bool,
 
@@ -275,6 +282,25 @@ pub struct Performance {
     /// Protects against runaway or adversarial upstreams streaming unboundedly.
     #[serde(default = "perf_default_max_response_body_bytes")]
     pub max_response_body_bytes: usize,
+
+    /// Hard cap on request body bytes per stream.
+    /// Requests exceeding this size are rejected with 413.
+    #[serde(default = "perf_default_max_request_body_bytes")]
+    pub max_request_body_bytes: usize,
+
+    /// Global cap for bytes buffered in request backpressure queues across a worker.
+    #[serde(default = "perf_default_request_buffer_global_cap_bytes")]
+    pub request_buffer_global_cap_bytes: usize,
+
+    /// Max bytes buffered for unknown-length upstream responses before headers are emitted.
+    /// Responses exceeding this prebuffer cap are terminated with overload response.
+    #[serde(default = "perf_default_unknown_length_response_prebuffer_bytes")]
+    pub unknown_length_response_prebuffer_bytes: usize,
+
+    /// Idle timeout for request body upload progress.
+    /// If no request-body bytes arrive for this period, the stream is failed.
+    #[serde(default = "perf_default_client_body_idle_timeout_ms")]
+    pub client_body_idle_timeout_ms: u64,
 }
 
 impl Default for Performance {
@@ -284,6 +310,7 @@ impl Default for Performance {
             control_plane_threads: perf_default_control_plane_threads(),
             packet_shards_per_worker: perf_default_packet_shards_per_worker(),
             packet_shard_queue_capacity: perf_default_packet_shard_queue_capacity(),
+            packet_shard_queue_max_bytes: perf_default_packet_shard_queue_max_bytes(),
             reuseport: perf_default_reuseport(),
             pin_workers: perf_default_pin_workers(),
             global_inflight_limit: perf_default_global_inflight_limit(),
@@ -307,6 +334,11 @@ impl Default for Performance {
             quic_initial_max_streams_bidi: perf_default_quic_initial_max_streams_bidi(),
             quic_initial_max_streams_uni: perf_default_quic_initial_max_streams_uni(),
             max_response_body_bytes: perf_default_max_response_body_bytes(),
+            max_request_body_bytes: perf_default_max_request_body_bytes(),
+            request_buffer_global_cap_bytes: perf_default_request_buffer_global_cap_bytes(),
+            unknown_length_response_prebuffer_bytes:
+                perf_default_unknown_length_response_prebuffer_bytes(),
+            client_body_idle_timeout_ms: perf_default_client_body_idle_timeout_ms(),
         }
     }
 }

--- a/crates/config/src/default.rs
+++ b/crates/config/src/default.rs
@@ -86,6 +86,10 @@ pub fn perf_default_packet_shard_queue_capacity() -> usize {
     2048
 }
 
+pub fn perf_default_packet_shard_queue_max_bytes() -> usize {
+    64 * 1024 * 1024
+}
+
 pub fn perf_default_reuseport() -> bool {
     true
 }
@@ -176,6 +180,22 @@ pub fn perf_default_quic_initial_max_streams_uni() -> u64 {
 
 pub fn perf_default_max_response_body_bytes() -> usize {
     100 * 1024 * 1024 // 100 MiB
+}
+
+pub fn perf_default_max_request_body_bytes() -> usize {
+    1_000_000 // 1 MiB
+}
+
+pub fn perf_default_request_buffer_global_cap_bytes() -> usize {
+    64 * 1024 * 1024 // 64 MiB
+}
+
+pub fn perf_default_unknown_length_response_prebuffer_bytes() -> usize {
+    2 * 1024 * 1024 // 2 MiB
+}
+
+pub fn perf_default_client_body_idle_timeout_ms() -> u64 {
+    10_000
 }
 
 pub fn resilience_default_adaptive_enabled() -> bool {

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -100,6 +100,11 @@ pub fn validate(config: &Config) -> bool {
         return false;
     }
 
+    if config.performance.packet_shard_queue_max_bytes == 0 {
+        error!("performance.packet_shard_queue_max_bytes must be greater than 0");
+        return false;
+    }
+
     if config.performance.worker_threads > 1 && !config.performance.reuseport {
         error!("performance.reuseport must be true when performance.worker_threads > 1");
         return false;
@@ -219,6 +224,26 @@ pub fn validate(config: &Config) -> bool {
         return false;
     }
 
+    if config.performance.max_request_body_bytes == 0 {
+        error!("performance.max_request_body_bytes must be greater than 0");
+        return false;
+    }
+
+    if config.performance.request_buffer_global_cap_bytes == 0 {
+        error!("performance.request_buffer_global_cap_bytes must be greater than 0");
+        return false;
+    }
+
+    if config.performance.unknown_length_response_prebuffer_bytes == 0 {
+        error!("performance.unknown_length_response_prebuffer_bytes must be greater than 0");
+        return false;
+    }
+
+    if config.performance.client_body_idle_timeout_ms == 0 {
+        error!("performance.client_body_idle_timeout_ms must be greater than 0");
+        return false;
+    }
+
     if config.performance.backend_connect_timeout_ms > config.performance.backend_timeout_ms {
         error!("performance.backend_connect_timeout_ms must be <= backend_timeout_ms");
         return false;
@@ -241,6 +266,39 @@ pub fn validate(config: &Config) -> bool {
     {
         error!(
             "performance.backend_body_total_timeout_ms must be <= backend_total_request_timeout_ms"
+        );
+        return false;
+    }
+
+    if config.performance.max_request_body_bytes
+        > config.performance.quic_initial_max_stream_data as usize
+    {
+        error!(
+            "performance.max_request_body_bytes ({}) must be <= quic_initial_max_stream_data ({})",
+            config.performance.max_request_body_bytes,
+            config.performance.quic_initial_max_stream_data
+        );
+        return false;
+    }
+
+    if config.performance.request_buffer_global_cap_bytes
+        < config.performance.max_request_body_bytes
+    {
+        error!(
+            "performance.request_buffer_global_cap_bytes ({}) must be >= max_request_body_bytes ({})",
+            config.performance.request_buffer_global_cap_bytes,
+            config.performance.max_request_body_bytes
+        );
+        return false;
+    }
+
+    if config.performance.unknown_length_response_prebuffer_bytes
+        > config.performance.max_response_body_bytes
+    {
+        error!(
+            "performance.unknown_length_response_prebuffer_bytes ({}) must be <= max_response_body_bytes ({})",
+            config.performance.unknown_length_response_prebuffer_bytes,
+            config.performance.max_response_body_bytes
         );
         return false;
     }
@@ -738,6 +796,10 @@ upstream:
         assert_eq!(cfg.performance.control_plane_threads, 2);
         assert_eq!(cfg.performance.packet_shards_per_worker, 1);
         assert_eq!(cfg.performance.packet_shard_queue_capacity, 2048);
+        assert_eq!(
+            cfg.performance.packet_shard_queue_max_bytes,
+            64 * 1024 * 1024
+        );
         assert!(cfg.performance.reuseport);
         assert!(!cfg.performance.pin_workers);
         assert_eq!(cfg.performance.global_inflight_limit, 4096);
@@ -753,6 +815,16 @@ upstream:
         assert_eq!(cfg.performance.h2_pool_max_idle_per_backend, 256);
         assert_eq!(cfg.performance.h2_pool_idle_timeout_ms, 90_000);
         assert_eq!(cfg.performance.per_backend_inflight_limit, 64);
+        assert_eq!(cfg.performance.max_request_body_bytes, 1_000_000);
+        assert_eq!(
+            cfg.performance.request_buffer_global_cap_bytes,
+            64 * 1024 * 1024
+        );
+        assert_eq!(
+            cfg.performance.unknown_length_response_prebuffer_bytes,
+            2 * 1024 * 1024
+        );
+        assert_eq!(cfg.performance.client_body_idle_timeout_ms, 10_000);
         assert!(!cfg.observability.metrics.enabled);
         assert_eq!(cfg.observability.metrics.path, "/metrics");
         assert!(cfg.resilience.adaptive_admission.enabled);
@@ -790,6 +862,10 @@ upstream:
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.performance.packet_shard_queue_capacity = 0;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.performance.packet_shard_queue_max_bytes = 0;
         assert!(!validate(&cfg));
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
@@ -870,6 +946,37 @@ upstream:
         assert!(!validate(&cfg));
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.performance.max_request_body_bytes = 0;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.performance.request_buffer_global_cap_bytes = 0;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.performance.unknown_length_response_prebuffer_bytes = 0;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.performance.client_body_idle_timeout_ms = 0;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.performance.max_request_body_bytes =
+            (cfg.performance.quic_initial_max_stream_data as usize).saturating_add(1);
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.performance.request_buffer_global_cap_bytes =
+            cfg.performance.max_request_body_bytes.saturating_sub(1);
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.performance.unknown_length_response_prebuffer_bytes =
+            cfg.performance.max_response_body_bytes.saturating_add(1);
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.resilience.route_queue.default_cap = 0;
         assert!(!validate(&cfg));
 
@@ -944,6 +1051,7 @@ upstream:
         cfg.performance.control_plane_threads = 2;
         cfg.performance.packet_shards_per_worker = 2;
         cfg.performance.packet_shard_queue_capacity = 1024;
+        cfg.performance.packet_shard_queue_max_bytes = 16 * 1024 * 1024;
         cfg.performance.reuseport = true;
         cfg.performance.pin_workers = true;
         cfg.performance.global_inflight_limit = 10_000;
@@ -959,6 +1067,10 @@ upstream:
         cfg.performance.h2_pool_max_idle_per_backend = 128;
         cfg.performance.h2_pool_idle_timeout_ms = 120_000;
         cfg.performance.per_backend_inflight_limit = 32;
+        cfg.performance.max_request_body_bytes = 512 * 1024;
+        cfg.performance.request_buffer_global_cap_bytes = 8 * 1024 * 1024;
+        cfg.performance.unknown_length_response_prebuffer_bytes = 512 * 1024;
+        cfg.performance.client_body_idle_timeout_ms = 7_500;
         cfg.resilience.route_queue.default_cap = 256;
         cfg.resilience.route_queue.global_cap = 2048;
         cfg.resilience.route_queue.shed_retry_after_seconds = 2;

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -81,6 +81,10 @@ impl SharedRuntimeState {
     pub fn inc_ingress_queue_drop(&self) {
         self.metrics.inc_ingress_queue_drop();
     }
+
+    pub fn inc_ingress_queue_drop_bytes(&self, bytes: usize) {
+        self.metrics.inc_ingress_queue_drop_bytes(bytes);
+    }
 }
 
 pub struct QUICListener {
@@ -103,8 +107,12 @@ pub struct QUICListener {
     pub backend_timeout: Duration,
     pub backend_body_idle_timeout: Duration,
     pub backend_body_total_timeout: Duration,
+    pub client_body_idle_timeout: Duration,
     pub backend_total_request_timeout: Duration,
+    pub max_request_body_bytes: usize,
     pub max_response_body_bytes: usize,
+    pub request_buffer_global_cap_bytes: usize,
+    pub unknown_length_response_prebuffer_bytes: usize,
 
     pub recv_buf: [u8; MAX_DATAGRAM_SIZE_BYTES],
     pub send_buf: [u8; MAX_DATAGRAM_SIZE_BYTES],
@@ -175,6 +183,8 @@ pub struct RequestEnvelope {
     pub body_buf_bytes: usize,
     /// Total body bytes received on this stream (buffered + already forwarded).
     pub body_bytes_received: usize,
+    /// Last observed request-body byte arrival time.
+    pub last_body_activity: Instant,
     /// Resolved backend address and index (for health marking on response).
     pub backend_addr: Option<String>,
     pub backend_index: Option<usize>,
@@ -237,6 +247,11 @@ pub struct Metrics {
     pub overload_shed: AtomicU64,
     pub ingress_packets_total: AtomicU64,
     pub ingress_queue_drops: AtomicU64,
+    pub ingress_queue_drop_bytes: AtomicU64,
+    pub request_buffered_bytes: AtomicU64,
+    pub request_buffered_high_watermark_bytes: AtomicU64,
+    pub request_buffer_limit_rejects: AtomicU64,
+    pub response_prebuffer_limit_rejects: AtomicU64,
     pub scid_rotations: AtomicU64,
     pub watchdog_restart_requests: AtomicU64,
     pub watchdog_restart_hooks: AtomicU64,
@@ -291,6 +306,11 @@ impl Default for Metrics {
             overload_shed: AtomicU64::new(0),
             ingress_packets_total: AtomicU64::new(0),
             ingress_queue_drops: AtomicU64::new(0),
+            ingress_queue_drop_bytes: AtomicU64::new(0),
+            request_buffered_bytes: AtomicU64::new(0),
+            request_buffered_high_watermark_bytes: AtomicU64::new(0),
+            request_buffer_limit_rejects: AtomicU64::new(0),
+            response_prebuffer_limit_rejects: AtomicU64::new(0),
             scid_rotations: AtomicU64::new(0),
             watchdog_restart_requests: AtomicU64::new(0),
             watchdog_restart_hooks: AtomicU64::new(0),
@@ -359,6 +379,74 @@ impl Metrics {
 
     pub fn inc_ingress_queue_drop(&self) {
         self.ingress_queue_drops.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_ingress_queue_drop_bytes(&self, bytes: usize) {
+        self.ingress_queue_drop_bytes
+            .fetch_add(bytes as u64, Ordering::Relaxed);
+    }
+
+    pub fn try_reserve_request_buffer(&self, bytes: usize, cap_bytes: usize) -> bool {
+        let add = bytes as u64;
+        let cap = cap_bytes as u64;
+        loop {
+            let current = self.request_buffered_bytes.load(Ordering::Relaxed);
+            let next = current.saturating_add(add);
+            if next > cap {
+                return false;
+            }
+            if self
+                .request_buffered_bytes
+                .compare_exchange(current, next, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                self.observe_request_buffer_high_water(next);
+                return true;
+            }
+        }
+    }
+
+    pub fn release_request_buffer(&self, bytes: usize) {
+        let sub = bytes as u64;
+        loop {
+            let current = self.request_buffered_bytes.load(Ordering::Relaxed);
+            let next = current.saturating_sub(sub);
+            if self
+                .request_buffered_bytes
+                .compare_exchange(current, next, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                return;
+            }
+        }
+    }
+
+    pub fn inc_request_buffer_limit_reject(&self) {
+        self.request_buffer_limit_rejects
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_response_prebuffer_limit_reject(&self) {
+        self.response_prebuffer_limit_rejects
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn observe_request_buffer_high_water(&self, candidate: u64) {
+        loop {
+            let current = self
+                .request_buffered_high_watermark_bytes
+                .load(Ordering::Relaxed);
+            if candidate <= current {
+                return;
+            }
+            if self
+                .request_buffered_high_watermark_bytes
+                .compare_exchange(current, candidate, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                return;
+            }
+        }
     }
 
     pub fn inc_scid_rotation(&self) {
@@ -542,6 +630,53 @@ impl Metrics {
             self.ingress_queue_drops.load(Ordering::Relaxed)
         ));
 
+        out.push_str(
+            "# HELP spooky_ingress_queue_drop_bytes Total UDP datagram bytes dropped due to full shard queues.\n",
+        );
+        out.push_str("# TYPE spooky_ingress_queue_drop_bytes counter\n");
+        out.push_str(&format!(
+            "spooky_ingress_queue_drop_bytes {}\n",
+            self.ingress_queue_drop_bytes.load(Ordering::Relaxed)
+        ));
+
+        out.push_str(
+            "# HELP spooky_request_buffered_bytes Current bytes buffered in request backpressure queues.\n",
+        );
+        out.push_str("# TYPE spooky_request_buffered_bytes gauge\n");
+        out.push_str(&format!(
+            "spooky_request_buffered_bytes {}\n",
+            self.request_buffered_bytes.load(Ordering::Relaxed)
+        ));
+
+        out.push_str(
+            "# HELP spooky_request_buffered_high_watermark_bytes Peak request-buffered bytes since process start.\n",
+        );
+        out.push_str("# TYPE spooky_request_buffered_high_watermark_bytes gauge\n");
+        out.push_str(&format!(
+            "spooky_request_buffered_high_watermark_bytes {}\n",
+            self.request_buffered_high_watermark_bytes
+                .load(Ordering::Relaxed)
+        ));
+
+        out.push_str(
+            "# HELP spooky_request_buffer_limit_rejects Total requests rejected due to request buffer byte caps.\n",
+        );
+        out.push_str("# TYPE spooky_request_buffer_limit_rejects counter\n");
+        out.push_str(&format!(
+            "spooky_request_buffer_limit_rejects {}\n",
+            self.request_buffer_limit_rejects.load(Ordering::Relaxed)
+        ));
+
+        out.push_str(
+            "# HELP spooky_response_prebuffer_limit_rejects Total unknown-length upstream responses rejected due to prebuffer cap.\n",
+        );
+        out.push_str("# TYPE spooky_response_prebuffer_limit_rejects counter\n");
+        out.push_str(&format!(
+            "spooky_response_prebuffer_limit_rejects {}\n",
+            self.response_prebuffer_limit_rejects
+                .load(Ordering::Relaxed)
+        ));
+
         out.push_str("# HELP spooky_scid_rotations Total SCID rotations.\n");
         out.push_str("# TYPE spooky_scid_rotations counter\n");
         out.push_str(&format!(
@@ -716,5 +851,25 @@ mod tests {
         let output = metrics.render_prometheus();
         assert!(output.contains("spooky_route_requests_total{route=\"route-000\"} 1"));
         assert!(output.contains("spooky_route_requests_total{route=\"route-127\"} 1"));
+    }
+
+    #[test]
+    fn request_buffer_reservation_respects_cap_and_releases() {
+        let metrics = Metrics::default();
+        assert!(metrics.try_reserve_request_buffer(512, 1024));
+        assert!(!metrics.try_reserve_request_buffer(600, 1024));
+        assert_eq!(metrics.request_buffered_bytes.load(Ordering::Relaxed), 512);
+        assert_eq!(
+            metrics
+                .request_buffered_high_watermark_bytes
+                .load(Ordering::Relaxed),
+            512
+        );
+
+        metrics.release_request_buffer(256);
+        assert_eq!(metrics.request_buffered_bytes.load(Ordering::Relaxed), 256);
+
+        metrics.release_request_buffer(512);
+        assert_eq!(metrics.request_buffered_bytes.load(Ordering::Relaxed), 0);
     }
 }

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -42,9 +42,8 @@ use crate::{
     ResponseChunk, RouteOutcome, SharedRuntimeState, StreamPhase,
     cid_radix::CidRadix,
     constants::{
-        DEFAULT_SCID_LEN_BYTES, MAX_DATAGRAM_SIZE_BYTES, MAX_REQUEST_BODY_BYTES,
-        MAX_STREAMS_PER_CONNECTION, MAX_UDP_PAYLOAD_BYTES, MIN_SCID_LEN_BYTES,
-        REQUEST_BUFFERED_CHUNK_BYTES_LIMIT, REQUEST_CHUNK_BYTES_LIMIT,
+        DEFAULT_SCID_LEN_BYTES, MAX_DATAGRAM_SIZE_BYTES, MAX_STREAMS_PER_CONNECTION,
+        MAX_UDP_PAYLOAD_BYTES, MIN_SCID_LEN_BYTES, REQUEST_CHUNK_BYTES_LIMIT,
         REQUEST_CHUNK_CHANNEL_CAPACITY, RESET_TOKEN_LEN_BYTES, RESPONSE_CHUNK_BYTES_LIMIT,
         RESPONSE_CHUNK_CHANNEL_CAPACITY, SCID_ROTATION_PACKET_THRESHOLD, UDP_READ_TIMEOUT_MS,
         scid_rotation_interval,
@@ -112,6 +111,12 @@ struct RequestValidationResult {
     method: String,
     path: String,
     authority: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RequestBufferError {
+    StreamCap,
+    GlobalCap,
 }
 
 fn request_content_length(headers: &[quiche::h3::Header]) -> Option<usize> {
@@ -402,8 +407,13 @@ pub(crate) fn sweep_closed_connections<C, F>(
 ///
 /// Returns the phase the stream was in at the time of abort (useful for
 /// logging and metrics at the call site).
-pub(crate) fn abort_stream(req: &mut RequestEnvelope) -> StreamPhase {
+pub(crate) fn abort_stream(req: &mut RequestEnvelope, metrics: &Metrics) -> StreamPhase {
     let phase = req.phase.clone();
+    if req.body_buf_bytes > 0 {
+        metrics.release_request_buffer(req.body_buf_bytes);
+        req.body_buf_bytes = 0;
+    }
+    req.body_buf.clear();
     req.body_tx = None;
     req.upstream_result_rx = None;
     req.response_chunk_rx = None;
@@ -433,7 +443,7 @@ impl QUICListener {
             .saturating_mul(worker_threads);
 
         info!(
-            "Performance profile: worker_threads={} control_plane_threads={} reuseport={} pin_workers={} global_inflight_limit={} per_upstream_inflight_limit={} per_backend_inflight_limit={} backend_connect_timeout_ms={} backend_timeout_ms={} backend_body_idle_timeout_ms={} backend_body_total_timeout_ms={} backend_total_request_timeout_ms={} udp_recv_buffer_bytes={} udp_send_buffer_bytes={} h2_pool_max_idle_per_backend={} h2_pool_idle_timeout_ms={}",
+            "Performance profile: worker_threads={} control_plane_threads={} reuseport={} pin_workers={} global_inflight_limit={} per_upstream_inflight_limit={} per_backend_inflight_limit={} backend_connect_timeout_ms={} backend_timeout_ms={} backend_body_idle_timeout_ms={} backend_body_total_timeout_ms={} backend_total_request_timeout_ms={} client_body_idle_timeout_ms={} max_request_body_bytes={} max_response_body_bytes={} request_buffer_global_cap_bytes={} unknown_length_response_prebuffer_bytes={} udp_recv_buffer_bytes={} udp_send_buffer_bytes={} h2_pool_max_idle_per_backend={} h2_pool_idle_timeout_ms={}",
             worker_threads,
             config.performance.control_plane_threads.max(1),
             config.performance.reuseport,
@@ -446,6 +456,11 @@ impl QUICListener {
             config.performance.backend_body_idle_timeout_ms,
             config.performance.backend_body_total_timeout_ms,
             config.performance.backend_total_request_timeout_ms,
+            config.performance.client_body_idle_timeout_ms,
+            config.performance.max_request_body_bytes,
+            config.performance.max_response_body_bytes,
+            config.performance.request_buffer_global_cap_bytes,
+            config.performance.unknown_length_response_prebuffer_bytes,
             config.performance.udp_recv_buffer_bytes,
             config.performance.udp_send_buffer_bytes,
             config.performance.h2_pool_max_idle_per_backend,
@@ -580,10 +595,16 @@ impl QUICListener {
             Duration::from_millis(config.performance.backend_body_idle_timeout_ms);
         let backend_body_total_timeout =
             Duration::from_millis(config.performance.backend_body_total_timeout_ms);
+        let client_body_idle_timeout =
+            Duration::from_millis(config.performance.client_body_idle_timeout_ms);
         let backend_total_request_timeout =
             Duration::from_millis(config.performance.backend_total_request_timeout_ms);
         let drain_timeout = Duration::from_millis(config.performance.shutdown_drain_timeout_ms);
+        let max_request_body_bytes = config.performance.max_request_body_bytes;
         let max_response_body_bytes = config.performance.max_response_body_bytes;
+        let request_buffer_global_cap_bytes = config.performance.request_buffer_global_cap_bytes;
+        let unknown_length_response_prebuffer_bytes =
+            config.performance.unknown_length_response_prebuffer_bytes;
         let conn_rate_limiter = TokenBucket::new(
             config.performance.new_connections_per_sec,
             config.performance.new_connections_burst,
@@ -609,8 +630,12 @@ impl QUICListener {
             backend_timeout,
             backend_body_idle_timeout,
             backend_body_total_timeout,
+            client_body_idle_timeout,
             backend_total_request_timeout,
+            max_request_body_bytes,
             max_response_body_bytes,
+            request_buffer_global_cap_bytes,
+            unknown_length_response_prebuffer_bytes,
             recv_buf: [0; MAX_DATAGRAM_SIZE_BYTES],
             send_buf: [0; MAX_DATAGRAM_SIZE_BYTES],
             connections: HashMap::new(),
@@ -1231,6 +1256,7 @@ impl QUICListener {
 
         if let Err(e) = connection.quic.recv(&mut recv_data, recv_info) {
             error!("QUIC recv failed: {:?}", e);
+            Self::release_connection_streams(&mut connection, &self.metrics);
             self.remove_connection_routes(&connection);
             return;
         }
@@ -1268,7 +1294,11 @@ impl QUICListener {
                 &self.routing_index,
                 &self.metrics,
                 &self.resilience,
+                self.max_request_body_bytes,
                 self.max_response_body_bytes,
+                self.request_buffer_global_cap_bytes,
+                self.unknown_length_response_prebuffer_bytes,
+                self.client_body_idle_timeout,
             )
         {
             error!("HTTP/3 handling failed: {:?}", e);
@@ -1295,6 +1325,7 @@ impl QUICListener {
             self.connections
                 .insert(Arc::clone(&new_primary), connection);
         } else {
+            Self::release_connection_streams(&mut connection, &self.metrics);
             self.remove_connection_routes(&connection);
             debug!("Connection closed, not storing");
         }
@@ -1313,6 +1344,7 @@ impl QUICListener {
                 Some(timeout) => timeout,
                 None => {
                     if connection.quic.is_closed() {
+                        Self::release_connection_streams(connection, &self.metrics);
                         to_remove.push(scid.clone());
                     }
                     continue;
@@ -1329,6 +1361,7 @@ impl QUICListener {
             }
 
             if connection.quic.is_closed() {
+                Self::release_connection_streams(connection, &self.metrics);
                 to_remove.push(scid.clone());
                 continue;
             }
@@ -1347,6 +1380,8 @@ impl QUICListener {
                     self.backend_total_request_timeout,
                     &self.resilience,
                     self.max_response_body_bytes,
+                    self.unknown_length_response_prebuffer_bytes,
+                    self.client_body_idle_timeout,
                 ) {
                     error!("advance_streams_non_blocking in timeout path: {:?}", e);
                 }
@@ -1378,22 +1413,56 @@ impl QUICListener {
         }
     }
 
-    fn push_request_chunk(req: &mut RequestEnvelope, chunk: Bytes) -> Result<(), ()> {
+    fn release_connection_streams(connection: &mut QuicConnection, metrics: &Metrics) {
+        for req in connection.streams.values_mut() {
+            abort_stream(req, metrics);
+        }
+        connection.streams.clear();
+    }
+
+    fn push_request_chunk(
+        req: &mut RequestEnvelope,
+        chunk: Bytes,
+        metrics: &Metrics,
+        max_request_body_bytes: usize,
+        request_buffer_global_cap_bytes: usize,
+    ) -> Result<(), RequestBufferError> {
+        let chunk_len = chunk.len();
+        if !metrics.try_reserve_request_buffer(chunk_len, request_buffer_global_cap_bytes) {
+            return Err(RequestBufferError::GlobalCap);
+        }
+
         let next = req.body_buf_bytes.saturating_add(chunk.len());
-        if next > REQUEST_BUFFERED_CHUNK_BYTES_LIMIT {
-            return Err(());
+        if next > max_request_body_bytes {
+            metrics.release_request_buffer(chunk_len);
+            return Err(RequestBufferError::StreamCap);
         }
         req.body_buf_bytes = next;
         req.body_buf.push_back(chunk);
         Ok(())
     }
 
-    fn enqueue_request_chunk(req: &mut RequestEnvelope, chunk: Bytes) -> Result<(), ()> {
+    fn enqueue_request_chunk(
+        req: &mut RequestEnvelope,
+        chunk: Bytes,
+        metrics: &Metrics,
+        max_request_body_bytes: usize,
+        request_buffer_global_cap_bytes: usize,
+    ) -> Result<(), RequestBufferError> {
         if let Some(tx) = &req.body_tx {
             match tx.try_send(chunk) {
                 Ok(()) => Ok(()),
-                Err(TrySendError::Full(chunk)) => Self::push_request_chunk(req, chunk),
+                Err(TrySendError::Full(chunk)) => Self::push_request_chunk(
+                    req,
+                    chunk,
+                    metrics,
+                    max_request_body_bytes,
+                    request_buffer_global_cap_bytes,
+                ),
                 Err(TrySendError::Closed(_chunk)) => {
+                    if req.body_buf_bytes > 0 {
+                        metrics.release_request_buffer(req.body_buf_bytes);
+                    }
                     req.body_tx = None;
                     req.body_buf.clear();
                     req.body_buf_bytes = 0;
@@ -1401,11 +1470,17 @@ impl QUICListener {
                 }
             }
         } else {
-            Self::push_request_chunk(req, chunk)
+            Self::push_request_chunk(
+                req,
+                chunk,
+                metrics,
+                max_request_body_bytes,
+                request_buffer_global_cap_bytes,
+            )
         }
     }
 
-    fn flush_request_buffer(req: &mut RequestEnvelope) {
+    fn flush_request_buffer(req: &mut RequestEnvelope, metrics: &Metrics) {
         let Some(tx) = req.body_tx.as_ref() else {
             return;
         };
@@ -1418,12 +1493,16 @@ impl QUICListener {
             match tx.try_send(chunk) {
                 Ok(()) => {
                     req.body_buf_bytes = req.body_buf_bytes.saturating_sub(len);
+                    metrics.release_request_buffer(len);
                 }
                 Err(TrySendError::Full(chunk)) => {
                     req.body_buf.push_front(chunk);
                     break;
                 }
                 Err(TrySendError::Closed(_chunk)) => {
+                    if req.body_buf_bytes > 0 {
+                        metrics.release_request_buffer(req.body_buf_bytes);
+                    }
                     req.body_buf.clear();
                     req.body_buf_bytes = 0;
                     req.body_tx = None;
@@ -1447,7 +1526,11 @@ impl QUICListener {
         routing_index: &RouteIndex,
         metrics: &Metrics,
         resilience: &RuntimeResilience,
+        max_request_body_bytes: usize,
         max_response_body_bytes: usize,
+        request_buffer_global_cap_bytes: usize,
+        unknown_length_response_prebuffer_bytes: usize,
+        client_body_idle_timeout: Duration,
     ) -> Result<(), quiche::h3::Error> {
         let mut body_buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
 
@@ -2035,6 +2118,7 @@ impl QUICListener {
                             body_buf: std::collections::VecDeque::new(),
                             body_buf_bytes: 0,
                             body_bytes_received: 0,
+                            last_body_activity: request_start,
                             backend_addr,
                             backend_index,
                             upstream_name,
@@ -2061,6 +2145,9 @@ impl QUICListener {
                             let mut reject_body_for_bodyless = None::<(String, Duration)>;
                             let mut payload_too_large = None::<(String, Duration)>;
                             if let Some(req) = connection.streams.get_mut(&stream_id) {
+                                if read > 0 {
+                                    req.last_body_activity = Instant::now();
+                                }
                                 if req.bodyless_mode && read > 0 {
                                     reject_body_for_bodyless = Some((
                                         req.upstream_name
@@ -2073,7 +2160,7 @@ impl QUICListener {
                                     // Enforce cap on total bytes received for the stream,
                                     // including chunks already forwarded to the H2 body channel.
                                     let next_total = req.body_bytes_received.saturating_add(read);
-                                    if next_total > MAX_REQUEST_BODY_BYTES {
+                                    if next_total > max_request_body_bytes {
                                         payload_too_large = Some((
                                             req.upstream_name
                                                 .clone()
@@ -2087,8 +2174,18 @@ impl QUICListener {
                                             body_buf[..read].chunks(REQUEST_CHUNK_BYTES_LIMIT)
                                         {
                                             let chunk = Bytes::copy_from_slice(chunk_slice);
-                                            if Self::enqueue_request_chunk(req, chunk).is_err() {
+                                            if let Err(err) = Self::enqueue_request_chunk(
+                                                req,
+                                                chunk,
+                                                metrics,
+                                                max_request_body_bytes,
+                                                request_buffer_global_cap_bytes,
+                                            ) {
                                                 shed_due_to_buffer_pressure = true;
+                                                metrics.inc_request_buffer_limit_reject();
+                                                if err == RequestBufferError::GlobalCap {
+                                                    debug!("global request buffer cap reached");
+                                                }
                                                 break;
                                             }
                                         }
@@ -2105,6 +2202,9 @@ impl QUICListener {
                                     http::StatusCode::BAD_REQUEST,
                                     b"request body not allowed for this request\n",
                                 )?;
+                                if let Some(req) = connection.streams.get_mut(&stream_id) {
+                                    abort_stream(req, metrics);
+                                }
                                 connection.streams.remove(&stream_id);
                                 resilience.adaptive_admission.observe(elapsed, true);
                                 break;
@@ -2119,12 +2219,15 @@ impl QUICListener {
                                     http::StatusCode::PAYLOAD_TOO_LARGE,
                                     b"request body too large\n",
                                 )?;
+                                if let Some(req) = connection.streams.get_mut(&stream_id) {
+                                    abort_stream(req, metrics);
+                                }
                                 connection.streams.remove(&stream_id);
                                 resilience.adaptive_admission.observe(elapsed, true);
                                 break;
                             }
                             if shed_due_to_buffer_pressure
-                                && let Some(req) = connection.streams.remove(&stream_id)
+                                && let Some(req) = connection.streams.get(&stream_id)
                             {
                                 metrics.inc_failure();
                                 metrics.inc_overload_shed();
@@ -2145,6 +2248,10 @@ impl QUICListener {
                                 resilience
                                     .adaptive_admission
                                     .observe(req.start.elapsed(), true);
+                                if let Some(req) = connection.streams.get_mut(&stream_id) {
+                                    abort_stream(req, metrics);
+                                }
+                                connection.streams.remove(&stream_id);
                                 break;
                             }
                         }
@@ -2154,7 +2261,7 @@ impl QUICListener {
                                 "HTTP/3 recv_body protocol error on stream {}: {:?}",
                                 stream_id, err
                             );
-                            if let Some(req) = connection.streams.remove(&stream_id) {
+                            if let Some(req) = connection.streams.get(&stream_id) {
                                 metrics.inc_failure();
                                 let route_label =
                                     req.upstream_name.as_deref().unwrap_or("unrouted");
@@ -2167,6 +2274,10 @@ impl QUICListener {
                                     .adaptive_admission
                                     .observe(req.start.elapsed(), true);
                             }
+                            if let Some(req) = connection.streams.get_mut(&stream_id) {
+                                abort_stream(req, metrics);
+                            }
+                            connection.streams.remove(&stream_id);
                             let _ = Self::send_simple_response(
                                 h3,
                                 &mut connection.quic,
@@ -2182,7 +2293,7 @@ impl QUICListener {
                     if let Some(req) = connection.streams.get_mut(&stream_id) {
                         req.request_fin_received = true;
 
-                        Self::flush_request_buffer(req);
+                        Self::flush_request_buffer(req, metrics);
                         // If buffer is now empty, drop body_tx to signal end-of-body.
                         if req.body_buf.is_empty() {
                             req.body_tx = None;
@@ -2195,7 +2306,7 @@ impl QUICListener {
                 }
                 Ok((stream_id, quiche::h3::Event::Reset(error_code))) => {
                     if let Some(req) = connection.streams.get_mut(&stream_id) {
-                        let phase = abort_stream(req);
+                        let phase = abort_stream(req, metrics);
                         debug!(
                             "stream {} reset by client (error_code={}, phase={:?}): resources released",
                             stream_id, error_code, phase
@@ -2222,6 +2333,8 @@ impl QUICListener {
             backend_total_request_timeout,
             resilience,
             max_response_body_bytes,
+            unknown_length_response_prebuffer_bytes,
+            client_body_idle_timeout,
         )?;
 
         Ok(())
@@ -2258,6 +2371,8 @@ impl QUICListener {
         _backend_total_request_timeout: Duration,
         resilience: &RuntimeResilience,
         max_response_body_bytes: usize,
+        unknown_length_response_prebuffer_bytes: usize,
+        client_body_idle_timeout: Duration,
     ) -> Result<(), quiche::h3::Error> {
         let stream_ids: Vec<u64> = streams.keys().copied().collect();
 
@@ -2285,7 +2400,35 @@ impl QUICListener {
                     .adaptive_admission
                     .observe(req.start.elapsed(), true);
                 if let Some(req) = streams.get_mut(&stream_id) {
-                    abort_stream(req);
+                    abort_stream(req, metrics);
+                }
+                streams.remove(&stream_id);
+                continue;
+            }
+
+            if let Some(req) = streams.get(&stream_id)
+                && req.phase == StreamPhase::ReceivingRequest
+                && !req.request_fin_received
+                && !req.bodyless_mode
+                && Instant::now().saturating_duration_since(req.last_body_activity)
+                    >= client_body_idle_timeout
+            {
+                metrics.inc_failure();
+                metrics.inc_timeout();
+                let route_label = req.upstream_name.as_deref().unwrap_or("unrouted");
+                metrics.record_route(route_label, req.start.elapsed(), RouteOutcome::Timeout);
+                let _ = Self::send_simple_response(
+                    h3,
+                    quic,
+                    stream_id,
+                    http::StatusCode::REQUEST_TIMEOUT,
+                    b"request body idle timeout\n",
+                );
+                resilience
+                    .adaptive_admission
+                    .observe(req.start.elapsed(), true);
+                if let Some(req) = streams.get_mut(&stream_id) {
+                    abort_stream(req, metrics);
                 }
                 streams.remove(&stream_id);
                 continue;
@@ -2293,7 +2436,7 @@ impl QUICListener {
 
             // ── 1 & 2: request body drain ────────────────────────────────────
             if let Some(req) = streams.get_mut(&stream_id) {
-                Self::flush_request_buffer(req);
+                Self::flush_request_buffer(req, metrics);
                 if req.request_fin_received && req.body_buf.is_empty() {
                     req.body_tx = None; // signals EOF to the upstream H2 task
                 }
@@ -2371,6 +2514,9 @@ impl QUICListener {
                                     b"upstream response body too large\n",
                                 );
                             }
+                            if let Some(req) = streams.get_mut(&stream_id) {
+                                abort_stream(req, metrics);
+                            }
                             streams.remove(&stream_id);
                             continue;
                         }
@@ -2426,6 +2572,9 @@ impl QUICListener {
                                     resilience
                                         .adaptive_admission
                                         .observe(req.start.elapsed(), true);
+                                }
+                                if let Some(req) = streams.get_mut(&stream_id) {
+                                    abort_stream(req, metrics);
                                 }
                                 streams.remove(&stream_id);
                                 continue;
@@ -2490,6 +2639,19 @@ impl QUICListener {
                                                         .send(ResponseChunk::Error(ProxyError::Pool(
                                                             PoolError::BackendOverloaded(
                                                                 "upstream response body too large".into(),
+                                                            ),
+                                                        )))
+                                                        .await;
+                                                    return;
+                                                }
+                                                if response_bytes_received
+                                                    > unknown_length_response_prebuffer_bytes
+                                                {
+                                                    let _ = chunk_tx
+                                                        .send(ResponseChunk::Error(ProxyError::Pool(
+                                                            PoolError::BackendOverloaded(
+                                                                "unknown-length response prebuffer limit exceeded"
+                                                                    .into(),
                                                             ),
                                                         )))
                                                         .await;
@@ -2640,7 +2802,7 @@ impl QUICListener {
                                 .observe(req.start.elapsed(), true);
                         }
                         if let Some(req) = streams.get_mut(&stream_id) {
-                            abort_stream(req);
+                            abort_stream(req, metrics);
                         }
                         streams.remove(&stream_id);
                         continue;
@@ -2858,7 +3020,7 @@ impl QUICListener {
             // ── 5: remove terminal streams ────────────────────────────────────
             if terminal {
                 if let Some(req) = streams.get_mut(&stream_id) {
-                    abort_stream(req);
+                    abort_stream(req, metrics);
                 }
                 streams.remove(&stream_id);
             }
@@ -3006,10 +3168,13 @@ impl QUICListener {
                     b"invalid request\n",
                 )
             }
-            Err(ProxyError::Pool(PoolError::BackendOverloaded(_))) => {
+            Err(ProxyError::Pool(PoolError::BackendOverloaded(reason))) => {
                 debug!("Backend overloaded");
                 metrics.inc_failure();
                 metrics.inc_overload_shed();
+                if reason.contains("unknown-length response prebuffer limit exceeded") {
+                    metrics.inc_response_prebuffer_limit_reject();
+                }
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::OverloadShed);
                 debug!(
                     "Upstream {} status 503 latency_ms {}",
@@ -3937,8 +4102,16 @@ mod tests {
 
         for i in 0u8..20 {
             let primary = cid(&[i, i, i, i, i, i, i, i]);
-            let alias = cid(&[i | 0x80, i | 0x80, i | 0x80, i | 0x80,
-                               i | 0x80, i | 0x80, i | 0x80, i | 0x80]);
+            let alias = cid(&[
+                i | 0x80,
+                i | 0x80,
+                i | 0x80,
+                i | 0x80,
+                i | 0x80,
+                i | 0x80,
+                i | 0x80,
+                i | 0x80,
+            ]);
             let addr = peer(5000 + u16::from(i));
 
             // Register
@@ -3959,8 +4132,14 @@ mod tests {
             );
         }
 
-        assert!(cid_routes.is_empty(), "cid_routes must be empty after all connections torn down");
-        assert!(peer_routes.is_empty(), "peer_routes must be empty after all connections torn down");
+        assert!(
+            cid_routes.is_empty(),
+            "cid_routes must be empty after all connections torn down"
+        );
+        assert!(
+            peer_routes.is_empty(),
+            "peer_routes must be empty after all connections torn down"
+        );
     }
 
     #[test]
@@ -3987,8 +4166,14 @@ mod tests {
             );
         }
 
-        assert!(cid_routes.is_empty(), "cid_routes must be empty after double purge");
-        assert!(peer_routes.is_empty(), "peer_routes must be empty after double purge");
+        assert!(
+            cid_routes.is_empty(),
+            "cid_routes must be empty after double purge"
+        );
+        assert!(
+            peer_routes.is_empty(),
+            "peer_routes must be empty after double purge"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -4018,7 +4203,6 @@ mod tests {
 
     fn register_stub(
         conn: &StubConn,
-        connections: &mut HashMap<Arc<[u8]>, StubConn>,
         cid_routes: &mut HashMap<Arc<[u8]>, Arc<[u8]>>,
         cid_radix: &mut CidRadix,
         peer_routes: &mut HashMap<SocketAddr, Arc<[u8]>>,
@@ -4039,9 +4223,17 @@ mod tests {
         cid_routes: &HashMap<Arc<[u8]>, Arc<[u8]>>,
         peer_routes: &HashMap<SocketAddr, Arc<[u8]>>,
     ) {
-        assert!(connections.is_empty(), "{}: connections must be empty", label);
+        assert!(
+            connections.is_empty(),
+            "{}: connections must be empty",
+            label
+        );
         assert!(cid_routes.is_empty(), "{}: cid_routes must be empty", label);
-        assert!(peer_routes.is_empty(), "{}: peer_routes must be empty", label);
+        assert!(
+            peer_routes.is_empty(),
+            "{}: peer_routes must be empty",
+            label
+        );
     }
 
     #[test]
@@ -4052,7 +4244,9 @@ mod tests {
 
         let conn = StubConn {
             primary_scid: Arc::clone(&primary),
-            routing_scids: [Arc::clone(&primary), Arc::clone(&alias)].into_iter().collect(),
+            routing_scids: [Arc::clone(&primary), Arc::clone(&alias)]
+                .into_iter()
+                .collect(),
             peer_address: addr,
         };
 
@@ -4061,7 +4255,7 @@ mod tests {
         let mut cid_radix = CidRadix::new();
         let mut peer_routes = HashMap::new();
 
-        register_stub(&conn, &mut connections, &mut cid_routes, &mut cid_radix, &mut peer_routes);
+        register_stub(&conn, &mut cid_routes, &mut cid_radix, &mut peer_routes);
         connections.insert(Arc::clone(&primary), conn);
 
         sweep_closed_connections(
@@ -4073,7 +4267,12 @@ mod tests {
             stub_routes,
         );
 
-        assert_maps_empty("after single sweep", &connections, &cid_routes, &peer_routes);
+        assert_maps_empty(
+            "after single sweep",
+            &connections,
+            &cid_routes,
+            &peer_routes,
+        );
         assert!(
             cid_radix.longest_prefix_match(primary.as_ref()).is_none(),
             "primary must be removed from radix"
@@ -4099,8 +4298,16 @@ mod tests {
         for i in 0..rounds {
             let b = i as u8;
             let primary = cid(&[b, b, b, b, b, b, b, b]);
-            let alias1 = cid(&[b | 0x80, b | 0x80, b | 0x80, b | 0x80,
-                                b | 0x80, b | 0x80, b | 0x80, b | 0x80]);
+            let alias1 = cid(&[
+                b | 0x80,
+                b | 0x80,
+                b | 0x80,
+                b | 0x80,
+                b | 0x80,
+                b | 0x80,
+                b | 0x80,
+                b | 0x80,
+            ]);
             let addr = peer(7000 + i as u16);
 
             let conn = StubConn {
@@ -4111,7 +4318,7 @@ mod tests {
                 peer_address: addr,
             };
 
-            register_stub(&conn, &mut connections, &mut cid_routes, &mut cid_radix, &mut peer_routes);
+            register_stub(&conn, &mut cid_routes, &mut cid_radix, &mut peer_routes);
             connections.insert(Arc::clone(&primary), conn);
 
             // Simulate handle_timeouts detecting this connection as closed.
@@ -4158,8 +4365,8 @@ mod tests {
         let mut cid_radix = CidRadix::new();
         let mut peer_routes = HashMap::new();
 
-        register_stub(&conn1, &mut connections, &mut cid_routes, &mut cid_radix, &mut peer_routes);
-        register_stub(&conn2, &mut connections, &mut cid_routes, &mut cid_radix, &mut peer_routes);
+        register_stub(&conn1, &mut cid_routes, &mut cid_radix, &mut peer_routes);
+        register_stub(&conn2, &mut cid_routes, &mut cid_radix, &mut peer_routes);
         connections.insert(Arc::clone(&p1), conn1);
         connections.insert(Arc::clone(&p2), conn2);
 
@@ -4214,8 +4421,8 @@ mod tests {
     // pending chunks are discarded.
     // -----------------------------------------------------------------------
 
-    use crate::{RequestEnvelope, StreamPhase};
     use crate::resilience::{AdaptiveAdmission, RouteQueueLimiter};
+    use crate::{RequestEnvelope, StreamPhase};
     use std::time::Instant;
     use tokio::sync::{Semaphore, mpsc, oneshot};
 
@@ -4228,6 +4435,7 @@ mod tests {
             body_buf: std::collections::VecDeque::new(),
             body_buf_bytes: 0,
             body_bytes_received: 0,
+            last_body_activity: Instant::now(),
             backend_addr: None,
             backend_index: None,
             upstream_name: None,
@@ -4251,6 +4459,7 @@ mod tests {
     /// Verifies permits are released and body_tx is dropped.
     #[test]
     fn abort_stream_receiving_request_releases_permits() {
+        let metrics = crate::Metrics::default();
         let global_sem = Arc::new(Semaphore::new(1));
         let upstream_sem = Arc::new(Semaphore::new(1));
         let adaptive = Arc::new(AdaptiveAdmission::new(false, 1, 100, 1, 1, 1000));
@@ -4270,13 +4479,21 @@ mod tests {
         req.route_queue_permit = Some(route_permit);
         req.body_tx = Some(body_tx);
 
-        let phase = abort_stream(&mut req);
+        let phase = abort_stream(&mut req, &metrics);
 
         assert_eq!(phase, StreamPhase::ReceivingRequest);
 
         // Permits released: semaphores should be available again.
-        assert_eq!(global_sem.available_permits(), 1, "global semaphore must be freed");
-        assert_eq!(upstream_sem.available_permits(), 1, "upstream semaphore must be freed");
+        assert_eq!(
+            global_sem.available_permits(),
+            1,
+            "global semaphore must be freed"
+        );
+        assert_eq!(
+            upstream_sem.available_permits(),
+            1,
+            "upstream semaphore must be freed"
+        );
 
         // body_tx dropped: body_rx should see the channel as disconnected.
         drop(body_rx); // safe to drop receiver — just checking channel is closed
@@ -4294,20 +4511,22 @@ mod tests {
     /// send will return Err and it will exit.
     #[test]
     fn abort_stream_awaiting_upstream_cancels_oneshot() {
+        let metrics = crate::Metrics::default();
         let (result_tx, result_rx) = oneshot::channel::<crate::ForwardResult>();
 
         let mut req = make_envelope(StreamPhase::AwaitingUpstream);
         req.upstream_result_rx = Some(result_rx);
 
-        let phase = abort_stream(&mut req);
+        let phase = abort_stream(&mut req, &metrics);
 
         assert_eq!(phase, StreamPhase::AwaitingUpstream);
-        assert!(req.upstream_result_rx.is_none(), "oneshot receiver must be cleared");
+        assert!(
+            req.upstream_result_rx.is_none(),
+            "oneshot receiver must be cleared"
+        );
 
         // Sending on the now-orphaned sender should return Err (closed).
-        let send_result = result_tx.send(Err(spooky_errors::ProxyError::Transport(
-            "test".into(),
-        )));
+        let send_result = result_tx.send(Err(spooky_errors::ProxyError::Transport("test".into())));
         assert!(
             send_result.is_err(),
             "upstream task send must fail after receiver dropped"
@@ -4319,17 +4538,24 @@ mod tests {
     /// return Err, making the task exit promptly.
     #[test]
     fn abort_stream_sending_response_closes_chunk_channel() {
+        let metrics = crate::Metrics::default();
         let (chunk_tx, chunk_rx) = mpsc::channel::<crate::ResponseChunk>(4);
 
         let mut req = make_envelope(StreamPhase::SendingResponse);
         req.response_chunk_rx = Some(chunk_rx);
         req.pending_chunk = Some(crate::ResponseChunk::End);
 
-        let phase = abort_stream(&mut req);
+        let phase = abort_stream(&mut req, &metrics);
 
         assert_eq!(phase, StreamPhase::SendingResponse);
-        assert!(req.response_chunk_rx.is_none(), "chunk receiver must be cleared");
-        assert!(req.pending_chunk.is_none(), "pending chunk must be discarded");
+        assert!(
+            req.response_chunk_rx.is_none(),
+            "chunk receiver must be cleared"
+        );
+        assert!(
+            req.pending_chunk.is_none(),
+            "pending chunk must be discarded"
+        );
 
         // The body-pump task's sender should observe a closed channel.
         let send_result = chunk_tx.try_send(crate::ResponseChunk::End);
@@ -4343,6 +4569,7 @@ mod tests {
     /// of which fields are populated.
     #[test]
     fn abort_stream_upstream_error_releases_all_resources() {
+        let metrics = crate::Metrics::default();
         let global_sem = Arc::new(Semaphore::new(2));
         let upstream_sem = Arc::new(Semaphore::new(2));
 
@@ -4359,11 +4586,19 @@ mod tests {
         req.response_chunk_rx = Some(chunk_rx);
         req.pending_chunk = Some(crate::ResponseChunk::End);
 
-        let phase = abort_stream(&mut req);
+        let phase = abort_stream(&mut req, &metrics);
 
         assert_eq!(phase, StreamPhase::SendingResponse);
-        assert_eq!(global_sem.available_permits(), 2, "global semaphore must be fully freed");
-        assert_eq!(upstream_sem.available_permits(), 2, "upstream semaphore must be fully freed");
+        assert_eq!(
+            global_sem.available_permits(),
+            2,
+            "global semaphore must be fully freed"
+        );
+        assert_eq!(
+            upstream_sem.available_permits(),
+            2,
+            "upstream semaphore must be fully freed"
+        );
         assert!(req.upstream_result_rx.is_none());
         assert!(req.response_chunk_rx.is_none());
         assert!(req.pending_chunk.is_none());
@@ -4376,15 +4611,20 @@ mod tests {
     /// double-decrement any semaphore.
     #[test]
     fn abort_stream_is_idempotent() {
+        let metrics = crate::Metrics::default();
         let global_sem = Arc::new(Semaphore::new(1));
         let permit = global_sem.clone().try_acquire_owned().unwrap();
 
         let mut req = make_envelope(StreamPhase::ReceivingRequest);
         req.global_inflight_permit = Some(permit);
 
-        abort_stream(&mut req);
-        abort_stream(&mut req); // second call must be a no-op
+        abort_stream(&mut req, &metrics);
+        abort_stream(&mut req, &metrics); // second call must be a no-op
 
-        assert_eq!(global_sem.available_permits(), 1, "must not double-release permit");
+        assert_eq!(
+            global_sem.available_permits(),
+            1,
+            "must not double-release permit"
+        );
     }
 }

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -1767,6 +1767,78 @@ fn slow_request_producer_over_cap_returns_413() {
 }
 
 #[test]
+fn request_body_idle_timeout_returns_408() {
+    let dir = tempdir().expect("failed to create temp dir");
+    let (cert, key) = write_test_certs(&dir);
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let backend_addr = rt.block_on(start_h2_backend());
+    let mut config = make_config(0, backend_addr.to_string(), cert, key);
+    config.performance.client_body_idle_timeout_ms = 120;
+    config.performance.backend_total_request_timeout_ms = 10_000;
+
+    let listener = QUICListener::new(config).expect("failed to create listener");
+    let listen_addr = listener.socket.local_addr().unwrap();
+    let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
+
+    let (status, body, got_reset) = run_h3_client_two_chunk_post(
+        listen_addr,
+        "/",
+        vec![0u8; 512],
+        vec![0u8; 512],
+        Duration::from_millis(250),
+        Duration::from_secs(REQUEST_TIMEOUT_SECS + 8),
+    )
+    .expect("slow request producer should complete");
+
+    assert_eq!(
+        status, "408",
+        "slow body producer should hit request-body idle timeout"
+    );
+    assert!(
+        String::from_utf8_lossy(&body).contains("request body idle timeout"),
+        "idle-timeout response body should explain failure"
+    );
+    assert!(
+        !got_reset,
+        "idle timeout should return HTTP response, not reset"
+    );
+}
+
+#[test]
+fn unknown_length_response_prebuffer_cap_returns_503() {
+    let dir = tempdir().expect("failed to create temp dir");
+    let (cert, key) = write_test_certs(&dir);
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let backend_addr = rt.block_on(start_h2_backend_with_regression_routes());
+    let mut config = make_config(0, backend_addr.to_string(), cert, key);
+    config.performance.max_response_body_bytes = 64 * 1024;
+    config.performance.unknown_length_response_prebuffer_bytes = 8;
+
+    let listener = QUICListener::new(config).expect("failed to create listener");
+    let listen_addr = listener.socket.local_addr().unwrap();
+    let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
+
+    let observations = run_h3_client_concurrent_get(
+        listen_addr,
+        &["/long-stream"],
+        Duration::from_secs(REQUEST_TIMEOUT_SECS + 8),
+    )
+    .expect("unknown-length prebuffer test should complete");
+    let stream = observation_for(&observations, "/long-stream");
+    assert_eq!(
+        stream.status.as_deref(),
+        Some("503"),
+        "unknown-length prebuffer cap should return 503"
+    );
+    assert_eq!(
+        stream.body, b"upstream response body too large\n",
+        "unknown-length prebuffer cap should return deterministic body"
+    );
+}
+
+#[test]
 fn slow_response_consumer_does_not_hang() {
     let dir = tempdir().expect("failed to create temp dir");
     let (cert, key) = write_test_certs(&dir);
@@ -3020,14 +3092,20 @@ fn make_quic_client(
     let mut buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
 
     // Initial packet.
-    let (w, si) = conn.send(&mut out).map_err(|e| format!("initial send: {e:?}"))?;
-    socket.send_to(&out[..w], si.to).map_err(|e| e.to_string())?;
+    let (w, si) = conn
+        .send(&mut out)
+        .map_err(|e| format!("initial send: {e:?}"))?;
+    socket
+        .send_to(&out[..w], si.to)
+        .map_err(|e| e.to_string())?;
 
     let deadline = Instant::now() + Duration::from_secs(REQUEST_TIMEOUT_SECS);
     loop {
         loop {
             match conn.send(&mut out) {
-                Ok((w, si)) => { let _ = socket.send_to(&out[..w], si.to); }
+                Ok((w, si)) => {
+                    let _ = socket.send_to(&out[..w], si.to);
+                }
                 Err(quiche::Error::Done) => break,
                 Err(e) => return Err(format!("send: {e:?}")),
             }
@@ -3038,11 +3116,18 @@ fn make_quic_client(
         socket.set_read_timeout(Some(quic_read_timeout(&conn))).ok();
         match socket.recv_from(&mut buf) {
             Ok((len, from)) => {
-                conn.recv(&mut buf[..len], quiche::RecvInfo { from, to: local_addr })
-                    .map_err(|e| format!("recv: {e:?}"))?;
+                conn.recv(
+                    &mut buf[..len],
+                    quiche::RecvInfo {
+                        from,
+                        to: local_addr,
+                    },
+                )
+                .map_err(|e| format!("recv: {e:?}"))?;
             }
-            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock
-                || e.kind() == std::io::ErrorKind::TimedOut =>
+            Err(ref e)
+                if e.kind() == std::io::ErrorKind::WouldBlock
+                    || e.kind() == std::io::ErrorKind::TimedOut =>
             {
                 conn.on_timeout();
             }
@@ -3059,14 +3144,12 @@ fn make_quic_client(
 }
 
 /// Flush QUIC send buffer to the socket.
-fn flush_quic(
-    conn: &mut quiche::Connection,
-    socket: &std::net::UdpSocket,
-    out: &mut [u8],
-) {
+fn flush_quic(conn: &mut quiche::Connection, socket: &std::net::UdpSocket, out: &mut [u8]) {
     loop {
         match conn.send(out) {
-            Ok((w, si)) => { let _ = socket.send_to(&out[..w], si.to); }
+            Ok((w, si)) => {
+                let _ = socket.send_to(&out[..w], si.to);
+            }
             Err(quiche::Error::Done) => break,
             Err(_) => break,
         }
@@ -3091,10 +3174,17 @@ fn pump_h3_until(
         socket.set_read_timeout(Some(quic_read_timeout(conn))).ok();
         match socket.recv_from(buf) {
             Ok((len, from)) => {
-                let _ = conn.recv(&mut buf[..len], quiche::RecvInfo { from, to: local_addr });
+                let _ = conn.recv(
+                    &mut buf[..len],
+                    quiche::RecvInfo {
+                        from,
+                        to: local_addr,
+                    },
+                );
             }
-            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock
-                || e.kind() == std::io::ErrorKind::TimedOut =>
+            Err(ref e)
+                if e.kind() == std::io::ErrorKind::WouldBlock
+                    || e.kind() == std::io::ErrorKind::TimedOut =>
             {
                 conn.on_timeout();
             }
@@ -3185,8 +3275,15 @@ fn teardown_client_reset_before_upstream_response() {
     let pump_end = Instant::now() + Duration::from_millis(200);
     let mut discard = Vec::new();
     pump_h3_until(
-        &mut conn, &mut h3, &socket, local_addr,
-        &mut out, &mut buf, slow_sid, pump_end, &mut discard,
+        &mut conn,
+        &mut h3,
+        &socket,
+        local_addr,
+        &mut out,
+        &mut buf,
+        slow_sid,
+        pump_end,
+        &mut discard,
     );
 
     // Follow-up /fast on a fresh connection. This avoids coupling the assertion
@@ -3262,7 +3359,10 @@ fn teardown_client_reset_during_response_streaming() {
                 Ok((len, from)) => {
                     let _ = conn.recv(
                         &mut buf[..len],
-                        quiche::RecvInfo { from, to: local_addr },
+                        quiche::RecvInfo {
+                            from,
+                            to: local_addr,
+                        },
                     );
                 }
                 Err(ref e)
@@ -3293,7 +3393,10 @@ fn teardown_client_reset_during_response_streaming() {
                 panic!("timed out waiting for /stream response data");
             }
         }
-        assert!(got_data, "must receive response data before dropping connection");
+        assert!(
+            got_data,
+            "must receive response data before dropping connection"
+        );
         // Connection drops here (socket + conn out of scope) — server is left
         // in SendingResponse with an orphaned body-pump task.
     }
@@ -3321,8 +3424,13 @@ fn teardown_client_reset_during_response_streaming() {
 
     let mut events = Vec::new();
     let done = pump_h3_until(
-        &mut conn2, &mut h3_2, &socket2, local_addr2,
-        &mut out2, &mut buf2, fast_sid,
+        &mut conn2,
+        &mut h3_2,
+        &socket2,
+        local_addr2,
+        &mut out2,
+        &mut buf2,
+        fast_sid,
         Instant::now() + Duration::from_secs(REQUEST_TIMEOUT_SECS + 2),
         &mut events,
     );
@@ -3418,7 +3526,10 @@ fn teardown_upstream_timeout_cleans_up_stream() {
         Instant::now() + Duration::from_secs(REQUEST_TIMEOUT_SECS + 2),
         &mut fast_events,
     );
-    assert!(done, "follow-up /fast request must complete after timeout teardown");
+    assert!(
+        done,
+        "follow-up /fast request must complete after timeout teardown"
+    );
     assert!(
         fast_events.iter().any(|e| e.starts_with("status:200")),
         "follow-up request must receive 200, got: {fast_events:?}"

--- a/spooky/src/main.rs
+++ b/spooky/src/main.rs
@@ -8,7 +8,7 @@ mod runtime_guard;
 
 use std::sync::{
     Arc,
-    atomic::{AtomicBool, Ordering},
+    atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 use std::{thread, time::Duration};
 
@@ -136,6 +136,7 @@ Use a port >= 1024 for unprivileged startup.",
 
     let pin_workers = config_yaml.performance.pin_workers;
     let shard_queue_capacity = config_yaml.performance.packet_shard_queue_capacity.max(1);
+    let shard_queue_max_bytes = config_yaml.performance.packet_shard_queue_max_bytes.max(1);
     let mut worker_handles = Vec::with_capacity(sockets.len());
     for (worker_idx, socket) in sockets.into_iter().enumerate() {
         let worker_config = config_yaml.clone();
@@ -159,6 +160,7 @@ Use a port >= 1024 for unprivileged startup.",
                     worker_idx,
                     shard_count,
                     shard_queue_capacity,
+                    shard_queue_max_bytes,
                     pin_workers,
                     worker_config,
                     socket,
@@ -224,6 +226,7 @@ fn run_sharded_listener_worker(
     worker_idx: usize,
     shard_count: usize,
     shard_queue_capacity: usize,
+    shard_queue_max_bytes: usize,
     pin_workers: bool,
     worker_config: spooky_config::config::Config,
     socket: std::net::UdpSocket,
@@ -238,6 +241,7 @@ fn run_sharded_listener_worker(
 
     let mut shard_handles = Vec::with_capacity(shard_count);
     let mut shard_txs: Vec<SyncSender<IngressPacket>> = Vec::with_capacity(shard_count);
+    let mut shard_queue_bytes: Vec<Arc<AtomicUsize>> = Vec::with_capacity(shard_count);
 
     for shard_idx in 0..shard_count {
         let shard_socket = socket.try_clone().map_err(|err| {
@@ -252,6 +256,8 @@ fn run_sharded_listener_worker(
         let shard_thread_idx = worker_idx
             .saturating_mul(shard_count)
             .saturating_add(shard_idx);
+        let shard_queue_bytes_counter = Arc::new(AtomicUsize::new(0));
+        shard_queue_bytes.push(Arc::clone(&shard_queue_bytes_counter));
 
         let (tx, rx) = mpsc::sync_channel::<IngressPacket>(shard_queue_capacity);
         shard_txs.push(tx);
@@ -277,10 +283,15 @@ fn run_sharded_listener_worker(
                 while !shard_shutdown.load(Ordering::Relaxed) {
                     match rx.recv_timeout(idle_timeout) {
                         Ok(packet) => {
+                            let packet_bytes = packet.bytes.len();
                             listener.process_datagram(
                                 packet.peer,
                                 packet.local_addr,
                                 &packet.bytes,
+                            );
+                            release_shard_queue_bytes(
+                                shard_queue_bytes_counter.as_ref(),
+                                packet_bytes,
                             );
                         }
                         Err(RecvTimeoutError::Timeout) => {
@@ -315,6 +326,16 @@ fn run_sharded_listener_worker(
                     continue;
                 }
                 let shard_idx = shard_index_for_peer(&peer, shard_count);
+                let packet_len = len;
+                if !try_reserve_shard_queue_bytes(
+                    shard_queue_bytes[shard_idx].as_ref(),
+                    packet_len,
+                    shard_queue_max_bytes,
+                ) {
+                    worker_shared.inc_ingress_queue_drop();
+                    worker_shared.inc_ingress_queue_drop_bytes(packet_len);
+                    continue;
+                }
                 let packet = IngressPacket {
                     peer,
                     local_addr,
@@ -322,10 +343,19 @@ fn run_sharded_listener_worker(
                 };
                 match shard_txs[shard_idx].try_send(packet) {
                     Ok(()) => {}
-                    Err(TrySendError::Full(_packet)) => {
+                    Err(TrySendError::Full(packet)) => {
+                        release_shard_queue_bytes(
+                            shard_queue_bytes[shard_idx].as_ref(),
+                            packet.bytes.len(),
+                        );
                         worker_shared.inc_ingress_queue_drop();
+                        worker_shared.inc_ingress_queue_drop_bytes(packet.bytes.len());
                     }
-                    Err(TrySendError::Disconnected(_packet)) => {
+                    Err(TrySendError::Disconnected(packet)) => {
+                        release_shard_queue_bytes(
+                            shard_queue_bytes[shard_idx].as_ref(),
+                            packet.bytes.len(),
+                        );
                         return Err(format!(
                             "worker {} shard {} dispatch channel disconnected",
                             worker_idx, shard_idx
@@ -398,10 +428,40 @@ fn shard_index_for_peer(peer: &SocketAddr, shard_count: usize) -> usize {
     (hasher.finish() as usize) % shard_count.max(1)
 }
 
+fn try_reserve_shard_queue_bytes(counter: &AtomicUsize, packet_bytes: usize, cap: usize) -> bool {
+    loop {
+        let current = counter.load(Ordering::Relaxed);
+        let next = current.saturating_add(packet_bytes);
+        if next > cap {
+            return false;
+        }
+        if counter
+            .compare_exchange(current, next, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+        {
+            return true;
+        }
+    }
+}
+
+fn release_shard_queue_bytes(counter: &AtomicUsize, packet_bytes: usize) {
+    loop {
+        let current = counter.load(Ordering::Relaxed);
+        let next = current.saturating_sub(packet_bytes);
+        if counter
+            .compare_exchange(current, next, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+        {
+            return;
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::shard_index_for_peer;
+    use super::{release_shard_queue_bytes, shard_index_for_peer, try_reserve_shard_queue_bytes};
     use std::net::SocketAddr;
+    use std::sync::atomic::AtomicUsize;
 
     #[test]
     fn shard_index_is_stable_for_same_peer() {
@@ -416,6 +476,23 @@ mod tests {
         let peer: SocketAddr = "10.1.2.3:443".parse().expect("peer addr");
         let idx = shard_index_for_peer(&peer, 16);
         assert!(idx < 16);
+    }
+
+    #[test]
+    fn shard_queue_byte_reservation_obeys_cap() {
+        let counter = AtomicUsize::new(0);
+        assert!(try_reserve_shard_queue_bytes(&counter, 10, 16));
+        assert!(!try_reserve_shard_queue_bytes(&counter, 7, 16));
+        assert_eq!(counter.load(std::sync::atomic::Ordering::Relaxed), 10);
+    }
+
+    #[test]
+    fn shard_queue_byte_release_is_saturating() {
+        let counter = AtomicUsize::new(8);
+        release_shard_queue_bytes(&counter, 3);
+        assert_eq!(counter.load(std::sync::atomic::Ordering::Relaxed), 5);
+        release_shard_queue_bytes(&counter, 10);
+        assert_eq!(counter.load(std::sync::atomic::Ordering::Relaxed), 0);
     }
 }
 


### PR DESCRIPTION
## Summary
This PR completes core runtime hardening for memory pressure and extreme traffic behavior (large bodies + slow clients), with production-oriented limits and deterministic overload behavior.

## What changed
- Added new performance controls for:
  - shard queue byte caps
  - max request body bytes
  - global buffered request body cap
  - unknown-length response prebuffer cap
  - client body idle timeout
- Enforced strict validation rules for these limits at config load time.
- Added runtime memory guardrails:
  - per-shard ingress queue byte accounting and drop-on-cap behavior
  - global request-buffer reservation/release accounting
  - per-stream + global request buffering limits
- Added slow-client and extreme-stream protections:
  - request body idle timeout with `408` response
  - unknown-length response prebuffer overflow handling with `503` response
- Fixed connection teardown cleanup so buffered bytes are always released on stream/connection close paths.
- Expanded metrics to expose buffering pressure, high-water marks, and overload rejects.

## Outcome
- Memory growth is bounded under backpressure and burst conditions.
- Slow or stalled clients cannot hold resources indefinitely.
- Runtime behavior under pressure is controlled (shed/fail fast) rather than degrading unpredictably.