### PR TITLE
docs: rename Spooky positioning from reverse proxy to edge proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0] - 2026-04-16
 
-Initial release of Spooky HTTP/3 to HTTP/2 reverse proxy and load balancer.
+Initial release of Spooky HTTP/3 edge proxy and load balancer.
 
 ### Core Features
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ## Contributing to Spooky
 
-Spooky is an HTTP/3-to-HTTP/2 reverse proxy in Rust. It terminates QUIC at the
+Spooky is an HTTP/3 edge proxy in Rust. It terminates QUIC at the
 edge and forwards to HTTP/2 backends.
 
 ### Setup

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Spooky
 
-**HTTP/3 to HTTP/2 reverse proxy and load balancer**
+**HTTP/3 edge proxy and load balancer**
 
 Spooky terminates HTTP/3/QUIC connections at the edge and forwards requests to HTTP/2 backends. Built in Rust for production environments requiring HTTP/3 client support without modifying existing infrastructure.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Spooky Documentation
 
-Technical documentation for the Spooky HTTP/3 to HTTP/2 reverse proxy and load balancer.
+Technical documentation for the Spooky HTTP/3 edge proxy and load balancer.
 
 ## Quick Navigation
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Spooky is a reverse proxy that terminates HTTP/3/QUIC connections and forwards requests to HTTP/2 backends. The architecture prioritizes correctness, observability, and operational simplicity.
+Spooky is an edge proxy that terminates HTTP/3/QUIC connections and forwards requests to HTTP/2 backends. The architecture prioritizes correctness, observability, and operational simplicity.
 
 ## Design Principles
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-Spooky is an HTTP/3 to HTTP/2 reverse proxy and load balancer implemented in Rust. It terminates QUIC connections at the edge and forwards HTTP requests to HTTP/2 backend servers, enabling modern HTTP/3 clients to communicate with existing HTTP/2 infrastructure without requiring backend modifications.
+Spooky is an HTTP/3 edge proxy and load balancer implemented in Rust. It terminates QUIC connections at the edge and forwards HTTP requests to HTTP/2 backend servers, enabling modern HTTP/3 clients to communicate with existing HTTP/2 infrastructure without requiring backend modifications.
 
 ## Design Principles
 

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -1,6 +1,6 @@
 # Overview
 
-Spooky is an HTTP/3 to HTTP/2 reverse proxy and load balancer. It terminates QUIC connections at the edge and forwards requests to HTTP/2 backends, enabling HTTP/3 client support without modifying existing infrastructure.
+Spooky is an HTTP/3 edge proxy and load balancer. It terminates QUIC connections at the edge and forwards requests to HTTP/2 backends, enabling HTTP/3 client support without modifying existing infrastructure.
 
 ## What Spooky Does
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Spooky
-site_description: HTTP/3 to HTTP/2 reverse proxy and load balancer
+site_description: HTTP/3 edge proxy and load balancer
 site_url: https://supernova-labs-org.github.io/spooky/
 repo_url: https://github.com/Supernova-Labs-Org/spooky
 repo_name: Supernova-Labs-Org/spooky


### PR DESCRIPTION
## Summary
This PR updates documentation and site metadata to consistently describe Spooky as an **HTTP/3 edge proxy and load balancer** rather than a reverse proxy.

## What Changed
- Reworded Spooky self-description to “edge proxy” across core docs and metadata:
  - `README.md`
  - `CONTRIBUTING.md`
  - `docs/README.md`
  - `docs/architecture.md`
  - `docs/architecture/overview.md`
  - `docs/getting-started/overview.md`
  - `mkdocs.yml`
  - `CHANGELOG.md`
- Kept one intentional reference to “reverse proxy” in `README.md` where it refers to an **external** frontend component (not Spooky itself).

## Why
- Aligns product positioning with actual deployment role at the edge.
- Reduces messaging confusion when comparing with generalized reverse proxies.
- Keeps architecture language consistent across docs and docs site metadata.

## Scope
- Documentation/metadata only.
- No code or behavior changes.