### PR TITLE
feat(metrics): complete Prometheus observability — queue-size gauge + full drop counter coverage

### DIFF
--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -121,6 +121,10 @@ impl SharedRuntimeState {
         self.metrics.inc_ingress_queue_drop_bytes(bytes);
     }
 
+    pub fn set_ingress_queue_bytes(&self, bytes: usize) {
+        self.metrics.set_ingress_queue_bytes(bytes);
+    }
+
     pub fn snapshot_backend_health(&self) -> (usize, usize) {
         let mut healthy = 0usize;
         let mut total = 0usize;
@@ -350,6 +354,13 @@ pub struct Metrics {
     pub ingress_packets_total: AtomicU64,
     pub ingress_queue_drops: AtomicU64,
     pub ingress_queue_drop_bytes: AtomicU64,
+    pub ingress_queue_bytes: AtomicU64,
+    pub ingress_bad_header_total: AtomicU64,
+    pub ingress_rate_limited_total: AtomicU64,
+    pub ingress_unroutable_total: AtomicU64,
+    pub ingress_draining_drops_total: AtomicU64,
+    pub ingress_connection_create_failed_total: AtomicU64,
+    pub ingress_version_neg_failed_total: AtomicU64,
     pub request_buffered_bytes: AtomicU64,
     pub request_buffered_high_watermark_bytes: AtomicU64,
     pub request_buffer_limit_rejects: AtomicU64,
@@ -480,6 +491,13 @@ impl Default for Metrics {
             ingress_packets_total: AtomicU64::new(0),
             ingress_queue_drops: AtomicU64::new(0),
             ingress_queue_drop_bytes: AtomicU64::new(0),
+            ingress_queue_bytes: AtomicU64::new(0),
+            ingress_bad_header_total: AtomicU64::new(0),
+            ingress_rate_limited_total: AtomicU64::new(0),
+            ingress_unroutable_total: AtomicU64::new(0),
+            ingress_draining_drops_total: AtomicU64::new(0),
+            ingress_connection_create_failed_total: AtomicU64::new(0),
+            ingress_version_neg_failed_total: AtomicU64::new(0),
             request_buffered_bytes: AtomicU64::new(0),
             request_buffered_high_watermark_bytes: AtomicU64::new(0),
             request_buffer_limit_rejects: AtomicU64::new(0),
@@ -651,6 +669,41 @@ impl Metrics {
         self.ingress_queue_drop_bytes
             .fetch_add(bytes as u64, Ordering::Relaxed);
         self.inc_worker_ingress_queue_drop_bytes(bytes as u64);
+    }
+
+    pub fn set_ingress_queue_bytes(&self, bytes: usize) {
+        self.ingress_queue_bytes
+            .store(bytes as u64, Ordering::Relaxed);
+    }
+
+    pub fn inc_ingress_bad_header(&self) {
+        self.ingress_bad_header_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_ingress_rate_limited(&self) {
+        self.ingress_rate_limited_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_ingress_unroutable(&self) {
+        self.ingress_unroutable_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_ingress_draining_drop(&self) {
+        self.ingress_draining_drops_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_ingress_connection_create_failed(&self) {
+        self.ingress_connection_create_failed_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_ingress_version_neg_failed(&self) {
+        self.ingress_version_neg_failed_total
+            .fetch_add(1, Ordering::Relaxed);
     }
 
     fn with_worker_stats_mut<F>(&self, mut update: F)
@@ -1118,6 +1171,71 @@ impl Metrics {
         ));
 
         out.push_str(
+            "# HELP spooky_ingress_queue_bytes Current bytes buffered in ingress shard queues.\n",
+        );
+        out.push_str("# TYPE spooky_ingress_queue_bytes gauge\n");
+        out.push_str(&format!(
+            "spooky_ingress_queue_bytes {}\n",
+            self.ingress_queue_bytes.load(Ordering::Relaxed)
+        ));
+
+        out.push_str(
+            "# HELP spooky_ingress_bad_header_total Ingress packets dropped due to unparseable QUIC header.\n",
+        );
+        out.push_str("# TYPE spooky_ingress_bad_header_total counter\n");
+        out.push_str(&format!(
+            "spooky_ingress_bad_header_total {}\n",
+            self.ingress_bad_header_total.load(Ordering::Relaxed)
+        ));
+
+        out.push_str(
+            "# HELP spooky_ingress_rate_limited_total Initial packets dropped by the new-connection rate limiter.\n",
+        );
+        out.push_str("# TYPE spooky_ingress_rate_limited_total counter\n");
+        out.push_str(&format!(
+            "spooky_ingress_rate_limited_total {}\n",
+            self.ingress_rate_limited_total.load(Ordering::Relaxed)
+        ));
+
+        out.push_str(
+            "# HELP spooky_ingress_unroutable_total Non-Initial packets received for unknown connections.\n",
+        );
+        out.push_str("# TYPE spooky_ingress_unroutable_total counter\n");
+        out.push_str(&format!(
+            "spooky_ingress_unroutable_total {}\n",
+            self.ingress_unroutable_total.load(Ordering::Relaxed)
+        ));
+
+        out.push_str(
+            "# HELP spooky_ingress_draining_drops_total Packets dropped because the listener is draining.\n",
+        );
+        out.push_str("# TYPE spooky_ingress_draining_drops_total counter\n");
+        out.push_str(&format!(
+            "spooky_ingress_draining_drops_total {}\n",
+            self.ingress_draining_drops_total.load(Ordering::Relaxed)
+        ));
+
+        out.push_str(
+            "# HELP spooky_ingress_connection_create_failed_total Packets dropped because quiche::accept() failed to create a new connection.\n",
+        );
+        out.push_str("# TYPE spooky_ingress_connection_create_failed_total counter\n");
+        out.push_str(&format!(
+            "spooky_ingress_connection_create_failed_total {}\n",
+            self.ingress_connection_create_failed_total
+                .load(Ordering::Relaxed)
+        ));
+
+        out.push_str(
+            "# HELP spooky_ingress_version_neg_failed_total Packets dropped because version negotiation response could not be constructed.\n",
+        );
+        out.push_str("# TYPE spooky_ingress_version_neg_failed_total counter\n");
+        out.push_str(&format!(
+            "spooky_ingress_version_neg_failed_total {}\n",
+            self.ingress_version_neg_failed_total
+                .load(Ordering::Relaxed)
+        ));
+
+        out.push_str(
             "# HELP spooky_request_buffered_bytes Current bytes buffered in request backpressure queues.\n",
         );
         out.push_str("# TYPE spooky_request_buffered_bytes gauge\n");
@@ -1515,6 +1633,35 @@ mod tests {
         assert!(output.contains("spooky_hedge_primary_won_after_trigger_total 1"));
         assert!(output.contains("spooky_hedge_primary_late_ms_total 42"));
         assert!(output.contains("spooky_hedge_primary_late_samples_total 1"));
+        assert!(output.contains("spooky_ingress_queue_bytes 0\n"));
+        assert!(output.contains("spooky_ingress_bad_header_total 0\n"));
+        assert!(output.contains("spooky_ingress_rate_limited_total 0\n"));
+        assert!(output.contains("spooky_ingress_unroutable_total 0\n"));
+        assert!(output.contains("spooky_ingress_draining_drops_total 0\n"));
+        assert!(output.contains("spooky_ingress_connection_create_failed_total 0\n"));
+        assert!(output.contains("spooky_ingress_version_neg_failed_total 0\n"));
+    }
+
+    #[test]
+    fn ingress_drop_counters_increment_correctly() {
+        let metrics = Metrics::default();
+        metrics.inc_ingress_bad_header();
+        metrics.inc_ingress_bad_header();
+        metrics.inc_ingress_rate_limited();
+        metrics.inc_ingress_unroutable();
+        metrics.inc_ingress_unroutable();
+        metrics.inc_ingress_unroutable();
+        metrics.inc_ingress_draining_drop();
+        metrics.inc_ingress_connection_create_failed();
+        metrics.inc_ingress_version_neg_failed();
+        metrics.inc_ingress_version_neg_failed();
+        let output = metrics.render_prometheus();
+        assert!(output.contains("spooky_ingress_bad_header_total 2\n"));
+        assert!(output.contains("spooky_ingress_rate_limited_total 1\n"));
+        assert!(output.contains("spooky_ingress_unroutable_total 3\n"));
+        assert!(output.contains("spooky_ingress_draining_drops_total 1\n"));
+        assert!(output.contains("spooky_ingress_connection_create_failed_total 1\n"));
+        assert!(output.contains("spooky_ingress_version_neg_failed_total 2\n"));
     }
 
     #[test]

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -1014,6 +1014,7 @@ impl QUICListener {
             Ok(hdr) => hdr,
             Err(_) => {
                 error!("Failed to parse QUIC packet header");
+                self.metrics.inc_ingress_bad_header();
                 return None;
             }
         };
@@ -1058,12 +1059,14 @@ impl QUICListener {
         }
 
         if self.draining {
+            self.metrics.inc_ingress_draining_drop();
             return None;
         }
 
         // Only create new connections for Initial packets
         if header.ty != quiche::Type::Initial {
             debug!("Non-Initial packet for unknown connection, ignoring");
+            self.metrics.inc_ingress_unroutable();
             return None;
         }
 
@@ -1080,6 +1083,7 @@ impl QUICListener {
                 "New connection rate limit exceeded, dropping Initial packet from {}",
                 peer
             );
+            self.metrics.inc_ingress_rate_limited();
             return None;
         }
 
@@ -1101,8 +1105,14 @@ impl QUICListener {
 
         let scid = quiche::ConnectionId::from_ref(&scid_bytes);
 
-        let quic_connection =
-            quiche::accept(&scid, None, local_addr, peer, &mut self.quic_config).ok()?;
+        let quic_connection = match quiche::accept(&scid, None, local_addr, peer, &mut self.quic_config) {
+            Ok(conn) => conn,
+            Err(e) => {
+                error!("quiche::accept failed: {:?}", e);
+                self.metrics.inc_ingress_connection_create_failed();
+                return None;
+            }
+        };
 
         let connection = QuicConnection {
             quic: quic_connection,
@@ -1318,6 +1328,7 @@ impl QUICListener {
             Ok(hdr) => hdr,
             Err(_) => {
                 error!("Failed to parse QUIC packet header");
+                self.metrics.inc_ingress_bad_header();
                 return;
             }
         };
@@ -1328,6 +1339,7 @@ impl QUICListener {
                     Ok(len) => len,
                     Err(e) => {
                         error!("Version negotiation failed: {:?}", e);
+                        self.metrics.inc_ingress_version_neg_failed();
                         return;
                     }
                 };

--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -472,17 +472,25 @@ For environments requiring mandatory access control, create appropriate policies
 
 ### Metrics Exposition
 
-**Note**: Metrics exposition is planned for future releases but not currently implemented. Spooky currently maintains internal counters only.
-
-When metrics are implemented, they will follow Prometheus exposition format for easy integration with monitoring systems. Example configuration (for future reference):
+Spooky exposes a Prometheus-compatible metrics endpoint. Configure it in `config.yaml`:
 
 ```yaml
-# prometheus.yml (planned)
+metrics:
+  enabled: true
+  address: "127.0.0.1"
+  port: 9090
+  path: "/metrics"
+```
+
+Scrape it with Prometheus:
+
+```yaml
+# prometheus.yml
 scrape_configs:
   - job_name: 'spooky'
     scrape_interval: 15s
     scrape_timeout: 10s
-    metrics_path: '/metrics'  # To be implemented
+    metrics_path: '/metrics'
     static_configs:
       - targets: ['spooky-01.internal:9090', 'spooky-02.internal:9090']
         labels:
@@ -493,27 +501,40 @@ scrape_configs:
 ### Key Metrics to Monitor
 
 **Throughput Metrics**
-- Requests per second (by route, backend, status code)
-- Bytes transferred (ingress/egress)
-- Active connections (QUIC, HTTP/2)
+- `spooky_requests_total` — total requests processed
+- `spooky_route_requests_total{route="..."}` — per-route request count
+- `spooky_worker_ingress_packets_total{worker="..."}` — UDP packets received per worker
 
 **Latency Metrics**
-- Request duration percentiles (p50, p95, p99)
-- Backend response time
-- Connection establishment time
-- TLS handshake duration
+- `spooky_route_latency_ms_p50/p95/p99{route="..."}` — per-route latency percentiles
 
-**Error Metrics**
-- HTTP 5xx error rate
-- Backend connection failures
-- Health check failure count
-- TLS handshake failures
+**Connection and Queue Gauges**
+- `spooky_active_connections` — current live QUIC connections
+- `spooky_ingress_queue_bytes` — bytes currently buffered in ingress shard queues
+
+**Drop and Error Counters**
+- `spooky_ingress_queue_drops` — packets dropped due to full shard queues
+- `spooky_ingress_queue_drop_bytes` — bytes dropped due to full shard queues
+- `spooky_ingress_bad_header_total` — packets with unparseable QUIC headers
+- `spooky_ingress_rate_limited_total` — Initial packets dropped by the connection rate limiter
+- `spooky_ingress_unroutable_total` — non-Initial packets for unknown connections
+- `spooky_ingress_draining_drops_total` — packets dropped during graceful shutdown
+- `spooky_ingress_connection_create_failed_total` — packets dropped due to QUIC accept failure
+- `spooky_connection_cap_rejects` — packets dropped because the connection cap was reached
+
+**Overload Shed Counters**
+- `spooky_overload_shed_by_reason_total{reason="..."}` — requests shed by the overload system, broken down by reason (`brownout`, `adaptive_admission`, `route_cap`, `route_global_cap`, `global_inflight`, `upstream_inflight`, `backend_inflight`, `request_buffer_cap`, `response_prebuffer_cap`, `connection_cap`)
+- `spooky_route_overload_shed_total{route="..."}` — overload shed per route
+
+**Backend Health Metrics**
+- `spooky_health_checks_total` / `spooky_health_checks_success` / `spooky_health_checks_failure`
+- `spooky_backend_timeouts` / `spooky_backend_errors`
+- `spooky_health_failures_total{reason="..."}` — health failures by reason (`5xx`, `timeout`, `transport`, `tls`)
 
 **Resource Metrics**
-- CPU utilization
-- Memory usage (RSS, heap)
-- File descriptor usage
-- Network buffer utilization
+- `spooky_request_buffered_bytes` — bytes currently buffered in request backpressure queues
+- `spooky_request_buffered_high_watermark_bytes` — peak request buffer usage since start
+- CPU utilization, memory (RSS), file descriptors — use node_exporter alongside Spooky
 
 ### Alerting Rules
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -31,7 +31,7 @@
 
 ### Observability
 
-- **Metrics export**: Prometheus endpoint for scraping metrics
+- **Metrics export**: Prometheus endpoint live — per-route counters, latency percentiles, active-connection and queue-size gauges, full drop counter coverage across all ingress paths
 - **Distributed tracing**: OpenTelemetry integration
 - **Request logging**: Per-request structured logs with correlation IDs
 - **Connection metrics**: Track QUIC RTT, packet loss, stream count
@@ -141,16 +141,15 @@
 ### High Priority (Next 3 months)
 
 1. Async data plane - unblock main thread
-2. Metrics export - essential for production
-3. Configuration hot reload - reduce operational friction
-4. Streaming bodies - reduce memory usage
-5. TLS peer verification - production security
+2. Configuration hot reload - reduce operational friction
+3. Streaming bodies - reduce memory usage
+4. TLS peer verification - production security
 
 ### Medium Priority (3-6 months)
 
 1. Circuit breakers - improve reliability
 2. Distributed tracing - debugging complex issues
-3. Rate limiting - protect backends
+3. Rate limiting - protect backends 
 4. Health check improvements - reduce contention
 5. Admin API - operational visibility
 
@@ -169,10 +168,9 @@
 1. **Blocking backend calls**: Main thread blocks during HTTP/2 requests
 2. **Full body buffering**: High memory usage for large requests/responses
 3. **Consistent hash rebuilds**: Ring rebuilt on every request
-4. **No metrics export**: Metrics collected but not exposed
-5. **Health check contention**: Shares connection pool with production traffic
-6. **Single-threaded**: QUIC processing limited to one thread
-7. **No TLS verification**: Development-only security posture
+4. **Health check contention**: Shares connection pool with production traffic
+5. **Single-threaded**: QUIC processing limited to one thread
+6. **No TLS verification**: Development-only security posture
 
 ### Refactoring Needs
 
@@ -199,8 +197,8 @@ Contributions are welcome. See [contributing guide](development/contributing.md)
 
 Priority areas for contributions:
 
-1. Metrics export (Prometheus)
-2. Streaming request/response bodies
-3. Configuration hot reload
+1. Streaming request/response bodies
+2. Configuration hot reload
+3. Distributed tracing (OpenTelemetry)
 4. Integration tests
 5. Documentation and examples

--- a/spooky/src/main.rs
+++ b/spooky/src/main.rs
@@ -373,6 +373,11 @@ fn run_sharded_listener_worker(
                 ) {
                     worker_shared.inc_ingress_queue_drop();
                     worker_shared.inc_ingress_queue_drop_bytes(packet_len);
+                    let total: usize = shard_queue_bytes
+                        .iter()
+                        .map(|c| c.load(Ordering::Relaxed))
+                        .sum();
+                    worker_shared.set_ingress_queue_bytes(total);
                     continue;
                 }
                 let packet = IngressPacket {
@@ -381,7 +386,13 @@ fn run_sharded_listener_worker(
                     bytes: recv_buf[..len].to_vec(),
                 };
                 match shard_txs[shard_idx].try_send(packet) {
-                    Ok(()) => {}
+                    Ok(()) => {
+                        let total: usize = shard_queue_bytes
+                            .iter()
+                            .map(|c| c.load(Ordering::Relaxed))
+                            .sum();
+                        worker_shared.set_ingress_queue_bytes(total);
+                    }
                     Err(TrySendError::Full(packet)) => {
                         release_shard_queue_bytes(
                             shard_queue_bytes[shard_idx].as_ref(),
@@ -389,6 +400,11 @@ fn run_sharded_listener_worker(
                         );
                         worker_shared.inc_ingress_queue_drop();
                         worker_shared.inc_ingress_queue_drop_bytes(packet.bytes.len());
+                        let total: usize = shard_queue_bytes
+                            .iter()
+                            .map(|c| c.load(Ordering::Relaxed))
+                            .sum();
+                        worker_shared.set_ingress_queue_bytes(total);
                     }
                     Err(TrySendError::Disconnected(packet)) => {
                         release_shard_queue_bytes(


### PR DESCRIPTION
### Summary

- Adds `spooky_ingress_queue_bytes` gauge tracking live byte fill level of ingress shard queues, updated on all three drop paths (byte-cap rejection, channel-full, and successful send)
- Adds 6 new counters covering every previously silent packet drop path in the ingress pipeline: `ingress_bad_header_total`, `ingress_rate_limited_total`, `ingress_unroutable_total`, `ingress_draining_drops_total`, `ingress_connection_create_failed_total`, `ingress_version_neg_failed_total`
- Converts silent `.ok()?` on `quiche::accept()` to an explicit match that increments the counter before returning `None`
- Updates `docs/deployment/production.md` monitoring section with the live endpoint config, Prometheus scrape config, and full metric reference
- Updates `docs/roadmap.md` to mark metrics export complete, remove it from Technical Debt and High Priority, and update contributing priorities