### PR TITLE
perf(runtime): reduce admission-path overhead and harden control-plane startup

### DIFF
--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -104,6 +104,7 @@ performance:
 observability:
     metrics:
         enabled: true
+        required: false          # set true to fail fast when metrics endpoint cannot start
         address: "127.0.0.1"
         port: 9901
         path: "/metrics"
@@ -111,6 +112,7 @@ observability:
         connection_timeout_ms: 30000
     control_api:
         enabled: true
+        required: false          # set true to fail fast when control API endpoint cannot start
         address: "127.0.0.1"
         port: 9902
         health_path: "/health"

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -768,6 +768,10 @@ pub struct MetricsEndpoint {
     #[serde(default)]
     pub enabled: bool,
 
+    /// When true, startup fails if metrics endpoint cannot be bound/registered.
+    #[serde(default)]
+    pub required: bool,
+
     #[serde(default = "observe_default_address")]
     pub address: String,
 
@@ -788,6 +792,7 @@ impl Default for MetricsEndpoint {
     fn default() -> Self {
         Self {
             enabled: false,
+            required: false,
             address: observe_default_address(),
             port: observe_default_port(),
             path: observe_default_metrics_path(),
@@ -802,6 +807,10 @@ impl Default for MetricsEndpoint {
 pub struct ControlApi {
     #[serde(default)]
     pub enabled: bool,
+
+    /// When true, startup fails if control API endpoint cannot be bound/registered.
+    #[serde(default)]
+    pub required: bool,
 
     #[serde(default = "observe_default_control_api_address")]
     pub address: String,
@@ -835,6 +844,7 @@ impl Default for ControlApi {
     fn default() -> Self {
         Self {
             enabled: false,
+            required: false,
             address: observe_default_control_api_address(),
             port: observe_default_control_api_port(),
             health_path: observe_default_control_api_health_path(),

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -1427,6 +1427,7 @@ upstream:
         cfg.observability = Observability {
             metrics: MetricsEndpoint {
                 enabled: true,
+                required: false,
                 address: "127.0.0.1".to_string(),
                 port: 9901,
                 path: "metrics".to_string(),
@@ -1531,6 +1532,7 @@ upstream:
         cfg.observability = Observability {
             metrics: MetricsEndpoint {
                 enabled: true,
+                required: false,
                 address: "127.0.0.1".to_string(),
                 port: 9901,
                 path: "/metrics".to_string(),

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -136,7 +136,7 @@ impl SharedRuntimeState {
             };
             let pool_total = guard.pool.len();
             total = total.saturating_add(pool_total);
-            healthy = healthy.saturating_add(guard.pool.healthy_indices().len().min(pool_total));
+            healthy = healthy.saturating_add(guard.pool.healthy_len().min(pool_total));
         }
 
         (healthy, total)
@@ -926,7 +926,11 @@ impl Metrics {
             Err(_) => return,
         };
 
-        let entry = guard.entry(route.to_string()).or_default();
+        let entry = if let Some(entry) = guard.get_mut(route) {
+            entry
+        } else {
+            guard.entry(route.to_owned()).or_default()
+        };
         entry.requests_total = entry.requests_total.saturating_add(1);
 
         match outcome {

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -155,7 +155,7 @@ impl ControlApiState {
             };
             let pool_total = guard.pool.len();
             total = total.saturating_add(pool_total);
-            healthy = healthy.saturating_add(guard.pool.healthy_indices().len().min(pool_total));
+            healthy = healthy.saturating_add(guard.pool.healthy_len().min(pool_total));
         }
         (healthy, total)
     }
@@ -545,7 +545,7 @@ pub(crate) fn abort_stream(req: &mut RequestEnvelope, metrics: &Metrics) -> Stre
 impl QUICListener {
     pub fn new(config: SpookyConfig) -> Result<Self, ProxyError> {
         let shared_state = Arc::new(Self::build_shared_state(&config)?);
-        Self::spawn_control_plane_tasks(&config, &shared_state, 1);
+        Self::spawn_control_plane_tasks(&config, &shared_state, 1)?;
         let socket = Self::bind_socket(&config, false)?;
         Self::new_with_socket_and_shared_state(config, socket, shared_state)
     }
@@ -671,7 +671,7 @@ impl QUICListener {
         config: &SpookyConfig,
         shared_state: &SharedRuntimeState,
         worker_count: usize,
-    ) {
+    ) -> Result<(), ProxyError> {
         shared_state
             .watchdog
             .set_expected_workers(worker_count.max(1));
@@ -683,8 +683,9 @@ impl QUICListener {
         ) {
             Ok(client) => Arc::new(client),
             Err(err) => {
-                error!("failed to initialize control-plane H2 client: {}", err);
-                return;
+                return Err(ProxyError::Transport(format!(
+                    "failed to initialize control-plane H2 client: {err}"
+                )));
             }
         };
         Self::spawn_health_checks(
@@ -692,14 +693,15 @@ impl QUICListener {
             health_client,
             Arc::clone(&shared_state.metrics),
         );
-        Self::spawn_metrics_endpoint(config, Arc::clone(&shared_state.metrics));
-        Self::spawn_control_api_endpoint(config, shared_state, worker_count);
+        Self::spawn_metrics_endpoint(config, Arc::clone(&shared_state.metrics))?;
+        Self::spawn_control_api_endpoint(config, shared_state, worker_count)?;
         Self::spawn_watchdog(
             config,
             Arc::clone(&shared_state.metrics),
             Arc::clone(&shared_state.resilience),
             Arc::clone(&shared_state.watchdog),
         );
+        Ok(())
     }
 
     pub fn bind_reuseport_sockets(
@@ -2070,55 +2072,6 @@ impl QUICListener {
                                         continue;
                                     }
                                 };
-
-                            match h2_pool.has_capacity(&addr) {
-                                Ok(true) => {}
-                                Ok(false) => {
-                                    drop(upstream_permit);
-                                    drop(global_permit);
-                                    metrics.inc_failure();
-                                    metrics.inc_overload_shed_reason(
-                                        OverloadShedReason::BackendInflight,
-                                    );
-                                    metrics.record_route(
-                                        &upstream_name,
-                                        request_start.elapsed(),
-                                        RouteOutcome::OverloadShed,
-                                    );
-                                    Self::send_overload_response(
-                                        h3,
-                                        &mut connection.quic,
-                                        stream_id,
-                                        b"backend overloaded, retry later\n",
-                                        resilience.shed_retry_after_seconds,
-                                    )?;
-                                    resilience
-                                        .adaptive_admission
-                                        .observe(request_start.elapsed(), true);
-                                    continue;
-                                }
-                                Err(_) => {
-                                    drop(upstream_permit);
-                                    drop(global_permit);
-                                    metrics.inc_failure();
-                                    metrics.record_route(
-                                        &upstream_name,
-                                        request_start.elapsed(),
-                                        RouteOutcome::Failure,
-                                    );
-                                    Self::send_simple_response(
-                                        h3,
-                                        &mut connection.quic,
-                                        stream_id,
-                                        http::StatusCode::SERVICE_UNAVAILABLE,
-                                        b"no upstream available\n",
-                                    )?;
-                                    resilience
-                                        .adaptive_admission
-                                        .observe(request_start.elapsed(), true);
-                                    continue;
-                                }
-                            }
 
                             let request_id = REQUEST_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
                             let incoming_traceparent = extract_header_value(&list, b"traceparent")
@@ -3561,7 +3514,7 @@ impl QUICListener {
             let idx = pool.pick(key);
             let idx = idx.ok_or_else(|| {
                 let total = pool.pool.len();
-                let healthy = pool.pool.healthy_indices().len();
+                let healthy = pool.pool.healthy_len();
                 error!(
                     "no healthy backends available: {}/{} backends healthy",
                     healthy, total
@@ -3602,8 +3555,7 @@ impl QUICListener {
         primary_index: usize,
     ) -> Option<(String, usize)> {
         let pool = upstream_pool.lock().ok()?;
-        let healthy = pool.pool.healthy_indices();
-        for index in healthy {
+        for index in pool.pool.healthy_indices_iter() {
             if index == primary_index {
                 continue;
             }
@@ -3981,11 +3933,15 @@ impl QUICListener {
         }
     }
 
-    fn spawn_metrics_endpoint(config: &SpookyConfig, metrics: Arc<Metrics>) {
+    fn spawn_metrics_endpoint(
+        config: &SpookyConfig,
+        metrics: Arc<Metrics>,
+    ) -> Result<(), ProxyError> {
         let endpoint = &config.observability.metrics;
         if !endpoint.enabled {
-            return;
+            return Ok(());
         }
+        let required = endpoint.required;
 
         let bind = format!("{}:{}", endpoint.address, endpoint.port);
         let metrics_path = endpoint.path.clone();
@@ -3995,8 +3951,12 @@ impl QUICListener {
         let handle = match runtime_handle() {
             Some(handle) => handle,
             None => {
-                error!("Metrics endpoint disabled (no Tokio runtime available)");
-                return;
+                let msg = "metrics endpoint disabled (no Tokio runtime available)".to_string();
+                if required {
+                    return Err(ProxyError::Transport(msg));
+                }
+                error!("{}", msg);
+                return Ok(());
             }
         };
 
@@ -4004,25 +3964,37 @@ impl QUICListener {
         let std_listener = match std::net::TcpListener::bind(&bind) {
             Ok(listener) => listener,
             Err(err) => {
-                error!("Failed to bind metrics endpoint {}: {}", bind, err);
-                return;
+                let msg = format!("failed to bind metrics endpoint {bind}: {err}");
+                if required {
+                    return Err(ProxyError::Transport(msg));
+                }
+                error!("{}", msg);
+                return Ok(());
             }
         };
         if let Err(err) = std_listener.set_nonblocking(true) {
-            error!(
-                "Failed to set metrics endpoint listener nonblocking ({}): {}",
+            let msg = format!(
+                "failed to set metrics endpoint listener nonblocking ({}): {}",
                 bind, err
             );
-            return;
+            if required {
+                return Err(ProxyError::Transport(msg));
+            }
+            error!("{}", msg);
+            return Ok(());
         }
         let listener = match tokio::net::TcpListener::from_std(std_listener) {
             Ok(listener) => listener,
             Err(err) => {
-                error!(
-                    "Failed to register metrics endpoint listener {}: {}",
+                let msg = format!(
+                    "failed to register metrics endpoint listener {}: {}",
                     bind, err
                 );
-                return;
+                if required {
+                    return Err(ProxyError::Transport(msg));
+                }
+                error!("{}", msg);
+                return Ok(());
             }
         };
 
@@ -4089,6 +4061,7 @@ impl QUICListener {
                 }
             },
         );
+        Ok(())
     }
 
     fn handle_metrics_request(
@@ -4121,11 +4094,12 @@ impl QUICListener {
         config: &SpookyConfig,
         shared_state: &SharedRuntimeState,
         worker_count: usize,
-    ) {
+    ) -> Result<(), ProxyError> {
         let endpoint = &config.observability.control_api;
         if !endpoint.enabled {
-            return;
+            return Ok(());
         }
+        let required = endpoint.required;
 
         let bind = format!("{}:{}", endpoint.address, endpoint.port);
         let max_connections = endpoint.max_connections.max(1);
@@ -4149,33 +4123,49 @@ impl QUICListener {
         let handle = match runtime_handle() {
             Some(handle) => handle,
             None => {
-                error!("Control API disabled (no Tokio runtime available)");
-                return;
+                let msg = "control API disabled (no Tokio runtime available)".to_string();
+                if required {
+                    return Err(ProxyError::Transport(msg));
+                }
+                error!("{}", msg);
+                return Ok(());
             }
         };
 
         let std_listener = match std::net::TcpListener::bind(&bind) {
             Ok(listener) => listener,
             Err(err) => {
-                error!("Failed to bind control API endpoint {}: {}", bind, err);
-                return;
+                let msg = format!("failed to bind control API endpoint {bind}: {err}");
+                if required {
+                    return Err(ProxyError::Transport(msg));
+                }
+                error!("{}", msg);
+                return Ok(());
             }
         };
         if let Err(err) = std_listener.set_nonblocking(true) {
-            error!(
-                "Failed to set control API endpoint listener nonblocking ({}): {}",
+            let msg = format!(
+                "failed to set control API endpoint listener nonblocking ({}): {}",
                 bind, err
             );
-            return;
+            if required {
+                return Err(ProxyError::Transport(msg));
+            }
+            error!("{}", msg);
+            return Ok(());
         }
         let listener = match tokio::net::TcpListener::from_std(std_listener) {
             Ok(listener) => listener,
             Err(err) => {
-                error!(
-                    "Failed to register control API endpoint listener {}: {}",
+                let msg = format!(
+                    "failed to register control API endpoint listener {}: {}",
                     bind, err
                 );
-                return;
+                if required {
+                    return Err(ProxyError::Transport(msg));
+                }
+                error!("{}", msg);
+                return Ok(());
             }
         };
 
@@ -4241,6 +4231,7 @@ impl QUICListener {
                 }
             },
         );
+        Ok(())
     }
 
     fn json_response(status: StatusCode, value: serde_json::Value) -> Response<Full<Bytes>> {
@@ -4623,7 +4614,7 @@ impl QUICListener {
                 "health-check",
                 Some(supervise_metrics),
                 async move {
-                    let interval = Duration::from_millis(health.interval.max(1));
+                    let base_interval_ms = health.interval.max(1);
                     let timeout = Duration::from_millis(health.timeout_ms.max(1));
                     let path: &str = if health.path.is_empty() {
                         "/"
@@ -4641,9 +4632,20 @@ impl QUICListener {
                         }
                     };
                     let health_uri = endpoint.uri_for_path(path);
+                    let initial_jitter_ms = if base_interval_ms > 1 {
+                        crate::stable_hash64(address.as_bytes()) % base_interval_ms
+                    } else {
+                        0
+                    };
+                    if initial_jitter_ms > 0 {
+                        tokio::time::sleep(Duration::from_millis(initial_jitter_ms)).await;
+                    }
+                    let mut consecutive_failures = 0u32;
 
                     loop {
-                        tokio::time::sleep(interval).await;
+                        let backoff_multiplier = 1u64 << consecutive_failures.min(2);
+                        let sleep_ms = base_interval_ms.saturating_mul(backoff_multiplier);
+                        tokio::time::sleep(Duration::from_millis(sleep_ms)).await;
 
                         let request = match http::Request::builder()
                             .method("GET")
@@ -4668,13 +4670,18 @@ impl QUICListener {
                             Ok(mut pool) => match outcome {
                                 HealthClassification::Success => {
                                     task_metrics.inc_health_check_success();
+                                    consecutive_failures = 0;
                                     pool.pool.mark_success(index)
                                 }
                                 HealthClassification::Failure => {
                                     task_metrics.inc_health_check_failure();
+                                    consecutive_failures = consecutive_failures.saturating_add(1);
                                     pool.pool.mark_failure(index)
                                 }
-                                HealthClassification::Neutral => None,
+                                HealthClassification::Neutral => {
+                                    consecutive_failures = 0;
+                                    None
+                                }
                             },
                             Err(_) => None,
                         };

--- a/crates/lb/src/lib.rs
+++ b/crates/lb/src/lib.rs
@@ -282,6 +282,14 @@ impl BackendPool {
         self.healthy.clone()
     }
 
+    pub fn healthy_len(&self) -> usize {
+        self.healthy.len()
+    }
+
+    pub fn healthy_indices_iter(&self) -> impl Iterator<Item = usize> + '_ {
+        self.healthy.iter().copied()
+    }
+
     pub fn all_indices(&self) -> Vec<usize> {
         (0..self.backends.len()).collect()
     }

--- a/crates/transport/src/h2_pool.rs
+++ b/crates/transport/src/h2_pool.rs
@@ -54,14 +54,6 @@ impl H2Pool {
         self.backends.contains_key(backend)
     }
 
-    pub fn has_capacity(&self, backend: &str) -> Result<bool, PoolError> {
-        let handle = self
-            .backends
-            .get(backend)
-            .ok_or_else(|| PoolError::UnknownBackend(backend.to_string()))?;
-        Ok(handle.inflight.available_permits() > 0)
-    }
-
     pub async fn send(
         &self,
         backend: &str,

--- a/crates/transport/tests/h2_pool.rs
+++ b/crates/transport/tests/h2_pool.rs
@@ -165,7 +165,7 @@ async fn pool_rejects_unknown_backend() {
 }
 
 #[tokio::test]
-async fn pool_capacity_probe_reflects_inflight_state() {
+async fn pool_reports_overload_when_inflight_is_exhausted() {
     let tracker = Arc::new(ConcurrencyTracker::new());
     let port = start_h2_server(tracker).await.unwrap();
     let backend = format!("127.0.0.1:{port}");
@@ -184,9 +184,12 @@ async fn pool_capacity_probe_reflects_inflight_state() {
         .expect("pool"),
     );
 
-    assert!(pool.has_capacity(&backend).unwrap());
-
-    let req = Request::builder()
+    let req1 = Request::builder()
+        .method("GET")
+        .uri(format!("http://{backend}/"))
+        .body(Full::new(Bytes::new()).boxed())
+        .unwrap();
+    let req2 = Request::builder()
         .method("GET")
         .uri(format!("http://{backend}/"))
         .body(Full::new(Bytes::new()).boxed())
@@ -194,10 +197,11 @@ async fn pool_capacity_probe_reflects_inflight_state() {
 
     let pool_task = Arc::clone(&pool);
     let backend_task = backend.clone();
-    let handle = tokio::spawn(async move { pool_task.send(&backend_task, req).await });
-    tokio::time::sleep(Duration::from_millis(10)).await;
+    let handle = tokio::spawn(async move { pool_task.send(&backend_task, req1).await });
 
-    assert!(!pool.has_capacity(&backend).unwrap());
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    let overload = pool.send(&backend, req2).await;
+    assert!(matches!(overload, Err(PoolError::BackendOverloaded(_))));
 
     let _ = handle.await.expect("request task join");
 }

--- a/spooky/src/main.rs
+++ b/spooky/src/main.rs
@@ -66,7 +66,7 @@ async fn main() {
 
     let config_path = cli
         .config
-        .unwrap_or_else(|| "./config/config.yaml".to_string());
+        .unwrap_or_else(|| "./config/config.development.yaml".to_string());
 
     // Read configuration file
     let config_yaml = match spooky_config::loader::read_config(&config_path) {
@@ -131,7 +131,12 @@ Use a port >= 1024 for unprivileged startup.",
         requested_workers
     };
     let effective_worker_count = worker_count.saturating_mul(shard_count);
-    QUICListener::spawn_control_plane_tasks(&config_yaml, &shared_state, effective_worker_count);
+    if let Err(err) =
+        QUICListener::spawn_control_plane_tasks(&config_yaml, &shared_state, effective_worker_count)
+    {
+        error!("Failed to initialize control-plane tasks: {}", err);
+        std::process::exit(1);
+    }
 
     let sockets = if worker_count > 1 {
         match QUICListener::bind_reuseport_sockets(&config_yaml, worker_count) {


### PR DESCRIPTION
## Summary
This PR delivers phase-1 runtime performance and HA hardening for Spooky’s edge data plane and control plane.

## What changed

### 1) Backend admission path correctness and latency
- Removed stale backend capacity pre-check from edge request admission.
- Kept a single authoritative backend inflight admission check inside `H2Pool::send`.
- This removes pre-check/send race behavior and simplifies overload handling.

### 2) Hot-path overhead reductions
- Added lightweight healthy-pool accessors in LB:
  - `healthy_len()`
  - `healthy_indices_iter()`
- Replaced clone-heavy usages in edge runtime:
  - health snapshots no longer clone healthy index vectors just to compute length
  - alternate backend selection iterates directly instead of cloning
- Optimized route metrics updates to avoid unconditional route key allocation when key already exists.

### 3) Health-check scalability/stability
- Added deterministic initial jitter to active health checks.
- Added bounded exponential backoff on consecutive failures.
- Goal: reduce synchronized probe bursts and lower control-plane contention under failure storms.

### 4) HA startup hardening
- Added config flags:
  - `observability.metrics.required`
  - `observability.control_api.required`
- When enabled, startup fails fast if those endpoints cannot initialize.
- Wired control-plane startup to return structured errors and fail startup cleanly when required components fail.

### 5) Operational ergonomics
- Updated default config path in binary startup:
  - from `./config/config.yaml`
  - to `./config/config.development.yaml`
- Documented new `required` endpoint flags in `config.sample.yaml`.

## Validation
Ran CI-equivalent checks locally and all passed:
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --lib --bins -- -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo audit`
- `PROFILE=ci FAIL_ON=severe BENCH_GATE_RETRIES=1 ./scripts/bench-gate.sh`

