### PR TITLE
fix: harden logging, backend validation, and CI test execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           toolchain: stable
       - name: Run tests
         timeout-minutes: 20
-        run: sudo env "PATH=$PATH" "HOME=$HOME" cargo test
+        run: cargo test
 
   bench-regression:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ brew install cmake pkg-config
 
 Spooky uses YAML configuration with validation at startup. See [configuration reference](docs/configuration/reference.md) for complete documentation.
 
+### Ingress Compatibility Posture
+
+Spooky currently accepts **HTTP/3 over QUIC only** on the ingress listener.
+
+- HTTP/1.1 and HTTP/2 clients are not accepted directly.
+- If legacy client compatibility is required, deploy an external frontend (CDN/LB/reverse proxy) that terminates HTTP/1.1 or HTTP/2 and forwards to a Spooky HTTP/3 ingress.
+
 ### Minimal Example
 
 ```yaml

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -697,6 +697,9 @@ pub fn validate(config: &Config) -> bool {
         return false;
     }
 
+    let mut seen_backend_origins: std::collections::HashMap<String, (String, String)> =
+        std::collections::HashMap::new();
+
     for (upstream_name, upstream) in &config.upstream {
         if upstream_name.is_empty() {
             error!("Upstream name is empty");
@@ -752,6 +755,17 @@ pub fn validate(config: &Config) -> bool {
                     "Backend '{}' in upstream '{}' uses explicit insecure cleartext transport ({})",
                     backend.id, upstream_name, backend.address
                 );
+            }
+
+            let origin = endpoint.origin();
+            if let Some((existing_upstream, existing_backend)) = seen_backend_origins
+                .insert(origin.clone(), (upstream_name.clone(), backend.id.clone()))
+            {
+                error!(
+                    "Duplicate backend address '{}' detected: upstream '{}' backend '{}' conflicts with upstream '{}' backend '{}'",
+                    origin, upstream_name, backend.id, existing_upstream, existing_backend
+                );
+                return false;
             }
 
             // Validate weight
@@ -816,8 +830,9 @@ pub fn validate(config: &Config) -> bool {
 mod tests {
     use super::validate;
     use crate::config::{
-        Backend, ClientAuth, Config, HealthCheck, Listen, LoadBalancing, Log, MetricsEndpoint,
-        LogFormat, Observability, Performance, Resilience, RouteMatch, Tls, Upstream, UpstreamTls,
+        Backend, ClientAuth, Config, HealthCheck, Listen, LoadBalancing, Log, LogFormat,
+        MetricsEndpoint, Observability, Performance, Resilience, RouteMatch, Tls, Upstream,
+        UpstreamTls,
     };
     use rcgen::{Certificate, CertificateParams, SanType};
     use std::collections::HashMap;
@@ -1314,6 +1329,21 @@ upstream:
             .expect("upstream")
             .backends[0]
             .address = "ftp://127.0.0.1:21".to_string();
+        assert!(!validate(&cfg));
+    }
+
+    #[test]
+    fn rejects_duplicate_backend_addresses_across_upstreams() {
+        let dir = tempdir().expect("tempdir");
+        let (cert, key) = write_test_certs(dir.path());
+
+        let mut cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        let mut duplicate = cfg.upstream.get("test_upstream").expect("upstream").clone();
+        duplicate.backends[0].id = "backend-2".to_string();
+        duplicate.route.path_prefix = Some("/v2".to_string());
+        cfg.upstream
+            .insert("test_upstream_2".to_string(), duplicate);
+
         assert!(!validate(&cfg));
     }
 }

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -38,8 +38,8 @@ use tokio::sync::{
 use spooky_config::{backend_endpoint::BackendEndpoint, config::Config as SpookyConfig};
 
 use crate::{
-    ChannelBody, ForwardResult, Metrics, OverloadShedReason, QUICListener,
-    QuicConnection, REQUEST_ID_COUNTER, RequestEnvelope, ResponseChunk, RetryReason, RouteOutcome,
+    ChannelBody, ForwardResult, Metrics, OverloadShedReason, QUICListener, QuicConnection,
+    REQUEST_ID_COUNTER, RequestEnvelope, ResponseChunk, RetryReason, RouteOutcome,
     SharedRuntimeState, StreamPhase, UpstreamResult,
     cid_radix::CidRadix,
     constants::{
@@ -479,12 +479,26 @@ impl QUICListener {
         );
 
         let mut backend_addresses = Vec::new();
+        let mut seen_backend_origins: HashMap<String, (String, String)> = HashMap::new();
         for (upstream_name, upstream) in &config.upstream {
             for backend in &upstream.backends {
-                if let Err(err) = BackendEndpoint::parse(&backend.address) {
+                let endpoint = match BackendEndpoint::parse(&backend.address) {
+                    Ok(endpoint) => endpoint,
+                    Err(err) => {
+                        return Err(ProxyError::Transport(format!(
+                            "invalid backend address '{}' in upstream '{}' (backend '{}'): {}",
+                            backend.address, upstream_name, backend.id, err
+                        )));
+                    }
+                };
+
+                let origin = endpoint.origin();
+                if let Some((existing_upstream, existing_backend)) = seen_backend_origins
+                    .insert(origin.clone(), (upstream_name.clone(), backend.id.clone()))
+                {
                     return Err(ProxyError::Transport(format!(
-                        "invalid backend address '{}' in upstream '{}' (backend '{}'): {}",
-                        backend.address, upstream_name, backend.id, err
+                        "duplicate backend address '{}' detected while building H2 pool: upstream '{}' backend '{}' conflicts with upstream '{}' backend '{}'",
+                        origin, upstream_name, backend.id, existing_upstream, existing_backend
                     )));
                 }
                 backend_addresses.push(backend.address.clone());
@@ -2433,7 +2447,8 @@ impl QUICListener {
                             error!(
                                 "request_id={} HTTP/3 recv_body protocol error on stream {}: {:?}",
                                 rid.map_or_else(|| "-".to_string(), |id| id.to_string()),
-                                stream_id, err
+                                stream_id,
+                                err
                             );
                             if let Some(req) = connection.streams.get(&stream_id) {
                                 metrics.inc_failure();
@@ -2956,7 +2971,10 @@ impl QUICListener {
                                                     p.pool.mark_success(idx)
                                                 }
                                                 crate::HealthClassification::Failure => {
-                                                    p.pool.mark_request_failure(idx, HealthFailureReason::HttpStatus5xx)
+                                                    p.pool.mark_request_failure(
+                                                        idx,
+                                                        HealthFailureReason::HttpStatus5xx,
+                                                    )
                                                 }
                                                 crate::HealthClassification::Neutral => None,
                                             },
@@ -3166,9 +3184,10 @@ impl QUICListener {
                             if let (Some(idx), Some(pool)) = (
                                 req.backend_index,
                                 upstream_name.and_then(|n| upstream_pools.get(n)),
-                            ) && let Some(t) =
-                                pool.lock().ok().and_then(|mut p| p.pool.mark_request_failure(idx, HealthFailureReason::HttpStatus5xx))
-                                && let Some(addr) = &req.backend_addr
+                            ) && let Some(t) = pool.lock().ok().and_then(|mut p| {
+                                p.pool
+                                    .mark_request_failure(idx, HealthFailureReason::HttpStatus5xx)
+                            }) && let Some(addr) = &req.backend_addr
                             {
                                 Self::log_health_transition(addr, t);
                             }
@@ -3491,10 +3510,10 @@ impl QUICListener {
                 error!("Upstream transport error");
                 metrics.inc_health_failure(HealthFailureReason::Transport);
                 if let Some(pool) = &upstream_pool
-                    && let Some(t) = pool
-                        .lock()
-                        .ok()
-                        .and_then(|mut p| p.pool.mark_request_failure(backend_index, HealthFailureReason::Transport))
+                    && let Some(t) = pool.lock().ok().and_then(|mut p| {
+                        p.pool
+                            .mark_request_failure(backend_index, HealthFailureReason::Transport)
+                    })
                 {
                     Self::log_health_transition(backend_addr, t);
                 }
@@ -3528,10 +3547,10 @@ impl QUICListener {
                 error!("request_id={} Upstream request timed out", req.request_id);
                 metrics.inc_health_failure(HealthFailureReason::Timeout);
                 if let Some(pool) = &upstream_pool
-                    && let Some(t) = pool
-                        .lock()
-                        .ok()
-                        .and_then(|mut p| p.pool.mark_request_failure(backend_index, HealthFailureReason::Timeout))
+                    && let Some(t) = pool.lock().ok().and_then(|mut p| {
+                        p.pool
+                            .mark_request_failure(backend_index, HealthFailureReason::Timeout)
+                    })
                 {
                     Self::log_health_transition(backend_addr, t);
                 }
@@ -4121,8 +4140,8 @@ static FALLBACK_RT_THREADS: AtomicUsize = AtomicUsize::new(2);
 mod tests {
     use std::{collections::HashMap, sync::Arc};
 
-    use crate::cid_radix::CidRadix;
     use crate::REQUEST_ID_COUNTER;
+    use crate::cid_radix::CidRadix;
 
     use std::collections::HashSet;
     use std::net::SocketAddr;

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -8,3 +8,4 @@ license.workspace = true
 env_logger.workspace = true
 log.workspace = true
 rustls-pki-types.workspace = true
+serde_json.workspace = true

--- a/crates/utils/src/logger.rs
+++ b/crates/utils/src/logger.rs
@@ -6,6 +6,7 @@ use std::{
 
 use env_logger::{Builder, Target};
 use log::LevelFilter;
+use serde_json::json;
 
 pub fn init_logger(log_level: &str, log_enabled: bool, log_file: &str, json: bool) {
     let level = match log_level.to_lowercase().as_str() {
@@ -37,15 +38,13 @@ pub fn init_logger(log_level: &str, log_enabled: bool, log_file: &str, json: boo
 
     if json {
         builder.format(|buf, record| {
-            let ts = buf.timestamp_seconds();
-            let level = record.level().as_str().to_ascii_lowercase();
-            let msg = record.args().to_string();
-            // Escape the message string minimally so it stays valid JSON.
-            let escaped = msg.replace('\\', "\\\\").replace('"', "\\\"");
-            writeln!(
-                buf,
-                "{{\"ts\":\"{ts}\",\"level\":\"{level}\",\"msg\":\"{escaped}\"}}"
-            )
+            let payload = json!({
+                "ts": buf.timestamp_seconds().to_string(),
+                "level": record.level().as_str().to_ascii_lowercase(),
+                "target": record.target(),
+                "msg": record.args().to_string(),
+            });
+            writeln!(buf, "{payload}")
         });
     } else {
         builder.format_timestamp_secs();

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -105,7 +105,7 @@ The following table lists all default configuration values used when properties 
 | Property | Default Value | Description |
 |----------|---------------|-------------|
 | `version` | `1` | Configuration format version |
-| `listen.protocol` | `"http3"` | Network protocol |
+| `listen.protocol` | `"http3"` | Ingress protocol (HTTP/3 over QUIC only) |
 | `listen.port` | `9889` | Listening port |
 | `listen.address` | `"0.0.0.0"` | Listening address |
 | `listen.tls.cert_file` | Required | TLS certificate file path |
@@ -141,7 +141,7 @@ Configures the listening interface for incoming client connections. HTTP/3 requi
 
 | Property | Type | Required | Default | Description |
 |----------|------|----------|---------|-------------|
-| `protocol` | string | No | `http3` | Protocol to listen on |
+| `protocol` | string | No | `http3` | Protocol to listen on (HTTP/3 over QUIC only) |
 | `address` | string | No | `0.0.0.0` | IP address to bind to |
 | `port` | integer | No | `9889` | Port to bind to |
 | `tls` | object | Yes | - | TLS configuration (required for HTTP/3) |
@@ -149,6 +149,8 @@ Configures the listening interface for incoming client connections. HTTP/3 requi
 ### Protocol Values
 
 - `http3`: HTTP/3 over QUIC (recommended)
+
+HTTP/1.1 and HTTP/2 ingress are not currently supported directly. If those clients must be supported, place an external frontend that terminates legacy protocols and forwards to Spooky over HTTP/3.
 
 ### TLS Configuration
 

--- a/spooky/src/main.rs
+++ b/spooky/src/main.rs
@@ -145,6 +145,10 @@ Use a port >= 1024 for unprivileged startup.",
     };
 
     info!("Spooky is starting");
+    warn!(
+        "Ingress compatibility: Spooky currently accepts HTTP/3/QUIC clients only. \
+Deploy an external HTTP/1.1 or HTTP/2 terminator in front if legacy clients must be supported."
+    );
     info!(
         "Data-plane workers={} packet_shards_per_worker={} reuseport={} pin_workers={}",
         sockets.len(),


### PR DESCRIPTION
## Summary
Closes four P1 infrastructure issues in Spooky:
1. JSON logging now uses proper structured serialization.
2. Ingress compatibility posture is explicitly documented as HTTP/3-only.
3. Duplicate backend addresses are rejected to avoid silent H2 pool overwrites.
4. CI tests no longer run as root.

## Changes
- Replace manual JSON escaping with `serde_json` output in logger.
- Add HTTP/3-only ingress compatibility warning in runtime startup logs.
- Add ingress compatibility guidance in README and configuration reference docs.
- Add duplicate backend address checks in config validator and shared-state build path.
- Update CI test job to run `cargo test` unprivileged.

## Validation
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
Both pass.
