### PR TITLE
docs: update namespace links to Supernova-Labs-Org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ edge and forwards to HTTP/2 backends.
 Requirements: Rust 1.85+, cmake, pkg-config
 
 ```sh
-git clone https://github.com/nishujangra/spooky.git
+git clone https://github.com/Supernova-Labs-Org/spooky.git
 cd spooky
 cargo build
     cargo test

--- a/docs/README.md
+++ b/docs/README.md
@@ -164,4 +164,4 @@ See [Contributing Guide](development/contributing.md) for more details.
 
 ## License
 
-Elastic License 2.0 (ELv2) - see [LICENSE](https://github.com/nishujangra/spooky/blob/master/LICENSE.md) for details.
+Elastic License 2.0 (ELv2) - see [LICENSE](https://github.com/Supernova-Labs-Org/spooky/blob/master/LICENSE.md) for details.

--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -47,7 +47,7 @@ Production deployments should use compiled release binaries:
 # Download release binary
 VERSION="0.1.0"
 ARCH="x86_64"
-wget "https://github.com/nishujangra/spooky/releases/download/v${VERSION}/spooky-linux-${ARCH}.tar.gz"
+wget "https://github.com/Supernova-Labs-Org/spooky/releases/download/v${VERSION}/spooky-linux-${ARCH}.tar.gz"
 tar xzf "spooky-linux-${ARCH}.tar.gz"
 
 # Verify checksum
@@ -302,7 +302,7 @@ openssl x509 -noout -text -in /etc/spooky/certs/fullchain.pem | grep -A1 "Subjec
 # /etc/systemd/system/spooky.service
 [Unit]
 Description=Spooky HTTP/3 to HTTP/2 Proxy
-Documentation=https://github.com/nishujangra/spooky
+Documentation=https://github.com/Supernova-Labs-Org/spooky
 After=network-online.target
 Wants=network-online.target
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -21,18 +21,18 @@
 
 ### Pre-built Binaries
 
-Download the latest release from [GitHub Releases](https://github.com/nishujangra/spooky/releases).
+Download the latest release from [GitHub Releases](https://github.com/Supernova-Labs-Org/spooky/releases).
 
 **Linux (x86_64):**
 ```bash
-wget https://github.com/nishujangra/spooky/releases/download/v0.1.0/spooky-linux-x86_64.tar.gz
+wget https://github.com/Supernova-Labs-Org/spooky/releases/download/v0.1.0/spooky-linux-x86_64.tar.gz
 tar -xzf spooky-linux-x86_64.tar.gz
 sudo install -m 755 spooky /usr/local/bin/spooky
 ```
 
 **macOS (x86_64/ARM64):**
 ```bash
-wget https://github.com/nishujangra/spooky/releases/download/v0.1.0/spooky-macos-universal.tar.gz
+wget https://github.com/Supernova-Labs-Org/spooky/releases/download/v0.1.0/spooky-macos-universal.tar.gz
 tar -xzf spooky-macos-universal.tar.gz
 sudo install -m 755 spooky /usr/local/bin/spooky
 ```
@@ -51,7 +51,7 @@ This compiles from source and installs to `~/.cargo/bin/`. Ensure this directory
 
 **Clone and build:**
 ```bash
-git clone https://github.com/nishujangra/spooky.git
+git clone https://github.com/Supernova-Labs-Org/spooky.git
 cd spooky
 cargo build --release
 ```
@@ -83,7 +83,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source ~/.cargo/env
 
 # Build and install
-git clone https://github.com/nishujangra/spooky.git
+git clone https://github.com/Supernova-Labs-Org/spooky.git
 cd spooky
 cargo build --release
 sudo install -m 755 target/release/spooky /usr/local/bin/spooky
@@ -101,7 +101,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source ~/.cargo/env
 
 # Build and install
-git clone https://github.com/nishujangra/spooky.git
+git clone https://github.com/Supernova-Labs-Org/spooky.git
 cd spooky
 cargo build --release
 sudo install -m 755 target/release/spooky /usr/local/bin/spooky
@@ -114,7 +114,7 @@ sudo install -m 755 target/release/spooky /usr/local/bin/spooky
 brew install cmake pkg-config rust
 
 # Build and install
-git clone https://github.com/nishujangra/spooky.git
+git clone https://github.com/Supernova-Labs-Org/spooky.git
 cd spooky
 cargo build --release
 sudo install -m 755 target/release/spooky /usr/local/bin/spooky
@@ -128,7 +128,7 @@ sudo install -m 755 target/release/spooky /usr/local/bin/spooky
 
 **Build:**
 ```powershell
-git clone https://github.com/nishujangra/spooky.git
+git clone https://github.com/Supernova-Labs-Org/spooky.git
 cd spooky
 cargo build --release
 ```

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -70,7 +70,7 @@ brew install cmake pkg-config
 
 ```bash
 # Clone and build
-git clone https://github.com/nishujangra/spooky.git
+git clone https://github.com/Supernova-Labs-Org/spooky.git
 cd spooky
 cargo build --release
 

--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -14,7 +14,7 @@ This guide demonstrates how to deploy a working Spooky HTTP/3 proxy in under 10 
 Clone the repository and build the release binary:
 
 ```bash
-git clone https://github.com/nishujangra/spooky.git
+git clone https://github.com/Supernova-Labs-Org/spooky.git
 cd spooky
 cargo build --release
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: Spooky
 site_description: HTTP/3 to HTTP/2 reverse proxy and load balancer
-site_url: https://nishujangra.github.io/spooky/
-repo_url: https://github.com/nishujangra/spooky
-repo_name: nishujangra/spooky
+site_url: https://supernova-labs-org.github.io/spooky/
+repo_url: https://github.com/Supernova-Labs-Org/spooky
+repo_name: Supernova-Labs-Org/spooky
 edit_uri: edit/master/docs/
 
 docs_dir: docs
@@ -62,7 +62,7 @@ nav:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/nishujangra/spooky
+      link: https://github.com/Supernova-Labs-Org/spooky
   version:
     provider: mike
 


### PR DESCRIPTION
## Summary
Updates docs and MkDocs metadata to remove personal namespace drift and consistently point to the org namespace.

## Changes
- Replaced `nishujangra/spooky` references with `Supernova-Labs-Org/spooky`.
- Updated MkDocs site/repo metadata and social link.
- Updated clone/release/documentation links in contributor/getting-started/deployment/tutorial docs.

## Validation
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
Both pass.
