### PR TITLE
feat(observability): complete resilience metrics and brownout operational docs

### DIFF
--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -213,6 +213,10 @@ pub struct UpstreamResult {
     pub forward: ForwardResult,
     pub hedge: HedgeTelemetry,
     pub retry_count: u8,
+    /// Set when a retry was attempted; the error reason that triggered it.
+    pub retry_attempt_reason: Option<RetryReason>,
+    /// Set when a retry was denied; the first denial reason encountered.
+    pub retry_denial_reason: Option<RetryReason>,
 }
 
 /// Lifecycle phase of a single HTTP/3 request stream.
@@ -377,6 +381,8 @@ pub struct Metrics {
     pub retry_reason_timeout: AtomicU64,
     pub retry_reason_transport: AtomicU64,
     pub retry_reason_pool: AtomicU64,
+    pub circuit_breaker_rejected_total: AtomicU64,
+    pub brownout_active: AtomicU64,
     pub health_failure_5xx: AtomicU64,
     pub health_failure_timeout: AtomicU64,
     pub health_failure_transport: AtomicU64,
@@ -514,6 +520,8 @@ impl Default for Metrics {
             retry_reason_timeout: AtomicU64::new(0),
             retry_reason_transport: AtomicU64::new(0),
             retry_reason_pool: AtomicU64::new(0),
+            circuit_breaker_rejected_total: AtomicU64::new(0),
+            brownout_active: AtomicU64::new(0),
             health_failure_5xx: AtomicU64::new(0),
             health_failure_timeout: AtomicU64::new(0),
             health_failure_transport: AtomicU64::new(0),
@@ -867,6 +875,16 @@ impl Metrics {
                     .fetch_add(1, Ordering::Relaxed);
             }
         }
+    }
+
+    pub fn inc_circuit_breaker_rejected(&self) {
+        self.circuit_breaker_rejected_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn set_brownout_active(&self, active: bool) {
+        self.brownout_active
+            .store(if active { 1 } else { 0 }, Ordering::Relaxed);
     }
 
     pub fn inc_health_failure(&self, reason: HealthFailureReason) {
@@ -1353,6 +1371,20 @@ impl Metrics {
             self.retry_reason_pool.load(Ordering::Relaxed)
         ));
 
+        out.push_str("# HELP spooky_circuit_breaker_rejected_total Requests rejected by an open circuit breaker.\n");
+        out.push_str("# TYPE spooky_circuit_breaker_rejected_total counter\n");
+        out.push_str(&format!(
+            "spooky_circuit_breaker_rejected_total {}\n",
+            self.circuit_breaker_rejected_total.load(Ordering::Relaxed)
+        ));
+
+        out.push_str("# HELP spooky_brownout_active Whether brownout mode is currently active (1=active, 0=inactive).\n");
+        out.push_str("# TYPE spooky_brownout_active gauge\n");
+        out.push_str(&format!(
+            "spooky_brownout_active {}\n",
+            self.brownout_active.load(Ordering::Relaxed)
+        ));
+
         out.push_str(
             "# HELP spooky_health_failures_total Backend health failures, by failure reason.\n",
         );
@@ -1640,6 +1672,27 @@ mod tests {
         assert!(output.contains("spooky_ingress_draining_drops_total 0\n"));
         assert!(output.contains("spooky_ingress_connection_create_failed_total 0\n"));
         assert!(output.contains("spooky_ingress_version_neg_failed_total 0\n"));
+        assert!(output.contains("spooky_circuit_breaker_rejected_total 0\n"));
+        assert!(output.contains("spooky_brownout_active 0\n"));
+    }
+
+    #[test]
+    fn resilience_metrics_increment_correctly() {
+        let metrics = Metrics::default();
+        metrics.inc_retry(RetryReason::BackendTimeout);
+        metrics.inc_retry(RetryReason::BudgetDenied);
+        metrics.inc_circuit_breaker_rejected();
+        metrics.inc_circuit_breaker_rejected();
+        metrics.set_brownout_active(true);
+        let output = metrics.render_prometheus();
+        assert!(output.contains("spooky_retries_total 2\n"));
+        assert!(output.contains("spooky_retry_attempts_total{reason=\"timeout\"} 1\n"));
+        assert!(output.contains("spooky_retry_denied_total{reason=\"budget\"} 1\n"));
+        assert!(output.contains("spooky_circuit_breaker_rejected_total 2\n"));
+        assert!(output.contains("spooky_brownout_active 1\n"));
+        metrics.set_brownout_active(false);
+        let output2 = metrics.render_prometheus();
+        assert!(output2.contains("spooky_brownout_active 0\n"));
     }
 
     #[test]

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -1846,6 +1846,7 @@ impl QUICListener {
                             resilience.brownout.observe_admission_pressure(
                                 resilience.adaptive_admission.inflight_percent(),
                             );
+                            metrics.set_brownout_active(resilience.brownout.is_active());
                             if !resilience.brownout.route_allowed(&upstream_name) {
                                 metrics.inc_failure();
                                 metrics.inc_overload_shed_reason(OverloadShedReason::Brownout);
@@ -2172,6 +2173,8 @@ impl QUICListener {
                             let fut = async move {
                                 let mut hedge_telemetry = crate::HedgeTelemetry::default();
                                 let mut retry_count: u8 = 0;
+                                let mut retry_attempt_reason: Option<RetryReason> = None;
+                                let mut retry_denial_reason: Option<RetryReason> = None;
                                 let result: ForwardResult = async {
                                     retry_budget.mark_primary(&route_name);
 
@@ -2291,11 +2294,20 @@ impl QUICListener {
                                             Ok(response) => response,
                                             Err(primary_err) => {
                                                 let retry_reason = classify_retry_reason(&primary_err);
+                                                let is_retryable_err = is_retryable(&primary_err);
+                                                let budget_ok = retry_budget.allow_retry(&route_name).is_ok();
                                                 let can_retry = bodyless_mode
-                                                    && is_retryable(&primary_err)
-                                                    && retry_budget.allow_retry(&route_name).is_ok()
+                                                    && is_retryable_err
+                                                    && budget_ok
                                                     && alternate_backend.is_some();
                                                 if !can_retry {
+                                                    if !bodyless_mode {
+                                                        retry_denial_reason = Some(RetryReason::NotBodylessMode);
+                                                    } else if !is_retryable_err || !budget_ok {
+                                                        retry_denial_reason = Some(RetryReason::BudgetDenied);
+                                                    } else {
+                                                        retry_denial_reason = Some(RetryReason::NoAlternateBackend);
+                                                    }
                                                     return Err(primary_err);
                                                 } else if let Some((retry_backend, _)) =
                                                         alternate_backend.clone()
@@ -2317,6 +2329,7 @@ impl QUICListener {
                                                     )
                                                 {
                                                     retry_count = retry_count.saturating_add(1);
+                                                    retry_attempt_reason = Some(retry_reason);
                                                     info!(
                                                         "request_id={} retrying request on alternate backend: route={} reason={:?}",
                                                         request_id, route_name, retry_reason
@@ -2344,6 +2357,8 @@ impl QUICListener {
                                     forward: result,
                                     hedge: hedge_telemetry,
                                     retry_count,
+                                    retry_attempt_reason,
+                                    retry_denial_reason,
                                 });
                             };
                             let spawned = match trace_span_for_upstream {
@@ -2814,6 +2829,8 @@ impl QUICListener {
                             )),
                             hedge: crate::HedgeTelemetry::default(),
                             retry_count: 0,
+                            retry_attempt_reason: None,
+                            retry_denial_reason: None,
                         }),
                     })
             } else {
@@ -2835,6 +2852,12 @@ impl QUICListener {
                 }
                 if forward_result.hedge.primary_late_ms > 0 {
                     metrics.observe_hedge_primary_late_ms(forward_result.hedge.primary_late_ms);
+                }
+                if let Some(reason) = forward_result.retry_attempt_reason {
+                    metrics.inc_retry(reason);
+                }
+                if let Some(reason) = forward_result.retry_denial_reason {
+                    metrics.inc_retry(reason);
                 }
 
                 if let Some(req) = streams.get_mut(&stream_id) {
@@ -3671,6 +3694,7 @@ impl QUICListener {
             }
             Err(ProxyError::Pool(PoolError::CircuitOpen(_))) => {
                 metrics.inc_failure();
+                metrics.inc_circuit_breaker_rejected();
                 metrics.inc_overload_shed_reason(OverloadShedReason::BackendInflight);
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::OverloadShed);
                 Self::log_access(req, 503);
@@ -5264,6 +5288,8 @@ mod tests {
             forward: Err(spooky_errors::ProxyError::Transport("test".into())),
             hedge: crate::HedgeTelemetry::default(),
             retry_count: 0,
+            retry_attempt_reason: None,
+            retry_denial_reason: None,
         });
         assert!(
             send_result.is_err(),

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -625,14 +625,55 @@ Fires a speculative second request to an alternate backend when the primary is s
 
 ### brownout
 
-Sheds non-core traffic when the global in-flight percent exceeds a threshold, protecting core routes.
+Brownout is a load-shedding mode that activates when the proxy is near capacity. When active, every incoming request whose upstream pool is **not** in `core_routes` is immediately rejected with `503 Service Unavailable` and a `Retry-After` header. Requests on core routes continue to be processed normally.
+
+**How it works**
+
+1. After each request is routed, Spooky samples the current global in-flight percent (active requests ÷ global limit × 100).
+2. If the sample reaches `trigger_inflight_percent`, brownout activates.
+3. Brownout stays active until the sample falls to or below `recover_inflight_percent`. The gap between the two thresholds is **hysteresis** — it prevents rapid oscillation when load is right at the boundary.
+4. While active, `spooky_brownout_active` gauge is `1` and `spooky_overload_shed_by_reason_total{reason="brownout"}` increments for every shed request.
+
+**Choosing `core_routes`**
+
+`core_routes` is a list of upstream pool names (the `id` field under `upstreams[].pool`). Routes not in this list are shed during brownout.
+
+- If `core_routes` is empty (the default), **all routes** are shed during brownout. This is safe but means brownout effectively becomes a full-stop — no requests get through.
+- List only the routes that must keep working during a partial outage: authentication, payments, health checks. Avoid listing high-volume non-critical routes or you defeat the purpose of shedding.
+- A route shed during brownout receives a `503` with the body `brownout active, non-core route shed` and a `Retry-After` hint. Clients that respect `Retry-After` will back off automatically.
+
+**Interaction with other overload mechanisms**
+
+Brownout runs after routing but before adaptive admission and circuit breakers. The order is:
+
+1. **Brownout** — shed non-core routes immediately (no backend resource consumed)
+2. **Adaptive admission** — dynamically cap total in-flight based on observed latency
+3. **Per-upstream / per-backend inflight limits** — static caps per pool and backend
+4. **Circuit breaker** — stop sending to a specific failing backend
+
+If brownout is active and shedding load, adaptive admission will also begin to recover (inflight drops → limit rises). Once the in-flight percent falls to `recover_inflight_percent`, brownout deactivates and full traffic resumes. Set `recover_inflight_percent` at least 20–30 points below `trigger_inflight_percent` to give the system time to recover before re-admitting full traffic.
+
+**Alerting**
+
+Alert on `spooky_brownout_active == 1` for more than a brief window — sustained brownout means backends are under-provisioned or a downstream dependency is slow:
+
+```yaml
+- alert: SpookyBrownoutActive
+  expr: spooky_brownout_active == 1
+  for: 30s
+  labels:
+    severity: warning
+  annotations:
+    summary: "Spooky brownout active on {{ $labels.instance }}"
+    description: "Non-core routes are being shed. Check backend latency and inflight metrics."
+```
 
 | Property | Type | Required | Default | Description |
 |----------|------|----------|---------|-------------|
 | `enabled` | bool | No | `true` | Enable brownout shedding |
 | `trigger_inflight_percent` | integer | No | `90` | Inflight % at which brownout activates (0–100) |
 | `recover_inflight_percent` | integer | No | `60` | Inflight % at which brownout deactivates; must be < `trigger_inflight_percent` |
-| `core_routes` | list | No | `[]` | Upstream pool names exempt from shedding during brownout |
+| `core_routes` | list | No | `[]` | Upstream pool names exempt from shedding; empty means all routes are shed |
 
 ### route_queue
 

--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -526,6 +526,18 @@ scrape_configs:
 - `spooky_overload_shed_by_reason_total{reason="..."}` — requests shed by the overload system, broken down by reason (`brownout`, `adaptive_admission`, `route_cap`, `route_global_cap`, `global_inflight`, `upstream_inflight`, `backend_inflight`, `request_buffer_cap`, `response_prebuffer_cap`, `connection_cap`)
 - `spooky_route_overload_shed_total{route="..."}` — overload shed per route
 
+**Resilience Metrics**
+- `spooky_retries_total` — total retry attempts fired across all routes
+- `spooky_retry_attempts_total{reason="timeout|transport|pool"}` — retries broken down by the error that triggered them
+- `spooky_retry_denied_total{reason="budget|no_bodyless|no_alternate"}` — retry denials broken down by reason: `budget` (retry budget exhausted), `no_bodyless` (request has a body so retry is unsafe), `no_alternate` (no alternate backend available)
+- `spooky_hedge_triggered_total` — hedge requests launched
+- `spooky_hedge_won_total` — times the hedge response was used (primary was slower)
+- `spooky_hedge_wasted_total` — times the hedge response arrived after the primary (wasted work)
+- `spooky_hedge_primary_won_after_trigger_total` — times the primary response arrived after the hedge launched but before it responded
+- `spooky_hedge_primary_late_ms_total` / `spooky_hedge_primary_late_samples_total` — aggregate and sample count for primary latency past the hedge trigger point
+- `spooky_circuit_breaker_rejected_total` — requests rejected because a backend circuit breaker was open
+- `spooky_brownout_active` — gauge; `1` while brownout mode is active (non-core routes are being shed), `0` otherwise
+
 **Backend Health Metrics**
 - `spooky_health_checks_total` / `spooky_health_checks_success` / `spooky_health_checks_failure`
 - `spooky_backend_timeouts` / `spooky_backend_errors`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -32,6 +32,7 @@
 ### Observability
 
 - **Metrics export**: Prometheus endpoint live — per-route counters, latency percentiles, active-connection and queue-size gauges, full drop counter coverage across all ingress paths
+- **Resilience metrics**: Per-feature counters for retries (attempt + denial by reason), hedges (triggered/won/wasted/latency), circuit breaker rejections, and brownout state gauge
 - **Distributed tracing**: OpenTelemetry integration
 - **Request logging**: Per-request structured logs with correlation IDs
 - **Connection metrics**: Track QUIC RTT, packet loss, stream count


### PR DESCRIPTION
## Summary

- **Retry counters wired**: `inc_retry(reason)` was defined but had zero callsites. Retry attempt and denial reasons are now threaded through `UpstreamResult` and emitted at the hedge telemetry consumption site. Each denial path (`NotBodylessMode`, `BudgetDenied`, `NoAlternateBackend`) is tracked individually.
- **Circuit breaker counter added**: `spooky_circuit_breaker_rejected_total` wired into `handle_forward_result` for the `CircuitOpen` error path, which was previously misclassified as `BackendInflight`.
- **Brownout state gauge added**: `spooky_brownout_active` (0/1) set after every `observe_admission_pressure()` call so Prometheus always reflects current state, not just shed event counts.
- **Brownout docs expanded**: `reference.md` now documents the trigger/recover state machine, hysteresis rationale, `core_routes` selection guidance, interaction order with other overload controls, and a ready-to-paste alert rule.

## Metrics added

| Metric | Type | Description |
|---|---|---|
| `spooky_retries_total` | counter | Total retry attempts fired |
| `spooky_retry_attempts_total{reason}` | counter | Retries by triggering error (`timeout`, `transport`, `pool`) |
| `spooky_retry_denied_total{reason}` | counter | Denials by reason (`budget`, `no_bodyless`, `no_alternate`) |
| `spooky_circuit_breaker_rejected_total` | counter | Requests rejected by an open circuit breaker |
| `spooky_brownout_active` | gauge | `1` while brownout is active, `0` otherwise |

## Docs changed

- `docs/configuration/reference.md` — brownout section expanded with mechanism prose, `core_routes` guidance, overload interaction order, and Prometheus alert rule
- `docs/deployment/production.md` — Resilience Metrics block added covering all retry, hedge, circuit breaker, and brownout metrics
- `docs/roadmap.md` — resilience metrics marked complete under Phase 1 Observability