### PR TITLE
Security Hardening: Verified Upstream TLS by Default, Optional Downstream mTLS, and Forwarded-Header Normalization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y cmake build-essential pkg-config
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
       - name: Run clippy panic-safety gates
         run: |
           cargo clippy --workspace --lib --bins -- -D clippy::unwrap_used -D clippy::expect_used
@@ -32,7 +34,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y cmake build-essential pkg-config
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
       - name: Run tests
         timeout-minutes: 20
         run: sudo env "PATH=$PATH" "HOME=$HOME" cargo test
@@ -48,7 +52,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y cmake build-essential pkg-config
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
       - name: Run benchmark regression gates
         run: |
           PROFILE=ci FAIL_ON=severe BENCH_GATE_RETRIES=1 ./scripts/bench-gate.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
       - name: Run tests
+        timeout-minutes: 20
         run: sudo env "PATH=$PATH" "HOME=$HOME" cargo test
 
   bench-regression:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,12 @@ hyper = "1"
 hyper-util = { version = "0.1", features = ["full"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["http2", "webpki-roots", "ring"] }
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
+rustls-pemfile = "2.2"
 log = "0.4.28"
 quiche = "0.24.6"
 rand = "0.8"
 rustls-pki-types = "1.12.0"
+webpki-roots = "0.26"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9.34"

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -7,6 +7,16 @@ listen:
     tls:
         cert: certs/proxy-fullchain.pem # path to cert
         key: certs/proxy-key-pkcs8.pem # path to key
+        client_auth:
+            enabled: false              # set true to request/verify client certificates (mTLS)
+            require_client_cert: false  # when true, close connections that complete handshake without a client cert
+            ca_file: null               # PEM CA bundle used to verify client certificates when enabled=true
+
+upstream_tls:
+    verify_certificates: true  # safe-by-default for HTTPS upstreams
+    strict_sni: true           # send backend host as SNI for HTTPS upstream connections
+    ca_file: null              # optional PEM CA bundle for private PKI
+    ca_dir: null               # optional directory of PEM CA bundles for private PKI
 
 upstream:
   api_pool:

--- a/crates/bench/src/main.rs
+++ b/crates/bench/src/main.rs
@@ -1070,49 +1070,13 @@ fn classify_regression(
     None
 }
 
-#[cfg(test)]
-mod tests {
-    use super::{GateMetric, RegressionSeverity, classify_regression};
-
-    fn gate(
-        warn_pct: f64,
-        severe_pct: f64,
-        zero_baseline_limit: f64,
-        min_delta_abs: f64,
-    ) -> GateMetric {
-        GateMetric {
-            warn_pct,
-            severe_pct,
-            zero_baseline_limit,
-            min_delta_abs,
-        }
-    }
-
-    #[test]
-    fn min_delta_abs_suppresses_small_absolute_memory_drift() {
-        let memory_gate = gate(0.20, 0.40, 128.0, 256.0);
-        let regression = classify_regression(320.0, 200.0, &memory_gate, 128.0);
-        assert!(regression.is_none());
-    }
-
-    #[test]
-    fn min_delta_abs_still_allows_large_absolute_memory_regressions() {
-        let memory_gate = gate(0.20, 0.40, 128.0, 256.0);
-        let regression = classify_regression(520.0, 200.0, &memory_gate, 128.0);
-        assert!(matches!(
-            regression,
-            Some((RegressionSeverity::Severe, _, _))
-        ));
-    }
-}
-
 fn median(values: &mut [f64]) -> f64 {
     if values.is_empty() {
         return 1.0;
     }
     values.sort_by(|left, right| left.partial_cmp(right).unwrap_or(std::cmp::Ordering::Equal));
     let mid = values.len() / 2;
-    if values.len() % 2 == 0 {
+    if values.len().is_multiple_of(2) {
         (values[mid - 1] + values[mid]) / 2.0
     } else {
         values[mid]
@@ -1516,11 +1480,13 @@ fn resolve_baseline_paths(
 }
 
 fn merge_reports(reports: Vec<BenchReport>) -> BenchReport {
-    let mut merged = BenchReport::default();
-    merged.suite = "spooky-performance-baseline".to_string();
-    merged.report_kind = "merged".to_string();
-    merged.profile = "baseline".to_string();
-    merged.generated_unix_secs = unix_now();
+    let mut merged = BenchReport {
+        suite: "spooky-performance-baseline".to_string(),
+        report_kind: "merged".to_string(),
+        profile: "baseline".to_string(),
+        generated_unix_secs: unix_now(),
+        ..BenchReport::default()
+    };
 
     for report in reports {
         merged.cases.extend(report.cases);
@@ -1687,4 +1653,40 @@ fn main() -> Result<(), String> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GateMetric, RegressionSeverity, classify_regression};
+
+    fn gate(
+        warn_pct: f64,
+        severe_pct: f64,
+        zero_baseline_limit: f64,
+        min_delta_abs: f64,
+    ) -> GateMetric {
+        GateMetric {
+            warn_pct,
+            severe_pct,
+            zero_baseline_limit,
+            min_delta_abs,
+        }
+    }
+
+    #[test]
+    fn min_delta_abs_suppresses_small_absolute_memory_drift() {
+        let memory_gate = gate(0.20, 0.40, 128.0, 256.0);
+        let regression = classify_regression(320.0, 200.0, &memory_gate, 128.0);
+        assert!(regression.is_none());
+    }
+
+    #[test]
+    fn min_delta_abs_still_allows_large_absolute_memory_regressions() {
+        let memory_gate = gate(0.20, 0.40, 128.0, 256.0);
+        let regression = classify_regression(520.0, 200.0, &memory_gate, 128.0);
+        assert!(matches!(
+            regression,
+            Some((RegressionSeverity::Severe, _, _))
+        ));
+    }
 }

--- a/crates/bridge/src/h3_to_h2.rs
+++ b/crates/bridge/src/h3_to_h2.rs
@@ -1,4 +1,8 @@
-use std::convert::Infallible;
+use std::{
+    collections::HashSet,
+    convert::Infallible,
+    net::{IpAddr, SocketAddr},
+};
 
 use bytes::Bytes;
 use http::{HeaderName, HeaderValue, Method, Request, Uri};
@@ -18,6 +22,8 @@ pub fn build_h2_request(
     headers: &[quiche::h3::Header],
     body: BoxBody<Bytes, Infallible>,
     content_length: Option<usize>,
+    client_addr: SocketAddr,
+    request_authority: Option<&str>,
 ) -> Result<Request<BoxBody<Bytes, Infallible>>, BridgeError> {
     let method = Method::from_bytes(method.as_bytes()).map_err(|_| BridgeError::InvalidMethod)?;
     let endpoint = BackendEndpoint::parse(backend).map_err(|_| BridgeError::InvalidUri)?;
@@ -27,8 +33,9 @@ pub fn build_h2_request(
     let uri = Uri::try_from(uri).map_err(|_| BridgeError::InvalidUri)?;
 
     let mut builder = Request::builder().method(method).uri(uri);
+    let connection_tokens = connection_header_tokens(headers);
+    let mut host_from_headers: Option<String> = None;
 
-    let mut saw_host = false;
     for header in headers {
         let name = header.name();
         if name.starts_with(b":") {
@@ -36,22 +43,24 @@ pub fn build_h2_request(
         }
 
         let header_name = HeaderName::from_bytes(name).map_err(|_| BridgeError::InvalidHeader)?;
-        if header_name == http::header::HOST {
-            saw_host = true;
-        }
-
-        if header_name == http::header::CONTENT_LENGTH {
+        if should_strip_request_header(&header_name, &connection_tokens) {
             continue;
         }
 
         let header_value =
             HeaderValue::from_bytes(header.value()).map_err(|_| BridgeError::InvalidHeader)?;
+        if header_name == http::header::HOST {
+            host_from_headers = header_value.to_str().ok().map(str::to_string);
+            continue;
+        }
         builder = builder.header(header_name, header_value);
     }
 
-    if !saw_host {
-        builder = builder.header(http::header::HOST, endpoint.authority());
-    }
+    let host_value = request_authority
+        .or(host_from_headers.as_deref())
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or(endpoint.authority());
+    builder = builder.header(http::header::HOST, host_value);
 
     if let Some(len) = content_length
         && len > 0
@@ -59,7 +68,90 @@ pub fn build_h2_request(
         builder = builder.header(http::header::CONTENT_LENGTH, len);
     }
 
+    let forwarded = format!(
+        "for={};proto=https;host=\"{}\"",
+        forwarded_for_value(client_addr.ip()),
+        escape_forwarded_host(host_value),
+    );
+    builder = builder
+        .header(
+            HeaderName::from_static("forwarded"),
+            HeaderValue::from_str(&forwarded).map_err(|_| BridgeError::InvalidHeader)?,
+        )
+        .header(
+            HeaderName::from_static("x-forwarded-for"),
+            HeaderValue::from_str(&client_addr.ip().to_string())
+                .map_err(|_| BridgeError::InvalidHeader)?,
+        )
+        .header(
+            HeaderName::from_static("x-forwarded-proto"),
+            HeaderValue::from_static("https"),
+        )
+        .header(
+            HeaderName::from_static("x-forwarded-host"),
+            HeaderValue::from_str(host_value).map_err(|_| BridgeError::InvalidHeader)?,
+        );
+
     builder.body(body).map_err(BridgeError::Build)
+}
+
+fn connection_header_tokens(headers: &[quiche::h3::Header]) -> HashSet<String> {
+    let mut tokens = HashSet::new();
+    for header in headers {
+        if !header.name().eq_ignore_ascii_case(b"connection") {
+            continue;
+        }
+        let Ok(value) = std::str::from_utf8(header.value()) else {
+            continue;
+        };
+        for token in value.split(',') {
+            let normalized = token.trim().to_ascii_lowercase();
+            if !normalized.is_empty() {
+                tokens.insert(normalized);
+            }
+        }
+    }
+    tokens
+}
+
+fn should_strip_request_header(name: &HeaderName, connection_tokens: &HashSet<String>) -> bool {
+    if connection_tokens.contains(name.as_str()) {
+        return true;
+    }
+
+    if name == http::header::CONTENT_LENGTH {
+        return true;
+    }
+
+    if name == http::header::CONNECTION
+        || name == http::header::PROXY_AUTHENTICATE
+        || name == http::header::PROXY_AUTHORIZATION
+        || name == http::header::TE
+        || name == http::header::TRAILER
+        || name == http::header::TRANSFER_ENCODING
+        || name == http::header::UPGRADE
+        || name.as_str().eq_ignore_ascii_case("keep-alive")
+        || name.as_str().eq_ignore_ascii_case("proxy-connection")
+        || name.as_str().eq_ignore_ascii_case("forwarded")
+        || name.as_str().eq_ignore_ascii_case("x-forwarded-for")
+        || name.as_str().eq_ignore_ascii_case("x-forwarded-proto")
+        || name.as_str().eq_ignore_ascii_case("x-forwarded-host")
+    {
+        return true;
+    }
+
+    false
+}
+
+fn forwarded_for_value(ip: IpAddr) -> String {
+    match ip {
+        IpAddr::V4(v4) => v4.to_string(),
+        IpAddr::V6(v6) => format!("\"[{}]\"", v6),
+    }
+}
+
+fn escape_forwarded_host(host: &str) -> String {
+    host.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
 #[cfg(test)]
@@ -67,6 +159,7 @@ mod tests {
     use bytes::Bytes;
     use http::header::HOST;
     use http_body_util::{BodyExt, Empty};
+    use quiche::h3::Header;
 
     use super::build_h2_request;
 
@@ -79,13 +172,21 @@ mod tests {
             &[],
             Empty::<Bytes>::new().boxed(),
             None,
+            "203.0.113.10:44321".parse().expect("client"),
+            Some("api.example.com"),
         )
         .expect("request");
 
         assert_eq!(req.uri().to_string(), "https://backend.internal:443/health");
         assert_eq!(
             req.headers().get(HOST).and_then(|h| h.to_str().ok()),
-            Some("backend.internal:443")
+            Some("api.example.com")
+        );
+        assert_eq!(
+            req.headers()
+                .get("x-forwarded-proto")
+                .and_then(|h| h.to_str().ok()),
+            Some("https")
         );
     }
 
@@ -97,6 +198,8 @@ mod tests {
             "/",
             &[],
             Empty::<Bytes>::new().boxed(),
+            None,
+            "198.51.100.3:5555".parse().expect("client"),
             None,
         )
         .expect("request");
@@ -117,9 +220,79 @@ mod tests {
             &[],
             Empty::<Bytes>::new().boxed(),
             None,
+            "127.0.0.1:12345".parse().expect("client"),
+            None,
         )
         .expect_err("invalid backend endpoint should fail");
 
         assert!(matches!(err, crate::h3_to_h2::BridgeError::InvalidUri));
+    }
+
+    #[test]
+    fn strips_spoofed_forwarded_headers_and_normalizes() {
+        let headers = vec![
+            Header::new(b"x-forwarded-for", b"1.2.3.4"),
+            Header::new(b"forwarded", b"for=1.2.3.4"),
+            Header::new(b"x-forwarded-host", b"evil.example"),
+            Header::new(b"x-forwarded-proto", b"http"),
+            Header::new(b"host", b"api.example.com"),
+            Header::new(b"connection", b"keep-alive, x-secret"),
+            Header::new(b"x-secret", b"drop-me"),
+            Header::new(b"x-keep", b"ok"),
+        ];
+
+        let req = build_h2_request(
+            "backend.internal:443",
+            "GET",
+            "/",
+            &headers,
+            Empty::<Bytes>::new().boxed(),
+            None,
+            "203.0.113.55:43210".parse().expect("client"),
+            Some("api.example.com"),
+        )
+        .expect("request");
+
+        assert_eq!(
+            req.headers()
+                .get("x-forwarded-for")
+                .and_then(|h| h.to_str().ok()),
+            Some("203.0.113.55")
+        );
+        assert_eq!(
+            req.headers()
+                .get("x-forwarded-host")
+                .and_then(|h| h.to_str().ok()),
+            Some("api.example.com")
+        );
+        assert_eq!(
+            req.headers().get("forwarded").and_then(|h| h.to_str().ok()),
+            Some("for=203.0.113.55;proto=https;host=\"api.example.com\"")
+        );
+        assert!(req.headers().get("x-secret").is_none());
+        assert_eq!(
+            req.headers().get("x-keep").and_then(|h| h.to_str().ok()),
+            Some("ok")
+        );
+    }
+
+    #[test]
+    fn forwarded_header_formats_ipv6_clients() {
+        let req = build_h2_request(
+            "backend.internal:443",
+            "GET",
+            "/",
+            &[],
+            Empty::<Bytes>::new().boxed(),
+            None,
+            "[2001:db8::1]:4444".parse().expect("client"),
+            Some("api.example.com"),
+        )
+        .expect("request");
+
+        assert_eq!(
+            req.headers().get("forwarded").and_then(|h| h.to_str().ok()),
+            Some("for=\"[2001:db8::1]\";proto=https;host=\"api.example.com\"")
+        );
     }
 }

--- a/crates/bridge/src/h3_to_h2.rs
+++ b/crates/bridge/src/h3_to_h2.rs
@@ -12,6 +12,11 @@ use spooky_config::backend_endpoint::BackendEndpoint;
 
 pub use spooky_errors::BridgeError;
 
+pub struct ForwardedContext<'a> {
+    pub client_addr: SocketAddr,
+    pub request_authority: Option<&'a str>,
+}
+
 /// Build an HTTP/2 request with a pre-boxed streaming body.
 /// `content_length` is `Some(n)` only when the full length is known upfront
 /// (i.e. the body was fully buffered); pass `None` for streaming bodies.
@@ -22,8 +27,7 @@ pub fn build_h2_request(
     headers: &[quiche::h3::Header],
     body: BoxBody<Bytes, Infallible>,
     content_length: Option<usize>,
-    client_addr: SocketAddr,
-    request_authority: Option<&str>,
+    forwarded_ctx: ForwardedContext<'_>,
 ) -> Result<Request<BoxBody<Bytes, Infallible>>, BridgeError> {
     let method = Method::from_bytes(method.as_bytes()).map_err(|_| BridgeError::InvalidMethod)?;
     let endpoint = BackendEndpoint::parse(backend).map_err(|_| BridgeError::InvalidUri)?;
@@ -56,7 +60,8 @@ pub fn build_h2_request(
         builder = builder.header(header_name, header_value);
     }
 
-    let host_value = request_authority
+    let host_value = forwarded_ctx
+        .request_authority
         .or(host_from_headers.as_deref())
         .filter(|value| !value.trim().is_empty())
         .unwrap_or(endpoint.authority());
@@ -68,19 +73,19 @@ pub fn build_h2_request(
         builder = builder.header(http::header::CONTENT_LENGTH, len);
     }
 
-    let forwarded = format!(
+    let forwarded_value = format!(
         "for={};proto=https;host=\"{}\"",
-        forwarded_for_value(client_addr.ip()),
+        forwarded_for_value(forwarded_ctx.client_addr.ip()),
         escape_forwarded_host(host_value),
     );
     builder = builder
         .header(
             HeaderName::from_static("forwarded"),
-            HeaderValue::from_str(&forwarded).map_err(|_| BridgeError::InvalidHeader)?,
+            HeaderValue::from_str(&forwarded_value).map_err(|_| BridgeError::InvalidHeader)?,
         )
         .header(
             HeaderName::from_static("x-forwarded-for"),
-            HeaderValue::from_str(&client_addr.ip().to_string())
+            HeaderValue::from_str(&forwarded_ctx.client_addr.ip().to_string())
                 .map_err(|_| BridgeError::InvalidHeader)?,
         )
         .header(
@@ -161,7 +166,7 @@ mod tests {
     use http_body_util::{BodyExt, Empty};
     use quiche::h3::Header;
 
-    use super::build_h2_request;
+    use super::{ForwardedContext, build_h2_request};
 
     #[test]
     fn defaults_to_https_origin_for_host_port_backend() {
@@ -172,8 +177,10 @@ mod tests {
             &[],
             Empty::<Bytes>::new().boxed(),
             None,
-            "203.0.113.10:44321".parse().expect("client"),
-            Some("api.example.com"),
+            ForwardedContext {
+                client_addr: "203.0.113.10:44321".parse().expect("client"),
+                request_authority: Some("api.example.com"),
+            },
         )
         .expect("request");
 
@@ -199,8 +206,10 @@ mod tests {
             &[],
             Empty::<Bytes>::new().boxed(),
             None,
-            "198.51.100.3:5555".parse().expect("client"),
-            None,
+            ForwardedContext {
+                client_addr: "198.51.100.3:5555".parse().expect("client"),
+                request_authority: None,
+            },
         )
         .expect("request");
 
@@ -220,8 +229,10 @@ mod tests {
             &[],
             Empty::<Bytes>::new().boxed(),
             None,
-            "127.0.0.1:12345".parse().expect("client"),
-            None,
+            ForwardedContext {
+                client_addr: "127.0.0.1:12345".parse().expect("client"),
+                request_authority: None,
+            },
         )
         .expect_err("invalid backend endpoint should fail");
 
@@ -248,8 +259,10 @@ mod tests {
             &headers,
             Empty::<Bytes>::new().boxed(),
             None,
-            "203.0.113.55:43210".parse().expect("client"),
-            Some("api.example.com"),
+            ForwardedContext {
+                client_addr: "203.0.113.55:43210".parse().expect("client"),
+                request_authority: Some("api.example.com"),
+            },
         )
         .expect("request");
 
@@ -285,8 +298,10 @@ mod tests {
             &[],
             Empty::<Bytes>::new().boxed(),
             None,
-            "[2001:db8::1]:4444".parse().expect("client"),
-            Some("api.example.com"),
+            ForwardedContext {
+                client_addr: "[2001:db8::1]:4444".parse().expect("client"),
+                request_authority: Some("api.example.com"),
+            },
         )
         .expect("request");
 

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -43,7 +43,8 @@ use crate::default::{
     resilience_default_watchdog_poll_stall_timeout_ms,
     resilience_default_watchdog_restart_cooldown_ms,
     resilience_default_watchdog_timeout_error_rate_percent,
-    resilience_default_watchdog_unhealthy_consecutive_windows,
+    resilience_default_watchdog_unhealthy_consecutive_windows, upstream_tls_default_strict_sni,
+    upstream_tls_default_verify_certificates,
 };
 
 #[derive(Debug, Deserialize, Clone)]
@@ -57,6 +58,9 @@ pub struct Config {
 
     #[serde(default)]
     pub load_balancing: Option<LoadBalancing>, // Global fallback load balancing
+
+    #[serde(default)]
+    pub upstream_tls: UpstreamTls,
 
     #[serde(default = "get_default_log")]
     pub log: Log,
@@ -88,6 +92,41 @@ pub struct Listen {
 pub struct Tls {
     pub cert: String, // "/path/to/cert"
     pub key: String,  // "/path/to/key"
+    #[serde(default)]
+    pub client_auth: ClientAuth,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct ClientAuth {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub require_client_cert: bool,
+    #[serde(default)]
+    pub ca_file: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct UpstreamTls {
+    #[serde(default = "upstream_tls_default_verify_certificates")]
+    pub verify_certificates: bool,
+    #[serde(default = "upstream_tls_default_strict_sni")]
+    pub strict_sni: bool,
+    #[serde(default)]
+    pub ca_file: Option<String>,
+    #[serde(default)]
+    pub ca_dir: Option<String>,
+}
+
+impl Default for UpstreamTls {
+    fn default() -> Self {
+        Self {
+            verify_certificates: upstream_tls_default_verify_certificates(),
+            strict_sni: upstream_tls_default_strict_sni(),
+            ca_file: None,
+            ca_dir: None,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -388,7 +388,7 @@ impl Default for Performance {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct Resilience {
     #[serde(default)]
     pub adaptive_admission: AdaptiveAdmission,
@@ -406,21 +406,6 @@ pub struct Resilience {
     pub brownout: Brownout,
     #[serde(default)]
     pub watchdog: Watchdog,
-}
-
-impl Default for Resilience {
-    fn default() -> Self {
-        Self {
-            adaptive_admission: AdaptiveAdmission::default(),
-            route_queue: RouteQueue::default(),
-            protocol: ProtocolPolicy::default(),
-            circuit_breaker: CircuitBreaker::default(),
-            hedging: Hedging::default(),
-            retry_budget: RetryBudget::default(),
-            brownout: Brownout::default(),
-            watchdog: Watchdog::default(),
-        }
-    }
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/crates/config/src/default.rs
+++ b/crates/config/src/default.rs
@@ -341,3 +341,11 @@ pub fn observe_default_port() -> u16 {
 pub fn observe_default_metrics_path() -> String {
     String::from("/metrics")
 }
+
+pub fn upstream_tls_default_verify_certificates() -> bool {
+    true
+}
+
+pub fn upstream_tls_default_strict_sni() -> bool {
+    true
+}

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -542,6 +542,72 @@ pub fn validate(config: &Config) -> bool {
         return false;
     }
 
+    // --- Validate optional downstream client-auth (mTLS) ---
+    if config.listen.tls.client_auth.require_client_cert && !config.listen.tls.client_auth.enabled {
+        error!("listen.tls.client_auth.require_client_cert requires client_auth.enabled=true");
+        return false;
+    }
+
+    if config.listen.tls.client_auth.enabled {
+        let Some(ca_file) = config.listen.tls.client_auth.ca_file.as_ref() else {
+            error!("listen.tls.client_auth.ca_file is required when client_auth.enabled=true");
+            return false;
+        };
+        if ca_file.trim().is_empty() {
+            error!("listen.tls.client_auth.ca_file cannot be empty");
+            return false;
+        }
+        if !std::path::Path::new(ca_file).exists() {
+            error!("listen.tls.client_auth.ca_file does not exist: {}", ca_file);
+            return false;
+        }
+        if let Err(err) = std::fs::read(ca_file) {
+            error!(
+                "Cannot read listen.tls.client_auth.ca_file '{}': {}",
+                ca_file, err
+            );
+            return false;
+        }
+    }
+
+    // --- Validate upstream TLS trust-store configuration ---
+    if !config.upstream_tls.verify_certificates {
+        warn!(
+            "upstream_tls.verify_certificates=false disables TLS certificate validation for HTTPS upstreams"
+        );
+    }
+
+    if let Some(ca_file) = config.upstream_tls.ca_file.as_ref() {
+        if ca_file.trim().is_empty() {
+            error!("upstream_tls.ca_file cannot be empty when provided");
+            return false;
+        }
+        if !std::path::Path::new(ca_file).exists() {
+            error!("upstream_tls.ca_file does not exist: {}", ca_file);
+            return false;
+        }
+        if let Err(err) = std::fs::read(ca_file) {
+            error!("Cannot read upstream_tls.ca_file '{}': {}", ca_file, err);
+            return false;
+        }
+    }
+
+    if let Some(ca_dir) = config.upstream_tls.ca_dir.as_ref() {
+        if ca_dir.trim().is_empty() {
+            error!("upstream_tls.ca_dir cannot be empty when provided");
+            return false;
+        }
+        let ca_path = std::path::Path::new(ca_dir);
+        if !ca_path.exists() {
+            error!("upstream_tls.ca_dir does not exist: {}", ca_dir);
+            return false;
+        }
+        if !ca_path.is_dir() {
+            error!("upstream_tls.ca_dir must be a directory: {}", ca_dir);
+            return false;
+        }
+    }
+
     // --- Validate upstream routes ---
     for (upstream_name, upstream) in &config.upstream {
         // Validate route matcher has at least one condition
@@ -700,8 +766,8 @@ pub fn validate(config: &Config) -> bool {
 mod tests {
     use super::validate;
     use crate::config::{
-        Backend, Config, HealthCheck, Listen, LoadBalancing, Log, MetricsEndpoint, Observability,
-        Performance, Resilience, RouteMatch, Tls, Upstream,
+        Backend, ClientAuth, Config, HealthCheck, Listen, LoadBalancing, Log, MetricsEndpoint,
+        Observability, Performance, Resilience, RouteMatch, Tls, Upstream, UpstreamTls,
     };
     use std::collections::HashMap;
     use tempfile::tempdir;
@@ -745,6 +811,7 @@ mod tests {
                 tls: Tls {
                     cert: cert.to_string(),
                     key: key.to_string(),
+                    client_auth: ClientAuth::default(),
                 },
             },
             upstream,
@@ -752,6 +819,7 @@ mod tests {
                 lb_type: "random".to_string(),
                 key: None,
             }),
+            upstream_tls: UpstreamTls::default(),
             log: Log {
                 level: "info".to_string(),
                 file: Default::default(),
@@ -833,6 +901,11 @@ upstream:
         assert_eq!(cfg.performance.client_body_idle_timeout_ms, 10_000);
         assert!(!cfg.observability.metrics.enabled);
         assert_eq!(cfg.observability.metrics.path, "/metrics");
+        assert!(cfg.upstream_tls.verify_certificates);
+        assert!(cfg.upstream_tls.strict_sni);
+        assert!(!cfg.listen.tls.client_auth.enabled);
+        assert!(!cfg.listen.tls.client_auth.require_client_cert);
+        assert!(cfg.listen.tls.client_auth.ca_file.is_none());
         assert!(cfg.resilience.adaptive_admission.enabled);
         assert_eq!(cfg.resilience.route_queue.default_cap, 512);
         assert_eq!(cfg.resilience.route_queue.global_cap, 2048);
@@ -1037,6 +1110,23 @@ upstream:
         assert!(!validate(&cfg));
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.listen.tls.client_auth.require_client_cert = true;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.listen.tls.client_auth.enabled = true;
+        cfg.listen.tls.client_auth.ca_file = None;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.upstream_tls.ca_file = Some("/path/does/not/exist.pem".to_string());
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.upstream_tls.ca_dir = Some("/path/does/not/exist".to_string());
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.observability = Observability {
             metrics: MetricsEndpoint {
                 enabled: true,
@@ -1092,6 +1182,13 @@ upstream:
         cfg.resilience.protocol.allowed_methods = vec!["GET".to_string(), "POST".to_string()];
         cfg.resilience.protocol.denied_path_prefixes = vec!["/admin".to_string()];
         cfg.resilience.retry_budget.ratio_percent = 30;
+        cfg.upstream_tls.verify_certificates = true;
+        cfg.upstream_tls.strict_sni = true;
+        cfg.upstream_tls.ca_file = Some(cert.to_string_lossy().to_string());
+        cfg.upstream_tls.ca_dir = Some(dir.path().to_string_lossy().to_string());
+        cfg.listen.tls.client_auth.enabled = true;
+        cfg.listen.tls.client_auth.require_client_cert = true;
+        cfg.listen.tls.client_auth.ca_file = Some(cert.to_string_lossy().to_string());
         cfg.observability = Observability {
             metrics: MetricsEndpoint {
                 enabled: true,

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -114,6 +114,7 @@ pub struct QUICListener {
     pub max_response_body_bytes: usize,
     pub request_buffer_global_cap_bytes: usize,
     pub unknown_length_response_prebuffer_bytes: usize,
+    pub require_client_cert: bool,
 
     pub recv_buf: [u8; MAX_DATAGRAM_SIZE_BYTES],
     pub send_buf: [u8; MAX_DATAGRAM_SIZE_BYTES],

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -3744,11 +3744,10 @@ impl QUICListener {
                     previous_requests = current_requests;
                     previous_timeouts = current_timeouts;
 
-                    let timeout_rate_percent = if request_delta == 0 {
-                        0
-                    } else {
-                        timeout_delta.saturating_mul(100) / request_delta
-                    };
+                    let timeout_rate_percent = timeout_delta
+                        .saturating_mul(100)
+                        .checked_div(request_delta)
+                        .unwrap_or(0);
 
                     let timeout_pressure = request_delta >= watchdog_config.min_requests_per_window
                         && timeout_rate_percent

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -1958,32 +1958,40 @@ impl QUICListener {
                                     ChannelBody::channel(REQUEST_CHUNK_CHANNEL_CAPACITY);
                                 (Some(tx), channel_body.boxed(), false)
                             };
-                            let request =
-                                match build_h2_request(&addr, &method, &path, &list, boxed, None) {
-                                    Ok(request) => request,
-                                    Err(err) => {
-                                        drop(upstream_permit);
-                                        drop(global_permit);
-                                        metrics.inc_failure();
-                                        metrics.record_route(
-                                            &upstream_name,
-                                            request_start.elapsed(),
-                                            RouteOutcome::Failure,
-                                        );
-                                        Self::send_simple_response(
-                                            h3,
-                                            &mut connection.quic,
-                                            stream_id,
-                                            http::StatusCode::BAD_REQUEST,
-                                            b"invalid request\n",
-                                        )?;
-                                        error!("failed to build upstream request: {}", err);
-                                        resilience
-                                            .adaptive_admission
-                                            .observe(request_start.elapsed(), true);
-                                        continue;
-                                    }
-                                };
+                            let request = match build_h2_request(
+                                &addr,
+                                &method,
+                                &path,
+                                &list,
+                                boxed,
+                                None,
+                                connection.peer_address,
+                                authority.as_deref(),
+                            ) {
+                                Ok(request) => request,
+                                Err(err) => {
+                                    drop(upstream_permit);
+                                    drop(global_permit);
+                                    metrics.inc_failure();
+                                    metrics.record_route(
+                                        &upstream_name,
+                                        request_start.elapsed(),
+                                        RouteOutcome::Failure,
+                                    );
+                                    Self::send_simple_response(
+                                        h3,
+                                        &mut connection.quic,
+                                        stream_id,
+                                        http::StatusCode::BAD_REQUEST,
+                                        b"invalid request\n",
+                                    )?;
+                                    error!("failed to build upstream request: {}", err);
+                                    resilience
+                                        .adaptive_admission
+                                        .observe(request_start.elapsed(), true);
+                                    continue;
+                                }
+                            };
 
                             let h2 = h2_pool.clone();
                             let fwd_addr = addr.clone();
@@ -1997,6 +2005,8 @@ impl QUICListener {
                                 Self::pick_alternate_backend(&upstream_pool, idx);
                             let method_owned = method.clone();
                             let path_owned = path.clone();
+                            let authority_owned = authority.clone();
+                            let client_addr = connection.peer_address;
                             let headers_owned = list.clone();
                             let (result_tx, result_rx) = oneshot::channel::<UpstreamResult>();
                             let fut = async move {
@@ -2039,6 +2049,8 @@ impl QUICListener {
                                                     &headers_owned,
                                                     BoxBody::new(Full::new(Bytes::new())),
                                                     Some(0),
+                                                    client_addr,
+                                                    authority_owned.as_deref(),
                                                 )
                                                 .ok()
                                                 .map(|req| (backend, req))
@@ -2122,6 +2134,8 @@ impl QUICListener {
                                                         &headers_owned,
                                                         BoxBody::new(Full::new(Bytes::new())),
                                                         Some(0),
+                                                        client_addr,
+                                                        authority_owned.as_deref(),
                                                     )
                                                 {
                                                     send_once(

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -26,7 +26,7 @@ use socket2::{Domain, Protocol, Socket, Type};
 use spooky_bridge::h3_to_h2::build_h2_request;
 use spooky_errors::{PoolError, ProxyError};
 use spooky_lb::{HealthTransition, UpstreamPool};
-use spooky_transport::h2_client::H2Client;
+use spooky_transport::h2_client::{H2Client, TlsClientConfig};
 use spooky_transport::h2_pool::H2Pool;
 use tokio::runtime::Handle;
 use tokio::sync::{
@@ -433,6 +433,15 @@ impl QUICListener {
         Self::new_with_socket_and_shared_state(config, socket, shared_state)
     }
 
+    fn upstream_tls_client_config(config: &SpookyConfig) -> TlsClientConfig {
+        TlsClientConfig {
+            verify_certificates: config.upstream_tls.verify_certificates,
+            strict_sni: config.upstream_tls.strict_sni,
+            ca_file: config.upstream_tls.ca_file.clone(),
+            ca_dir: config.upstream_tls.ca_dir.clone(),
+        }
+    }
+
     pub fn build_shared_state(config: &SpookyConfig) -> Result<SharedRuntimeState, ProxyError> {
         let worker_threads = config.performance.worker_threads.max(1);
         let per_upstream_limit = config.performance.per_upstream_inflight_limit.max(1);
@@ -481,13 +490,17 @@ impl QUICListener {
             }
         }
 
-        let h2_pool = Arc::new(H2Pool::new(
-            backend_addresses,
-            max_inflight_per_backend,
-            config.performance.h2_pool_max_idle_per_backend,
-            Duration::from_millis(config.performance.h2_pool_idle_timeout_ms),
-            Duration::from_millis(config.performance.backend_connect_timeout_ms),
-        ));
+        let h2_pool = Arc::new(
+            H2Pool::new(
+                backend_addresses,
+                max_inflight_per_backend,
+                config.performance.h2_pool_max_idle_per_backend,
+                Duration::from_millis(config.performance.h2_pool_idle_timeout_ms),
+                Duration::from_millis(config.performance.backend_connect_timeout_ms),
+                Self::upstream_tls_client_config(config),
+            )
+            .map_err(ProxyError::Tls)?,
+        );
         let mut upstream_pools = HashMap::new();
         let mut upstream_inflight = HashMap::new();
 
@@ -527,14 +540,21 @@ impl QUICListener {
         shared_state
             .watchdog
             .set_expected_workers(worker_count.max(1));
+        let health_client = match H2Client::new(
+            config.performance.h2_pool_max_idle_per_backend.max(1),
+            Duration::from_millis(config.performance.h2_pool_idle_timeout_ms.max(1)),
+            Duration::from_millis(config.performance.backend_connect_timeout_ms.max(1)),
+            Self::upstream_tls_client_config(config),
+        ) {
+            Ok(client) => Arc::new(client),
+            Err(err) => {
+                error!("failed to initialize control-plane H2 client: {}", err);
+                return;
+            }
+        };
         Self::spawn_health_checks(
             shared_state.upstream_pools.clone(),
-            Arc::new(H2Client::new(
-                config.performance.h2_pool_max_idle_per_backend.max(1),
-                Duration::from_millis(config.performance.h2_pool_idle_timeout_ms.max(1)),
-                Duration::from_millis(config.performance.backend_connect_timeout_ms.max(1)),
-                false,
-            )),
+            health_client,
             Arc::clone(&shared_state.metrics),
         );
         Self::spawn_metrics_endpoint(config, Arc::clone(&shared_state.metrics));
@@ -607,6 +627,7 @@ impl QUICListener {
         let request_buffer_global_cap_bytes = config.performance.request_buffer_global_cap_bytes;
         let unknown_length_response_prebuffer_bytes =
             config.performance.unknown_length_response_prebuffer_bytes;
+        let require_client_cert = config.listen.tls.client_auth.require_client_cert;
         let conn_rate_limiter = TokenBucket::new(
             config.performance.new_connections_per_sec,
             config.performance.new_connections_burst,
@@ -639,6 +660,7 @@ impl QUICListener {
             max_response_body_bytes,
             request_buffer_global_cap_bytes,
             unknown_length_response_prebuffer_bytes,
+            require_client_cert,
             recv_buf: [0; MAX_DATAGRAM_SIZE_BYTES],
             send_buf: [0; MAX_DATAGRAM_SIZE_BYTES],
             connections: HashMap::new(),
@@ -785,7 +807,36 @@ impl QUICListener {
         quic_config.set_initial_max_streams_bidi(config.performance.quic_initial_max_streams_bidi);
         quic_config.set_initial_max_streams_uni(config.performance.quic_initial_max_streams_uni);
         quic_config.set_disable_active_migration(true);
-        quic_config.verify_peer(false);
+
+        if config.listen.tls.client_auth.enabled {
+            let ca_file = config
+                .listen
+                .tls
+                .client_auth
+                .ca_file
+                .as_ref()
+                .ok_or_else(|| {
+                    ProxyError::Tls(
+                        "listen.tls.client_auth.ca_file is required when mTLS is enabled"
+                            .to_string(),
+                    )
+                })?;
+            quic_config
+                .load_verify_locations_from_file(ca_file)
+                .map_err(|err| {
+                    ProxyError::Tls(format!(
+                        "failed to load listen.tls.client_auth.ca_file '{}': {}",
+                        ca_file, err
+                    ))
+                })?;
+            quic_config.verify_peer(true);
+            info!(
+                "Downstream mTLS enabled (require_client_cert={})",
+                config.listen.tls.client_auth.require_client_cert
+            );
+        } else {
+            quic_config.verify_peer(false);
+        }
 
         Ok(quic_config)
     }
@@ -1298,7 +1349,21 @@ impl QUICListener {
             connection.quic.is_closed()
         );
 
-        if (connection.quic.is_established() || connection.quic.is_in_early_data())
+        if self.require_client_cert
+            && connection.quic.is_established()
+            && connection.quic.peer_cert().is_none()
+        {
+            warn!(
+                "closing connection {}: downstream mTLS requires a client certificate",
+                connection.quic.trace_id()
+            );
+            let _ = connection
+                .quic
+                .close(true, 0x01A0, b"client certificate required");
+        }
+
+        if !connection.quic.is_closed()
+            && (connection.quic.is_established() || connection.quic.is_in_early_data())
             && let Err(e) = Self::handle_h3(
                 &mut connection,
                 Arc::clone(&h2_pool),

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -23,7 +23,7 @@ use quiche::Config;
 use quiche::h3::NameValue;
 use rand::RngCore;
 use socket2::{Domain, Protocol, Socket, Type};
-use spooky_bridge::h3_to_h2::build_h2_request;
+use spooky_bridge::h3_to_h2::{ForwardedContext, build_h2_request};
 use spooky_errors::{PoolError, ProxyError};
 use spooky_lb::{HealthTransition, UpstreamPool};
 use spooky_transport::h2_client::{H2Client, TlsClientConfig};
@@ -1965,8 +1965,10 @@ impl QUICListener {
                                 &list,
                                 boxed,
                                 None,
-                                connection.peer_address,
-                                authority.as_deref(),
+                                ForwardedContext {
+                                    client_addr: connection.peer_address,
+                                    request_authority: authority.as_deref(),
+                                },
                             ) {
                                 Ok(request) => request,
                                 Err(err) => {
@@ -2049,8 +2051,11 @@ impl QUICListener {
                                                     &headers_owned,
                                                     BoxBody::new(Full::new(Bytes::new())),
                                                     Some(0),
-                                                    client_addr,
-                                                    authority_owned.as_deref(),
+                                                    ForwardedContext {
+                                                        client_addr,
+                                                        request_authority: authority_owned
+                                                            .as_deref(),
+                                                    },
                                                 )
                                                 .ok()
                                                 .map(|req| (backend, req))
@@ -2134,8 +2139,11 @@ impl QUICListener {
                                                         &headers_owned,
                                                         BoxBody::new(Full::new(Bytes::new())),
                                                         Some(0),
-                                                        client_addr,
-                                                        authority_owned.as_deref(),
+                                                        ForwardedContext {
+                                                            client_addr,
+                                                            request_authority: authority_owned
+                                                                .as_deref(),
+                                                        },
                                                     )
                                                 {
                                                     send_once(
@@ -4040,6 +4048,11 @@ mod tests {
         ConnectionRoutes, TokenBucket, abort_stream, purge_connection_routes,
         resolve_primary_from_radix_prefix, sweep_closed_connections,
     };
+    type RoutingMaps = (
+        HashMap<Arc<[u8]>, Arc<[u8]>>,
+        CidRadix,
+        HashMap<SocketAddr, Arc<[u8]>>,
+    );
 
     fn cid(bytes: &[u8]) -> Arc<[u8]> {
         Arc::from(bytes)
@@ -4068,7 +4081,7 @@ mod tests {
 
         assert_eq!(resolved.as_ref(), primary.as_ref());
         assert!(
-            cid_routes.get(alias.as_ref()).is_some(),
+            cid_routes.contains_key(alias.as_ref()),
             "live alias should remain mapped to active primary"
         );
         assert!(
@@ -4097,7 +4110,7 @@ mod tests {
             resolve_primary_from_radix_prefix(&dcid, &connections, &mut cid_routes, &mut cid_radix);
         assert!(resolved.is_none(), "stale alias must not resolve");
         assert!(
-            cid_routes.get(alias.as_ref()).is_none(),
+            !cid_routes.contains_key(alias.as_ref()),
             "stale alias mapping should be removed"
         );
         assert!(
@@ -4190,11 +4203,7 @@ mod tests {
         primary: &Arc<[u8]>,
         aliases: &[Arc<[u8]>],
         addr: SocketAddr,
-    ) -> (
-        HashMap<Arc<[u8]>, Arc<[u8]>>,
-        CidRadix,
-        HashMap<SocketAddr, Arc<[u8]>>,
-    ) {
+    ) -> RoutingMaps {
         let mut cid_routes: HashMap<Arc<[u8]>, Arc<[u8]>> = HashMap::new();
         let mut cid_radix = CidRadix::new();
         let mut peer_routes: HashMap<SocketAddr, Arc<[u8]>> = HashMap::new();
@@ -4230,7 +4239,7 @@ mod tests {
             "primary SCID must be removed from radix after cleanup"
         );
         assert!(
-            peer_routes.get(&addr).is_none(),
+            !peer_routes.contains_key(&addr),
             "peer_routes entry must be removed after cleanup"
         );
     }
@@ -4257,11 +4266,11 @@ mod tests {
         );
 
         assert!(
-            cid_routes.get(alias1.as_ref()).is_none(),
+            !cid_routes.contains_key(alias1.as_ref()),
             "alias1 must be removed from cid_routes"
         );
         assert!(
-            cid_routes.get(alias2.as_ref()).is_none(),
+            !cid_routes.contains_key(alias2.as_ref()),
             "alias2 must be removed from cid_routes"
         );
         assert!(
@@ -4273,7 +4282,7 @@ mod tests {
             "alias2 must be removed from radix"
         );
         assert!(
-            peer_routes.get(&addr).is_none(),
+            !peer_routes.contains_key(&addr),
             "peer_routes entry must be removed"
         );
     }
@@ -4576,11 +4585,11 @@ mod tests {
             "surviving connection must remain in connections"
         );
         assert!(
-            peer_routes.get(&addr2).is_some(),
+            peer_routes.contains_key(&addr2),
             "surviving connection peer_route must remain"
         );
         assert!(
-            peer_routes.get(&addr1).is_none(),
+            !peer_routes.contains_key(&addr1),
             "timed-out connection peer_route must be removed"
         );
         assert!(

--- a/crates/edge/src/route_index.rs
+++ b/crates/edge/src/route_index.rs
@@ -83,7 +83,7 @@ impl RouteIndex {
         // Build a stable route list first. This keeps tie-breaking deterministic even if
         // upstreams came from a map with non-deterministic iteration order.
         let mut ordered: Vec<(&String, &Upstream)> = upstreams.iter().collect();
-        ordered.sort_by(|(left, _), (right, _)| left.cmp(right));
+        ordered.sort_by_key(|(left, _)| *left);
 
         for (order, (name, upstream)) in ordered.into_iter().enumerate() {
             let upstream_idx = upstream_names.len();

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -30,7 +30,9 @@ use rcgen::{Certificate, CertificateParams, SanType};
 use tempfile::{TempDir, tempdir};
 use tokio::net::TcpListener;
 
-use spooky_config::config::{Backend, Config, HealthCheck, Listen, LoadBalancing, Log, Tls};
+use spooky_config::config::{
+    Backend, ClientAuth, Config, HealthCheck, Listen, LoadBalancing, Log, Tls, UpstreamTls,
+};
 use spooky_edge::QUICListener;
 use spooky_edge::constants::{
     BACKEND_TIMEOUT_SECS, MAX_DATAGRAM_SIZE_BYTES, MAX_REQUEST_BODY_BYTES,
@@ -96,13 +98,18 @@ fn make_config(port: u32, backend_addr: String, cert: String, key: String) -> Co
             protocol: "http3".to_string(),
             port,
             address: "127.0.0.1".to_string(),
-            tls: Tls { cert, key },
+            tls: Tls {
+                cert,
+                key,
+                client_auth: ClientAuth::default(),
+            },
         },
         upstream,
         load_balancing: Some(LoadBalancing {
             lb_type: "random".to_string(),
             key: None,
         }),
+        upstream_tls: UpstreamTls::default(),
         log: Log {
             level: "info".to_string(),
             file: Default::default(),

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -1098,57 +1098,6 @@ async fn start_h2_backend_with_drain_probe(inflight_seen: Arc<AtomicBool>) -> So
     addr
 }
 
-async fn start_h2_backend_with_body_routes() -> SocketAddr {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-
-    tokio::spawn(async move {
-        loop {
-            let (stream, _) = match listener.accept().await {
-                Ok(v) => v,
-                Err(_) => break,
-            };
-
-            let io = TokioIo::new(stream);
-            let service = service_fn(|req: Request<Incoming>| async move {
-                let path = req.uri().path().to_string();
-                let collected = req.into_body().collect().await;
-                let body_len = match collected {
-                    Ok(body) => body.to_bytes().len(),
-                    Err(_) => {
-                        let resp = Response::builder()
-                            .status(500)
-                            .body(Full::new(Bytes::from_static(b"read-failed\n")).boxed())
-                            .unwrap();
-                        return Ok::<_, hyper::Error>(resp);
-                    }
-                };
-
-                let response: Response<TestBody> = match path.as_str() {
-                    "/slow" => {
-                        tokio::time::sleep(Duration::from_millis(700)).await;
-                        Response::new(
-                            Full::new(Bytes::from(format!("slow-body-bytes={body_len}\n"))).boxed(),
-                        )
-                    }
-                    _ => Response::new(
-                        Full::new(Bytes::from(format!("body-bytes={body_len}\n"))).boxed(),
-                    ),
-                };
-                Ok::<_, hyper::Error>(response)
-            });
-
-            tokio::spawn(async move {
-                let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
-                    .serve_connection(io, service)
-                    .await;
-            });
-        }
-    });
-
-    addr
-}
-
 async fn start_h2_backend_with_chaos_routes() -> SocketAddr {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -1182,7 +1131,10 @@ async fn start_h2_backend_with_chaos_routes() -> SocketAddr {
                             Response::new(Full::new(Bytes::from_static(b"late-loss\n")).boxed())
                         }
                         "/flap" => {
-                            if flap_counter.fetch_add(1, Ordering::Relaxed) % 2 == 0 {
+                            if flap_counter
+                                .fetch_add(1, Ordering::Relaxed)
+                                .is_multiple_of(2)
+                            {
                                 Response::new(Full::new(Bytes::from_static(b"flap-ok\n")).boxed())
                             } else {
                                 Response::builder()
@@ -3167,29 +3119,35 @@ fn flush_quic(conn: &mut quiche::Connection, socket: &std::net::UdpSocket, out: 
     }
 }
 
+struct PumpIo<'a> {
+    socket: &'a std::net::UdpSocket,
+    local_addr: std::net::SocketAddr,
+    out: &'a mut [u8],
+    buf: &'a mut [u8],
+}
+
 /// Pump the QUIC event loop until `target_sid` finishes/resets OR `deadline`
 /// passes.  Collects H3 status/finished/reset events.  Returns true if done.
 fn pump_h3_until(
     conn: &mut quiche::Connection,
     h3: &mut quiche::h3::Connection,
-    socket: &std::net::UdpSocket,
-    local_addr: std::net::SocketAddr,
-    out: &mut [u8],
-    buf: &mut [u8],
+    io: &mut PumpIo<'_>,
     target_sid: u64,
     deadline: Instant,
     events: &mut Vec<String>,
 ) -> bool {
     while Instant::now() < deadline {
-        flush_quic(conn, socket, out);
-        socket.set_read_timeout(Some(quic_read_timeout(conn))).ok();
-        match socket.recv_from(buf) {
+        flush_quic(conn, io.socket, io.out);
+        io.socket
+            .set_read_timeout(Some(quic_read_timeout(conn)))
+            .ok();
+        match io.socket.recv_from(io.buf) {
             Ok((len, from)) => {
                 let _ = conn.recv(
-                    &mut buf[..len],
+                    &mut io.buf[..len],
                     quiche::RecvInfo {
                         from,
-                        to: local_addr,
+                        to: io.local_addr,
                     },
                 );
             }
@@ -3285,13 +3243,16 @@ fn teardown_client_reset_before_upstream_response() {
     // Pump briefly so the listener processes the reset and calls abort_stream.
     let pump_end = Instant::now() + Duration::from_millis(200);
     let mut discard = Vec::new();
+    let mut io = PumpIo {
+        socket: &socket,
+        local_addr,
+        out: &mut out,
+        buf: &mut buf,
+    };
     pump_h3_until(
         &mut conn,
         &mut h3,
-        &socket,
-        local_addr,
-        &mut out,
-        &mut buf,
+        &mut io,
         slow_sid,
         pump_end,
         &mut discard,
@@ -3362,7 +3323,6 @@ fn teardown_client_reset_during_response_streaming() {
         // Wait for first response data chunk — this guarantees the server is in
         // SendingResponse and actively streaming.
         let data_deadline = Instant::now() + Duration::from_secs(REQUEST_TIMEOUT_SECS);
-        let mut got_data = false;
         'wait: loop {
             flush_quic(&mut conn, &socket, &mut out);
             socket.set_read_timeout(Some(quic_read_timeout(&conn))).ok();
@@ -3389,7 +3349,6 @@ fn teardown_client_reset_during_response_streaming() {
                     Ok((sid, quiche::h3::Event::Data)) if sid == stream_sid => {
                         let mut tmp = [0u8; 4096];
                         while h3.recv_body(&mut conn, sid, &mut tmp).is_ok() {}
-                        got_data = true;
                         break 'wait;
                     }
                     Ok((sid, quiche::h3::Event::Finished)) if sid == stream_sid => {
@@ -3404,10 +3363,6 @@ fn teardown_client_reset_during_response_streaming() {
                 panic!("timed out waiting for /stream response data");
             }
         }
-        assert!(
-            got_data,
-            "must receive response data before dropping connection"
-        );
         // Connection drops here (socket + conn out of scope) — server is left
         // in SendingResponse with an orphaned body-pump task.
     }
@@ -3434,13 +3389,16 @@ fn teardown_client_reset_during_response_streaming() {
         .expect("send_request /fast on second connection");
 
     let mut events = Vec::new();
+    let mut io = PumpIo {
+        socket: &socket2,
+        local_addr: local_addr2,
+        out: &mut out2,
+        buf: &mut buf2,
+    };
     let done = pump_h3_until(
         &mut conn2,
         &mut h3_2,
-        &socket2,
-        local_addr2,
-        &mut out2,
-        &mut buf2,
+        &mut io,
         fast_sid,
         Instant::now() + Duration::from_secs(REQUEST_TIMEOUT_SECS + 2),
         &mut events,
@@ -3496,13 +3454,16 @@ fn teardown_upstream_timeout_cleans_up_stream() {
 
     let mut timeout_events = Vec::new();
     // backend_timeout_ms=200ms + some margin for the listener to respond
+    let mut io = PumpIo {
+        socket: &socket,
+        local_addr,
+        out: &mut out,
+        buf: &mut buf,
+    };
     let done = pump_h3_until(
         &mut conn,
         &mut h3,
-        &socket,
-        local_addr,
-        &mut out,
-        &mut buf,
+        &mut io,
         timeout_sid,
         Instant::now() + Duration::from_secs(5),
         &mut timeout_events,
@@ -3526,13 +3487,16 @@ fn teardown_upstream_timeout_cleans_up_stream() {
         .expect("send_request /fast after timeout");
 
     let mut fast_events = Vec::new();
+    let mut io = PumpIo {
+        socket: &socket,
+        local_addr,
+        out: &mut out,
+        buf: &mut buf,
+    };
     let done = pump_h3_until(
         &mut conn,
         &mut h3,
-        &socket,
-        local_addr,
-        &mut out,
-        &mut buf,
+        &mut io,
         fast_sid,
         Instant::now() + Duration::from_secs(REQUEST_TIMEOUT_SECS + 2),
         &mut fast_events,

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -869,6 +869,13 @@ fn run_h3_client_concurrent_get(
         .map_err(|e| format!("send_to: {e:?}"))?;
 
     loop {
+        if start.elapsed() > timeout {
+            return Err(format!(
+                "timeout waiting for responses (done={finished}, expected={})",
+                paths.len()
+            ));
+        }
+
         loop {
             match conn.send(&mut out) {
                 Ok((write, send_info)) => {
@@ -879,7 +886,15 @@ fn run_h3_client_concurrent_get(
             }
         }
 
-        let read_timeout = quic_read_timeout(&conn);
+        let remaining = timeout.saturating_sub(start.elapsed());
+        let read_timeout = quic_read_timeout(&conn)
+            .min(remaining)
+            .min(Duration::from_millis(50));
+        let read_timeout = if read_timeout.is_zero() {
+            Duration::from_millis(1)
+        } else {
+            read_timeout
+        };
         socket
             .set_read_timeout(Some(read_timeout))
             .map_err(|e| format!("timeout: {e:?}"))?;
@@ -977,12 +992,6 @@ fn run_h3_client_concurrent_get(
             return Ok(observations);
         }
 
-        if start.elapsed() > timeout {
-            return Err(format!(
-                "timeout waiting for responses (done={finished}, expected={})",
-                paths.len()
-            ));
-        }
     }
 }
 

--- a/crates/edge/tests/h3_edge.rs
+++ b/crates/edge/tests/h3_edge.rs
@@ -17,7 +17,9 @@ use rcgen::{Certificate, CertificateParams, SanType};
 use tempfile::{TempDir, tempdir};
 use tokio::net::TcpListener;
 
-use spooky_config::config::{Backend, Config, HealthCheck, Listen, LoadBalancing, Log, Tls};
+use spooky_config::config::{
+    Backend, ClientAuth, Config, HealthCheck, Listen, LoadBalancing, Log, Tls, UpstreamTls,
+};
 use spooky_edge::QUICListener;
 use spooky_edge::constants::{
     MAX_DATAGRAM_SIZE_BYTES, MAX_UDP_PAYLOAD_BYTES, QUIC_IDLE_TIMEOUT_MS, QUIC_INITIAL_MAX_DATA,
@@ -82,13 +84,18 @@ fn make_config(port: u32, cert: String, key: String, backend_address: String) ->
             protocol: "http3".to_string(),
             port,
             address: "127.0.0.1".to_string(),
-            tls: Tls { cert, key },
+            tls: Tls {
+                cert,
+                key,
+                client_auth: ClientAuth::default(),
+            },
         },
         upstream,
         load_balancing: Some(LoadBalancing {
             lb_type: "random".to_string(),
             key: None,
         }),
+        upstream_tls: UpstreamTls::default(),
         log: Log {
             level: "info".to_string(),
             file: Default::default(),
@@ -813,13 +820,18 @@ fn make_config_with_rate_limit(
             protocol: "http3".to_string(),
             port,
             address: "127.0.0.1".to_string(),
-            tls: Tls { cert, key },
+            tls: Tls {
+                cert,
+                key,
+                client_auth: ClientAuth::default(),
+            },
         },
         upstream,
         load_balancing: Some(LoadBalancing {
             lb_type: "random".to_string(),
             key: None,
         }),
+        upstream_tls: UpstreamTls::default(),
         log: Log {
             level: "error".to_string(),
             file: Default::default(),

--- a/crates/edge/tests/h3_edge.rs
+++ b/crates/edge/tests/h3_edge.rs
@@ -449,7 +449,7 @@ fn assert_cid_sync_invariants(listener: &QUICListener) {
 
             if cid.as_ref() == connection.primary_scid.as_ref() {
                 assert!(
-                    listener.cid_routes.get(cid.as_ref()).is_none(),
+                    !listener.cid_routes.contains_key(cid.as_ref()),
                     "primary SCID must not be present in alias map"
                 );
             } else {
@@ -1149,13 +1149,8 @@ fn stress_connect(
 fn stress_close_gracefully(socket: &UdpSocket, conn: &mut quiche::Connection) {
     let _ = conn.close(false, 0, b"done");
     let mut out = [0u8; MAX_UDP_PAYLOAD_BYTES];
-    loop {
-        match conn.send(&mut out) {
-            Ok((w, si)) => {
-                let _ = socket.send_to(&out[..w], si.to);
-            }
-            Err(_) => break,
-        }
+    while let Ok((w, si)) = conn.send(&mut out) {
+        let _ = socket.send_to(&out[..w], si.to);
     }
 }
 

--- a/crates/edge/tests/lb_integration.rs
+++ b/crates/edge/tests/lb_integration.rs
@@ -17,7 +17,8 @@ use tempfile::{TempDir, tempdir};
 use tokio::net::TcpListener;
 
 use spooky_config::config::{
-    Backend, Config, HealthCheck, Listen, LoadBalancing, Log, RouteMatch, Tls, Upstream,
+    Backend, ClientAuth, Config, HealthCheck, Listen, LoadBalancing, Log, RouteMatch, Tls,
+    Upstream, UpstreamTls,
 };
 use spooky_edge::QUICListener;
 use spooky_edge::constants::{
@@ -108,13 +109,18 @@ fn make_config(
             protocol: "http3".to_string(),
             port,
             address: "127.0.0.1".to_string(),
-            tls: Tls { cert, key },
+            tls: Tls {
+                cert,
+                key,
+                client_auth: ClientAuth::default(),
+            },
         },
         upstream,
         load_balancing: Some(LoadBalancing {
             lb_type: lb_type.to_string(),
             key: None,
         }),
+        upstream_tls: UpstreamTls::default(),
         log: Log {
             level: "info".to_string(),
             file: Default::default(),

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -11,5 +11,7 @@ hyper.workspace = true
 hyper-util.workspace = true
 hyper-rustls.workspace = true
 rustls.workspace = true
+rustls-pemfile.workspace = true
 tokio.workspace = true
+webpki-roots.workspace = true
 spooky-errors = { path = "../errors" }

--- a/crates/transport/src/h2_client.rs
+++ b/crates/transport/src/h2_client.rs
@@ -138,13 +138,15 @@ impl H2Client {
 
 impl Default for H2Client {
     fn default() -> Self {
-        Self::new(
+        match Self::new(
             64,
             Duration::from_secs(30),
             Duration::from_secs(2),
             TlsClientConfig::default(),
-        )
-        .expect("default H2 client config must be valid")
+        ) {
+            Ok(client) => client,
+            Err(err) => panic!("default H2 client config must be valid: {err}"),
+        }
     }
 }
 

--- a/crates/transport/src/h2_client.rs
+++ b/crates/transport/src/h2_client.rs
@@ -1,5 +1,9 @@
 use std::convert::Infallible;
+use std::ffi::OsStr;
+use std::fs::File;
 use std::future::Future;
+use std::io::BufReader;
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -8,9 +12,28 @@ use hyper::body::Bytes;
 use hyper::{Request, rt::Executor};
 use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
 use hyper_util::client::legacy::{Client, connect::HttpConnector};
-use rustls::ClientConfig;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::{ClientConfig, RootCertStore};
+
+#[derive(Debug, Clone)]
+pub struct TlsClientConfig {
+    pub verify_certificates: bool,
+    pub strict_sni: bool,
+    pub ca_file: Option<String>,
+    pub ca_dir: Option<String>,
+}
+
+impl Default for TlsClientConfig {
+    fn default() -> Self {
+        Self {
+            verify_certificates: true,
+            strict_sni: true,
+            ca_file: None,
+            ca_dir: None,
+        }
+    }
+}
 
 pub struct H2Client {
     client: Client<HttpsConnector<HttpConnector>, BoxBody<Bytes, Infallible>>,
@@ -83,29 +106,18 @@ impl H2Client {
         max_idle_per_host: usize,
         pool_idle_timeout: Duration,
         connect_timeout: Duration,
-        tls_verify: bool,
-    ) -> Self {
+        tls: TlsClientConfig,
+    ) -> Result<Self, String> {
         let mut http = HttpConnector::new();
         http.enforce_http(false);
         http.set_connect_timeout(Some(connect_timeout));
 
-        let https = if tls_verify {
-            HttpsConnectorBuilder::new()
-                .with_webpki_roots()
-                .https_or_http()
-                .enable_http2()
-                .wrap_connector(http)
-        } else {
-            let tls_config = ClientConfig::builder()
-                .dangerous()
-                .with_custom_certificate_verifier(Arc::new(NoVerifier))
-                .with_no_client_auth();
-            HttpsConnectorBuilder::new()
-                .with_tls_config(tls_config)
-                .https_or_http()
-                .enable_http2()
-                .wrap_connector(http)
-        };
+        let tls_config = build_tls_config(&tls)?;
+        let https = HttpsConnectorBuilder::new()
+            .with_tls_config(tls_config)
+            .https_or_http()
+            .enable_http2()
+            .wrap_connector(http);
 
         let client = Client::builder(TokioExecutor)
             .http2_only(true)
@@ -113,7 +125,7 @@ impl H2Client {
             .pool_idle_timeout(pool_idle_timeout)
             .build(https);
 
-        Self { client }
+        Ok(Self { client })
     }
 
     pub async fn send(
@@ -126,6 +138,173 @@ impl H2Client {
 
 impl Default for H2Client {
     fn default() -> Self {
-        Self::new(64, Duration::from_secs(30), Duration::from_secs(2), true)
+        Self::new(
+            64,
+            Duration::from_secs(30),
+            Duration::from_secs(2),
+            TlsClientConfig::default(),
+        )
+        .expect("default H2 client config must be valid")
+    }
+}
+
+fn build_tls_config(tls: &TlsClientConfig) -> Result<ClientConfig, String> {
+    if !tls.verify_certificates {
+        let mut cfg = ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(NoVerifier))
+            .with_no_client_auth();
+        cfg.enable_sni = tls.strict_sni;
+        return Ok(cfg);
+    }
+
+    let mut roots = RootCertStore::empty();
+    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+
+    if let Some(ca_file) = tls.ca_file.as_ref() {
+        let path = Path::new(ca_file);
+        for cert in read_pem_certificates(path)? {
+            roots.add(cert).map_err(|err| {
+                format!(
+                    "failed to add certificate from upstream_tls.ca_file '{}': {}",
+                    path.display(),
+                    err
+                )
+            })?;
+        }
+    }
+
+    if let Some(ca_dir) = tls.ca_dir.as_ref() {
+        let loaded = load_ca_directory(&mut roots, Path::new(ca_dir))?;
+        if loaded == 0 {
+            return Err(format!(
+                "upstream_tls.ca_dir '{}' did not contain any readable PEM certificates",
+                ca_dir
+            ));
+        }
+    }
+
+    let mut cfg = ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    cfg.enable_sni = tls.strict_sni;
+    Ok(cfg)
+}
+
+fn read_pem_certificates(path: &Path) -> Result<Vec<CertificateDer<'static>>, String> {
+    let file = File::open(path).map_err(|err| {
+        format!(
+            "failed to open certificate file '{}': {}",
+            path.display(),
+            err
+        )
+    })?;
+    let mut reader = BufReader::new(file);
+    let certs = rustls_pemfile::certs(&mut reader)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|err| {
+            format!(
+                "failed to parse PEM certificates from '{}': {}",
+                path.display(),
+                err
+            )
+        })?;
+    if certs.is_empty() {
+        return Err(format!(
+            "certificate file '{}' does not contain any PEM certificates",
+            path.display()
+        ));
+    }
+    Ok(certs)
+}
+
+fn load_ca_directory(roots: &mut RootCertStore, dir: &Path) -> Result<usize, String> {
+    let entries = std::fs::read_dir(dir).map_err(|err| {
+        format!(
+            "failed to read upstream_tls.ca_dir '{}': {}",
+            dir.display(),
+            err
+        )
+    })?;
+
+    let mut loaded = 0usize;
+    for entry in entries {
+        let entry = entry.map_err(|err| {
+            format!(
+                "failed to read entry in upstream_tls.ca_dir '{}': {}",
+                dir.display(),
+                err
+            )
+        })?;
+        let path = entry.path();
+        if !path.is_file() || !is_pem_like_path(&path) {
+            continue;
+        }
+
+        for cert in read_pem_certificates(&path)? {
+            roots.add(cert).map_err(|err| {
+                format!(
+                    "failed to add certificate from '{}': {}",
+                    path.display(),
+                    err
+                )
+            })?;
+            loaded = loaded.saturating_add(1);
+        }
+    }
+
+    Ok(loaded)
+}
+
+fn is_pem_like_path(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(OsStr::to_str),
+        Some("pem" | "crt" | "cer" | "PEM" | "CRT" | "CER")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{H2Client, TlsClientConfig};
+    use std::time::Duration;
+
+    #[test]
+    fn default_tls_client_config_builds_h2_client() {
+        let client = H2Client::new(
+            8,
+            Duration::from_secs(5),
+            Duration::from_secs(1),
+            TlsClientConfig::default(),
+        );
+        assert!(client.is_ok());
+    }
+
+    #[test]
+    fn invalid_ca_file_is_rejected() {
+        let unique = format!(
+            "spooky-invalid-ca-{}-{}.pem",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        );
+        let path = std::env::temp_dir().join(unique);
+        std::fs::write(&path, b"not-a-pem-certificate").expect("write temp file");
+
+        let client = H2Client::new(
+            8,
+            Duration::from_secs(5),
+            Duration::from_secs(1),
+            TlsClientConfig {
+                verify_certificates: true,
+                strict_sni: true,
+                ca_file: Some(path.to_string_lossy().to_string()),
+                ca_dir: None,
+            },
+        );
+        assert!(client.is_err());
+
+        let _ = std::fs::remove_file(path);
     }
 }

--- a/crates/transport/src/h2_pool.rs
+++ b/crates/transport/src/h2_pool.rs
@@ -5,7 +5,7 @@ use hyper::Request;
 use hyper::body::{Bytes, Incoming};
 use tokio::sync::{Semaphore, TryAcquireError};
 
-use crate::h2_client::H2Client;
+use crate::h2_client::{H2Client, TlsClientConfig};
 pub use spooky_errors::PoolError;
 
 struct BackendHandle {
@@ -24,7 +24,8 @@ impl H2Pool {
         max_idle_per_backend: usize,
         pool_idle_timeout: Duration,
         connect_timeout: Duration,
-    ) -> Self
+        tls: TlsClientConfig,
+    ) -> Result<Self, String>
     where
         I: IntoIterator<Item = String>,
     {
@@ -32,15 +33,21 @@ impl H2Pool {
         let max_idle_per_backend = max_idle_per_backend.max(1);
         let mut map = HashMap::new();
         for backend in backends {
+            let client = H2Client::new(
+                max_idle_per_backend,
+                pool_idle_timeout,
+                connect_timeout,
+                tls.clone(),
+            )?;
             map.insert(
                 backend,
                 BackendHandle {
-                    client: H2Client::new(max_idle_per_backend, pool_idle_timeout, connect_timeout, false),
+                    client,
                     inflight: Arc::new(Semaphore::new(inflight)),
                 },
             );
         }
-        Self { backends: map }
+        Ok(Self { backends: map })
     }
 
     pub fn has_backend(&self, backend: &str) -> bool {

--- a/crates/transport/tests/h2_pool.rs
+++ b/crates/transport/tests/h2_pool.rs
@@ -12,7 +12,10 @@ use hyper::{Request, Response, body::Incoming, service::service_fn};
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use tokio::net::TcpListener;
 
-use spooky_transport::h2_pool::{H2Pool, PoolError};
+use spooky_transport::{
+    h2_client::TlsClientConfig,
+    h2_pool::{H2Pool, PoolError},
+};
 
 struct ConcurrencyTracker {
     current: AtomicUsize,
@@ -84,13 +87,20 @@ async fn pool_limits_inflight_per_backend() {
     let port = start_h2_server(tracker.clone()).await.unwrap();
     let backend = format!("127.0.0.1:{port}");
 
-    let pool = Arc::new(H2Pool::new(
-        vec![backend.clone()],
-        1,
-        64,
-        Duration::from_secs(30),
-        Duration::from_secs(2),
-    ));
+    let pool = Arc::new(
+        H2Pool::new(
+            vec![backend.clone()],
+            1,
+            64,
+            Duration::from_secs(30),
+            Duration::from_secs(2),
+            TlsClientConfig {
+                verify_certificates: false,
+                ..TlsClientConfig::default()
+            },
+        )
+        .expect("pool"),
+    );
     let req1 = Request::builder()
         .method("GET")
         .uri(format!("http://{backend}/"))
@@ -135,7 +145,12 @@ async fn pool_rejects_unknown_backend() {
         64,
         Duration::from_secs(30),
         Duration::from_secs(2),
-    );
+        TlsClientConfig {
+            verify_certificates: false,
+            ..TlsClientConfig::default()
+        },
+    )
+    .expect("pool");
     let req = Request::builder()
         .method("GET")
         .uri("http://127.0.0.1:12345/")
@@ -154,13 +169,20 @@ async fn pool_capacity_probe_reflects_inflight_state() {
     let tracker = Arc::new(ConcurrencyTracker::new());
     let port = start_h2_server(tracker).await.unwrap();
     let backend = format!("127.0.0.1:{port}");
-    let pool = Arc::new(H2Pool::new(
-        vec![backend.clone()],
-        1,
-        64,
-        Duration::from_secs(30),
-        Duration::from_secs(2),
-    ));
+    let pool = Arc::new(
+        H2Pool::new(
+            vec![backend.clone()],
+            1,
+            64,
+            Duration::from_secs(30),
+            Duration::from_secs(2),
+            TlsClientConfig {
+                verify_certificates: false,
+                ..TlsClientConfig::default()
+            },
+        )
+        .expect("pool"),
+    );
 
     assert!(pool.has_capacity(&backend).unwrap());
 

--- a/spooky/src/main.rs
+++ b/spooky/src/main.rs
@@ -457,6 +457,44 @@ fn release_shard_queue_bytes(counter: &AtomicUsize, packet_bytes: usize) {
     }
 }
 
+fn maybe_pin_worker(worker_idx: usize, pin_workers: bool) {
+    if !pin_workers {
+        return;
+    }
+
+    let Some(core_ids) = core_affinity::get_core_ids() else {
+        warn!("Worker pinning requested but core list is unavailable");
+        return;
+    };
+
+    if core_ids.is_empty() {
+        warn!("Worker pinning requested but no cores were reported");
+        return;
+    }
+
+    let core_id = core_ids[worker_idx % core_ids.len()];
+    if !core_affinity::set_for_current(core_id) {
+        warn!("Failed to pin worker {} to core {}", worker_idx, core_id.id);
+    }
+}
+
+fn join_worker_handle(handle: thread::JoinHandle<Result<(), String>>, worker_failed: &mut bool) {
+    match handle.join() {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => {
+            *worker_failed = true;
+            error!("Worker exited with error: {}", err);
+        }
+        Err(payload) => {
+            *worker_failed = true;
+            error!(
+                "Worker thread panicked: {}",
+                runtime_guard::panic_payload_message(payload.as_ref())
+            );
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{release_shard_queue_bytes, shard_index_for_peer, try_reserve_shard_queue_bytes};
@@ -493,43 +531,5 @@ mod tests {
         assert_eq!(counter.load(std::sync::atomic::Ordering::Relaxed), 5);
         release_shard_queue_bytes(&counter, 10);
         assert_eq!(counter.load(std::sync::atomic::Ordering::Relaxed), 0);
-    }
-}
-
-fn maybe_pin_worker(worker_idx: usize, pin_workers: bool) {
-    if !pin_workers {
-        return;
-    }
-
-    let Some(core_ids) = core_affinity::get_core_ids() else {
-        warn!("Worker pinning requested but core list is unavailable");
-        return;
-    };
-
-    if core_ids.is_empty() {
-        warn!("Worker pinning requested but no cores were reported");
-        return;
-    }
-
-    let core_id = core_ids[worker_idx % core_ids.len()];
-    if !core_affinity::set_for_current(core_id) {
-        warn!("Failed to pin worker {} to core {}", worker_idx, core_id.id);
-    }
-}
-
-fn join_worker_handle(handle: thread::JoinHandle<Result<(), String>>, worker_failed: &mut bool) {
-    match handle.join() {
-        Ok(Ok(())) => {}
-        Ok(Err(err)) => {
-            *worker_failed = true;
-            error!("Worker exited with error: {}", err);
-        }
-        Err(payload) => {
-            *worker_failed = true;
-            error!(
-                "Worker thread panicked: {}",
-                runtime_guard::panic_payload_message(payload.as_ref())
-            );
-        }
     }
 }


### PR DESCRIPTION
## Why
Spooky needed safer enterprise defaults for transport trust and request-header handling. The previous posture allowed insecure upstream trust behavior and did not fully normalize proxy forwarding headers.

## What Changed
- Added upstream TLS security policy controls with secure defaults:
  - certificate verification enabled by default
  - strict SNI support
  - optional custom CA bundle / CA directory
- Added optional downstream mTLS support:
  - client certificate verification toggle
  - required client-cert mode for strict environments
  - config validation for mTLS prerequisites
- Hardened request header handling in the bridge path:
  - strips unsafe/hop-by-hop and spoofable forwarding headers
  - writes canonical `Forwarded`, `X-Forwarded-For`, `X-Forwarded-Proto`, and `X-Forwarded-Host`
  - preserves safe headers while enforcing deterministic forwarding metadata

## Outcome
- Safe-by-default TLS posture for upstream connections
- Enterprise-ready optional mTLS on downstream ingress
- Stronger header trust boundary and cleaner forwarded-header semantics for upstream apps