### PR TITLE
feat(resilience): add retry/health reason primitives and prevent false unhealthy on upstream send/TLS failures

### DIFF
--- a/config/config.minimal.yaml
+++ b/config/config.minimal.yaml
@@ -15,6 +15,11 @@ upstream:
         health_check:
           path: "/health"
 
+# For Dev-work
+upstream_tls:
+  verify_certificates: false
+
+
 performance:
   packet_shards_per_worker: 1
   packet_shard_queue_capacity: 2048

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -353,14 +353,7 @@ pub enum RetryReason {
     NoAlternateBackend,
 }
 
-#[derive(Clone, Copy, Debug)]
-pub enum HealthFailureReason {
-    HttpStatus5xx,
-    Timeout,
-    Transport,
-    Tls,
-    CircuitOpen,
-}
+pub use spooky_lb::HealthFailureReason;
 
 impl Default for Metrics {
     fn default() -> Self {

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -291,6 +291,17 @@ pub struct Metrics {
     pub watchdog_restart_hooks: AtomicU64,
     pub watchdog_degraded_windows: AtomicU64,
     pub runtime_panics: AtomicU64,
+    pub retries_total: AtomicU64,
+    pub retry_denied_budget: AtomicU64,
+    pub retry_denied_no_bodyless: AtomicU64,
+    pub retry_denied_no_alternate: AtomicU64,
+    pub retry_reason_timeout: AtomicU64,
+    pub retry_reason_transport: AtomicU64,
+    pub retry_reason_pool: AtomicU64,
+    pub health_failure_5xx: AtomicU64,
+    pub health_failure_timeout: AtomicU64,
+    pub health_failure_transport: AtomicU64,
+    pub health_failure_tls: AtomicU64,
     route_stats_shards: Vec<Mutex<HashMap<String, RouteStats>>>,
 }
 
@@ -330,6 +341,25 @@ pub enum OverloadShedReason {
     RequestBufferCap,
     ResponsePrebufferCap,
     ConnectionCap,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum RetryReason {
+    BackendTimeout,
+    BackendTransport,
+    BackendPool,
+    BudgetDenied,
+    NotBodylessMode,
+    NoAlternateBackend,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum HealthFailureReason {
+    HttpStatus5xx,
+    Timeout,
+    Transport,
+    Tls,
+    CircuitOpen,
 }
 
 impl Default for Metrics {
@@ -382,6 +412,17 @@ impl Default for Metrics {
             watchdog_restart_hooks: AtomicU64::new(0),
             watchdog_degraded_windows: AtomicU64::new(0),
             runtime_panics: AtomicU64::new(0),
+            retries_total: AtomicU64::new(0),
+            retry_denied_budget: AtomicU64::new(0),
+            retry_denied_no_bodyless: AtomicU64::new(0),
+            retry_denied_no_alternate: AtomicU64::new(0),
+            retry_reason_timeout: AtomicU64::new(0),
+            retry_reason_transport: AtomicU64::new(0),
+            retry_reason_pool: AtomicU64::new(0),
+            health_failure_5xx: AtomicU64::new(0),
+            health_failure_timeout: AtomicU64::new(0),
+            health_failure_transport: AtomicU64::new(0),
+            health_failure_tls: AtomicU64::new(0),
             route_stats_shards: shards,
         }
     }
@@ -611,6 +652,48 @@ impl Metrics {
 
     pub fn inc_runtime_panic(&self) {
         self.runtime_panics.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_retry(&self, reason: RetryReason) {
+        self.retries_total.fetch_add(1, Ordering::Relaxed);
+        match reason {
+            RetryReason::BackendTimeout => {
+                self.retry_reason_timeout.fetch_add(1, Ordering::Relaxed);
+            }
+            RetryReason::BackendTransport => {
+                self.retry_reason_transport.fetch_add(1, Ordering::Relaxed);
+            }
+            RetryReason::BackendPool => {
+                self.retry_reason_pool.fetch_add(1, Ordering::Relaxed);
+            }
+            RetryReason::BudgetDenied => {
+                self.retry_denied_budget.fetch_add(1, Ordering::Relaxed);
+            }
+            RetryReason::NotBodylessMode => {
+                self.retry_denied_no_bodyless.fetch_add(1, Ordering::Relaxed);
+            }
+            RetryReason::NoAlternateBackend => {
+                self.retry_denied_no_alternate.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+
+    pub fn inc_health_failure(&self, reason: HealthFailureReason) {
+        match reason {
+            HealthFailureReason::HttpStatus5xx => {
+                self.health_failure_5xx.fetch_add(1, Ordering::Relaxed);
+            }
+            HealthFailureReason::Timeout => {
+                self.health_failure_timeout.fetch_add(1, Ordering::Relaxed);
+            }
+            HealthFailureReason::Transport => {
+                self.health_failure_transport.fetch_add(1, Ordering::Relaxed);
+            }
+            HealthFailureReason::Tls => {
+                self.health_failure_tls.fetch_add(1, Ordering::Relaxed);
+            }
+            HealthFailureReason::CircuitOpen => {}
+        }
     }
 
     pub fn record_route(&self, route: &str, latency: Duration, outcome: RouteOutcome) {
@@ -970,6 +1053,62 @@ impl Metrics {
         out.push_str(&format!(
             "spooky_watchdog_degraded_windows {}\n",
             self.watchdog_degraded_windows.load(Ordering::Relaxed)
+        ));
+
+        out.push_str("# HELP spooky_retries_total Total retry attempts across all routes.\n");
+        out.push_str("# TYPE spooky_retries_total counter\n");
+        out.push_str(&format!(
+            "spooky_retries_total {}\n",
+            self.retries_total.load(Ordering::Relaxed)
+        ));
+
+        out.push_str("# HELP spooky_retry_denied_total Total retry attempts blocked, by denial reason.\n");
+        out.push_str("# TYPE spooky_retry_denied_total counter\n");
+        out.push_str(&format!(
+            "spooky_retry_denied_total{{reason=\"budget\"}} {}\n",
+            self.retry_denied_budget.load(Ordering::Relaxed)
+        ));
+        out.push_str(&format!(
+            "spooky_retry_denied_total{{reason=\"no_bodyless\"}} {}\n",
+            self.retry_denied_no_bodyless.load(Ordering::Relaxed)
+        ));
+        out.push_str(&format!(
+            "spooky_retry_denied_total{{reason=\"no_alternate\"}} {}\n",
+            self.retry_denied_no_alternate.load(Ordering::Relaxed)
+        ));
+
+        out.push_str("# HELP spooky_retry_attempts_total Total retries triggered, by error reason.\n");
+        out.push_str("# TYPE spooky_retry_attempts_total counter\n");
+        out.push_str(&format!(
+            "spooky_retry_attempts_total{{reason=\"timeout\"}} {}\n",
+            self.retry_reason_timeout.load(Ordering::Relaxed)
+        ));
+        out.push_str(&format!(
+            "spooky_retry_attempts_total{{reason=\"transport\"}} {}\n",
+            self.retry_reason_transport.load(Ordering::Relaxed)
+        ));
+        out.push_str(&format!(
+            "spooky_retry_attempts_total{{reason=\"pool\"}} {}\n",
+            self.retry_reason_pool.load(Ordering::Relaxed)
+        ));
+
+        out.push_str("# HELP spooky_health_failures_total Backend health failures, by failure reason.\n");
+        out.push_str("# TYPE spooky_health_failures_total counter\n");
+        out.push_str(&format!(
+            "spooky_health_failures_total{{reason=\"5xx\"}} {}\n",
+            self.health_failure_5xx.load(Ordering::Relaxed)
+        ));
+        out.push_str(&format!(
+            "spooky_health_failures_total{{reason=\"timeout\"}} {}\n",
+            self.health_failure_timeout.load(Ordering::Relaxed)
+        ));
+        out.push_str(&format!(
+            "spooky_health_failures_total{{reason=\"transport\"}} {}\n",
+            self.health_failure_transport.load(Ordering::Relaxed)
+        ));
+        out.push_str(&format!(
+            "spooky_health_failures_total{{reason=\"tls\"}} {}\n",
+            self.health_failure_tls.load(Ordering::Relaxed)
         ));
 
         let mut snapshot: Vec<(String, RouteStats)> = Vec::new();

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -3420,8 +3420,33 @@ impl QUICListener {
                     overload_retry_after_seconds,
                 )
             }
+            Err(ProxyError::Pool(PoolError::Send(ref send_err))) => {
+                // Log the full inner error — commonly exposes TLS/cert/SNI mismatches
+                // that look like transport failures but are actually local config errors.
+                // Do NOT mark the backend unhealthy: the backend may be fully operational;
+                // the connection failure is a proxy-side config issue.
+                error!(
+                    "Upstream send failed for {} (possible TLS/cert/SNI misconfiguration): {}",
+                    backend_addr, send_err
+                );
+                metrics.inc_health_failure(HealthFailureReason::Tls);
+                metrics.inc_failure();
+                metrics.inc_backend_error();
+                metrics.record_route(route_label, start.elapsed(), RouteOutcome::BackendError);
+                debug!(
+                    "Upstream {} status 502 latency_ms {}",
+                    backend_addr,
+                    start.elapsed().as_millis()
+                );
+                Self::send_simple_response(
+                    h3,
+                    quic,
+                    stream_id,
+                    http::StatusCode::BAD_GATEWAY,
+                    b"upstream error\n",
+                )
+            }
             Err(ProxyError::Transport(_))
-            | Err(ProxyError::Pool(PoolError::Send(_)))
             | Err(ProxyError::Pool(PoolError::InflightLimiterClosed))
             | Err(ProxyError::Pool(PoolError::UnknownBackend(_))) => {
                 error!("Upstream transport error");

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -2922,7 +2922,7 @@ impl QUICListener {
                                                     p.pool.mark_success(idx)
                                                 }
                                                 crate::HealthClassification::Failure => {
-                                                    p.pool.mark_failure(idx)
+                                                    p.pool.mark_request_failure(idx, HealthFailureReason::HttpStatus5xx)
                                                 }
                                                 crate::HealthClassification::Neutral => None,
                                             },
@@ -3138,7 +3138,7 @@ impl QUICListener {
                                 req.backend_index,
                                 upstream_name.and_then(|n| upstream_pools.get(n)),
                             ) && let Some(t) =
-                                pool.lock().ok().and_then(|mut p| p.pool.mark_failure(idx))
+                                pool.lock().ok().and_then(|mut p| p.pool.mark_request_failure(idx, HealthFailureReason::HttpStatus5xx))
                                 && let Some(addr) = &req.backend_addr
                             {
                                 Self::log_health_transition(addr, t);
@@ -3430,7 +3430,7 @@ impl QUICListener {
                     && let Some(t) = pool
                         .lock()
                         .ok()
-                        .and_then(|mut p| p.pool.mark_failure_with_reason(backend_index, HealthFailureReason::Transport))
+                        .and_then(|mut p| p.pool.mark_request_failure(backend_index, HealthFailureReason::Transport))
                 {
                     Self::log_health_transition(backend_addr, t);
                 }
@@ -3470,7 +3470,7 @@ impl QUICListener {
                     && let Some(t) = pool
                         .lock()
                         .ok()
-                        .and_then(|mut p| p.pool.mark_failure_with_reason(backend_index, HealthFailureReason::Timeout))
+                        .and_then(|mut p| p.pool.mark_request_failure(backend_index, HealthFailureReason::Timeout))
                 {
                     Self::log_health_transition(backend_addr, t);
                 }

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -24,8 +24,8 @@ use quiche::h3::NameValue;
 use rand::RngCore;
 use socket2::{Domain, Protocol, Socket, Type};
 use spooky_bridge::h3_to_h2::{ForwardedContext, build_h2_request};
-use spooky_errors::{PoolError, ProxyError};
-use spooky_lb::{HealthTransition, UpstreamPool};
+use spooky_errors::{PoolError, ProxyError, is_retryable};
+use spooky_lb::{HealthFailureReason, HealthTransition, UpstreamPool};
 use spooky_transport::h2_client::{H2Client, TlsClientConfig};
 use spooky_transport::h2_pool::H2Pool;
 use tokio::runtime::Handle;
@@ -38,8 +38,9 @@ use tokio::sync::{
 use spooky_config::{backend_endpoint::BackendEndpoint, config::Config as SpookyConfig};
 
 use crate::{
-    ChannelBody, ForwardResult, Metrics, OverloadShedReason, QUICListener, QuicConnection,
-    RequestEnvelope, ResponseChunk, RouteOutcome, SharedRuntimeState, StreamPhase, UpstreamResult,
+    ChannelBody, ForwardResult, Metrics, OverloadShedReason, QUICListener,
+    QuicConnection, RequestEnvelope, ResponseChunk, RetryReason, RouteOutcome, SharedRuntimeState,
+    StreamPhase, UpstreamResult,
     cid_radix::CidRadix,
     constants::{
         DEFAULT_SCID_LEN_BYTES, MAX_DATAGRAM_SIZE_BYTES, MAX_STREAMS_PER_CONNECTION,
@@ -2128,9 +2129,16 @@ impl QUICListener {
                                         {
                                             Ok(response) => response,
                                             Err(primary_err) => {
-                                                if bodyless_mode
-                                                    && retry_budget.allow_retry(&route_name).is_ok()
-                                                    && let Some((retry_backend, _)) =
+                                                let retry_reason = classify_retry_reason(&primary_err);
+                                                if !bodyless_mode {
+                                                    return Err(primary_err);
+                                                } else if !is_retryable(&primary_err) {
+                                                    return Err(primary_err);
+                                                } else if retry_budget.allow_retry(&route_name).is_err() {
+                                                    return Err(primary_err);
+                                                } else if alternate_backend.is_none() {
+                                                    return Err(primary_err);
+                                                } else if let Some((retry_backend, _)) =
                                                         alternate_backend.clone()
                                                     && let Ok(retry_request) = build_h2_request(
                                                         &retry_backend,
@@ -2146,6 +2154,10 @@ impl QUICListener {
                                                         },
                                                     )
                                                 {
+                                                    info!(
+                                                        "retrying request on alternate backend: route={} reason={:?}",
+                                                        route_name, retry_reason
+                                                    );
                                                     send_once(
                                                         retry_backend,
                                                         retry_request,
@@ -3254,7 +3266,15 @@ impl QUICListener {
             }
             let lb_type = pool.lb_name();
             let idx = pool.pick(key);
-            let idx = idx.ok_or_else(|| ProxyError::Transport("no healthy servers".into()))?;
+            let idx = idx.ok_or_else(|| {
+                let total = pool.pool.len();
+                let healthy = pool.pool.healthy_indices().len();
+                error!(
+                    "no healthy backends available: {}/{} backends healthy",
+                    healthy, total
+                );
+                ProxyError::Transport("no healthy servers".into())
+            })?;
             let backend_addr = pool
                 .pool
                 .address(idx)
@@ -3407,11 +3427,12 @@ impl QUICListener {
             | Err(ProxyError::Pool(PoolError::InflightLimiterClosed))
             | Err(ProxyError::Pool(PoolError::UnknownBackend(_))) => {
                 error!("Upstream transport error");
+                metrics.inc_health_failure(HealthFailureReason::Transport);
                 if let Some(pool) = &upstream_pool
                     && let Some(t) = pool
                         .lock()
                         .ok()
-                        .and_then(|mut p| p.pool.mark_failure(backend_index))
+                        .and_then(|mut p| p.pool.mark_failure_with_reason(backend_index, HealthFailureReason::Transport))
                 {
                     Self::log_health_transition(backend_addr, t);
                 }
@@ -3446,11 +3467,12 @@ impl QUICListener {
             }
             Err(ProxyError::Timeout) => {
                 error!("Upstream request timed out");
+                metrics.inc_health_failure(HealthFailureReason::Timeout);
                 if let Some(pool) = &upstream_pool
                     && let Some(t) = pool
                         .lock()
                         .ok()
-                        .and_then(|mut p| p.pool.mark_failure(backend_index))
+                        .and_then(|mut p| p.pool.mark_failure_with_reason(backend_index, HealthFailureReason::Timeout))
                 {
                     Self::log_health_transition(backend_addr, t);
                 }
@@ -3472,6 +3494,7 @@ impl QUICListener {
             }
             Err(ProxyError::Tls(err)) => {
                 error!("TLS error: {}", err);
+                metrics.inc_health_failure(HealthFailureReason::Tls);
                 metrics.inc_failure();
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::Failure);
                 debug!(
@@ -3955,6 +3978,15 @@ impl QUICListener {
                 },
             );
         }
+    }
+}
+
+fn classify_retry_reason(err: &ProxyError) -> RetryReason {
+    match err {
+        ProxyError::Timeout => RetryReason::BackendTimeout,
+        ProxyError::Transport(_) => RetryReason::BackendTransport,
+        ProxyError::Pool(_) => RetryReason::BackendPool,
+        _ => RetryReason::BackendTransport,
     }
 }
 

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -2082,7 +2082,7 @@ impl QUICListener {
                                                 _ = &mut hedge_sleep => None,
                                             } {
                                                 result?
-                                            } else if retry_budget.allow_retry(&route_name) {
+                                            } else if retry_budget.allow_retry(&route_name).is_ok() {
                                                 hedge_telemetry.launched = true;
                                                 let hedge_fut = send_once(
                                                     hedge_backend,
@@ -2129,7 +2129,7 @@ impl QUICListener {
                                             Ok(response) => response,
                                             Err(primary_err) => {
                                                 if bodyless_mode
-                                                    && retry_budget.allow_retry(&route_name)
+                                                    && retry_budget.allow_retry(&route_name).is_ok()
                                                     && let Some((retry_backend, _)) =
                                                         alternate_backend.clone()
                                                     && let Ok(retry_request) = build_h2_request(

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -2130,13 +2130,11 @@ impl QUICListener {
                                             Ok(response) => response,
                                             Err(primary_err) => {
                                                 let retry_reason = classify_retry_reason(&primary_err);
-                                                if !bodyless_mode {
-                                                    return Err(primary_err);
-                                                } else if !is_retryable(&primary_err) {
-                                                    return Err(primary_err);
-                                                } else if retry_budget.allow_retry(&route_name).is_err() {
-                                                    return Err(primary_err);
-                                                } else if alternate_backend.is_none() {
+                                                let can_retry = bodyless_mode
+                                                    && is_retryable(&primary_err)
+                                                    && retry_budget.allow_retry(&route_name).is_ok()
+                                                    && alternate_backend.is_some();
+                                                if !can_retry {
                                                     return Err(primary_err);
                                                 } else if let Some((retry_backend, _)) =
                                                         alternate_backend.clone()

--- a/crates/edge/src/resilience.rs
+++ b/crates/edge/src/resilience.rs
@@ -9,6 +9,8 @@ use std::{
 
 use spooky_config::config::Resilience as ResilienceConfig;
 
+use crate::RetryReason;
+
 pub struct AdaptiveAdmission {
     enabled: bool,
     min_limit: usize,
@@ -324,9 +326,9 @@ impl RetryBudget {
         }
     }
 
-    pub fn allow_retry(&self, route: &str) -> bool {
+    pub fn allow_retry(&self, route: &str) -> Result<(), RetryReason> {
         if !self.enabled {
-            return false;
+            return Err(RetryReason::BudgetDenied);
         }
 
         let ratio = self
@@ -340,7 +342,7 @@ impl RetryBudget {
         let retries = self.global_retries.load(Ordering::Relaxed);
         let global_limit = ((primary * ratio as u64) / 100).saturating_add(1);
         if retries >= global_limit {
-            return false;
+            return Err(RetryReason::BudgetDenied);
         }
 
         let mut route_allowed = true;
@@ -354,11 +356,11 @@ impl RetryBudget {
             }
         }
         if !route_allowed {
-            return false;
+            return Err(RetryReason::BudgetDenied);
         }
 
         self.global_retries.fetch_add(1, Ordering::Relaxed);
-        true
+        Ok(())
     }
 }
 
@@ -596,8 +598,8 @@ mod tests {
     fn retry_budget_respects_ratio() {
         let rb = RetryBudget::new(true, 50, HashMap::new());
         rb.mark_primary("api");
-        assert!(rb.allow_retry("api"));
-        assert!(!rb.allow_retry("api"));
+        assert!(rb.allow_retry("api").is_ok());
+        assert!(rb.allow_retry("api").is_err());
     }
 
     #[test]

--- a/crates/errors/src/lib.rs
+++ b/crates/errors/src/lib.rs
@@ -59,9 +59,11 @@ pub enum ProxyError {
 
 
 pub fn is_retryable(err: &ProxyError) -> bool {
-    // TLS and Protocol errors are not retryable
-    matches!(
-        err,
-        ProxyError::Transport(_) | ProxyError::Timeout | ProxyError::Pool(_)
-    )
+    match err {
+        ProxyError::Transport(_) | ProxyError::Timeout => true,
+        // Pool send failures are connection-level (TLS/cert/SNI) — not transient
+        ProxyError::Pool(PoolError::Send(_)) => false,
+        ProxyError::Pool(_) => true,
+        _ => false,
+    }
 }

--- a/crates/errors/src/lib.rs
+++ b/crates/errors/src/lib.rs
@@ -56,3 +56,12 @@ pub enum ProxyError {
     #[error("TLS error: {0}")]
     Tls(String),
 }
+
+
+pub fn is_retryable(err: &ProxyError) -> bool {
+    // TLS and Protocol errors are not retryable
+    matches!(
+        err,
+        ProxyError::Transport(_) | ProxyError::Timeout | ProxyError::Pool(_)
+    )
+}

--- a/crates/lb/src/lib.rs
+++ b/crates/lb/src/lib.rs
@@ -28,6 +28,8 @@ pub struct BackendState {
 #[derive(Clone)]
 enum HealthState {
     Healthy,
+    // `reason` is stored for future introspection; suppressed until wired to metrics
+    #[allow(dead_code)]
     Unhealthy { until: Instant, successes: u32, reason: HealthFailureReason },
 }
 

--- a/crates/lb/src/lib.rs
+++ b/crates/lb/src/lib.rs
@@ -3,6 +3,15 @@ use std::time::{Duration, Instant};
 use rand::Rng;
 use spooky_config::config::{Backend, HealthCheck};
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HealthFailureReason {
+    HttpStatus5xx,
+    Timeout,
+    Transport,
+    Tls,
+    CircuitOpen,
+}
+
 const DEFAULT_REPLICAS: u32 = 64;
 const FNV_OFFSET: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x00000100000001b3;
@@ -19,7 +28,7 @@ pub struct BackendState {
 #[derive(Clone)]
 enum HealthState {
     Healthy,
-    Unhealthy { until: Instant, successes: u32 },
+    Unhealthy { until: Instant, successes: u32, reason: HealthFailureReason },
 }
 
 pub enum HealthTransition {
@@ -60,7 +69,7 @@ impl BackendState {
                 self.consecutive_failures = 0;
                 None
             }
-            HealthState::Unhealthy { until, successes } => {
+            HealthState::Unhealthy { until, successes, .. } => {
                 if Instant::now() < *until {
                     return None;
                 }
@@ -76,7 +85,7 @@ impl BackendState {
         }
     }
 
-    pub fn record_failure(&mut self) -> Option<HealthTransition> {
+    pub fn record_failure(&mut self, reason: HealthFailureReason) -> Option<HealthTransition> {
         self.consecutive_failures = self.consecutive_failures.saturating_add(1);
         let threshold = self.health_check.failure_threshold;
         if self.consecutive_failures < threshold {
@@ -88,6 +97,7 @@ impl BackendState {
         self.health_state = HealthState::Unhealthy {
             until: Instant::now() + cooldown,
             successes: 0,
+            reason,
         };
         Some(HealthTransition::BecameUnhealthy)
     }
@@ -184,6 +194,14 @@ impl BackendPool {
     }
 
     pub fn mark_failure(&mut self, index: usize) -> Option<HealthTransition> {
+        self.mark_failure_with_reason(index, HealthFailureReason::HttpStatus5xx)
+    }
+
+    pub fn mark_failure_with_reason(
+        &mut self,
+        index: usize,
+        reason: HealthFailureReason,
+    ) -> Option<HealthTransition> {
         if index >= self.backends.len() {
             return None;
         }
@@ -191,7 +209,7 @@ impl BackendPool {
         let (was_healthy, is_healthy, transition) = {
             let backend = &mut self.backends[index];
             let was_healthy = backend.is_healthy();
-            let transition = backend.record_failure();
+            let transition = backend.record_failure(reason);
             let is_healthy = backend.is_healthy();
             (was_healthy, is_healthy, transition)
         };

--- a/crates/lb/src/lib.rs
+++ b/crates/lb/src/lib.rs
@@ -53,6 +53,13 @@ impl BackendState {
         matches!(self.health_state, HealthState::Healthy)
     }
 
+    /// Returns true when an active health-check loop is running for this backend.
+    /// When active checks are present, only the health-check loop should drive
+    /// consecutive_failures — request-path failures should not contribute.
+    pub fn has_active_health_check(&self) -> bool {
+        self.health_check.interval > 0
+    }
+
     pub fn address(&self) -> &str {
         &self.address
     }
@@ -195,8 +202,23 @@ impl BackendPool {
         transition
     }
 
+    /// Mark a failure from the active health-check loop — always recorded.
     pub fn mark_failure(&mut self, index: usize) -> Option<HealthTransition> {
         self.mark_failure_with_reason(index, HealthFailureReason::HttpStatus5xx)
+    }
+
+    /// Mark a failure from the request path (passive).
+    /// Skipped when an active health-check loop is running for this backend,
+    /// because the loop is the sole authority on consecutive_failures in that case.
+    pub fn mark_request_failure(
+        &mut self,
+        index: usize,
+        reason: HealthFailureReason,
+    ) -> Option<HealthTransition> {
+        if index < self.backends.len() && self.backends[index].has_active_health_check() {
+            return None;
+        }
+        self.mark_failure_with_reason(index, reason)
     }
 
     pub fn mark_failure_with_reason(


### PR DESCRIPTION
### Summary

- Adds `is_retryable(err: &ProxyError) -> bool` in `crates/errors` so retryability policy is explicit (retry: transport/timeout/pool; do not retry: TLS/protocol/bridge).
- Introduces retry/health reason primitives in `crates/edge` + `crates/lb`:
  - `RetryReason` enum
  - `HealthFailureReason` enum reuse in edge metrics
  - `HealthState::Unhealthy { reason, ... }`
- Changes `RetryBudget::allow_retry` to return `Result<(), RetryReason>` so budget denials are explicit.
- Adds Prometheus families for retry and health-failure reason breakdowns:
  - `spooky_retries_total`
  - `spooky_retry_denied_total{reason=...}`
  - `spooky_retry_attempts_total{reason=...}`
  - `spooky_health_failures_total{reason=...}`
- Fixes a major misclassification path in `quic_listener`:
  - `PoolError::Send` is now logged with inner cause (`client error (Connect)` etc.)
  - request-path send failures are treated as likely local TLS/cert/SNI config issues
  - backend is no longer marked unhealthy for this class of proxy-side failure
- Fixes request-path vs active health-check race in `lb` by adding `mark_request_failure(...)` and preventing request-path failures from mutating consecutive-failure state when active health checks are running.

### New Metrics

| Metric | Labels | Description |
|--------|--------|-------------|
| `spooky_retries_total` | none | Total retry events counted by edge metrics |
| `spooky_retry_denied_total` | `reason` | Retries blocked: `budget`, `no_bodyless`, `no_alternate` |
| `spooky_retry_attempts_total` | `reason` | Retries triggered by: `timeout`, `transport`, `pool` |
| `spooky_health_failures_total` | `reason` | Backend failures by: `5xx`, `timeout`, `transport`, `tls` |