### PR TITLE
docs: reclassify Spooky from experimental to beta and define GA criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,9 +219,9 @@ make load-scenarios
 
 ## Project Status
 
-**Experimental.** Spooky is not production-ready yet. Core features are implemented and continuously hardened, but it should still be treated as pre-GA software.
+**Beta.** Spooky is feature-complete for core HTTP/3 edge proxying and can be used in controlled production rollouts. It remains pre-GA, so operators should follow the deployment hardening guidance and roll out progressively.
 
-See [roadmap](docs/roadmap.md) for known issues and planned improvements.
+See [release maturity](docs/release-maturity.md) for scope and GA exit criteria, and [roadmap](docs/roadmap.md) for planned improvements.
 
 ## Documentation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ Technical documentation for the Spooky HTTP/3 to HTTP/2 reverse proxy and load b
 
 ### Planning
 - [Roadmap](roadmap.md) - Feature roadmap and priorities
+- [Release Maturity](release-maturity.md) - Beta scope and GA exit criteria
 
 ## Documentation Structure
 

--- a/docs/benchmarks/vex.md
+++ b/docs/benchmarks/vex.md
@@ -79,7 +79,7 @@ Latency (ms):
 ## Implications
 
 - **Not production-ready** for concurrent workloads
-- Blocking I/O must be addressed before beta
+- Blocking I/O must be addressed before GA
 - Async backend forwarding is critical for improving throughput
 - Current design suitable only for low-concurrency scenarios (<20 workers)
 

--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -1,6 +1,6 @@
 # Production Deployment
 
-> **Warning:** Spooky is experimental software. It is not production-ready. This guide documents deployment procedures for evaluation and staging environments. Do not use Spooky in production without thoroughly understanding its current limitations (see [Roadmap](../roadmap.md) for known issues).
+> **Warning:** Spooky is beta software. It can be deployed to production only with controlled rollout, strict monitoring, and rollback readiness. Review current limitations and GA exit criteria before broad adoption (see [Release Maturity](../release-maturity.md) and [Roadmap](../roadmap.md)).
 
 This guide covers deployment procedures, system configuration, and operational considerations for Spooky HTTP/3 load balancer deployments.
 

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -136,7 +136,7 @@ curl --http3-only -k \
 
 ## Project Status
 
-**Spooky is experimental.** Core features are implemented and functional, but the project is not production-ready. Expect rough edges, missing features, and breaking changes.
+**Spooky is in beta.** Core features are implemented and functional, and the project is suitable for controlled production rollout. The project is still pre-GA, so expect continued hardening and targeted breaking changes where needed.
 
 Currently working:
 
@@ -145,6 +145,8 @@ Currently working:
 - Multiple load balancing algorithms
 - Active health checking with automatic recovery
 - Path and host-based routing with upstream pools
+
+See [Release Maturity](../release-maturity.md) for beta scope and GA promotion criteria.
 
 ## Next Steps
 

--- a/docs/release-maturity.md
+++ b/docs/release-maturity.md
@@ -1,0 +1,37 @@
+# Release Maturity
+
+## Current Stage
+
+Spooky is currently in **Beta**.
+
+Beta means:
+- Core proxying, routing, load balancing, and health-check features are implemented and actively validated.
+- Controlled production rollout is supported with strict observability, staged traffic, and rollback plans.
+- The project remains pre-GA; operational hardening and long-duration validation are still in progress.
+
+## Environment Guidance
+
+- **Development**: Fully supported.
+- **Staging**: Fully supported.
+- **Production**: Supported for controlled rollout and bounded blast radius deployments.
+
+## Not Yet GA
+
+The following categories remain required for GA promotion:
+- Extended soak validation under sustained production-like load.
+- Broader failure-mode validation and runbook hardening.
+- Continued performance and allocation optimization for high-scale routing paths.
+- Stability window with no critical regressions across release cycles.
+
+## Operator Expectations In Beta
+
+- Roll out gradually (canary or segmented traffic).
+- Enforce SLO-based alerting before increasing traffic share.
+- Keep rollback paths tested and immediately available.
+- Revisit release notes and roadmap on each upgrade.
+
+## Related Docs
+
+- [Roadmap](roadmap.md)
+- [Production Deployment](deployment/production.md)
+- [Troubleshooting](troubleshooting/common-issues.md)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 ## Current Status
 
-**Experimental. Core features functional and tested.** Spooky can terminate HTTP/3 connections, forward to HTTP/2 backends, and perform load balancing with health checks. It is not production-ready — significant known limitations exist (see Technical Debt below).
+**Beta. Core features are functional and tested.** Spooky can terminate HTTP/3 connections, forward to HTTP/2 backends, and perform load balancing with health checks. It is pre-GA and should be deployed with production guardrails (see [Release Maturity](release-maturity.md) and Technical Debt below).
 
 ### Completed
 

--- a/docs/user-guide/basics.md
+++ b/docs/user-guide/basics.md
@@ -416,7 +416,7 @@ spooky --config dev-config.yaml
 
 ### Example Multi-Backend Setup
 
-> **Note:** Spooky is experimental. The configuration below shows how a multi-backend setup would look, but is not a production deployment recommendation.
+> **Note:** Spooky is beta. The configuration below demonstrates structure and routing patterns; use the deployment guide hardening checklist before production rollout.
 
 ```bash
 # Obtain certificates (Let's Encrypt)


### PR DESCRIPTION
## Summary
This PR updates project documentation to reflect Spooky’s current maturity as **Beta** (instead of Experimental), and clarifies how to operate it safely before GA.

## Changes
- Updated status language in top-level and core docs from Experimental → Beta
- Added a new release maturity document with:
  - Beta scope
  - Production rollout expectations
  - GA promotion criteria
- Aligned deployment and user-guide warnings with beta-stage guardrails
- Linked release maturity guidance from README and docs index
- Adjusted benchmark wording from “before beta” to “before GA”

## Files Updated
- `README.md`
- `docs/README.md`
- `docs/roadmap.md`
- `docs/getting-started/overview.md`
- `docs/deployment/production.md`
- `docs/user-guide/basics.md`
- `docs/benchmarks/vex.md`
- `docs/release-maturity.md` (new)

## Notes
- Documentation-only change
- No runtime/code behavior changes