### PR TITLE
feat(observability): add request_id propagation and structured access logs (plain/json)

### DIFF
--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -61,6 +61,7 @@ load_balancing:
 
 log:
     level: debug
+    format: plain  # plain | json
     file:
         enabled: true
         path: /var/log/spooky/spooky.log

--- a/crates/bridge/src/h3_to_h2.rs
+++ b/crates/bridge/src/h3_to_h2.rs
@@ -15,6 +15,7 @@ pub use spooky_errors::BridgeError;
 pub struct ForwardedContext<'a> {
     pub client_addr: SocketAddr,
     pub request_authority: Option<&'a str>,
+    pub request_id: u64,
 }
 
 /// Build an HTTP/2 request with a pre-boxed streaming body.
@@ -71,6 +72,17 @@ pub fn build_h2_request(
         && len > 0
     {
         builder = builder.header(http::header::CONTENT_LENGTH, len);
+    }
+
+    let has_request_id = builder
+        .headers_ref()
+        .is_some_and(|h| h.contains_key("x-request-id"));
+    if !has_request_id {
+        builder = builder.header(
+            HeaderName::from_static("x-request-id"),
+            HeaderValue::from_str(&forwarded_ctx.request_id.to_string())
+                .map_err(|_| BridgeError::InvalidHeader)?,
+        );
     }
 
     let forwarded_value = format!(
@@ -180,6 +192,7 @@ mod tests {
             ForwardedContext {
                 client_addr: "203.0.113.10:44321".parse().expect("client"),
                 request_authority: Some("api.example.com"),
+                request_id: 0,
             },
         )
         .expect("request");
@@ -209,6 +222,7 @@ mod tests {
             ForwardedContext {
                 client_addr: "198.51.100.3:5555".parse().expect("client"),
                 request_authority: None,
+                request_id: 0,
             },
         )
         .expect("request");
@@ -232,6 +246,7 @@ mod tests {
             ForwardedContext {
                 client_addr: "127.0.0.1:12345".parse().expect("client"),
                 request_authority: None,
+                request_id: 0,
             },
         )
         .expect_err("invalid backend endpoint should fail");
@@ -262,6 +277,7 @@ mod tests {
             ForwardedContext {
                 client_addr: "203.0.113.55:43210".parse().expect("client"),
                 request_authority: Some("api.example.com"),
+                request_id: 0,
             },
         )
         .expect("request");
@@ -301,6 +317,7 @@ mod tests {
             ForwardedContext {
                 client_addr: "[2001:db8::1]:4444".parse().expect("client"),
                 request_authority: Some("api.example.com"),
+                request_id: 0,
             },
         )
         .expect("request");

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -209,6 +209,17 @@ pub struct Log {
 
     #[serde(default)]
     pub file: LogFile,
+
+    #[serde(default)]
+    pub format: LogFormat,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum LogFormat {
+    #[default]
+    Plain,
+    Json,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]

--- a/crates/config/src/default.rs
+++ b/crates/config/src/default.rs
@@ -1,4 +1,4 @@
-use crate::config::{LoadBalancing, Log, LogFile};
+use crate::config::{LoadBalancing, Log, LogFile, LogFormat};
 
 // default values
 pub fn get_default_version() -> u32 {
@@ -67,6 +67,7 @@ pub fn get_default_log() -> Log {
             enabled: false,
             path: String::from(""),
         },
+        format: LogFormat::Plain,
     }
 }
 

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -767,7 +767,7 @@ mod tests {
     use super::validate;
     use crate::config::{
         Backend, ClientAuth, Config, HealthCheck, Listen, LoadBalancing, Log, MetricsEndpoint,
-        Observability, Performance, Resilience, RouteMatch, Tls, Upstream, UpstreamTls,
+        LogFormat, Observability, Performance, Resilience, RouteMatch, Tls, Upstream, UpstreamTls,
     };
     use std::collections::HashMap;
     use tempfile::tempdir;
@@ -823,6 +823,7 @@ mod tests {
             log: Log {
                 level: "info".to_string(),
                 file: Default::default(),
+                format: LogFormat::Plain,
             },
             performance: Performance::default(),
             observability: Observability::default(),

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -158,6 +158,7 @@ pub struct HedgeTelemetry {
 pub struct UpstreamResult {
     pub forward: ForwardResult,
     pub hedge: HedgeTelemetry,
+    pub retry_count: u8,
 }
 
 /// Lifecycle phase of a single HTTP/3 request stream.
@@ -216,6 +217,9 @@ pub struct RequestEnvelope {
     pub start: Instant,
     pub total_request_deadline: Instant,
     pub bodyless_mode: bool,
+
+    pub retry_count: u8,
+    pub error_kind: Option<&'static str>,
 
     /// Current lifecycle phase of this stream.
     pub phase: StreamPhase,

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -27,6 +27,8 @@ use crate::constants::MAX_DATAGRAM_SIZE_BYTES;
 use crate::resilience::{AdaptivePermit, RouteQueuePermit, RuntimeResilience};
 use crate::watchdog::WatchdogCoordinator;
 
+static REQUEST_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
+
 /// A streaming HTTP body backed by a tokio mpsc channel.
 /// The quiche Data handler sends chunks through the sender;
 /// hyper reads them from the receiver as the H2 request body.
@@ -188,6 +190,8 @@ pub enum ResponseChunk {
 }
 
 pub struct RequestEnvelope {
+    pub request_id: u64,
+
     pub method: String,
     pub path: String,
     pub authority: Option<String>,
@@ -225,6 +229,12 @@ pub struct RequestEnvelope {
     pub response_headers_sent: bool,
     /// A chunk that could not be written due to QUIC send backpressure; retried next poll.
     pub pending_chunk: Option<ResponseChunk>,
+}
+
+impl RequestEnvelope {
+    pub fn request_id(&self) -> u64 {
+        self.request_id
+    }
 }
 
 #[derive(Debug)]

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -4122,9 +4122,11 @@ mod tests {
     use std::{collections::HashMap, sync::Arc};
 
     use crate::cid_radix::CidRadix;
+    use crate::REQUEST_ID_COUNTER;
 
     use std::collections::HashSet;
     use std::net::SocketAddr;
+    use std::sync::atomic::Ordering;
 
     use super::{
         ConnectionRoutes, TokenBucket, abort_stream, purge_connection_routes,

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -1671,8 +1671,6 @@ impl QUICListener {
                     let path = request.path;
                     let authority = request.authority;
 
-                    debug!("HTTP/3 request {} {}", method, path);
-
                     metrics.inc_total();
                     let request_start = Instant::now();
 
@@ -1720,6 +1718,7 @@ impl QUICListener {
                         route_queue_permit,
                         request_fin_received,
                         bodyless_mode,
+                        request_id,
                     ) = match resolved {
                         Ok((upstream_name, addr, idx, upstream_pool)) => {
                             resilience.brownout.observe_admission_pressure(
@@ -1950,6 +1949,7 @@ impl QUICListener {
                                 }
                             }
 
+                            let request_id = REQUEST_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
                             let content_length = request_content_length(&list);
                             let bodyless_mode = content_length.unwrap_or(0) == 0
                                 && (method.eq_ignore_ascii_case("GET")
@@ -1973,6 +1973,7 @@ impl QUICListener {
                                 ForwardedContext {
                                     client_addr: connection.peer_address,
                                     request_authority: authority.as_deref(),
+                                    request_id,
                                 },
                             ) {
                                 Ok(request) => request,
@@ -2061,6 +2062,7 @@ impl QUICListener {
                                                         client_addr,
                                                         request_authority: authority_owned
                                                             .as_deref(),
+                                                        request_id,
                                                     },
                                                 )
                                                 .ok()
@@ -2154,13 +2156,14 @@ impl QUICListener {
                                                             client_addr,
                                                             request_authority: authority_owned
                                                                 .as_deref(),
+                                                            request_id,
                                                         },
                                                     )
                                                 {
                                                     retry_count = retry_count.saturating_add(1);
                                                     info!(
-                                                        "retrying request on alternate backend: route={} reason={:?}",
-                                                        route_name, retry_reason
+                                                        "request_id={} retrying request on alternate backend: route={} reason={:?}",
+                                                        request_id, route_name, retry_reason
                                                     );
                                                     send_once(
                                                         retry_backend,
@@ -2202,6 +2205,7 @@ impl QUICListener {
                                 Some(route_queue_permit),
                                 request_fin_received,
                                 bodyless_mode,
+                                request_id,
                             )
                         }
                         Err(err) => {
@@ -2269,7 +2273,7 @@ impl QUICListener {
                     connection.streams.insert(
                         stream_id,
                         RequestEnvelope {
-                            request_id: REQUEST_ID_COUNTER.fetch_add(1, Ordering::Relaxed),
+                            request_id,
                             method,
                             path,
                             authority,
@@ -2298,6 +2302,12 @@ impl QUICListener {
                             pending_chunk: None,
                         },
                     );
+                    if let Some(req) = connection.streams.get(&stream_id) {
+                        debug!(
+                            "request_id={} method={} path={} stream_id={}",
+                            req.request_id, req.method, req.path, stream_id
+                        );
+                    }
                 }
                 Ok((stream_id, quiche::h3::Event::Data)) => loop {
                     match h3.recv_body(&mut connection.quic, stream_id, &mut body_buf) {
@@ -2419,8 +2429,10 @@ impl QUICListener {
                         }
                         Err(quiche::h3::Error::Done) => break,
                         Err(err) => {
+                            let rid = connection.streams.get(&stream_id).map(|r| r.request_id);
                             error!(
-                                "HTTP/3 recv_body protocol error on stream {}: {:?}",
+                                "request_id={} HTTP/3 recv_body protocol error on stream {}: {:?}",
+                                rid.map_or_else(|| "-".to_string(), |id| id.to_string()),
                                 stream_id, err
                             );
                             if let Some(req) = connection.streams.get(&stream_id) {
@@ -2695,7 +2707,8 @@ impl QUICListener {
                                     .adaptive_admission
                                     .observe(req.start.elapsed(), true);
                                 warn!(
-                                    "upstream declared content-length over cap ({} > {}) on stream {}",
+                                    "request_id={} upstream declared content-length over cap ({} > {}) on stream {}",
+                                    req.request_id,
                                     upstream_content_length.unwrap_or_default(),
                                     max_response_body_bytes,
                                     stream_id
@@ -2963,12 +2976,7 @@ impl QUICListener {
                             resilience
                                 .adaptive_admission
                                 .observe(req.start.elapsed(), false);
-                            debug!(
-                                "Upstream {} status {} latency_ms {}",
-                                req.backend_addr.as_deref().unwrap_or("?"),
-                                status,
-                                req.start.elapsed().as_millis()
-                            );
+                            Self::log_access(req, status.as_u16());
                         }
                     }
                     Err(err) => {
@@ -3328,6 +3336,34 @@ impl QUICListener {
         None
     }
 
+    fn log_access(req: &RequestEnvelope, status: u16) {
+        match req.error_kind {
+            Some(e) => info!(
+                "request_id={} method={} path={} status={} backend={} upstream={} latency_ms={} retries={} error={}",
+                req.request_id,
+                req.method,
+                req.path,
+                status,
+                req.backend_addr.as_deref().unwrap_or("-"),
+                req.upstream_name.as_deref().unwrap_or("-"),
+                req.start.elapsed().as_millis(),
+                req.retry_count,
+                e,
+            ),
+            None => info!(
+                "request_id={} method={} path={} status={} backend={} upstream={} latency_ms={} retries={}",
+                req.request_id,
+                req.method,
+                req.path,
+                status,
+                req.backend_addr.as_deref().unwrap_or("-"),
+                req.upstream_name.as_deref().unwrap_or("-"),
+                req.start.elapsed().as_millis(),
+                req.retry_count,
+            ),
+        }
+    }
+
     /// Handle an already-resolved `ForwardResult`, applying health transitions
     /// and sending the H3 response.
     #[allow(clippy::too_many_arguments)]
@@ -3387,11 +3423,7 @@ impl QUICListener {
                 error!("Bridge error: {:?}", err);
                 metrics.inc_failure();
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::Failure);
-                debug!(
-                    "Upstream {} status 400 latency_ms {}",
-                    backend_addr,
-                    start.elapsed().as_millis()
-                );
+                Self::log_access(req, 400);
                 Self::send_simple_response(
                     h3,
                     quic,
@@ -3401,7 +3433,6 @@ impl QUICListener {
                 )
             }
             Err(ProxyError::Pool(PoolError::BackendOverloaded(reason))) => {
-                debug!("Backend overloaded");
                 metrics.inc_failure();
                 if reason.contains("unknown-length response prebuffer limit exceeded") {
                     metrics.inc_response_prebuffer_limit_reject();
@@ -3410,11 +3441,7 @@ impl QUICListener {
                     metrics.inc_overload_shed_reason(OverloadShedReason::BackendInflight);
                 }
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::OverloadShed);
-                debug!(
-                    "Upstream {} status 503 latency_ms {}",
-                    backend_addr,
-                    start.elapsed().as_millis()
-                );
+                Self::log_access(req, 503);
                 Self::send_overload_response(
                     h3,
                     quic,
@@ -3424,15 +3451,10 @@ impl QUICListener {
                 )
             }
             Err(ProxyError::Pool(PoolError::CircuitOpen(_))) => {
-                debug!("Backend circuit open");
                 metrics.inc_failure();
                 metrics.inc_overload_shed_reason(OverloadShedReason::BackendInflight);
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::OverloadShed);
-                debug!(
-                    "Upstream {} status 503 latency_ms {}",
-                    backend_addr,
-                    start.elapsed().as_millis()
-                );
+                Self::log_access(req, 503);
                 Self::send_overload_response(
                     h3,
                     quic,
@@ -3454,11 +3476,7 @@ impl QUICListener {
                 metrics.inc_failure();
                 metrics.inc_backend_error();
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::BackendError);
-                debug!(
-                    "Upstream {} status 502 latency_ms {}",
-                    backend_addr,
-                    start.elapsed().as_millis()
-                );
+                Self::log_access(req, 502);
                 Self::send_simple_response(
                     h3,
                     quic,
@@ -3483,11 +3501,7 @@ impl QUICListener {
                 metrics.inc_failure();
                 metrics.inc_backend_error();
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::BackendError);
-                debug!(
-                    "Upstream {} status 502 latency_ms {}",
-                    backend_addr,
-                    start.elapsed().as_millis()
-                );
+                Self::log_access(req, 502);
                 Self::send_simple_response(
                     h3,
                     quic,
@@ -3497,10 +3511,11 @@ impl QUICListener {
                 )
             }
             Err(ProxyError::Protocol(err)) => {
-                error!("Protocol error: {}", err);
+                error!("request_id={} Protocol error: {}", req.request_id, err);
                 metrics.inc_failure();
                 metrics.inc_backend_error();
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::BackendError);
+                Self::log_access(req, 502);
                 Self::send_simple_response(
                     h3,
                     quic,
@@ -3510,7 +3525,7 @@ impl QUICListener {
                 )
             }
             Err(ProxyError::Timeout) => {
-                error!("Upstream request timed out");
+                error!("request_id={} Upstream request timed out", req.request_id);
                 metrics.inc_health_failure(HealthFailureReason::Timeout);
                 if let Some(pool) = &upstream_pool
                     && let Some(t) = pool
@@ -3523,11 +3538,7 @@ impl QUICListener {
                 metrics.inc_failure();
                 metrics.inc_timeout();
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::Timeout);
-                debug!(
-                    "Upstream {} status 503 latency_ms {}",
-                    backend_addr,
-                    start.elapsed().as_millis()
-                );
+                Self::log_access(req, 503);
                 Self::send_simple_response(
                     h3,
                     quic,
@@ -3541,11 +3552,7 @@ impl QUICListener {
                 metrics.inc_health_failure(HealthFailureReason::Tls);
                 metrics.inc_failure();
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::Failure);
-                debug!(
-                    "TLS error for stream {} latency_ms {}",
-                    stream_id,
-                    start.elapsed().as_millis()
-                );
+                Self::log_access(req, 500);
                 Self::send_simple_response(
                     h3,
                     quic,

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -2018,6 +2018,7 @@ impl QUICListener {
                             let (result_tx, result_rx) = oneshot::channel::<UpstreamResult>();
                             let fut = async move {
                                 let mut hedge_telemetry = crate::HedgeTelemetry::default();
+                                let mut retry_count: u8 = 0;
                                 let result: ForwardResult = async {
                                     retry_budget.mark_primary(&route_name);
 
@@ -2156,6 +2157,7 @@ impl QUICListener {
                                                         },
                                                     )
                                                 {
+                                                    retry_count = retry_count.saturating_add(1);
                                                     info!(
                                                         "retrying request on alternate backend: route={} reason={:?}",
                                                         route_name, retry_reason
@@ -2182,6 +2184,7 @@ impl QUICListener {
                                 let _ = result_tx.send(UpstreamResult {
                                     forward: result,
                                     hedge: hedge_telemetry,
+                                    retry_count,
                                 });
                             };
                             if !spawn_async_task(fut, "upstream") {
@@ -2285,6 +2288,8 @@ impl QUICListener {
                             start: request_start,
                             total_request_deadline: request_start + backend_total_request_timeout,
                             bodyless_mode,
+                            retry_count: 0,
+                            error_kind: None,
                             phase: StreamPhase::ReceivingRequest,
                             request_fin_received,
                             upstream_result_rx,
@@ -2627,6 +2632,7 @@ impl QUICListener {
                                 "upstream task dropped sender".into(),
                             )),
                             hedge: crate::HedgeTelemetry::default(),
+                            retry_count: 0,
                         }),
                     })
             } else {
@@ -2652,6 +2658,16 @@ impl QUICListener {
 
                 if let Some(req) = streams.get_mut(&stream_id) {
                     req.upstream_result_rx = None;
+                    req.retry_count = forward_result.retry_count;
+                    req.error_kind = match &forward_result.forward {
+                        Err(ProxyError::Timeout) => Some("timeout"),
+                        Err(ProxyError::Tls(_)) => Some("tls"),
+                        Err(ProxyError::Transport(_)) => Some("transport"),
+                        Err(ProxyError::Pool(_)) => Some("pool"),
+                        Err(ProxyError::Protocol(_)) => Some("protocol"),
+                        Err(ProxyError::Bridge(_)) => Some("bridge"),
+                        Ok(_) => None,
+                    };
                 }
                 match forward_result.forward {
                     Ok((status, resp_headers, body)) => {
@@ -4702,6 +4718,8 @@ mod tests {
             start: Instant::now(),
             total_request_deadline: Instant::now() + std::time::Duration::from_secs(30),
             bodyless_mode: false,
+            retry_count: 0,
+            error_kind: None,
             phase,
             request_fin_received: false,
             upstream_result_rx: None,
@@ -4785,6 +4803,7 @@ mod tests {
         let send_result = result_tx.send(crate::UpstreamResult {
             forward: Err(spooky_errors::ProxyError::Transport("test".into())),
             hedge: crate::HedgeTelemetry::default(),
+            retry_count: 0,
         });
         assert!(
             send_result.is_err(),

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -39,8 +39,8 @@ use spooky_config::{backend_endpoint::BackendEndpoint, config::Config as SpookyC
 
 use crate::{
     ChannelBody, ForwardResult, Metrics, OverloadShedReason, QUICListener,
-    QuicConnection, RequestEnvelope, ResponseChunk, RetryReason, RouteOutcome, SharedRuntimeState,
-    StreamPhase, UpstreamResult,
+    QuicConnection, REQUEST_ID_COUNTER, RequestEnvelope, ResponseChunk, RetryReason, RouteOutcome,
+    SharedRuntimeState, StreamPhase, UpstreamResult,
     cid_radix::CidRadix,
     constants::{
         DEFAULT_SCID_LEN_BYTES, MAX_DATAGRAM_SIZE_BYTES, MAX_STREAMS_PER_CONNECTION,
@@ -2266,6 +2266,7 @@ impl QUICListener {
                     connection.streams.insert(
                         stream_id,
                         RequestEnvelope {
+                            request_id: REQUEST_ID_COUNTER.fetch_add(1, Ordering::Relaxed),
                             method,
                             path,
                             authority,
@@ -4682,6 +4683,7 @@ mod tests {
 
     fn make_envelope(phase: StreamPhase) -> RequestEnvelope {
         RequestEnvelope {
+            request_id: REQUEST_ID_COUNTER.fetch_add(1, Ordering::Relaxed),
             method: "GET".into(),
             path: "/".into(),
             authority: None,

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -31,7 +31,8 @@ use tempfile::{TempDir, tempdir};
 use tokio::net::TcpListener;
 
 use spooky_config::config::{
-    Backend, ClientAuth, Config, HealthCheck, Listen, LoadBalancing, Log, Tls, UpstreamTls,
+    Backend, ClientAuth, Config, HealthCheck, Listen, LoadBalancing, Log, LogFormat, Tls,
+    UpstreamTls,
 };
 use spooky_edge::QUICListener;
 use spooky_edge::constants::{
@@ -113,6 +114,7 @@ fn make_config(port: u32, backend_addr: String, cert: String, key: String) -> Co
         log: Log {
             level: "info".to_string(),
             file: Default::default(),
+            format: LogFormat::Plain,
         },
         performance: spooky_config::config::Performance::default(),
         observability: spooky_config::config::Observability::default(),

--- a/crates/edge/tests/h3_edge.rs
+++ b/crates/edge/tests/h3_edge.rs
@@ -18,7 +18,8 @@ use tempfile::{TempDir, tempdir};
 use tokio::net::TcpListener;
 
 use spooky_config::config::{
-    Backend, ClientAuth, Config, HealthCheck, Listen, LoadBalancing, Log, Tls, UpstreamTls,
+    Backend, ClientAuth, Config, HealthCheck, Listen, LoadBalancing, Log, LogFormat, Tls,
+    UpstreamTls,
 };
 use spooky_edge::QUICListener;
 use spooky_edge::constants::{
@@ -99,6 +100,7 @@ fn make_config(port: u32, cert: String, key: String, backend_address: String) ->
         log: Log {
             level: "info".to_string(),
             file: Default::default(),
+            format: LogFormat::Plain,
         },
         performance: spooky_config::config::Performance::default(),
         observability: spooky_config::config::Observability::default(),
@@ -835,6 +837,7 @@ fn make_config_with_rate_limit(
         log: Log {
             level: "error".to_string(),
             file: Default::default(),
+            format: LogFormat::Plain,
         },
         performance: Performance {
             new_connections_per_sec,

--- a/crates/edge/tests/lb_integration.rs
+++ b/crates/edge/tests/lb_integration.rs
@@ -17,8 +17,8 @@ use tempfile::{TempDir, tempdir};
 use tokio::net::TcpListener;
 
 use spooky_config::config::{
-    Backend, ClientAuth, Config, HealthCheck, Listen, LoadBalancing, Log, RouteMatch, Tls,
-    Upstream, UpstreamTls,
+    Backend, ClientAuth, Config, HealthCheck, Listen, LoadBalancing, Log, LogFormat, RouteMatch,
+    Tls, Upstream, UpstreamTls,
 };
 use spooky_edge::QUICListener;
 use spooky_edge::constants::{
@@ -124,6 +124,7 @@ fn make_config(
         log: Log {
             level: "info".to_string(),
             file: Default::default(),
+            format: LogFormat::Plain,
         },
         performance: spooky_config::config::Performance::default(),
         observability: spooky_config::config::Observability::default(),

--- a/crates/utils/src/logger.rs
+++ b/crates/utils/src/logger.rs
@@ -1,12 +1,13 @@
 use std::{
     fs::{OpenOptions, create_dir_all},
+    io::Write,
     path::Path,
 };
 
 use env_logger::{Builder, Target};
 use log::LevelFilter;
 
-pub fn init_logger(log_level: &str, log_enabled: bool, log_file: &str) {
+pub fn init_logger(log_level: &str, log_enabled: bool, log_file: &str, json: bool) {
     let level = match log_level.to_lowercase().as_str() {
         "whisper" => LevelFilter::Trace,
         "haunt" => LevelFilter::Debug,
@@ -32,7 +33,23 @@ pub fn init_logger(log_level: &str, log_enabled: bool, log_file: &str) {
     };
 
     let mut builder = Builder::new();
-    builder.filter_level(level).format_timestamp_secs();
+    builder.filter_level(level);
+
+    if json {
+        builder.format(|buf, record| {
+            let ts = buf.timestamp_seconds();
+            let level = record.level().as_str().to_ascii_lowercase();
+            let msg = record.args().to_string();
+            // Escape the message string minimally so it stays valid JSON.
+            let escaped = msg.replace('\\', "\\\\").replace('"', "\\\"");
+            writeln!(
+                buf,
+                "{{\"ts\":\"{ts}\",\"level\":\"{level}\",\"msg\":\"{escaped}\"}}"
+            )
+        });
+    } else {
+        builder.format_timestamp_secs();
+    }
 
     // only write to file if enabled
     if log_enabled {

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -69,6 +69,7 @@ upstream:
 
 log:
   level: info
+  format: plain
 ```
 
 ## Top-Level Configuration
@@ -119,6 +120,7 @@ The following table lists all default configuration values used when properties 
 | `upstream[].backends[].health_check.cooldown_ms` | `5000` | Cooldown after failure (ms) |
 | `upstream[].load_balancing.type` | `"round-robin"` | Per-upstream load balancing algorithm |
 | `log.level` | `"info"` | Logging verbosity level |
+| `log.format` | `"plain"` | Log output format (`plain` or `json`) |
 | `log.file.enabled` | `false` | Write logs to file instead of stderr |
 | `log.file.path` | `"/var/log/spooky/spooky.log"` | Log file path (used when `log.file.enabled` is true) |
 | `performance.new_connections_per_sec` | `2000` | Token-bucket refill rate for new QUIC connections (conns/sec) |
@@ -435,6 +437,7 @@ Controls logging output, verbosity, and destination.
 | Property | Type | Required | Default | Description |
 |----------|------|----------|---------|-------------|
 | `level` | string | No | `info` | Log level |
+| `format` | string | No | `plain` | Output format: `plain` (human-readable) or `json` (structured) |
 | `file.enabled` | bool | No | `false` | Write logs to a file instead of stderr |
 | `file.path` | string | No | `/var/log/spooky/spooky.log` | Log file path (used when `file.enabled` is `true`) |
 
@@ -464,21 +467,30 @@ Standard log level mapping:
 # stderr only (default)
 log:
   level: info
+  format: plain
 
 # Write to file
 log:
   level: info
+  format: plain
   file:
     enabled: true
     path: /var/log/spooky/spooky.log
 
+# Structured JSON logs (recommended for log pipelines)
+log:
+  level: info
+  format: json
+
 # Development — debug to stderr
 log:
   level: haunt  # debug level
+  format: plain
 
 # Troubleshooting — trace to file
 log:
   level: whisper  # trace level
+  format: json
   file:
     enabled: true
     path: /tmp/spooky-trace.log
@@ -794,4 +806,5 @@ upstream:
 
 log:
   level: debug
+  format: plain
 ```

--- a/spooky/src/main.rs
+++ b/spooky/src/main.rs
@@ -66,6 +66,7 @@ Use a port >= 1024 for unprivileged startup.",
         &config_yaml.log.level,
         config_yaml.log.file.enabled,
         &config_yaml.log.file.path,
+        config_yaml.log.format == spooky_config::config::LogFormat::Json,
     );
     runtime_guard::install_panic_hook();
 


### PR DESCRIPTION
### Summary
This PR improves request-level observability by introducing end-to-end `request_id` propagation and consolidated access logging, with optional JSON log output.

### What Changed
- Added `request_id` generation and propagation through request lifecycle.
- Added `x-request-id` injection in upstream H2 requests when client does not provide one.
- Added `retry_count` and `error_kind` tracking on request envelopes/results.
- Reworked edge logging to emit a single consolidated access log line per completed request:
  - `request_id`, `method`, `path`, `status`, `backend`, `upstream`, `latency_ms`, `retries`
  - includes `error` field when applicable
- Added configurable log format:
  - `log.format: plain | json`
  - default remains `plain` for backward compatibility
- Updated sample config to expose `log.format`.

### Config Changes
- New field: `log.format` in config (`plain` by default).
- Example:
  ```yaml
  log:
    level: debug
    format: json
    file:
      enabled: true
      path: /var/log/spooky/spooky.log
  ```

### Files Touched
- `config/config.sample.yaml`
- `crates/config/src/config.rs`
- `crates/config/src/default.rs`
- `crates/utils/src/logger.rs`
- `crates/edge/src/lib.rs`
- `crates/edge/src/quic_listener.rs`
- `crates/bridge/src/h3_to_h2.rs`
- `spooky/src/main.rs`

### Why
Current logs make cross-hop request tracing and failure correlation difficult. This change provides stable request correlation IDs and machine-readable logs for ingestion by log platforms.

### Backward Compatibility
- Existing configs continue to work (default log format is `plain`).
- Existing runtime behavior is preserved; this is observability-focused.