### PR TITLE
fix: close P0 gaps in admission, shutdown, and TLS validation

### DIFF
--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -11,3 +11,4 @@ serde_yaml.workspace = true
 
 [dev-dependencies]
 tempfile = "3"
+rcgen = "0.12"

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 log.workspace = true
 serde.workspace = true
 serde_yaml.workspace = true
+rustls-pemfile.workspace = true
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -1,6 +1,9 @@
 use crate::backend_endpoint::{BackendEndpoint, BackendScheme};
 use crate::config::Config;
 use log::{error, info, warn};
+use std::fs::File;
+use std::io::BufReader;
+use std::path::Path;
 
 pub const VALID_LOG_LEVELS: &[&str] = &[
     "whisper",
@@ -26,6 +29,67 @@ pub const VALID_LB_TYPES: &[&str] = &[
     "consistent_hash",
     "ch",
 ];
+
+fn validate_pem_certificates(path: &str, field_name: &str) -> bool {
+    let file = match File::open(path) {
+        Ok(file) => file,
+        Err(err) => {
+            error!("Cannot open {} '{}': {}", field_name, path, err);
+            return false;
+        }
+    };
+
+    let mut reader = BufReader::new(file);
+    let certs = match rustls_pemfile::certs(&mut reader).collect::<Result<Vec<_>, _>>() {
+        Ok(certs) => certs,
+        Err(err) => {
+            error!(
+                "Cannot parse PEM certificates from {} '{}': {}",
+                field_name, path, err
+            );
+            return false;
+        }
+    };
+
+    if certs.is_empty() {
+        error!(
+            "{} '{}' does not contain any PEM certificate blocks",
+            field_name, path
+        );
+        return false;
+    }
+
+    true
+}
+
+fn validate_pem_private_key(path: &str, field_name: &str) -> bool {
+    let file = match File::open(path) {
+        Ok(file) => file,
+        Err(err) => {
+            error!("Cannot open {} '{}': {}", field_name, path, err);
+            return false;
+        }
+    };
+
+    let mut reader = BufReader::new(file);
+    match rustls_pemfile::private_key(&mut reader) {
+        Ok(Some(_)) => true,
+        Ok(None) => {
+            error!(
+                "{} '{}' does not contain a PEM private key",
+                field_name, path
+            );
+            false
+        }
+        Err(err) => {
+            error!(
+                "Cannot parse PEM private key from {} '{}': {}",
+                field_name, path, err
+            );
+            false
+        }
+    }
+}
 
 pub fn validate(config: &Config) -> bool {
     info!("Starting configuration validation...");
@@ -509,7 +573,7 @@ pub fn validate(config: &Config) -> bool {
     }
 
     // --- Validate TLS certs ---
-    if !std::path::Path::new(&config.listen.tls.cert).exists() {
+    if !Path::new(&config.listen.tls.cert).exists() {
         error!(
             "TLS certificate file does not exist: {}",
             config.listen.tls.cert
@@ -517,7 +581,7 @@ pub fn validate(config: &Config) -> bool {
         return false;
     }
 
-    if !std::path::Path::new(&config.listen.tls.key).exists() {
+    if !Path::new(&config.listen.tls.key).exists() {
         error!(
             "TLS private key file does not exist: {}",
             config.listen.tls.key
@@ -525,20 +589,11 @@ pub fn validate(config: &Config) -> bool {
         return false;
     }
 
-    // Optional: Try to read the files to ensure they're accessible
-    if let Err(e) = std::fs::read(&config.listen.tls.cert) {
-        error!(
-            "Cannot read TLS certificate file '{}': {}",
-            config.listen.tls.cert, e
-        );
+    if !validate_pem_certificates(&config.listen.tls.cert, "listen.tls.cert") {
         return false;
     }
 
-    if let Err(e) = std::fs::read(&config.listen.tls.key) {
-        error!(
-            "Cannot read TLS private key file '{}': {}",
-            config.listen.tls.key, e
-        );
+    if !validate_pem_private_key(&config.listen.tls.key, "listen.tls.key") {
         return false;
     }
 
@@ -557,15 +612,11 @@ pub fn validate(config: &Config) -> bool {
             error!("listen.tls.client_auth.ca_file cannot be empty");
             return false;
         }
-        if !std::path::Path::new(ca_file).exists() {
+        if !Path::new(ca_file).exists() {
             error!("listen.tls.client_auth.ca_file does not exist: {}", ca_file);
             return false;
         }
-        if let Err(err) = std::fs::read(ca_file) {
-            error!(
-                "Cannot read listen.tls.client_auth.ca_file '{}': {}",
-                ca_file, err
-            );
+        if !validate_pem_certificates(ca_file, "listen.tls.client_auth.ca_file") {
             return false;
         }
     }
@@ -582,12 +633,11 @@ pub fn validate(config: &Config) -> bool {
             error!("upstream_tls.ca_file cannot be empty when provided");
             return false;
         }
-        if !std::path::Path::new(ca_file).exists() {
+        if !Path::new(ca_file).exists() {
             error!("upstream_tls.ca_file does not exist: {}", ca_file);
             return false;
         }
-        if let Err(err) = std::fs::read(ca_file) {
-            error!("Cannot read upstream_tls.ca_file '{}': {}", ca_file, err);
+        if !validate_pem_certificates(ca_file, "upstream_tls.ca_file") {
             return false;
         }
     }
@@ -597,7 +647,7 @@ pub fn validate(config: &Config) -> bool {
             error!("upstream_tls.ca_dir cannot be empty when provided");
             return false;
         }
-        let ca_path = std::path::Path::new(ca_dir);
+        let ca_path = Path::new(ca_dir);
         if !ca_path.exists() {
             error!("upstream_tls.ca_dir does not exist: {}", ca_dir);
             return false;
@@ -769,8 +819,26 @@ mod tests {
         Backend, ClientAuth, Config, HealthCheck, Listen, LoadBalancing, Log, MetricsEndpoint,
         LogFormat, Observability, Performance, Resilience, RouteMatch, Tls, Upstream, UpstreamTls,
     };
+    use rcgen::{Certificate, CertificateParams, SanType};
     use std::collections::HashMap;
     use tempfile::tempdir;
+
+    fn write_test_certs(dir: &std::path::Path) -> (std::path::PathBuf, std::path::PathBuf) {
+        let mut params = CertificateParams::new(vec!["localhost".into()]);
+        params
+            .subject_alt_names
+            .push(SanType::IpAddress("127.0.0.1".parse().expect("ip")));
+        let cert = Certificate::from_params(params).expect("failed to build cert");
+
+        let cert_path = dir.join("cert.pem");
+        let key_path = dir.join("key.pem");
+
+        std::fs::write(&cert_path, cert.serialize_pem().expect("serialize cert"))
+            .expect("write cert");
+        std::fs::write(&key_path, cert.serialize_private_key_pem()).expect("write key");
+
+        (cert_path, key_path)
+    }
 
     fn base_config(cert: &str, key: &str) -> Config {
         let mut upstream = HashMap::new();
@@ -834,10 +902,7 @@ mod tests {
     #[test]
     fn yaml_parse_applies_performance_and_observability_defaults() {
         let dir = tempdir().expect("tempdir");
-        let cert = dir.path().join("cert.pem");
-        let key = dir.path().join("key.pem");
-        std::fs::write(&cert, "cert").expect("write cert");
-        std::fs::write(&key, "key").expect("write key");
+        let (cert, key) = write_test_certs(dir.path());
 
         let yaml = format!(
             r#"
@@ -922,10 +987,7 @@ upstream:
     #[test]
     fn rejects_invalid_performance_and_observability_values() {
         let dir = tempdir().expect("tempdir");
-        let cert = dir.path().join("cert.pem");
-        let key = dir.path().join("key.pem");
-        std::fs::write(&cert, "cert").expect("write cert");
-        std::fs::write(&key, "key").expect("write key");
+        let (cert, key) = write_test_certs(dir.path());
 
         let mut cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.performance.worker_threads = 0;
@@ -1140,12 +1202,21 @@ upstream:
     }
 
     #[test]
-    fn accepts_valid_metrics_and_performance_configuration() {
+    fn rejects_unparseable_tls_material() {
         let dir = tempdir().expect("tempdir");
         let cert = dir.path().join("cert.pem");
         let key = dir.path().join("key.pem");
-        std::fs::write(&cert, "cert").expect("write cert");
-        std::fs::write(&key, "key").expect("write key");
+        std::fs::write(&cert, "not-a-pem-cert").expect("write cert");
+        std::fs::write(&key, "not-a-pem-key").expect("write key");
+
+        let cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        assert!(!validate(&cfg));
+    }
+
+    #[test]
+    fn accepts_valid_metrics_and_performance_configuration() {
+        let dir = tempdir().expect("tempdir");
+        let (cert, key) = write_test_certs(dir.path());
 
         let mut cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.performance.worker_threads = 4;
@@ -1205,10 +1276,7 @@ upstream:
     #[test]
     fn backend_address_validation_supports_secure_default_and_explicit_http() {
         let dir = tempdir().expect("tempdir");
-        let cert = dir.path().join("cert.pem");
-        let key = dir.path().join("key.pem");
-        std::fs::write(&cert, "cert").expect("write cert");
-        std::fs::write(&key, "key").expect("write key");
+        let (cert, key) = write_test_certs(dir.path());
 
         // Bare host:port defaults to HTTPS policy.
         let mut cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
@@ -1231,10 +1299,7 @@ upstream:
     #[test]
     fn backend_address_validation_rejects_invalid_urls() {
         let dir = tempdir().expect("tempdir");
-        let cert = dir.path().join("cert.pem");
-        let key = dir.path().join("key.pem");
-        std::fs::write(&cert, "cert").expect("write cert");
-        std::fs::write(&key, "key").expect("write key");
+        let (cert, key) = write_test_certs(dir.path());
 
         let mut cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.upstream

--- a/crates/edge/src/resilience.rs
+++ b/crates/edge/src/resilience.rs
@@ -69,16 +69,27 @@ impl AdaptiveAdmission {
             return;
         }
         let latency_ms = latency.as_millis() as u64;
-        if overloaded || latency_ms >= self.high_latency_ms {
+        let decrease = overloaded || latency_ms >= self.high_latency_ms;
+        loop {
             let cur = self.current_limit.load(Ordering::Relaxed);
-            let next = cur.saturating_sub(self.decrease_step).max(self.min_limit);
-            self.current_limit.store(next, Ordering::Relaxed);
-            return;
-        }
+            let next = if decrease {
+                cur.saturating_sub(self.decrease_step).max(self.min_limit)
+            } else {
+                cur.saturating_add(self.increase_step).min(self.max_limit)
+            };
 
-        let cur = self.current_limit.load(Ordering::Relaxed);
-        let next = cur.saturating_add(self.increase_step).min(self.max_limit);
-        self.current_limit.store(next, Ordering::Relaxed);
+            if next == cur {
+                return;
+            }
+
+            if self
+                .current_limit
+                .compare_exchange_weak(cur, next, Ordering::AcqRel, Ordering::Relaxed)
+                .is_ok()
+            {
+                return;
+            }
+        }
     }
 
     pub fn current_limit(&self) -> usize {

--- a/spooky/src/main.rs
+++ b/spooky/src/main.rs
@@ -32,6 +32,32 @@ struct IngressPacket {
     bytes: Vec<u8>,
 }
 
+#[cfg(unix)]
+async fn wait_for_shutdown_signal() {
+    use tokio::signal::unix::{SignalKind, signal};
+
+    match signal(SignalKind::terminate()) {
+        Ok(mut sigterm) => {
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => {}
+                _ = sigterm.recv() => {}
+            }
+        }
+        Err(err) => {
+            warn!(
+                "Failed to register SIGTERM handler ({}); falling back to Ctrl+C only",
+                err
+            );
+            let _ = tokio::signal::ctrl_c().await;
+        }
+    }
+}
+
+#[cfg(not(unix))]
+async fn wait_for_shutdown_signal() {
+    let _ = tokio::signal::ctrl_c().await;
+}
+
 #[tokio::main]
 async fn main() {
     // Parse CLI arguments
@@ -131,7 +157,7 @@ Use a port >= 1024 for unprivileged startup.",
     let shutdown_flag = shutdown.clone();
 
     tokio::spawn(async move {
-        let _ = tokio::signal::ctrl_c().await;
+        wait_for_shutdown_signal().await;
         shutdown_flag.store(true, Ordering::Relaxed);
     });
 


### PR DESCRIPTION
## Summary
This PR closes three P0 issues in `spooky`:

1. Fixes a lost-update race in adaptive admission limit updates.
2. Adds graceful SIGTERM handling for container/orchestrator shutdown paths.
3. Strengthens TLS config validation from file-exists/readable checks to parseable PEM validation.

## Changes
- `AdaptiveAdmission::observe` now uses a CAS retry loop on `current_limit` to avoid concurrent write clobbering.
- Added shutdown signal helper that listens for both:
  - `Ctrl+C` (`SIGINT`)
  - `SIGTERM` (on Unix)
- Config validation now:
  - Parses `listen.tls.cert` as PEM cert chain
  - Parses `listen.tls.key` as PEM private key
  - Parses `listen.tls.client_auth.ca_file` as PEM certs when enabled
  - Parses `upstream_tls.ca_file` as PEM certs when provided
- Updated validator tests to generate valid test cert/key pairs and added a test that rejects unparseable TLS material.

## Why
- Prevents admission limit drift under concurrency.
- Ensures graceful shutdown behavior in production container environments.
- Fails fast on invalid TLS material during config validation rather than at runtime.

## Impact
- No API changes.
- Runtime behavior is more robust under load and during shutdown.
- Misconfigured TLS files are rejected earlier with clearer validation errors.
