### PR TITLE
feat(perf): enforce active connection cap and expand hedging/backpressure observability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run build build-spooky clean test test-edge test-transport certs certs-selfsigned certs-ca certs-clean certs-verify certs-dir bench-micro bench-macro bench-gate bench-promote-baseline
+.PHONY: run build build-spooky clean test test-edge test-transport certs certs-selfsigned certs-ca certs-clean certs-verify certs-dir bench-micro bench-macro bench-gate bench-promote-baseline load-scenarios
 
 CERTS_DIR := certs
 SAN_CONF := $(CERTS_DIR)/san.conf
@@ -142,3 +142,6 @@ bench-promote-baseline:
 		exit 1; \
 	fi
 	./scripts/bench-promote-baseline.sh "$(RELEASE)"
+
+load-scenarios:
+	./scripts/load-scenarios.sh

--- a/README.md
+++ b/README.md
@@ -194,6 +194,9 @@ cargo test -p spooky-edge
 # Run integration tests
 cargo test -p spooky-edge --test lb_integration
 cargo test -p spooky-edge --test h3_bridge
+
+# Run load scenarios (burst / slow-upstream / quic-loss profile)
+make load-scenarios
 ```
 
 

--- a/bench/load/.gitignore
+++ b/bench/load/.gitignore
@@ -1,0 +1,3 @@
+latest.md
+latest.json
+latest.tsv

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -78,6 +78,7 @@ performance:
     per_backend_inflight_limit: 64
     new_connections_per_sec: 2000   # max new QUIC connections accepted per second (token-bucket refill rate)
     new_connections_burst: 500      # burst capacity above the steady-state rate; must be >= 1
+    max_active_connections: 20000   # hard cap on active QUIC connections per worker
     quic_max_idle_timeout_ms: 5000          # close idle QUIC connections after this many ms
     quic_initial_max_data: 10000000         # connection-level flow control window (bytes)
     quic_initial_max_stream_data: 1000000   # per-stream flow control window (bytes); must be <= quic_initial_max_data

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -13,21 +13,21 @@ use crate::default::{
     perf_default_backend_total_request_timeout_ms, perf_default_client_body_idle_timeout_ms,
     perf_default_control_plane_threads, perf_default_global_inflight_limit,
     perf_default_h2_pool_idle_timeout_ms, perf_default_h2_pool_max_idle_per_backend,
-    perf_default_max_request_body_bytes, perf_default_max_response_body_bytes,
-    perf_default_new_connections_burst, perf_default_new_connections_per_sec,
-    perf_default_packet_shard_queue_capacity, perf_default_packet_shard_queue_max_bytes,
-    perf_default_packet_shards_per_worker, perf_default_per_backend_inflight_limit,
-    perf_default_per_upstream_inflight_limit, perf_default_pin_workers,
-    perf_default_quic_initial_max_data, perf_default_quic_initial_max_stream_data,
-    perf_default_quic_initial_max_streams_bidi, perf_default_quic_initial_max_streams_uni,
-    perf_default_quic_max_idle_timeout_ms, perf_default_request_buffer_global_cap_bytes,
-    perf_default_reuseport, perf_default_shutdown_drain_timeout_ms,
-    perf_default_udp_recv_buffer_bytes, perf_default_udp_send_buffer_bytes,
-    perf_default_unknown_length_response_prebuffer_bytes, perf_default_worker_threads,
-    resilience_default_adaptive_decrease_step, resilience_default_adaptive_enabled,
-    resilience_default_adaptive_high_latency_ms, resilience_default_adaptive_increase_step,
-    resilience_default_adaptive_min_limit, resilience_default_brownout_enabled,
-    resilience_default_brownout_recover_inflight_percent,
+    perf_default_max_active_connections, perf_default_max_request_body_bytes,
+    perf_default_max_response_body_bytes, perf_default_new_connections_burst,
+    perf_default_new_connections_per_sec, perf_default_packet_shard_queue_capacity,
+    perf_default_packet_shard_queue_max_bytes, perf_default_packet_shards_per_worker,
+    perf_default_per_backend_inflight_limit, perf_default_per_upstream_inflight_limit,
+    perf_default_pin_workers, perf_default_quic_initial_max_data,
+    perf_default_quic_initial_max_stream_data, perf_default_quic_initial_max_streams_bidi,
+    perf_default_quic_initial_max_streams_uni, perf_default_quic_max_idle_timeout_ms,
+    perf_default_request_buffer_global_cap_bytes, perf_default_reuseport,
+    perf_default_shutdown_drain_timeout_ms, perf_default_udp_recv_buffer_bytes,
+    perf_default_udp_send_buffer_bytes, perf_default_unknown_length_response_prebuffer_bytes,
+    perf_default_worker_threads, resilience_default_adaptive_decrease_step,
+    resilience_default_adaptive_enabled, resilience_default_adaptive_high_latency_ms,
+    resilience_default_adaptive_increase_step, resilience_default_adaptive_min_limit,
+    resilience_default_brownout_enabled, resilience_default_brownout_recover_inflight_percent,
     resilience_default_brownout_trigger_inflight_percent, resilience_default_cb_enabled,
     resilience_default_cb_failure_threshold, resilience_default_cb_half_open_max_probes,
     resilience_default_cb_open_ms, resilience_default_hedging_delay_ms,
@@ -255,6 +255,11 @@ pub struct Performance {
     #[serde(default = "perf_default_new_connections_burst")]
     pub new_connections_burst: u32,
 
+    /// Hard cap on concurrently tracked active QUIC connections per worker.
+    /// New Initial packets above this cap are dropped deterministically.
+    #[serde(default = "perf_default_max_active_connections")]
+    pub max_active_connections: usize,
+
     /// QUIC idle timeout: connection is closed after this many ms of inactivity.
     #[serde(default = "perf_default_quic_max_idle_timeout_ms")]
     pub quic_max_idle_timeout_ms: u64,
@@ -328,6 +333,7 @@ impl Default for Performance {
             per_backend_inflight_limit: perf_default_per_backend_inflight_limit(),
             new_connections_per_sec: perf_default_new_connections_per_sec(),
             new_connections_burst: perf_default_new_connections_burst(),
+            max_active_connections: perf_default_max_active_connections(),
             quic_max_idle_timeout_ms: perf_default_quic_max_idle_timeout_ms(),
             quic_initial_max_data: perf_default_quic_initial_max_data(),
             quic_initial_max_stream_data: perf_default_quic_initial_max_stream_data(),

--- a/crates/config/src/default.rs
+++ b/crates/config/src/default.rs
@@ -158,6 +158,10 @@ pub fn perf_default_new_connections_burst() -> u32 {
     500
 }
 
+pub fn perf_default_max_active_connections() -> usize {
+    20_000
+}
+
 pub fn perf_default_quic_max_idle_timeout_ms() -> u64 {
     5_000
 }

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -185,6 +185,11 @@ pub fn validate(config: &Config) -> bool {
         return false;
     }
 
+    if config.performance.max_active_connections == 0 {
+        error!("performance.max_active_connections must be greater than 0");
+        return false;
+    }
+
     if config.performance.quic_max_idle_timeout_ms == 0 {
         error!("performance.quic_max_idle_timeout_ms must be greater than 0");
         return false;
@@ -815,6 +820,7 @@ upstream:
         assert_eq!(cfg.performance.h2_pool_max_idle_per_backend, 256);
         assert_eq!(cfg.performance.h2_pool_idle_timeout_ms, 90_000);
         assert_eq!(cfg.performance.per_backend_inflight_limit, 64);
+        assert_eq!(cfg.performance.max_active_connections, 20_000);
         assert_eq!(cfg.performance.max_request_body_bytes, 1_000_000);
         assert_eq!(
             cfg.performance.request_buffer_global_cap_bytes,
@@ -913,6 +919,10 @@ upstream:
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.performance.new_connections_burst = 0;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.performance.max_active_connections = 0;
         assert!(!validate(&cfg));
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
@@ -1067,6 +1077,7 @@ upstream:
         cfg.performance.h2_pool_max_idle_per_backend = 128;
         cfg.performance.h2_pool_idle_timeout_ms = 120_000;
         cfg.performance.per_backend_inflight_limit = 32;
+        cfg.performance.max_active_connections = 50_000;
         cfg.performance.max_request_body_bytes = 512 * 1024;
         cfg.performance.request_buffer_global_cap_bytes = 8 * 1024 * 1024;
         cfg.performance.unknown_length_response_prebuffer_bytes = 512 * 1024;

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -109,6 +109,7 @@ pub struct QUICListener {
     pub backend_body_total_timeout: Duration,
     pub client_body_idle_timeout: Duration,
     pub backend_total_request_timeout: Duration,
+    pub max_active_connections: usize,
     pub max_request_body_bytes: usize,
     pub max_response_body_bytes: usize,
     pub request_buffer_global_cap_bytes: usize,
@@ -141,6 +142,20 @@ pub struct QuicConnection {
 /// Result type returned by the in-flight H2 forwarding task.
 pub type ForwardResult =
     Result<(http::StatusCode, http::HeaderMap, hyper::body::Incoming), ProxyError>;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct HedgeTelemetry {
+    pub launched: bool,
+    pub hedge_won: bool,
+    pub hedge_wasted: bool,
+    pub primary_won_after_trigger: bool,
+    pub primary_late_ms: u64,
+}
+
+pub struct UpstreamResult {
+    pub forward: ForwardResult,
+    pub hedge: HedgeTelemetry,
+}
 
 /// Lifecycle phase of a single HTTP/3 request stream.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -202,7 +217,7 @@ pub struct RequestEnvelope {
     /// True once the client has sent FIN on the request stream.
     pub request_fin_received: bool,
     /// Receives the upstream H2 response (status, headers, body stream).
-    pub upstream_result_rx: Option<oneshot::Receiver<ForwardResult>>,
+    pub upstream_result_rx: Option<oneshot::Receiver<UpstreamResult>>,
     /// Receives response body chunks to write back over QUIC.
     pub response_chunk_rx: Option<mpsc::Receiver<ResponseChunk>>,
     /// True once downstream response headers are emitted on this stream.
@@ -245,6 +260,24 @@ pub struct Metrics {
     pub backend_timeouts: AtomicU64,
     pub backend_errors: AtomicU64,
     pub overload_shed: AtomicU64,
+    pub overload_shed_brownout: AtomicU64,
+    pub overload_shed_adaptive: AtomicU64,
+    pub overload_shed_route_cap: AtomicU64,
+    pub overload_shed_route_global_cap: AtomicU64,
+    pub overload_shed_global_inflight: AtomicU64,
+    pub overload_shed_upstream_inflight: AtomicU64,
+    pub overload_shed_backend_inflight: AtomicU64,
+    pub overload_shed_request_buffer: AtomicU64,
+    pub overload_shed_response_prebuffer: AtomicU64,
+    pub overload_shed_connection_cap: AtomicU64,
+    pub active_connections: AtomicU64,
+    pub connection_cap_rejects: AtomicU64,
+    pub hedge_triggered: AtomicU64,
+    pub hedge_won: AtomicU64,
+    pub hedge_wasted: AtomicU64,
+    pub hedge_primary_won_after_trigger: AtomicU64,
+    pub hedge_primary_late_ms_total: AtomicU64,
+    pub hedge_primary_late_samples: AtomicU64,
     pub ingress_packets_total: AtomicU64,
     pub ingress_queue_drops: AtomicU64,
     pub ingress_queue_drop_bytes: AtomicU64,
@@ -284,6 +317,20 @@ pub enum RouteOutcome {
     OverloadShed,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OverloadShedReason {
+    Brownout,
+    AdaptiveAdmission,
+    RouteCap,
+    RouteGlobalCap,
+    GlobalInflight,
+    UpstreamInflight,
+    BackendInflight,
+    RequestBufferCap,
+    ResponsePrebufferCap,
+    ConnectionCap,
+}
+
 impl Default for Metrics {
     fn default() -> Self {
         let mut shards = Vec::with_capacity(ROUTE_STATS_SHARDS);
@@ -304,6 +351,24 @@ impl Default for Metrics {
             backend_timeouts: AtomicU64::new(0),
             backend_errors: AtomicU64::new(0),
             overload_shed: AtomicU64::new(0),
+            overload_shed_brownout: AtomicU64::new(0),
+            overload_shed_adaptive: AtomicU64::new(0),
+            overload_shed_route_cap: AtomicU64::new(0),
+            overload_shed_route_global_cap: AtomicU64::new(0),
+            overload_shed_global_inflight: AtomicU64::new(0),
+            overload_shed_upstream_inflight: AtomicU64::new(0),
+            overload_shed_backend_inflight: AtomicU64::new(0),
+            overload_shed_request_buffer: AtomicU64::new(0),
+            overload_shed_response_prebuffer: AtomicU64::new(0),
+            overload_shed_connection_cap: AtomicU64::new(0),
+            active_connections: AtomicU64::new(0),
+            connection_cap_rejects: AtomicU64::new(0),
+            hedge_triggered: AtomicU64::new(0),
+            hedge_won: AtomicU64::new(0),
+            hedge_wasted: AtomicU64::new(0),
+            hedge_primary_won_after_trigger: AtomicU64::new(0),
+            hedge_primary_late_ms_total: AtomicU64::new(0),
+            hedge_primary_late_samples: AtomicU64::new(0),
             ingress_packets_total: AtomicU64::new(0),
             ingress_queue_drops: AtomicU64::new(0),
             ingress_queue_drop_bytes: AtomicU64::new(0),
@@ -371,6 +436,82 @@ impl Metrics {
 
     pub fn inc_overload_shed(&self) {
         self.overload_shed.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_overload_shed_reason(&self, reason: OverloadShedReason) {
+        self.overload_shed.fetch_add(1, Ordering::Relaxed);
+        match reason {
+            OverloadShedReason::Brownout => {
+                self.overload_shed_brownout.fetch_add(1, Ordering::Relaxed);
+            }
+            OverloadShedReason::AdaptiveAdmission => {
+                self.overload_shed_adaptive.fetch_add(1, Ordering::Relaxed);
+            }
+            OverloadShedReason::RouteCap => {
+                self.overload_shed_route_cap.fetch_add(1, Ordering::Relaxed);
+            }
+            OverloadShedReason::RouteGlobalCap => {
+                self.overload_shed_route_global_cap
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            OverloadShedReason::GlobalInflight => {
+                self.overload_shed_global_inflight
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            OverloadShedReason::UpstreamInflight => {
+                self.overload_shed_upstream_inflight
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            OverloadShedReason::BackendInflight => {
+                self.overload_shed_backend_inflight
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            OverloadShedReason::RequestBufferCap => {
+                self.overload_shed_request_buffer
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            OverloadShedReason::ResponsePrebufferCap => {
+                self.overload_shed_response_prebuffer
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            OverloadShedReason::ConnectionCap => {
+                self.overload_shed_connection_cap
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+
+    pub fn set_active_connections(&self, count: usize) {
+        self.active_connections
+            .store(count as u64, Ordering::Relaxed);
+    }
+
+    pub fn inc_connection_cap_reject(&self) {
+        self.connection_cap_rejects.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_hedge_triggered(&self) {
+        self.hedge_triggered.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_hedge_won(&self) {
+        self.hedge_won.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_hedge_wasted(&self) {
+        self.hedge_wasted.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_hedge_primary_won_after_trigger(&self) {
+        self.hedge_primary_won_after_trigger
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn observe_hedge_primary_late_ms(&self, late_ms: u64) {
+        self.hedge_primary_late_ms_total
+            .fetch_add(late_ms, Ordering::Relaxed);
+        self.hedge_primary_late_samples
+            .fetch_add(1, Ordering::Relaxed);
     }
 
     pub fn inc_ingress_packet(&self) {
@@ -610,6 +751,120 @@ impl Metrics {
         out.push_str(&format!(
             "spooky_overload_shed {}\n",
             self.overload_shed.load(Ordering::Relaxed)
+        ));
+
+        out.push_str(
+            "# HELP spooky_overload_shed_by_reason_total Total overload shed decisions grouped by reason.\n",
+        );
+        out.push_str("# TYPE spooky_overload_shed_by_reason_total counter\n");
+        out.push_str(&format!(
+            "spooky_overload_shed_by_reason_total{{reason=\"brownout\"}} {}\n",
+            self.overload_shed_brownout.load(Ordering::Relaxed)
+        ));
+        out.push_str(&format!(
+            "spooky_overload_shed_by_reason_total{{reason=\"adaptive_admission\"}} {}\n",
+            self.overload_shed_adaptive.load(Ordering::Relaxed)
+        ));
+        out.push_str(&format!(
+            "spooky_overload_shed_by_reason_total{{reason=\"route_cap\"}} {}\n",
+            self.overload_shed_route_cap.load(Ordering::Relaxed)
+        ));
+        out.push_str(&format!(
+            "spooky_overload_shed_by_reason_total{{reason=\"route_global_cap\"}} {}\n",
+            self.overload_shed_route_global_cap.load(Ordering::Relaxed)
+        ));
+        out.push_str(&format!(
+            "spooky_overload_shed_by_reason_total{{reason=\"global_inflight\"}} {}\n",
+            self.overload_shed_global_inflight.load(Ordering::Relaxed)
+        ));
+        out.push_str(&format!(
+            "spooky_overload_shed_by_reason_total{{reason=\"upstream_inflight\"}} {}\n",
+            self.overload_shed_upstream_inflight.load(Ordering::Relaxed)
+        ));
+        out.push_str(&format!(
+            "spooky_overload_shed_by_reason_total{{reason=\"backend_inflight\"}} {}\n",
+            self.overload_shed_backend_inflight.load(Ordering::Relaxed)
+        ));
+        out.push_str(&format!(
+            "spooky_overload_shed_by_reason_total{{reason=\"request_buffer_cap\"}} {}\n",
+            self.overload_shed_request_buffer.load(Ordering::Relaxed)
+        ));
+        out.push_str(&format!(
+            "spooky_overload_shed_by_reason_total{{reason=\"response_prebuffer_cap\"}} {}\n",
+            self.overload_shed_response_prebuffer
+                .load(Ordering::Relaxed)
+        ));
+        out.push_str(&format!(
+            "spooky_overload_shed_by_reason_total{{reason=\"connection_cap\"}} {}\n",
+            self.overload_shed_connection_cap.load(Ordering::Relaxed)
+        ));
+
+        out.push_str("# HELP spooky_active_connections Current active QUIC connections.\n");
+        out.push_str("# TYPE spooky_active_connections gauge\n");
+        out.push_str(&format!(
+            "spooky_active_connections {}\n",
+            self.active_connections.load(Ordering::Relaxed)
+        ));
+
+        out.push_str(
+            "# HELP spooky_connection_cap_rejects Total new-connection attempts rejected by max_active_connections cap.\n",
+        );
+        out.push_str("# TYPE spooky_connection_cap_rejects counter\n");
+        out.push_str(&format!(
+            "spooky_connection_cap_rejects {}\n",
+            self.connection_cap_rejects.load(Ordering::Relaxed)
+        ));
+
+        out.push_str("# HELP spooky_hedge_triggered_total Total hedge attempts started.\n");
+        out.push_str("# TYPE spooky_hedge_triggered_total counter\n");
+        out.push_str(&format!(
+            "spooky_hedge_triggered_total {}\n",
+            self.hedge_triggered.load(Ordering::Relaxed)
+        ));
+
+        out.push_str(
+            "# HELP spooky_hedge_won_total Total requests where hedge response arrived first.\n",
+        );
+        out.push_str("# TYPE spooky_hedge_won_total counter\n");
+        out.push_str(&format!(
+            "spooky_hedge_won_total {}\n",
+            self.hedge_won.load(Ordering::Relaxed)
+        ));
+
+        out.push_str(
+            "# HELP spooky_hedge_wasted_total Total hedge attempts that did not win the race.\n",
+        );
+        out.push_str("# TYPE spooky_hedge_wasted_total counter\n");
+        out.push_str(&format!(
+            "spooky_hedge_wasted_total {}\n",
+            self.hedge_wasted.load(Ordering::Relaxed)
+        ));
+
+        out.push_str(
+            "# HELP spooky_hedge_primary_won_after_trigger_total Total hedged requests where primary still won.\n",
+        );
+        out.push_str("# TYPE spooky_hedge_primary_won_after_trigger_total counter\n");
+        out.push_str(&format!(
+            "spooky_hedge_primary_won_after_trigger_total {}\n",
+            self.hedge_primary_won_after_trigger.load(Ordering::Relaxed)
+        ));
+
+        out.push_str(
+            "# HELP spooky_hedge_primary_late_ms_total Aggregate milliseconds primary was late after hedge trigger.\n",
+        );
+        out.push_str("# TYPE spooky_hedge_primary_late_ms_total counter\n");
+        out.push_str(&format!(
+            "spooky_hedge_primary_late_ms_total {}\n",
+            self.hedge_primary_late_ms_total.load(Ordering::Relaxed)
+        ));
+
+        out.push_str(
+            "# HELP spooky_hedge_primary_late_samples_total Number of late-primary observations used in hedge tuning.\n",
+        );
+        out.push_str("# TYPE spooky_hedge_primary_late_samples_total counter\n");
+        out.push_str(&format!(
+            "spooky_hedge_primary_late_samples_total {}\n",
+            self.hedge_primary_late_samples.load(Ordering::Relaxed)
         ));
 
         out.push_str(
@@ -871,5 +1126,35 @@ mod tests {
 
         metrics.release_request_buffer(512);
         assert_eq!(metrics.request_buffered_bytes.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn metrics_render_includes_overload_reasons_and_hedge_counters() {
+        let metrics = Metrics::default();
+        metrics.inc_overload_shed_reason(OverloadShedReason::GlobalInflight);
+        metrics.inc_overload_shed_reason(OverloadShedReason::BackendInflight);
+        metrics.set_active_connections(7);
+        metrics.inc_connection_cap_reject();
+        metrics.inc_hedge_triggered();
+        metrics.inc_hedge_won();
+        metrics.inc_hedge_wasted();
+        metrics.inc_hedge_primary_won_after_trigger();
+        metrics.observe_hedge_primary_late_ms(42);
+
+        let output = metrics.render_prometheus();
+        assert!(
+            output.contains("spooky_overload_shed_by_reason_total{reason=\"global_inflight\"} 1")
+        );
+        assert!(
+            output.contains("spooky_overload_shed_by_reason_total{reason=\"backend_inflight\"} 1")
+        );
+        assert!(output.contains("spooky_active_connections 7"));
+        assert!(output.contains("spooky_connection_cap_rejects 1"));
+        assert!(output.contains("spooky_hedge_triggered_total 1"));
+        assert!(output.contains("spooky_hedge_won_total 1"));
+        assert!(output.contains("spooky_hedge_wasted_total 1"));
+        assert!(output.contains("spooky_hedge_primary_won_after_trigger_total 1"));
+        assert!(output.contains("spooky_hedge_primary_late_ms_total 42"));
+        assert!(output.contains("spooky_hedge_primary_late_samples_total 1"));
     }
 }

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -38,8 +38,8 @@ use tokio::sync::{
 use spooky_config::{backend_endpoint::BackendEndpoint, config::Config as SpookyConfig};
 
 use crate::{
-    ChannelBody, ForwardResult, Metrics, QUICListener, QuicConnection, RequestEnvelope,
-    ResponseChunk, RouteOutcome, SharedRuntimeState, StreamPhase,
+    ChannelBody, ForwardResult, Metrics, OverloadShedReason, QUICListener, QuicConnection,
+    RequestEnvelope, ResponseChunk, RouteOutcome, SharedRuntimeState, StreamPhase, UpstreamResult,
     cid_radix::CidRadix,
     constants::{
         DEFAULT_SCID_LEN_BYTES, MAX_DATAGRAM_SIZE_BYTES, MAX_STREAMS_PER_CONNECTION,
@@ -443,7 +443,7 @@ impl QUICListener {
             .saturating_mul(worker_threads);
 
         info!(
-            "Performance profile: worker_threads={} control_plane_threads={} reuseport={} pin_workers={} global_inflight_limit={} per_upstream_inflight_limit={} per_backend_inflight_limit={} backend_connect_timeout_ms={} backend_timeout_ms={} backend_body_idle_timeout_ms={} backend_body_total_timeout_ms={} backend_total_request_timeout_ms={} client_body_idle_timeout_ms={} max_request_body_bytes={} max_response_body_bytes={} request_buffer_global_cap_bytes={} unknown_length_response_prebuffer_bytes={} udp_recv_buffer_bytes={} udp_send_buffer_bytes={} h2_pool_max_idle_per_backend={} h2_pool_idle_timeout_ms={}",
+            "Performance profile: worker_threads={} control_plane_threads={} reuseport={} pin_workers={} global_inflight_limit={} per_upstream_inflight_limit={} per_backend_inflight_limit={} max_active_connections={} backend_connect_timeout_ms={} backend_timeout_ms={} backend_body_idle_timeout_ms={} backend_body_total_timeout_ms={} backend_total_request_timeout_ms={} client_body_idle_timeout_ms={} max_request_body_bytes={} max_response_body_bytes={} request_buffer_global_cap_bytes={} unknown_length_response_prebuffer_bytes={} udp_recv_buffer_bytes={} udp_send_buffer_bytes={} h2_pool_max_idle_per_backend={} h2_pool_idle_timeout_ms={}",
             worker_threads,
             config.performance.control_plane_threads.max(1),
             config.performance.reuseport,
@@ -451,6 +451,7 @@ impl QUICListener {
             global_inflight_limit,
             per_upstream_limit,
             config.performance.per_backend_inflight_limit,
+            config.performance.max_active_connections,
             config.performance.backend_connect_timeout_ms,
             config.performance.backend_timeout_ms,
             config.performance.backend_body_idle_timeout_ms,
@@ -600,6 +601,7 @@ impl QUICListener {
         let backend_total_request_timeout =
             Duration::from_millis(config.performance.backend_total_request_timeout_ms);
         let drain_timeout = Duration::from_millis(config.performance.shutdown_drain_timeout_ms);
+        let max_active_connections = config.performance.max_active_connections.max(1);
         let max_request_body_bytes = config.performance.max_request_body_bytes;
         let max_response_body_bytes = config.performance.max_response_body_bytes;
         let request_buffer_global_cap_bytes = config.performance.request_buffer_global_cap_bytes;
@@ -632,6 +634,7 @@ impl QUICListener {
             backend_body_total_timeout,
             client_body_idle_timeout,
             backend_total_request_timeout,
+            max_active_connections,
             max_request_body_bytes,
             max_response_body_bytes,
             request_buffer_global_cap_bytes,
@@ -837,6 +840,7 @@ impl QUICListener {
         self.cid_routes.clear();
         self.peer_routes.clear();
         self.cid_radix.clear();
+        self.refresh_active_connection_metric();
     }
 
     fn take_or_create_connection(
@@ -914,6 +918,19 @@ impl QUICListener {
         if !self.conn_rate_limiter.try_consume() {
             debug!(
                 "New connection rate limit exceeded, dropping Initial packet from {}",
+                peer
+            );
+            return None;
+        }
+
+        if self.connections.len() >= self.max_active_connections {
+            self.metrics.inc_connection_cap_reject();
+            self.metrics
+                .inc_overload_shed_reason(OverloadShedReason::ConnectionCap);
+            debug!(
+                "Active connection cap reached (cap={}, active={}), dropping Initial packet from {}",
+                self.max_active_connections,
+                self.connections.len(),
                 peer
             );
             return None;
@@ -1258,6 +1275,7 @@ impl QUICListener {
             error!("QUIC recv failed: {:?}", e);
             Self::release_connection_streams(&mut connection, &self.metrics);
             self.remove_connection_routes(&connection);
+            self.refresh_active_connection_metric();
             return;
         }
 
@@ -1329,6 +1347,8 @@ impl QUICListener {
             self.remove_connection_routes(&connection);
             debug!("Connection closed, not storing");
         }
+
+        self.refresh_active_connection_metric();
     }
 
     fn handle_timeouts(&mut self) {
@@ -1398,6 +1418,7 @@ impl QUICListener {
             to_remove,
             |c| ConnectionRoutes::from(c),
         );
+        self.refresh_active_connection_metric();
     }
 
     fn handle_timeout(socket: &UdpSocket, send_buf: &mut [u8], connection: &mut QuicConnection) {
@@ -1411,6 +1432,10 @@ impl QUICListener {
             connection.last_activity = Instant::now();
             Self::flush_send(socket, send_buf, connection);
         }
+    }
+
+    fn refresh_active_connection_metric(&self) {
+        self.metrics.set_active_connections(self.connections.len());
     }
 
     fn release_connection_streams(connection: &mut QuicConnection, metrics: &Metrics) {
@@ -1632,7 +1657,7 @@ impl QUICListener {
                             );
                             if !resilience.brownout.route_allowed(&upstream_name) {
                                 metrics.inc_failure();
-                                metrics.inc_overload_shed();
+                                metrics.inc_overload_shed_reason(OverloadShedReason::Brownout);
                                 metrics.record_route(
                                     &upstream_name,
                                     request_start.elapsed(),
@@ -1656,7 +1681,9 @@ impl QUICListener {
                                 Some(permit) => permit,
                                 None => {
                                     metrics.inc_failure();
-                                    metrics.inc_overload_shed();
+                                    metrics.inc_overload_shed_reason(
+                                        OverloadShedReason::AdaptiveAdmission,
+                                    );
                                     metrics.record_route(
                                         &upstream_name,
                                         request_start.elapsed(),
@@ -1681,7 +1708,8 @@ impl QUICListener {
                                     Ok(permit) => permit,
                                     Err(RouteQueueRejection::RouteCap) => {
                                         metrics.inc_failure();
-                                        metrics.inc_overload_shed();
+                                        metrics
+                                            .inc_overload_shed_reason(OverloadShedReason::RouteCap);
                                         metrics.record_route(
                                             &upstream_name,
                                             request_start.elapsed(),
@@ -1701,7 +1729,9 @@ impl QUICListener {
                                     }
                                     Err(RouteQueueRejection::GlobalCap) => {
                                         metrics.inc_failure();
-                                        metrics.inc_overload_shed();
+                                        metrics.inc_overload_shed_reason(
+                                            OverloadShedReason::RouteGlobalCap,
+                                        );
                                         metrics.record_route(
                                             &upstream_name,
                                             request_start.elapsed(),
@@ -1726,7 +1756,9 @@ impl QUICListener {
                                     Ok(permit) => permit,
                                     Err(_) => {
                                         metrics.inc_failure();
-                                        metrics.inc_overload_shed();
+                                        metrics.inc_overload_shed_reason(
+                                            OverloadShedReason::GlobalInflight,
+                                        );
                                         metrics.record_route(
                                             &upstream_name,
                                             request_start.elapsed(),
@@ -1753,7 +1785,9 @@ impl QUICListener {
                                         Err(_) => {
                                             drop(global_permit);
                                             metrics.inc_failure();
-                                            metrics.inc_overload_shed();
+                                            metrics.inc_overload_shed_reason(
+                                                OverloadShedReason::UpstreamInflight,
+                                            );
                                             metrics.record_route(
                                                 &upstream_name,
                                                 request_start.elapsed(),
@@ -1775,7 +1809,9 @@ impl QUICListener {
                                     None => {
                                         drop(global_permit);
                                         metrics.inc_failure();
-                                        metrics.inc_overload_shed();
+                                        metrics.inc_overload_shed_reason(
+                                            OverloadShedReason::UpstreamInflight,
+                                        );
                                         metrics.record_route(
                                             &upstream_name,
                                             request_start.elapsed(),
@@ -1801,7 +1837,9 @@ impl QUICListener {
                                     drop(upstream_permit);
                                     drop(global_permit);
                                     metrics.inc_failure();
-                                    metrics.inc_overload_shed();
+                                    metrics.inc_overload_shed_reason(
+                                        OverloadShedReason::BackendInflight,
+                                    );
                                     metrics.record_route(
                                         &upstream_name,
                                         request_start.elapsed(),
@@ -1895,9 +1933,10 @@ impl QUICListener {
                             let method_owned = method.clone();
                             let path_owned = path.clone();
                             let headers_owned = list.clone();
-                            let (result_tx, result_rx) = oneshot::channel::<ForwardResult>();
+                            let (result_tx, result_rx) = oneshot::channel::<UpstreamResult>();
                             let fut = async move {
-                                let result = async {
+                                let mut hedge_telemetry = crate::HedgeTelemetry::default();
+                                let result: ForwardResult = async {
                                     retry_budget.mark_primary(&route_name);
 
                                     let send_once =
@@ -1944,6 +1983,7 @@ impl QUICListener {
                                         if let Some((hedge_backend, hedge_request)) =
                                             hedge_candidate
                                         {
+                                            let primary_started = Instant::now();
                                             let primary_backend = fwd_addr.clone();
                                             let primary_fut = send_once(
                                                 primary_backend,
@@ -1961,6 +2001,7 @@ impl QUICListener {
                                             } {
                                                 result?
                                             } else if retry_budget.allow_retry(&route_name) {
+                                                hedge_telemetry.launched = true;
                                                 let hedge_fut = send_once(
                                                     hedge_backend,
                                                     hedge_request,
@@ -1969,8 +2010,18 @@ impl QUICListener {
                                                 );
                                                 tokio::pin!(hedge_fut);
                                                 tokio::select! {
-                                                    result = &mut primary_fut => result?,
-                                                    result = &mut hedge_fut => result?,
+                                                    result = &mut primary_fut => {
+                                                        hedge_telemetry.primary_won_after_trigger = true;
+                                                        hedge_telemetry.hedge_wasted = true;
+                                                        result?
+                                                    },
+                                                    result = &mut hedge_fut => {
+                                                        hedge_telemetry.hedge_won = true;
+                                                        let elapsed_ms = primary_started.elapsed().as_millis() as u64;
+                                                        let delay_ms = hedge_delay.as_millis() as u64;
+                                                        hedge_telemetry.primary_late_ms = elapsed_ms.saturating_sub(delay_ms);
+                                                        result?
+                                                    },
                                                 }
                                             } else {
                                                 primary_fut.await?
@@ -2027,7 +2078,10 @@ impl QUICListener {
                                 }
                                 .await;
                                 // Ignore send error: receiver dropped means the stream was reset.
-                                let _ = result_tx.send(result);
+                                let _ = result_tx.send(UpstreamResult {
+                                    forward: result,
+                                    hedge: hedge_telemetry,
+                                });
                             };
                             if !spawn_async_task(fut, "upstream") {
                                 error!("dropping upstream task: no runtime available");
@@ -2230,7 +2284,8 @@ impl QUICListener {
                                 && let Some(req) = connection.streams.get(&stream_id)
                             {
                                 metrics.inc_failure();
-                                metrics.inc_overload_shed();
+                                metrics
+                                    .inc_overload_shed_reason(OverloadShedReason::RequestBufferCap);
                                 let route_label =
                                     req.upstream_name.as_deref().unwrap_or("unrouted");
                                 metrics.record_route(
@@ -2454,30 +2509,49 @@ impl QUICListener {
                     && req.body_buf.is_empty()
             });
 
-            // upstream_ready: Option<ForwardResult>
+            // upstream_ready: Option<UpstreamResult>
             //   None          → oneshot not yet resolved (or not eligible), skip
             //   Some(Ok(...)) → upstream responded successfully
             //   Some(Err(.))  → upstream error (or sender dropped)
-            let upstream_ready: Option<ForwardResult> = if can_poll_upstream {
+            let upstream_ready: Option<UpstreamResult> = if can_poll_upstream {
                 streams
                     .get_mut(&stream_id)
                     .and_then(|req| req.upstream_result_rx.as_mut())
                     .and_then(|rx| match rx.try_recv() {
                         Ok(result) => Some(result),
                         Err(oneshot::error::TryRecvError::Empty) => None,
-                        Err(oneshot::error::TryRecvError::Closed) => Some(Err(
-                            ProxyError::Transport("upstream task dropped sender".into()),
-                        )),
+                        Err(oneshot::error::TryRecvError::Closed) => Some(UpstreamResult {
+                            forward: Err(ProxyError::Transport(
+                                "upstream task dropped sender".into(),
+                            )),
+                            hedge: crate::HedgeTelemetry::default(),
+                        }),
                     })
             } else {
                 None
             };
 
             if let Some(forward_result) = upstream_ready {
+                if forward_result.hedge.launched {
+                    metrics.inc_hedge_triggered();
+                }
+                if forward_result.hedge.hedge_won {
+                    metrics.inc_hedge_won();
+                }
+                if forward_result.hedge.hedge_wasted {
+                    metrics.inc_hedge_wasted();
+                }
+                if forward_result.hedge.primary_won_after_trigger {
+                    metrics.inc_hedge_primary_won_after_trigger();
+                }
+                if forward_result.hedge.primary_late_ms > 0 {
+                    metrics.observe_hedge_primary_late_ms(forward_result.hedge.primary_late_ms);
+                }
+
                 if let Some(req) = streams.get_mut(&stream_id) {
                     req.upstream_result_rx = None;
                 }
-                match forward_result {
+                match forward_result.forward {
                     Ok((status, resp_headers, body)) => {
                         // If upstream advertised a response length beyond our hard cap,
                         // fail fast with 503 before sending any downstream headers/body.
@@ -2489,7 +2563,9 @@ impl QUICListener {
                         {
                             if let Some(req) = streams.get(&stream_id) {
                                 metrics.inc_failure();
-                                metrics.inc_overload_shed();
+                                metrics.inc_overload_shed_reason(
+                                    OverloadShedReason::ResponsePrebufferCap,
+                                );
                                 let route_label =
                                     req.upstream_name.as_deref().unwrap_or("unrouted");
                                 metrics.record_route(
@@ -2990,6 +3066,36 @@ impl QUICListener {
                                         req.start.elapsed().as_millis()
                                     );
                                 }
+                                ProxyError::Pool(PoolError::BackendOverloaded(reason)) => {
+                                    metrics.inc_failure();
+                                    if reason.contains(
+                                        "unknown-length response prebuffer limit exceeded",
+                                    ) {
+                                        metrics.inc_response_prebuffer_limit_reject();
+                                        metrics.inc_overload_shed_reason(
+                                            OverloadShedReason::ResponsePrebufferCap,
+                                        );
+                                    } else {
+                                        metrics.inc_overload_shed_reason(
+                                            OverloadShedReason::BackendInflight,
+                                        );
+                                    }
+                                    let route_label =
+                                        req.upstream_name.as_deref().unwrap_or("unrouted");
+                                    metrics.record_route(
+                                        route_label,
+                                        req.start.elapsed(),
+                                        RouteOutcome::OverloadShed,
+                                    );
+                                    resilience
+                                        .adaptive_admission
+                                        .observe(req.start.elapsed(), true);
+                                    error!(
+                                        "Upstream {} overload in response body path: {}",
+                                        req.backend_addr.as_deref().unwrap_or("?"),
+                                        reason
+                                    );
+                                }
                                 _ => {
                                     metrics.inc_failure();
                                     metrics.inc_backend_error();
@@ -3171,9 +3277,11 @@ impl QUICListener {
             Err(ProxyError::Pool(PoolError::BackendOverloaded(reason))) => {
                 debug!("Backend overloaded");
                 metrics.inc_failure();
-                metrics.inc_overload_shed();
                 if reason.contains("unknown-length response prebuffer limit exceeded") {
                     metrics.inc_response_prebuffer_limit_reject();
+                    metrics.inc_overload_shed_reason(OverloadShedReason::ResponsePrebufferCap);
+                } else {
+                    metrics.inc_overload_shed_reason(OverloadShedReason::BackendInflight);
                 }
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::OverloadShed);
                 debug!(
@@ -3192,7 +3300,7 @@ impl QUICListener {
             Err(ProxyError::Pool(PoolError::CircuitOpen(_))) => {
                 debug!("Backend circuit open");
                 metrics.inc_failure();
-                metrics.inc_overload_shed();
+                metrics.inc_overload_shed_reason(OverloadShedReason::BackendInflight);
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::OverloadShed);
                 debug!(
                     "Upstream {} status 503 latency_ms {}",
@@ -4512,7 +4620,7 @@ mod tests {
     #[test]
     fn abort_stream_awaiting_upstream_cancels_oneshot() {
         let metrics = crate::Metrics::default();
-        let (result_tx, result_rx) = oneshot::channel::<crate::ForwardResult>();
+        let (result_tx, result_rx) = oneshot::channel::<crate::UpstreamResult>();
 
         let mut req = make_envelope(StreamPhase::AwaitingUpstream);
         req.upstream_result_rx = Some(result_rx);
@@ -4526,7 +4634,10 @@ mod tests {
         );
 
         // Sending on the now-orphaned sender should return Err (closed).
-        let send_result = result_tx.send(Err(spooky_errors::ProxyError::Transport("test".into())));
+        let send_result = result_tx.send(crate::UpstreamResult {
+            forward: Err(spooky_errors::ProxyError::Transport("test".into())),
+            hedge: crate::HedgeTelemetry::default(),
+        });
         assert!(
             send_result.is_err(),
             "upstream task send must fail after receiver dropped"
@@ -4576,7 +4687,7 @@ mod tests {
         let global_permit = global_sem.clone().try_acquire_owned().unwrap();
         let upstream_permit = upstream_sem.clone().try_acquire_owned().unwrap();
 
-        let (_result_tx, result_rx) = oneshot::channel::<crate::ForwardResult>();
+        let (_result_tx, result_rx) = oneshot::channel::<crate::UpstreamResult>();
         let (chunk_tx, chunk_rx) = mpsc::channel::<crate::ResponseChunk>(4);
 
         let mut req = make_envelope(StreamPhase::SendingResponse);

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -2156,6 +2156,10 @@ fn metrics_endpoint_exposes_route_slo_metrics() {
     assert!(metrics.contains("spooky_route_latency_ms_p50{route=\"test_pool\"}"));
     assert!(metrics.contains("spooky_route_latency_ms_p95{route=\"test_pool\"}"));
     assert!(metrics.contains("spooky_route_latency_ms_p99{route=\"test_pool\"}"));
+    assert!(metrics.contains("spooky_overload_shed_by_reason_total"));
+    assert!(metrics.contains("spooky_active_connections"));
+    assert!(metrics.contains("spooky_connection_cap_rejects"));
+    assert!(metrics.contains("spooky_hedge_triggered_total"));
 }
 
 #[test]

--- a/crates/edge/tests/h3_edge.rs
+++ b/crates/edge/tests/h3_edge.rs
@@ -897,6 +897,40 @@ fn connection_flood_is_rate_limited() {
     );
 }
 
+/// Hard cap on active connections should reject additional Initial packets
+/// even when token-bucket rate limits are permissive.
+#[test]
+fn active_connection_cap_rejects_excess_initial_packets() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_certs(&dir);
+    let mut config =
+        make_config_with_rate_limit(0, cert, key, "127.0.0.1:1".to_string(), 10_000, 10_000);
+    config.performance.max_active_connections = 1;
+    let mut listener = QUICListener::new(config).expect("listener");
+    let addr = listener.socket.local_addr().unwrap();
+
+    const FLOOD_COUNT: usize = 8;
+    for _ in 0..FLOOD_COUNT {
+        let pkt = build_initial_packet(addr);
+        send_udp(addr, &pkt);
+        listener.poll();
+    }
+
+    assert!(
+        listener.connections.len() <= 1,
+        "active connection cap must keep at most one connection, got {}",
+        listener.connections.len()
+    );
+    assert!(
+        listener
+            .metrics
+            .connection_cap_rejects
+            .load(Ordering::Relaxed)
+            > 0,
+        "connection cap should emit rejection metrics"
+    );
+}
+
 /// Once draining starts, unknown/new Initial packets must not create a
 /// connection, even if admission limits would otherwise allow it.
 #[test]
@@ -1040,9 +1074,8 @@ fn stress_connect(
     rand::thread_rng().fill_bytes(&mut scid_bytes);
     let scid = quiche::ConnectionId::from_ref(&scid_bytes);
 
-    let mut conn =
-        quiche::connect(Some("localhost"), &scid, local_addr, server_addr, &mut cfg)
-            .map_err(|e| format!("connect: {e:?}"))?;
+    let mut conn = quiche::connect(Some("localhost"), &scid, local_addr, server_addr, &mut cfg)
+        .map_err(|e| format!("connect: {e:?}"))?;
 
     let mut out = [0u8; MAX_UDP_PAYLOAD_BYTES];
     let mut buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
@@ -1070,8 +1103,14 @@ fn stress_connect(
 
         match socket.recv_from(&mut buf) {
             Ok((len, from)) => {
-                conn.recv(&mut buf[..len], quiche::RecvInfo { from, to: local_addr })
-                    .map_err(|e| format!("recv: {e:?}"))?;
+                conn.recv(
+                    &mut buf[..len],
+                    quiche::RecvInfo {
+                        from,
+                        to: local_addr,
+                    },
+                )
+                .map_err(|e| format!("recv: {e:?}"))?;
             }
             Err(ref e)
                 if e.kind() == std::io::ErrorKind::WouldBlock
@@ -1095,10 +1134,7 @@ fn stress_connect(
 }
 
 /// Send a graceful QUIC CONNECTION_CLOSE and flush.
-fn stress_close_gracefully(
-    socket: &UdpSocket,
-    conn: &mut quiche::Connection,
-) {
+fn stress_close_gracefully(socket: &UdpSocket, conn: &mut quiche::Connection) {
     let _ = conn.close(false, 0, b"done");
     let mut out = [0u8; MAX_UDP_PAYLOAD_BYTES];
     loop {

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -123,6 +123,7 @@ The following table lists all default configuration values used when properties 
 | `log.file.path` | `"/var/log/spooky/spooky.log"` | Log file path (used when `log.file.enabled` is true) |
 | `performance.new_connections_per_sec` | `2000` | Token-bucket refill rate for new QUIC connections (conns/sec) |
 | `performance.new_connections_burst` | `500` | Burst capacity for new QUIC connections |
+| `performance.max_active_connections` | `20000` | Hard cap on concurrently tracked active QUIC connections per worker |
 | `performance.quic_max_idle_timeout_ms` | `5000` | QUIC idle timeout — connection closed after this many ms of inactivity |
 | `performance.quic_initial_max_data` | `10000000` | Connection-level flow control window (bytes) |
 | `performance.quic_initial_max_stream_data` | `1000000` | Per-stream flow control window (bytes) |
@@ -510,6 +511,7 @@ Controls resource limits, tuning knobs, and connection-flood protection. All fie
 | `h2_pool_idle_timeout_ms` | integer | No | `90000` | How long an idle H2 connection is kept before being closed (ms) |
 | `new_connections_per_sec` | integer | No | `2000` | Steady-state rate at which new QUIC connections are accepted (token-bucket refill, connections/sec) |
 | `new_connections_burst` | integer | No | `500` | Burst capacity above the steady-state rate; the bucket starts full so the first burst of legitimate connections always succeeds |
+| `max_active_connections` | integer | No | `20000` | Hard cap on active QUIC connections per worker; unknown `Initial` packets are dropped once this cap is reached |
 | `quic_max_idle_timeout_ms` | integer | No | `5000` | QUIC idle timeout in ms; connection is closed after this period of inactivity |
 | `quic_initial_max_data` | integer | No | `10000000` | Connection-level QUIC flow control window in bytes |
 | `quic_initial_max_stream_data` | integer | No | `1000000` | Per-stream QUIC flow control window in bytes; must be ≤ `quic_initial_max_data` |
@@ -521,10 +523,13 @@ Controls resource limits, tuning knobs, and connection-flood protection. All fie
 
 `new_connections_per_sec` and `new_connections_burst` implement a token-bucket rate limiter on new QUIC connection accepts. The bucket starts full so legitimate burst traffic at startup is never penalised. Packets for **existing** connections are never affected by this limit — only unknown `Initial` packets that would create a new connection state entry are gated.
 
+`max_active_connections` is a separate hard guardrail for total connection state. Use it to enforce deterministic memory limits under sustained handshake floods even when token-bucket limits allow temporary bursts.
+
 ```yaml
 performance:
   new_connections_per_sec: 2000   # refill rate: 2 k new conns/sec
   new_connections_burst: 500      # allow a burst of up to 500 above the rate
+  max_active_connections: 20000   # hard ceiling for concurrently tracked connections
 ```
 
 Set `new_connections_burst` to `1` and `new_connections_per_sec` to a low value to aggressively throttle connection floods at the cost of rejecting legitimate concurrent handshakes.

--- a/scripts/load-scenarios.sh
+++ b/scripts/load-scenarios.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET="${TARGET:-127.0.0.1:9889}"
+HOST="${HOST:-localhost}"
+H3_CLIENT_BIN="${H3_CLIENT_BIN:-./target/release/h3_client}"
+OUT_DIR="${OUT_DIR:-bench/load}"
+
+BURST_PATH="${BURST_PATH:-/api}"
+BURST_REQUESTS="${BURST_REQUESTS:-3000}"
+BURST_CONCURRENCY="${BURST_CONCURRENCY:-200}"
+
+SLOW_PATH="${SLOW_PATH:-/slow}"
+SLOW_REQUESTS="${SLOW_REQUESTS:-1000}"
+SLOW_CONCURRENCY="${SLOW_CONCURRENCY:-80}"
+
+LOSS_PATH="${LOSS_PATH:-/api}"
+LOSS_REQUESTS="${LOSS_REQUESTS:-1500}"
+LOSS_CONCURRENCY="${LOSS_CONCURRENCY:-120}"
+LOSS_PERCENT="${LOSS_PERCENT:-2}"
+NETEM_IFACE="${NETEM_IFACE:-}"
+
+usage() {
+  cat <<USAGE
+Usage: scripts/load-scenarios.sh
+
+Environment overrides:
+  TARGET=127.0.0.1:9889
+  HOST=localhost
+  H3_CLIENT_BIN=./target/release/h3_client
+  OUT_DIR=bench/load
+
+  BURST_PATH=/api BURST_REQUESTS=3000 BURST_CONCURRENCY=200
+  SLOW_PATH=/slow SLOW_REQUESTS=1000 SLOW_CONCURRENCY=80
+  LOSS_PATH=/api LOSS_REQUESTS=1500 LOSS_CONCURRENCY=120
+
+Optional Linux netem injection for packet-loss scenario:
+  NETEM_IFACE=eth0 LOSS_PERCENT=2 scripts/load-scenarios.sh
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ ! -x "${H3_CLIENT_BIN}" ]]; then
+  echo "error: h3 client binary not found at ${H3_CLIENT_BIN}" >&2
+  echo "build it with: cargo build --release -p spooky --bin h3_client" >&2
+  exit 1
+fi
+
+mkdir -p "${OUT_DIR}"
+
+results_tsv="${OUT_DIR}/latest.tsv"
+results_json="${OUT_DIR}/latest.json"
+results_md="${OUT_DIR}/latest.md"
+
+echo -n >"${results_tsv}"
+
+now_ns() {
+  perl -MTime::HiRes=time -e 'printf("%.0f\n", time()*1000000000)'
+}
+
+percentile_from_sorted_file() {
+  local p="$1"
+  local file="$2"
+  local count
+  count=$(wc -l <"${file}")
+  if [[ "${count}" -eq 0 ]]; then
+    echo 0
+    return
+  fi
+  local idx=$(( (p * count + 99) / 100 ))
+  if [[ "${idx}" -lt 1 ]]; then
+    idx=1
+  fi
+  sed -n "${idx}p" "${file}"
+}
+
+run_single_request() {
+  local path="$1"
+  local out_file="$2"
+  local start_ns
+  local end_ns
+  local ok
+
+  start_ns="$(now_ns)"
+  if "${H3_CLIENT_BIN}" --connect "${TARGET}" --host "${HOST}" --path "${path}" --insecure >/dev/null 2>&1; then
+    ok=1
+  else
+    ok=0
+  fi
+  end_ns="$(now_ns)"
+
+  printf "%s %s\n" "${ok}" "$((end_ns - start_ns))" >>"${out_file}"
+}
+
+run_scenario() {
+  local name="$1"
+  local path="$2"
+  local requests="$3"
+  local concurrency="$4"
+
+  local raw
+  local lat_ok
+  raw="$(mktemp)"
+  lat_ok="$(mktemp)"
+
+  local start_ns
+  local end_ns
+  start_ns="$(now_ns)"
+
+  local helper
+  helper="$(mktemp)"
+  cat >"${helper}" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+path="$1"
+out_file="$2"
+client="$3"
+target="$4"
+host="$5"
+start_ns="$(perl -MTime::HiRes=time -e 'printf("%.0f\n", time()*1000000000)')"
+if "${client}" --connect "${target}" --host "${host}" --path "${path}" --insecure >/dev/null 2>&1; then
+  ok=1
+else
+  ok=0
+fi
+end_ns="$(perl -MTime::HiRes=time -e 'printf("%.0f\n", time()*1000000000)')"
+printf "%s %s\n" "${ok}" "$((end_ns - start_ns))" >>"${out_file}"
+SH
+  chmod +x "${helper}"
+
+  seq "${requests}" | xargs -P "${concurrency}" -I{} "${helper}" "${path}" "${raw}" "${H3_CLIENT_BIN}" "${TARGET}" "${HOST}"
+
+  end_ns="$(now_ns)"
+  rm -f "${helper}"
+
+  local success
+  local errors
+  success=$(awk '$1 == 1 {c++} END {print c+0}' "${raw}")
+  errors=$((requests - success))
+
+  awk '$1 == 1 {print $2}' "${raw}" | sort -n >"${lat_ok}"
+
+  local min_ns avg_ns p50_ns p95_ns p99_ns max_ns
+  min_ns=$(awk 'NR==1{print; exit}' "${lat_ok}")
+  avg_ns=$(awk '{s+=$1} END {if (NR==0) print 0; else printf "%.0f", s/NR}' "${lat_ok}")
+  p50_ns=$(percentile_from_sorted_file 50 "${lat_ok}")
+  p95_ns=$(percentile_from_sorted_file 95 "${lat_ok}")
+  p99_ns=$(percentile_from_sorted_file 99 "${lat_ok}")
+  max_ns=$(awk 'END{print ($1+0)}' "${lat_ok}")
+
+  min_ns=${min_ns:-0}
+  avg_ns=${avg_ns:-0}
+  p50_ns=${p50_ns:-0}
+  p95_ns=${p95_ns:-0}
+  p99_ns=${p99_ns:-0}
+  max_ns=${max_ns:-0}
+
+  local dur_ns
+  local throughput
+  dur_ns=$((end_ns - start_ns))
+  throughput=$(awk -v ok="${success}" -v ns="${dur_ns}" 'BEGIN { if (ns <= 0) print "0.00"; else printf "%.2f", (ok*1000000000.0)/ns }')
+
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+    "${name}" "${path}" "${requests}" "${concurrency}" "${success}" "${errors}" \
+    "${throughput}" "${min_ns}" "${avg_ns}" "${p50_ns}" "${p95_ns}" "${p99_ns}" >>"${results_tsv}"
+
+  rm -f "${raw}" "${lat_ok}"
+}
+
+apply_netem_loss_if_configured() {
+  if [[ -z "${NETEM_IFACE}" ]]; then
+    return 1
+  fi
+  if ! command -v tc >/dev/null 2>&1; then
+    echo "warn: tc not available; running quic_loss scenario without netem injection" >&2
+    return 1
+  fi
+
+  sudo tc qdisc replace dev "${NETEM_IFACE}" root netem loss "${LOSS_PERCENT}%"
+  return 0
+}
+
+clear_netem_loss_if_configured() {
+  if [[ -z "${NETEM_IFACE}" ]]; then
+    return 0
+  fi
+  if ! command -v tc >/dev/null 2>&1; then
+    return 0
+  fi
+  sudo tc qdisc del dev "${NETEM_IFACE}" root >/dev/null 2>&1 || true
+}
+
+trap clear_netem_loss_if_configured EXIT
+
+run_scenario "burst" "${BURST_PATH}" "${BURST_REQUESTS}" "${BURST_CONCURRENCY}"
+run_scenario "slow_upstream" "${SLOW_PATH}" "${SLOW_REQUESTS}" "${SLOW_CONCURRENCY}"
+if apply_netem_loss_if_configured; then
+  run_scenario "quic_loss" "${LOSS_PATH}" "${LOSS_REQUESTS}" "${LOSS_CONCURRENCY}"
+  clear_netem_loss_if_configured
+else
+  run_scenario "quic_loss" "${LOSS_PATH}" "${LOSS_REQUESTS}" "${LOSS_CONCURRENCY}"
+fi
+
+# JSON export
+{
+  echo '{'
+  echo '  "target": "'"${TARGET}"'",'
+  echo '  "host": "'"${HOST}"'",'
+  echo '  "generated_unix_secs": '"$(date +%s)"','
+  echo '  "scenarios": ['
+  awk -F'\t' 'BEGIN{first=1} {
+    if (!first) printf(",\n");
+    first=0;
+    printf("    {\"name\":\"%s\",\"path\":\"%s\",\"requests\":%s,\"concurrency\":%s,\"success\":%s,\"errors\":%s,\"throughput_req_s\":%s,\"latency_ns\":{\"min\":%s,\"avg\":%s,\"p50\":%s,\"p95\":%s,\"p99\":%s}}",
+      $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+  } END{printf("\n")} ' "${results_tsv}"
+  echo '  ]'
+  echo '}'
+} >"${results_json}"
+
+# Markdown export
+{
+  echo "# Spooky Load Scenarios"
+  echo
+  echo "- Target: \\`${TARGET}\\`"
+  echo "- Host: \\`${HOST}\\`"
+  echo "- Generated: $(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+  echo
+  echo "| scenario | path | requests | concurrency | success | errors | throughput req/s | min ms | avg ms | p50 ms | p95 ms | p99 ms |"
+  echo "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
+  awk -F'\t' '{
+    min_ms=$8/1000000.0; avg_ms=$9/1000000.0; p50_ms=$10/1000000.0; p95_ms=$11/1000000.0; p99_ms=$12/1000000.0;
+    printf("| %s | %s | %s | %s | %s | %s | %s | %.3f | %.3f | %.3f | %.3f | %.3f |\n",
+      $1,$2,$3,$4,$5,$6,$7,min_ms,avg_ms,p50_ms,p95_ms,p99_ms)
+  }' "${results_tsv}"
+} >"${results_md}"
+
+echo "Load scenario report: ${results_md}"
+echo "Load scenario data:   ${results_json}"


### PR DESCRIPTION
## Summary
This PR hardens performance behavior under load by adding an explicit active-connection cap, richer overload/hedging telemetry, and a reproducible load-scenario runner for burst, slow-upstream, and QUIC-loss style testing.

## What’s included
- Added `performance.max_active_connections` (default `20000`) with config defaults, validation, and docs.
- Enforced active-connection cap in QUIC new-connection admission path.
- Added active-connection and cap-reject metrics:
  - `spooky_active_connections`
  - `spooky_connection_cap_rejects`
- Added reason-coded overload shed metrics:
  - `spooky_overload_shed_by_reason_total{reason=...}`
- Added hedging telemetry metrics:
  - `spooky_hedge_triggered_total`
  - `spooky_hedge_won_total`
  - `spooky_hedge_wasted_total`
  - `spooky_hedge_primary_won_after_trigger_total`
  - `spooky_hedge_primary_late_ms_total`
  - `spooky_hedge_primary_late_samples_total`
- Added load scenario runner:
  - `scripts/load-scenarios.sh`
  - `make load-scenarios`
  - outputs under `bench/load/` (`latest.md`, `latest.json`, `latest.tsv`)

## Why
- Makes max connections explicitly configurable and enforceable.
- Improves end-to-end backpressure visibility (not just total shed count).
- Makes hedging threshold tuning measurable in real traffic behavior.
- Standardizes scenario-based load validation beyond micro/macro benchmarks.
