### PR TITLE
perf: remove key hot-path lock/allocation overhead in edge request path

### DIFF
--- a/crates/bridge/src/h3_to_h2.rs
+++ b/crates/bridge/src/h3_to_h2.rs
@@ -31,9 +31,28 @@ pub fn build_h2_request(
     content_length: Option<usize>,
     forwarded_ctx: ForwardedContext<'_>,
 ) -> Result<Request<BoxBody<Bytes, Infallible>>, BridgeError> {
-    let method = Method::from_bytes(method.as_bytes()).map_err(|_| BridgeError::InvalidMethod)?;
     let endpoint = BackendEndpoint::parse(backend).map_err(|_| BridgeError::InvalidUri)?;
+    build_h2_request_for_endpoint(
+        &endpoint,
+        method,
+        path,
+        headers,
+        body,
+        content_length,
+        forwarded_ctx,
+    )
+}
 
+pub fn build_h2_request_for_endpoint(
+    endpoint: &BackendEndpoint,
+    method: &str,
+    path: &str,
+    headers: &[quiche::h3::Header],
+    body: BoxBody<Bytes, Infallible>,
+    content_length: Option<usize>,
+    forwarded_ctx: ForwardedContext<'_>,
+) -> Result<Request<BoxBody<Bytes, Infallible>>, BridgeError> {
+    let method = Method::from_bytes(method.as_bytes()).map_err(|_| BridgeError::InvalidMethod)?;
     let request_path = if path.is_empty() { "/" } else { path };
     let uri = endpoint.uri_for_path(request_path);
     let uri = Uri::try_from(uri).map_err(|_| BridgeError::InvalidUri)?;

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -150,6 +150,7 @@ impl SharedRuntimeState {
 
 pub struct QUICListener {
     pub socket: UdpSocket,
+    pub local_addr: SocketAddr,
     pub config: Config,
     pub quic_config: quiche::Config,
     pub h3_config: Arc<quiche::h3::Config>,

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -17,6 +17,7 @@ use std::{
 use core::net::SocketAddr;
 
 use hyper::body::{Body, Frame};
+use spooky_config::backend_endpoint::BackendEndpoint;
 use spooky_config::config::Config;
 use spooky_errors::ProxyError;
 use spooky_lb::UpstreamPool;
@@ -105,6 +106,7 @@ pub use quic_listener::configure_async_runtime;
 
 pub struct SharedRuntimeState {
     pub(crate) h2_pool: Arc<H2Pool>,
+    pub(crate) backend_endpoints: Arc<HashMap<String, BackendEndpoint>>,
     pub(crate) upstream_pools: HashMap<String, Arc<RwLock<UpstreamPool>>>,
     pub(crate) upstream_inflight: HashMap<String, Arc<Semaphore>>,
     pub(crate) global_inflight: Arc<Semaphore>,
@@ -155,6 +157,7 @@ pub struct QUICListener {
     pub quic_config: quiche::Config,
     pub h3_config: Arc<quiche::h3::Config>,
     pub h2_pool: Arc<H2Pool>,
+    pub backend_endpoints: Arc<HashMap<String, BackendEndpoint>>,
     pub upstream_pools: HashMap<String, Arc<RwLock<UpstreamPool>>>,
     pub upstream_inflight: HashMap<String, Arc<Semaphore>>,
     pub global_inflight: Arc<Semaphore>,

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -1,13 +1,13 @@
 use bytes::Bytes;
-use std::thread;
 use std::{
+    cell::Cell,
     collections::{HashMap, HashSet, VecDeque},
     convert::Infallible,
     env,
     net::UdpSocket,
     pin::Pin,
     sync::{
-        Arc, Mutex, RwLock,
+        Arc, RwLock,
         atomic::{AtomicU64, Ordering},
     },
     task::{Context, Poll},
@@ -114,6 +114,10 @@ pub struct SharedRuntimeState {
 }
 
 impl SharedRuntimeState {
+    pub fn bind_metrics_worker_slot(&self, slot: usize) {
+        self.metrics.bind_worker_slot(slot);
+    }
+
     pub fn inc_ingress_queue_drop(&self) {
         self.metrics.inc_ingress_queue_drop();
     }
@@ -399,15 +403,17 @@ pub struct Metrics {
     pub health_failure_tls: AtomicU64,
     route_latency_sample_every: u64,
     route_latency_sample_counter: AtomicU64,
-    route_stats_shards: Vec<Mutex<HashMap<String, RouteStats>>>,
-    worker_stats_shards: Vec<Mutex<HashMap<String, WorkerStats>>>,
+    route_labels: Vec<String>,
+    route_label_to_id: HashMap<String, usize>,
+    route_stats: Vec<RouteStatsAtomic>,
+    unrouted_route_id: usize,
+    worker_labels: Vec<String>,
+    worker_stats: Vec<WorkerStatsAtomic>,
 }
 
 const LATENCY_BUCKETS_MS: [u64; 14] = [
     1, 5, 10, 25, 50, 100, 250, 500, 1_000, 2_000, 5_000, 10_000, 30_000, 60_000,
 ];
-const ROUTE_STATS_SHARDS: usize = 32;
-const WORKER_STATS_SHARDS: usize = 32;
 const ROUTE_LATENCY_SAMPLE_EVERY_ENV: &str = "SPOOKY_ROUTE_LATENCY_SAMPLE_EVERY";
 
 #[derive(Default, Clone)]
@@ -429,6 +435,80 @@ struct WorkerStats {
     ingress_packets_total: u64,
     ingress_queue_drops: u64,
     ingress_queue_drop_bytes: u64,
+}
+
+struct RouteStatsAtomic {
+    requests_total: AtomicU64,
+    success: AtomicU64,
+    failure: AtomicU64,
+    timeout: AtomicU64,
+    backend_error: AtomicU64,
+    overload_shed: AtomicU64,
+    latency_buckets: [AtomicU64; LATENCY_BUCKETS_MS.len() + 1],
+}
+
+impl RouteStatsAtomic {
+    fn new() -> Self {
+        Self {
+            requests_total: AtomicU64::new(0),
+            success: AtomicU64::new(0),
+            failure: AtomicU64::new(0),
+            timeout: AtomicU64::new(0),
+            backend_error: AtomicU64::new(0),
+            overload_shed: AtomicU64::new(0),
+            latency_buckets: std::array::from_fn(|_| AtomicU64::new(0)),
+        }
+    }
+
+    fn snapshot(&self) -> RouteStats {
+        let mut latency_buckets = [0u64; LATENCY_BUCKETS_MS.len() + 1];
+        for (idx, bucket) in self.latency_buckets.iter().enumerate() {
+            latency_buckets[idx] = bucket.load(Ordering::Relaxed);
+        }
+
+        RouteStats {
+            requests_total: self.requests_total.load(Ordering::Relaxed),
+            success: self.success.load(Ordering::Relaxed),
+            failure: self.failure.load(Ordering::Relaxed),
+            timeout: self.timeout.load(Ordering::Relaxed),
+            backend_error: self.backend_error.load(Ordering::Relaxed),
+            overload_shed: self.overload_shed.load(Ordering::Relaxed),
+            latency_buckets,
+        }
+    }
+}
+
+struct WorkerStatsAtomic {
+    requests_total: AtomicU64,
+    requests_success: AtomicU64,
+    requests_failure: AtomicU64,
+    ingress_packets_total: AtomicU64,
+    ingress_queue_drops: AtomicU64,
+    ingress_queue_drop_bytes: AtomicU64,
+}
+
+impl WorkerStatsAtomic {
+    fn new() -> Self {
+        Self {
+            requests_total: AtomicU64::new(0),
+            requests_success: AtomicU64::new(0),
+            requests_failure: AtomicU64::new(0),
+            ingress_packets_total: AtomicU64::new(0),
+            ingress_queue_drops: AtomicU64::new(0),
+            ingress_queue_drop_bytes: AtomicU64::new(0),
+        }
+    }
+
+    fn snapshot(&self) -> WorkerStats {
+        WorkerStats {
+            requests_total: self.requests_total.load(Ordering::Relaxed),
+            requests_success: self.requests_success.load(Ordering::Relaxed),
+            requests_failure: self.requests_failure.load(Ordering::Relaxed),
+            ingress_packets_total: self.ingress_packets_total.load(Ordering::Relaxed),
+            ingress_queue_drops: self.ingress_queue_drops.load(Ordering::Relaxed),
+            ingress_queue_drop_bytes: self.ingress_queue_drop_bytes.load(Ordering::Relaxed),
+        }
+    }
 }
 
 pub enum RouteOutcome {
@@ -467,20 +547,55 @@ pub use spooky_lb::HealthFailureReason;
 
 impl Default for Metrics {
     fn default() -> Self {
+        Self::new(1, [String::from("unrouted")])
+    }
+}
+
+thread_local! {
+    static WORKER_METRICS_SLOT: Cell<usize> = const { Cell::new(0) };
+}
+
+impl Metrics {
+    pub fn new<I>(worker_slots: usize, route_labels: I) -> Self
+    where
+        I: IntoIterator<Item = String>,
+    {
         let route_latency_sample_every = env::var(ROUTE_LATENCY_SAMPLE_EVERY_ENV)
             .ok()
             .and_then(|raw| raw.trim().parse::<u64>().ok())
             .filter(|value| *value > 0)
             .unwrap_or(1);
 
-        let mut shards = Vec::with_capacity(ROUTE_STATS_SHARDS);
-        for _ in 0..ROUTE_STATS_SHARDS {
-            shards.push(Mutex::new(HashMap::new()));
+        let mut route_labels_dedup = Vec::new();
+        let mut route_label_to_id = HashMap::new();
+        for raw in route_labels {
+            let label = raw.trim();
+            if label.is_empty() || route_label_to_id.contains_key(label) {
+                continue;
+            }
+            let id = route_labels_dedup.len();
+            route_labels_dedup.push(label.to_string());
+            route_label_to_id.insert(label.to_string(), id);
         }
-        let mut worker_shards = Vec::with_capacity(WORKER_STATS_SHARDS);
-        for _ in 0..WORKER_STATS_SHARDS {
-            worker_shards.push(Mutex::new(HashMap::new()));
+        if !route_label_to_id.contains_key("unrouted") {
+            let id = route_labels_dedup.len();
+            route_labels_dedup.push("unrouted".to_string());
+            route_label_to_id.insert("unrouted".to_string(), id);
         }
+        let unrouted_route_id = route_label_to_id.get("unrouted").copied().unwrap_or(0);
+
+        let worker_slots = worker_slots.max(1);
+        let worker_labels = (0..worker_slots)
+            .map(|idx| format!("worker-{idx}"))
+            .collect::<Vec<_>>();
+        let worker_stats = (0..worker_slots)
+            .map(|_| WorkerStatsAtomic::new())
+            .collect::<Vec<_>>();
+        let route_stats = route_labels_dedup
+            .iter()
+            .map(|_| RouteStatsAtomic::new())
+            .collect::<Vec<_>>();
+
         Self {
             requests_total: AtomicU64::new(0),
             requests_success: AtomicU64::new(0),
@@ -547,13 +662,20 @@ impl Default for Metrics {
             health_failure_tls: AtomicU64::new(0),
             route_latency_sample_every,
             route_latency_sample_counter: AtomicU64::new(0),
-            route_stats_shards: shards,
-            worker_stats_shards: worker_shards,
+            route_labels: route_labels_dedup,
+            route_label_to_id,
+            route_stats,
+            unrouted_route_id,
+            worker_labels,
+            worker_stats,
         }
     }
-}
 
-impl Metrics {
+    pub fn bind_worker_slot(&self, slot: usize) {
+        let max_index = self.worker_stats.len().saturating_sub(1);
+        WORKER_METRICS_SLOT.with(|current| current.set(slot.min(max_index)));
+    }
+
     pub fn inc_total(&self) {
         self.requests_total.fetch_add(1, Ordering::Relaxed);
         self.inc_worker_requests_total();
@@ -735,56 +857,47 @@ impl Metrics {
             .fetch_add(1, Ordering::Relaxed);
     }
 
-    fn with_worker_stats_mut<F>(&self, mut update: F)
-    where
-        F: FnMut(&mut WorkerStats),
-    {
-        let worker = current_worker_label();
-        let shard_idx = worker_stats_shard(&worker);
-        let Some(shard) = self.worker_stats_shards.get(shard_idx) else {
-            return;
-        };
-        let Ok(mut guard) = shard.lock() else {
-            return;
-        };
-        let entry = guard.entry(worker).or_default();
-        update(entry);
+    fn current_worker_stats(&self) -> Option<&WorkerStatsAtomic> {
+        let idx = WORKER_METRICS_SLOT.with(|current| current.get());
+        self.worker_stats
+            .get(idx)
+            .or_else(|| self.worker_stats.first())
     }
 
     fn inc_worker_requests_total(&self) {
-        self.with_worker_stats_mut(|entry| {
-            entry.requests_total = entry.requests_total.saturating_add(1);
-        });
+        if let Some(stats) = self.current_worker_stats() {
+            stats.requests_total.fetch_add(1, Ordering::Relaxed);
+        }
     }
 
     fn inc_worker_requests_success(&self) {
-        self.with_worker_stats_mut(|entry| {
-            entry.requests_success = entry.requests_success.saturating_add(1);
-        });
+        if let Some(stats) = self.current_worker_stats() {
+            stats.requests_success.fetch_add(1, Ordering::Relaxed);
+        }
     }
 
     fn inc_worker_requests_failure(&self) {
-        self.with_worker_stats_mut(|entry| {
-            entry.requests_failure = entry.requests_failure.saturating_add(1);
-        });
+        if let Some(stats) = self.current_worker_stats() {
+            stats.requests_failure.fetch_add(1, Ordering::Relaxed);
+        }
     }
 
     fn inc_worker_ingress_packets_total(&self) {
-        self.with_worker_stats_mut(|entry| {
-            entry.ingress_packets_total = entry.ingress_packets_total.saturating_add(1);
-        });
+        if let Some(stats) = self.current_worker_stats() {
+            stats.ingress_packets_total.fetch_add(1, Ordering::Relaxed);
+        }
     }
 
     fn inc_worker_ingress_queue_drops(&self) {
-        self.with_worker_stats_mut(|entry| {
-            entry.ingress_queue_drops = entry.ingress_queue_drops.saturating_add(1);
-        });
+        if let Some(stats) = self.current_worker_stats() {
+            stats.ingress_queue_drops.fetch_add(1, Ordering::Relaxed);
+        }
     }
 
     fn inc_worker_ingress_queue_drop_bytes(&self, bytes: u64) {
-        self.with_worker_stats_mut(|entry| {
-            entry.ingress_queue_drop_bytes = entry.ingress_queue_drop_bytes.saturating_add(bytes);
-        });
+        if let Some(stats) = self.current_worker_stats() {
+            stats.ingress_queue_drop_bytes.fetch_add(bytes, Ordering::Relaxed);
+        }
     }
 
     pub fn try_reserve_request_buffer(&self, bytes: usize, cap_bytes: usize) -> bool {
@@ -928,38 +1041,31 @@ impl Metrics {
     }
 
     pub fn record_route(&self, route: &str, latency: Duration, outcome: RouteOutcome) {
-        let shard_idx = route_stats_shard(route);
-        let shard = match self.route_stats_shards.get(shard_idx) {
-            Some(shard) => shard,
-            None => return,
+        let route_id = self
+            .route_label_to_id
+            .get(route)
+            .copied()
+            .unwrap_or(self.unrouted_route_id);
+        let Some(entry) = self.route_stats.get(route_id) else {
+            return;
         };
-        let mut guard = match shard.lock() {
-            Ok(g) => g,
-            Err(_) => return,
-        };
-
-        let entry = if let Some(entry) = guard.get_mut(route) {
-            entry
-        } else {
-            guard.entry(route.to_owned()).or_default()
-        };
-        entry.requests_total = entry.requests_total.saturating_add(1);
+        entry.requests_total.fetch_add(1, Ordering::Relaxed);
 
         match outcome {
             RouteOutcome::Success => {
-                entry.success = entry.success.saturating_add(1);
+                entry.success.fetch_add(1, Ordering::Relaxed);
             }
             RouteOutcome::Failure => {
-                entry.failure = entry.failure.saturating_add(1);
+                entry.failure.fetch_add(1, Ordering::Relaxed);
             }
             RouteOutcome::Timeout => {
-                entry.timeout = entry.timeout.saturating_add(1);
+                entry.timeout.fetch_add(1, Ordering::Relaxed);
             }
             RouteOutcome::BackendError => {
-                entry.backend_error = entry.backend_error.saturating_add(1);
+                entry.backend_error.fetch_add(1, Ordering::Relaxed);
             }
             RouteOutcome::OverloadShed => {
-                entry.overload_shed = entry.overload_shed.saturating_add(1);
+                entry.overload_shed.fetch_add(1, Ordering::Relaxed);
             }
         }
 
@@ -977,7 +1083,7 @@ impl Metrics {
             .iter()
             .position(|cutoff| latency_ms <= *cutoff)
             .unwrap_or(LATENCY_BUCKETS_MS.len());
-        entry.latency_buckets[bucket] = entry.latency_buckets[bucket].saturating_add(1);
+        entry.latency_buckets[bucket].fetch_add(1, Ordering::Relaxed);
     }
 
     pub fn render_prometheus(&self) -> String {
@@ -1448,16 +1554,16 @@ impl Metrics {
             self.route_latency_sample_every
         ));
 
-        let mut snapshot: Vec<(String, RouteStats)> = Vec::new();
-        for shard in &self.route_stats_shards {
-            if let Ok(route_stats) = shard.lock() {
-                snapshot.extend(
-                    route_stats
-                        .iter()
-                        .map(|(route, stats)| (route.clone(), stats.clone())),
-                );
-            }
-        }
+        let mut snapshot: Vec<(String, RouteStats)> = self
+            .route_labels
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, route)| {
+                self.route_stats
+                    .get(idx)
+                    .map(|stats| (route.clone(), stats.snapshot()))
+            })
+            .collect();
         snapshot.sort_by(|(left, _), (right, _)| left.cmp(right));
 
         for (route, stats) in snapshot {
@@ -1503,16 +1609,16 @@ impl Metrics {
             ));
         }
 
-        let mut worker_snapshot: Vec<(String, WorkerStats)> = Vec::new();
-        for shard in &self.worker_stats_shards {
-            if let Ok(worker_stats) = shard.lock() {
-                worker_snapshot.extend(
-                    worker_stats
-                        .iter()
-                        .map(|(worker, stats)| (worker.clone(), stats.clone())),
-                );
-            }
-        }
+        let mut worker_snapshot: Vec<(String, WorkerStats)> = self
+            .worker_labels
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, worker)| {
+                self.worker_stats
+                    .get(idx)
+                    .map(|stats| (worker.clone(), stats.snapshot()))
+            })
+            .collect();
         worker_snapshot.sort_by(|(left, _), (right, _)| left.cmp(right));
 
         out.push_str(
@@ -1570,21 +1676,6 @@ impl Metrics {
 
         out
     }
-}
-
-fn route_stats_shard(route: &str) -> usize {
-    (stable_hash64(route.as_bytes()) as usize) % ROUTE_STATS_SHARDS
-}
-
-fn worker_stats_shard(worker: &str) -> usize {
-    (stable_hash64(worker.as_bytes()) as usize) % WORKER_STATS_SHARDS
-}
-
-fn current_worker_label() -> String {
-    thread::current()
-        .name()
-        .map(|name| name.to_string())
-        .unwrap_or_else(|| "unknown".to_string())
 }
 
 fn percentile_ms(stats: &RouteStats, quantile: f64) -> f64 {

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -900,7 +900,9 @@ impl Metrics {
 
     fn inc_worker_ingress_queue_drop_bytes(&self, bytes: u64) {
         if let Some(stats) = self.current_worker_stats() {
-            stats.ingress_queue_drop_bytes.fetch_add(bytes, Ordering::Relaxed);
+            stats
+                .ingress_queue_drop_bytes
+                .fetch_add(bytes, Ordering::Relaxed);
         }
     }
 
@@ -1717,7 +1719,7 @@ mod tests {
 
     #[test]
     fn metrics_render_includes_route_percentiles() {
-        let metrics = Metrics::default();
+        let metrics = Metrics::new(1, [String::from("api_pool")]);
         metrics.record_route("api_pool", Duration::from_millis(12), RouteOutcome::Success);
         metrics.record_route(
             "api_pool",
@@ -1739,11 +1741,11 @@ mod tests {
 
     #[test]
     fn metrics_render_collects_routes_from_multiple_shards() {
-        let metrics = Metrics::default();
-        for idx in 0..128 {
-            let route = format!("route-{idx:03}");
+        let routes: Vec<String> = (0..128).map(|idx| format!("route-{idx:03}")).collect();
+        let metrics = Metrics::new(1, routes.clone());
+        for (idx, route) in routes.iter().enumerate().take(128) {
             metrics.record_route(
-                &route,
+                route,
                 Duration::from_millis(5 + idx as u64),
                 RouteOutcome::Success,
             );

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -1125,29 +1125,29 @@ impl QUICListener {
         dcid: &[u8],
         has_token: bool,
     ) -> Option<(QuicConnection, Arc<[u8]>)> {
-        let dcid_bytes: Arc<[u8]> = Arc::from(dcid);
         debug!(
             "Packet DCID (len={}): {:02x?}, type: {:?}, active connections: {}",
-            dcid_bytes.len(),
-            &dcid_bytes,
+            dcid.len(),
+            dcid,
             packet_type,
             self.connections.len()
         );
 
         // Try exact match first
-        if let Some(mut connection) = self.connections.remove(&dcid_bytes) {
-            debug!("Found existing connection for DCID: {:02x?}", &dcid_bytes);
+        if let Some(mut connection) = self.connections.remove(dcid) {
+            debug!("Found existing connection for DCID: {:02x?}", dcid);
+            let primary = Arc::clone(&connection.primary_scid);
             self.peer_routes.remove(&connection.peer_address);
             connection.peer_address = peer;
-            return Some((connection, dcid_bytes));
+            return Some((connection, primary));
         }
 
         // For Short packets, try prefix match (client may append bytes to our SCID)
         // This handles cases where client uses longer DCIDs based on server's SCID
         if packet_type == quiche::Type::Short
-            && dcid_bytes.len() > MIN_SCID_LEN_BYTES
+            && dcid.len() > MIN_SCID_LEN_BYTES
             && let Some(primary_cid) = resolve_primary_from_radix_prefix(
-                &dcid_bytes,
+                dcid,
                 &self.connections,
                 &mut self.cid_routes,
                 &mut self.cid_radix,
@@ -1155,7 +1155,7 @@ impl QUICListener {
         {
             debug!(
                 "Found connection via prefix match. Resolved CID: {:02x?}, Packet DCID: {:02x?}",
-                primary_cid, &dcid_bytes
+                primary_cid, dcid
             );
             if let Some(mut connection) = self.connections.remove(primary_cid.as_ref()) {
                 self.peer_routes.remove(&connection.peer_address);
@@ -1403,7 +1403,12 @@ impl QUICListener {
         };
 
         debug!("Received UDP datagram ({} bytes)", len);
-        self.process_datagram_inner(peer, self.local_addr, &mut self.recv_buf[..len]);
+        let local_addr = self.local_addr;
+        let packet_ptr = self.recv_buf.as_mut_ptr();
+        // SAFETY: `packet_ptr` points into `self.recv_buf` and remains valid for this call.
+        // We do not access `self.recv_buf` again until `process_datagram_inner` returns.
+        let packet = unsafe { std::slice::from_raw_parts_mut(packet_ptr, len) };
+        self.process_datagram_inner(peer, local_addr, packet);
     }
 
     pub fn poll_idle(&mut self) {
@@ -1443,7 +1448,7 @@ impl QUICListener {
         };
         let packet_type = header.ty;
         let header_has_token = header.token.is_some();
-        let lookup_key: Arc<[u8]> = Arc::from(header.dcid.as_ref());
+        let dcid = header.dcid.as_ref();
 
         if packet_type == quiche::Type::VersionNegotiation {
             let len =
@@ -1467,32 +1472,33 @@ impl QUICListener {
         // First, try to find existing connection by DCID
         debug!(
             "Looking up connection with DCID: {:?}",
-            hex::encode(&lookup_key)
+            hex::encode(dcid)
         );
         let (mut connection, current_primary) =
-            if let Some(mut conn) = self.connections.remove(&lookup_key) {
+            if let Some(mut conn) = self.connections.remove(dcid) {
+                let primary = Arc::clone(&conn.primary_scid);
                 self.peer_routes.remove(&conn.peer_address);
                 conn.peer_address = peer;
                 debug!("Found existing connection for {}", peer);
-                (conn, lookup_key)
-            } else if let Some(primary) = self.cid_routes.get(lookup_key.as_ref()).cloned() {
+                (conn, primary)
+            } else if let Some(primary) = self.cid_routes.get(dcid).cloned() {
                 if let Some(mut conn) = self.connections.remove(&primary) {
                     self.peer_routes.remove(&conn.peer_address);
                     conn.peer_address = peer;
                     debug!(
                         "Found existing connection via SCID alias {} -> {}",
-                        hex::encode(&lookup_key),
+                        hex::encode(dcid),
                         hex::encode(&primary)
                     );
                     (conn, primary)
                 } else {
                     // Stale alias entry.
-                    self.cid_routes.remove(lookup_key.as_ref());
+                    self.cid_routes.remove(dcid);
                     match self.take_or_create_connection(
                         peer,
                         local_addr,
                         packet_type,
-                        lookup_key.as_ref(),
+                        dcid,
                         header_has_token,
                     ) {
                         Some(conn) => {
@@ -1503,7 +1509,7 @@ impl QUICListener {
                             debug!(
                                 "Dropping packet for unknown connection from {} (DCID: {:?})",
                                 peer,
-                                hex::encode(&lookup_key)
+                                hex::encode(dcid)
                             );
                             return;
                         }
@@ -1526,7 +1532,7 @@ impl QUICListener {
                         peer,
                         local_addr,
                         packet_type,
-                        lookup_key.as_ref(),
+                        dcid,
                         header_has_token,
                     ) {
                         Some(conn_pair) => {
@@ -1537,7 +1543,7 @@ impl QUICListener {
                             debug!(
                                 "Dropping packet for unknown connection from {} (DCID: {:?})",
                                 peer,
-                                hex::encode(&lookup_key)
+                                hex::encode(dcid)
                             );
                             return;
                         }
@@ -1549,7 +1555,7 @@ impl QUICListener {
                     peer,
                     local_addr,
                     packet_type,
-                    lookup_key.as_ref(),
+                    dcid,
                     header_has_token,
                 ) {
                     Some(conn_pair) => {
@@ -1560,7 +1566,7 @@ impl QUICListener {
                         debug!(
                             "Dropping packet for unknown connection from {} (DCID: {:?})",
                             peer,
-                            hex::encode(&lookup_key)
+                            hex::encode(dcid)
                         );
                         return;
                     }
@@ -1617,6 +1623,7 @@ impl QUICListener {
             && let Err(e) = Self::handle_h3(
                 &mut connection,
                 Arc::clone(&h2_pool),
+                Arc::clone(&self.backend_endpoints),
                 &self.upstream_pools,
                 &self.upstream_inflight,
                 Arc::clone(&self.global_inflight),
@@ -1859,6 +1866,7 @@ impl QUICListener {
     fn handle_h3(
         connection: &mut QuicConnection,
         h2_pool: Arc<H2Pool>,
+        backend_endpoints: Arc<HashMap<String, BackendEndpoint>>,
         upstream_pools: &HashMap<String, Arc<RwLock<UpstreamPool>>>,
         upstream_inflight: &HashMap<String, Arc<Semaphore>>,
         global_inflight: Arc<Semaphore>,
@@ -2213,7 +2221,7 @@ impl QUICListener {
                                     ChannelBody::channel(REQUEST_CHUNK_CHANNEL_CAPACITY);
                                 (Some(tx), channel_body.boxed(), false)
                             };
-                            let backend_endpoint = match self.backend_endpoints.get(&addr).cloned() {
+                            let backend_endpoint = match backend_endpoints.get(&addr).cloned() {
                                 Some(endpoint) => endpoint,
                                 None => {
                                     drop(upstream_permit);
@@ -2282,7 +2290,7 @@ impl QUICListener {
                             let cb = Arc::clone(&resilience.circuit_breakers);
                             let retry_budget = Arc::clone(&resilience.retry_budget);
                             let route_name = upstream_name.clone();
-                            let backend_endpoints = Arc::clone(&self.backend_endpoints);
+                            let backend_endpoints = Arc::clone(&backend_endpoints);
                             let allow_hedge = bodyless_mode
                                 && resilience.hedging_allowed_for(&method, &upstream_name, true);
                             let hedge_delay = resilience.hedging_delay;
@@ -3054,6 +3062,10 @@ impl QUICListener {
                         }
 
                         let defer_headers_until_body_validated = upstream_content_length.is_none();
+                        let immediate_end = upstream_content_length == Some(0)
+                            || status == http::StatusCode::NO_CONTENT
+                            || status == http::StatusCode::NOT_MODIFIED;
+                        let mut immediate_terminal = false;
 
                         if !defer_headers_until_body_validated {
                             // For declared-length responses within cap, emit headers immediately
@@ -3066,7 +3078,8 @@ impl QUICListener {
                             for (name, value) in &owned_h3_headers {
                                 h3_headers.push(quiche::h3::Header::new(name, value));
                             }
-                            if let Err(err) = h3.send_response(quic, stream_id, &h3_headers, false)
+                            if let Err(err) =
+                                h3.send_response(quic, stream_id, &h3_headers, immediate_end)
                             {
                                 if let Some(req) = streams.get(&stream_id) {
                                     let protocol = ProxyError::Protocol(format!(
@@ -3101,99 +3114,182 @@ impl QUICListener {
                             }
                         }
 
-                        // Spawn a task that pumps body frames into a ResponseChunk channel.
-                        // Enforces body deadlines; for unknown-length responses it first
-                        // validates total body size against cap before emitting any headers.
-                        let (chunk_tx, chunk_rx) =
-                            mpsc::channel::<ResponseChunk>(RESPONSE_CHUNK_CHANNEL_CAPACITY);
-                        let fail_tx = chunk_tx.clone();
-                        // `backend_body_total_timeout` is used as a pre-first-byte guard:
-                        // once the upstream starts making body progress, the idle timeout
-                        // governs pacing and the stream may continue until request deadline.
-                        let first_byte_deadline =
-                            tokio::time::Instant::now() + backend_body_total_timeout;
-                        let deferred_status = status;
-                        let deferred_headers = owned_h3_headers.clone();
-                        let fut = async move {
-                            use http_body_util::BodyExt;
-                            let mut body: hyper::body::Incoming = body;
-                            let mut response_bytes_received: usize = 0;
-                            let mut buffered_chunks: Vec<Bytes> = Vec::new();
-                            let mut saw_body_progress = false;
-                            loop {
-                                let frame_fut = BodyExt::frame(&mut body);
-                                let now = tokio::time::Instant::now();
-                                if !saw_body_progress && now >= first_byte_deadline {
-                                    let _ = chunk_tx
-                                        .send(ResponseChunk::Error(ProxyError::Timeout))
-                                        .await;
-                                    return;
+                        if immediate_end {
+                            if defer_headers_until_body_validated {
+                                let mut h3_headers = Vec::with_capacity(owned_h3_headers.len() + 1);
+                                h3_headers.push(quiche::h3::Header::new(
+                                    b":status",
+                                    status.as_str().as_bytes(),
+                                ));
+                                for (name, value) in &owned_h3_headers {
+                                    h3_headers.push(quiche::h3::Header::new(name, value));
                                 }
-                                let wait_timeout = if saw_body_progress {
-                                    backend_body_idle_timeout
-                                } else {
-                                    first_byte_deadline
-                                        .saturating_duration_since(now)
-                                        .min(backend_body_idle_timeout)
-                                };
-                                let result = tokio::time::timeout(wait_timeout, frame_fut).await;
-                                match result {
-                                    Err(_elapsed) => {
-                                        // Body read idle timeout — signal timeout to flush loop.
+                                if let Err(err) = h3.send_response(quic, stream_id, &h3_headers, true)
+                                {
+                                    if let Some(req) = streams.get(&stream_id) {
+                                        let protocol = ProxyError::Protocol(format!(
+                                            "failed to send HTTP/3 response headers: {:?}",
+                                            err
+                                        ));
+                                        if let Err(protocol_err) = Self::handle_forward_result(
+                                            h3,
+                                            quic,
+                                            stream_id,
+                                            req,
+                                            Err(protocol),
+                                            upstream_pools,
+                                            routing_index,
+                                            metrics,
+                                            resilience.shed_retry_after_seconds,
+                                        ) {
+                                            error!(
+                                                "failed to emit protocol recovery response on stream {}: {:?}",
+                                                stream_id, protocol_err
+                                            );
+                                        }
+                                        resilience
+                                            .adaptive_admission
+                                            .observe(req.start.elapsed(), true);
+                                    }
+                                    if let Some(req) = streams.get_mut(&stream_id) {
+                                        abort_stream(req, metrics);
+                                    }
+                                    streams.remove(&stream_id);
+                                    continue;
+                                }
+                            }
+                            if let Some(req) = streams.get_mut(&stream_id) {
+                                req.response_chunk_rx = None;
+                                req.response_headers_sent = true;
+                                req.phase = StreamPhase::Completed;
+                                req.response_status = Some(status.as_u16());
+                            }
+                            immediate_terminal = true;
+                        } else {
+                            // Spawn a task that pumps body frames into a ResponseChunk channel.
+                            // Enforces body deadlines; for unknown-length responses it first
+                            // validates total body size against cap before emitting any headers.
+                            let (chunk_tx, chunk_rx) =
+                                mpsc::channel::<ResponseChunk>(RESPONSE_CHUNK_CHANNEL_CAPACITY);
+                            let fail_tx = chunk_tx.clone();
+                            // `backend_body_total_timeout` is used as a pre-first-byte guard:
+                            // once the upstream starts making body progress, the idle timeout
+                            // governs pacing and the stream may continue until request deadline.
+                            let first_byte_deadline =
+                                tokio::time::Instant::now() + backend_body_total_timeout;
+                            let deferred_status = status;
+                            let deferred_headers = owned_h3_headers.clone();
+                            let fut = async move {
+                                use http_body_util::BodyExt;
+                                let mut body: hyper::body::Incoming = body;
+                                let mut response_bytes_received: usize = 0;
+                                let mut buffered_chunks: Vec<Bytes> = Vec::new();
+                                let mut saw_body_progress = false;
+                                loop {
+                                    let frame_fut = BodyExt::frame(&mut body);
+                                    let now = tokio::time::Instant::now();
+                                    if !saw_body_progress && now >= first_byte_deadline {
                                         let _ = chunk_tx
                                             .send(ResponseChunk::Error(ProxyError::Timeout))
                                             .await;
                                         return;
                                     }
-                                    Ok(Some(Ok(f))) => {
-                                        if let Ok(data) = f.into_data() {
-                                            if !data.is_empty() {
-                                                saw_body_progress = true;
+                                    let wait_timeout = if saw_body_progress {
+                                        backend_body_idle_timeout
+                                    } else {
+                                        first_byte_deadline
+                                            .saturating_duration_since(now)
+                                            .min(backend_body_idle_timeout)
+                                    };
+                                    let result = tokio::time::timeout(wait_timeout, frame_fut).await;
+                                    match result {
+                                        Err(_elapsed) => {
+                                            // Body read idle timeout — signal timeout to flush loop.
+                                            let _ = chunk_tx
+                                                .send(ResponseChunk::Error(ProxyError::Timeout))
+                                                .await;
+                                            return;
+                                        }
+                                        Ok(Some(Ok(f))) => {
+                                            if let Ok(data) = f.into_data() {
+                                                if !data.is_empty() {
+                                                    saw_body_progress = true;
+                                                }
+                                                if defer_headers_until_body_validated {
+                                                    response_bytes_received = response_bytes_received
+                                                        .saturating_add(data.len());
+                                                    if response_bytes_received > max_response_body_bytes
+                                                    {
+                                                        let _ = chunk_tx
+                                                            .send(ResponseChunk::Error(ProxyError::Pool(
+                                                                PoolError::BackendOverloaded(
+                                                                    "upstream response body too large".into(),
+                                                                ),
+                                                            )))
+                                                            .await;
+                                                        return;
+                                                    }
+                                                    if response_bytes_received
+                                                        > unknown_length_response_prebuffer_bytes
+                                                    {
+                                                        let _ = chunk_tx
+                                                            .send(ResponseChunk::Error(ProxyError::Pool(
+                                                                PoolError::BackendOverloaded(
+                                                                    "unknown-length response prebuffer limit exceeded"
+                                                                        .into(),
+                                                                ),
+                                                            )))
+                                                            .await;
+                                                        return;
+                                                    }
+                                                    for start in (0..data.len())
+                                                        .step_by(RESPONSE_CHUNK_BYTES_LIMIT)
+                                                    {
+                                                        let end = (start + RESPONSE_CHUNK_BYTES_LIMIT)
+                                                            .min(data.len());
+                                                        buffered_chunks.push(data.slice(start..end));
+                                                    }
+                                                } else {
+                                                    for start in (0..data.len())
+                                                        .step_by(RESPONSE_CHUNK_BYTES_LIMIT)
+                                                    {
+                                                        let end = (start + RESPONSE_CHUNK_BYTES_LIMIT)
+                                                            .min(data.len());
+                                                        if chunk_tx
+                                                            .send(ResponseChunk::Data(data.slice(start..end)))
+                                                            .await
+                                                            .is_err()
+                                                        {
+                                                            return;
+                                                        }
+                                                    }
+                                                }
                                             }
+                                            // skip trailers / other frame types
+                                        }
+                                        Ok(Some(Err(_))) => {
+                                            let _ = chunk_tx
+                                                .send(ResponseChunk::Error(ProxyError::Transport(
+                                                    "upstream body error".into(),
+                                                )))
+                                                .await;
+                                            return;
+                                        }
+                                        Ok(None) => {
                                             if defer_headers_until_body_validated {
-                                                response_bytes_received = response_bytes_received
-                                                    .saturating_add(data.len());
-                                                if response_bytes_received > max_response_body_bytes
+                                                if chunk_tx
+                                                    .send(ResponseChunk::Start {
+                                                        status: deferred_status,
+                                                        headers: deferred_headers,
+                                                    })
+                                                    .await
+                                                    .is_err()
                                                 {
-                                                    let _ = chunk_tx
-                                                        .send(ResponseChunk::Error(ProxyError::Pool(
-                                                            PoolError::BackendOverloaded(
-                                                                "upstream response body too large".into(),
-                                                            ),
-                                                        )))
-                                                        .await;
                                                     return;
                                                 }
-                                                if response_bytes_received
-                                                    > unknown_length_response_prebuffer_bytes
-                                                {
-                                                    let _ = chunk_tx
-                                                        .send(ResponseChunk::Error(ProxyError::Pool(
-                                                            PoolError::BackendOverloaded(
-                                                                "unknown-length response prebuffer limit exceeded"
-                                                                    .into(),
-                                                            ),
-                                                        )))
-                                                        .await;
-                                                    return;
-                                                }
-                                                for start in (0..data.len())
-                                                    .step_by(RESPONSE_CHUNK_BYTES_LIMIT)
-                                                {
-                                                    let end = (start + RESPONSE_CHUNK_BYTES_LIMIT)
-                                                        .min(data.len());
-                                                    buffered_chunks.push(data.slice(start..end));
-                                                }
-                                            } else {
-                                                for start in (0..data.len())
-                                                    .step_by(RESPONSE_CHUNK_BYTES_LIMIT)
-                                                {
-                                                    let end = (start + RESPONSE_CHUNK_BYTES_LIMIT)
-                                                        .min(data.len());
+                                                for chunk in buffered_chunks {
                                                     if chunk_tx
-                                                        .send(ResponseChunk::Data(
-                                                            data.slice(start..end),
-                                                        ))
+                                                        .send(ResponseChunk::Data(chunk))
                                                         .await
                                                         .is_err()
                                                     {
@@ -3201,63 +3297,31 @@ impl QUICListener {
                                                     }
                                                 }
                                             }
+                                            let _ = chunk_tx.send(ResponseChunk::End).await;
+                                            return;
                                         }
-                                        // skip trailers / other frame types
-                                    }
-                                    Ok(Some(Err(_))) => {
-                                        let _ = chunk_tx
-                                            .send(ResponseChunk::Error(ProxyError::Transport(
-                                                "upstream body error".into(),
-                                            )))
-                                            .await;
-                                        return;
-                                    }
-                                    Ok(None) => {
-                                        if defer_headers_until_body_validated {
-                                            if chunk_tx
-                                                .send(ResponseChunk::Start {
-                                                    status: deferred_status,
-                                                    headers: deferred_headers,
-                                                })
-                                                .await
-                                                .is_err()
-                                            {
-                                                return;
-                                            }
-                                            for chunk in buffered_chunks {
-                                                if chunk_tx
-                                                    .send(ResponseChunk::Data(chunk))
-                                                    .await
-                                                    .is_err()
-                                                {
-                                                    return;
-                                                }
-                                            }
-                                        }
-                                        let _ = chunk_tx.send(ResponseChunk::End).await;
-                                        return;
                                     }
                                 }
+                            };
+                            let request_span = streams
+                                .get(&stream_id)
+                                .and_then(|req| req.trace_span.clone());
+                            let spawned = match request_span {
+                                Some(span) => spawn_async_task(fut.instrument(span), "body-pump"),
+                                None => spawn_async_task(fut, "body-pump"),
+                            };
+                            if !spawned {
+                                let _ = fail_tx.try_send(ResponseChunk::Error(ProxyError::Transport(
+                                    "runtime unavailable".into(),
+                                )));
                             }
-                        };
-                        let request_span = streams
-                            .get(&stream_id)
-                            .and_then(|req| req.trace_span.clone());
-                        let spawned = match request_span {
-                            Some(span) => spawn_async_task(fut.instrument(span), "body-pump"),
-                            None => spawn_async_task(fut, "body-pump"),
-                        };
-                        if !spawned {
-                            let _ = fail_tx.try_send(ResponseChunk::Error(ProxyError::Transport(
-                                "runtime unavailable".into(),
-                            )));
-                        }
 
-                        if let Some(req) = streams.get_mut(&stream_id) {
-                            req.response_chunk_rx = Some(chunk_rx);
-                            req.response_headers_sent = !defer_headers_until_body_validated;
-                            req.phase = StreamPhase::SendingResponse;
-                            req.response_status = Some(status.as_u16());
+                            if let Some(req) = streams.get_mut(&stream_id) {
+                                req.response_chunk_rx = Some(chunk_rx);
+                                req.response_headers_sent = !defer_headers_until_body_validated;
+                                req.phase = StreamPhase::SendingResponse;
+                                req.response_status = Some(status.as_u16());
+                            }
                         }
 
                         // Update health/metrics for successful upstream response.
@@ -3294,6 +3358,13 @@ impl QUICListener {
                                 .adaptive_admission
                                 .observe(req.start.elapsed(), false);
                             Self::log_access(req, status.as_u16());
+                        }
+                        if immediate_terminal {
+                            if let Some(req) = streams.get_mut(&stream_id) {
+                                abort_stream(req, metrics);
+                            }
+                            streams.remove(&stream_id);
+                            continue;
                         }
                     }
                     Err(err) => {

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -595,6 +595,13 @@ impl QUICListener {
 
     pub fn build_shared_state(config: &SpookyConfig) -> Result<SharedRuntimeState, ProxyError> {
         let worker_threads = config.performance.worker_threads.max(1);
+        let shard_count = config.performance.packet_shards_per_worker.max(1);
+        let active_worker_threads = if worker_threads > 1 && !config.performance.reuseport {
+            1
+        } else {
+            worker_threads
+        };
+        let worker_slots = active_worker_threads.saturating_mul(shard_count).max(1);
         let per_upstream_limit = config.performance.per_upstream_inflight_limit.max(1);
         let global_inflight_limit = config.performance.global_inflight_limit.max(1);
         let max_inflight_per_backend = config
@@ -717,13 +724,15 @@ impl QUICListener {
             global_inflight_limit,
         ));
         let watchdog = Arc::new(WatchdogCoordinator::new(&config.resilience.watchdog));
+        let mut route_labels = config.upstream.keys().cloned().collect::<Vec<_>>();
+        route_labels.push("unrouted".to_string());
 
         Ok(SharedRuntimeState {
             h2_pool,
             upstream_pools,
             upstream_inflight,
             global_inflight: Arc::new(Semaphore::new(global_inflight_limit)),
-            metrics: Arc::new(Metrics::default()),
+            metrics: Arc::new(Metrics::new(worker_slots, route_labels)),
             resilience,
             watchdog,
         })

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -3683,7 +3683,7 @@ impl QUICListener {
         };
 
         let (backend_index, lb_type, backend_addr) = {
-            let (read_lb_type, read_fast_pick) = {
+            let (read_lb_type, read_fast_selected) = {
                 let pool = upstream_pool
                     .read()
                     .map_err(|_| ProxyError::Transport("upstream pool lock poisoned".into()))?;
@@ -3695,24 +3695,23 @@ impl QUICListener {
                 let fast_pick = pool
                     .pick_readonly(key)
                     .and_then(|idx| pool.pool.address(idx).map(|addr| (idx, addr.to_string())));
-                (lb_type, fast_pick)
+                let fast_selected = fast_pick
+                    .and_then(|(idx, addr)| pool.begin_request_if_healthy(idx).then_some((idx, addr)));
+                (lb_type, fast_selected)
             };
 
-            let mut pool = upstream_pool
-                .write()
-                .map_err(|_| ProxyError::Transport("upstream pool lock poisoned".into()))?;
-            if pool.pool.is_empty() {
-                return Err(ProxyError::Transport("no servers in upstream".into()));
-            }
-            let lb_type = pool.lb_name();
-            let key = key_for_lb(lb_type);
-
-            if lb_type == read_lb_type
-                && let Some((idx, addr)) = read_fast_pick
-                && pool.begin_request_if_healthy(idx)
-            {
-                (idx, lb_type, addr)
+            if let Some((idx, addr)) = read_fast_selected {
+                (idx, read_lb_type, addr)
             } else {
+                let mut pool = upstream_pool
+                    .write()
+                    .map_err(|_| ProxyError::Transport("upstream pool lock poisoned".into()))?;
+                if pool.pool.is_empty() {
+                    return Err(ProxyError::Transport("no servers in upstream".into()));
+                }
+                let lb_type = pool.lb_name();
+                let key = key_for_lb(lb_type);
+
                 let idx = pool.pick(key).ok_or_else(|| {
                     let total = pool.pool.len();
                     let healthy = pool.pool.healthy_len();

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -24,7 +24,7 @@ use quiche::h3::NameValue;
 use rand::RngCore;
 use serde_json::json;
 use socket2::{Domain, Protocol, Socket, Type};
-use spooky_bridge::h3_to_h2::{ForwardedContext, build_h2_request};
+use spooky_bridge::h3_to_h2::{ForwardedContext, build_h2_request_for_endpoint};
 use spooky_errors::{PoolError, ProxyError, is_retryable};
 use spooky_lb::{HealthFailureReason, HealthTransition, UpstreamPool};
 use spooky_transport::h2_client::{H2Client, TlsClientConfig};
@@ -139,10 +139,10 @@ struct ForwardRequestMeta {
 impl ForwardRequestMeta {
     fn build_bodyless_request(
         &self,
-        backend: &str,
+        endpoint: &BackendEndpoint,
     ) -> Result<Request<BoxBody<Bytes, std::convert::Infallible>>, ProxyError> {
-        build_h2_request(
-            backend,
+        build_h2_request_for_endpoint(
+            endpoint,
             &self.method,
             &self.path,
             self.headers.as_slice(),
@@ -729,6 +729,18 @@ impl QUICListener {
 
         Ok(SharedRuntimeState {
             h2_pool,
+            backend_endpoints: Arc::new(
+                config
+                    .upstream
+                    .values()
+                    .flat_map(|upstream| upstream.backends.iter())
+                    .filter_map(|backend| {
+                        BackendEndpoint::parse(&backend.address)
+                            .ok()
+                            .map(|endpoint| (backend.address.clone(), endpoint))
+                    })
+                    .collect(),
+            ),
             upstream_pools,
             upstream_inflight,
             global_inflight: Arc::new(Semaphore::new(global_inflight_limit)),
@@ -849,6 +861,7 @@ impl QUICListener {
             quic_config,
             h3_config,
             h2_pool: Arc::clone(&shared_state.h2_pool),
+            backend_endpoints: Arc::clone(&shared_state.backend_endpoints),
             upstream_pools: shared_state.upstream_pools.clone(),
             upstream_inflight: shared_state.upstream_inflight.clone(),
             global_inflight: Arc::clone(&shared_state.global_inflight),
@@ -2200,8 +2213,33 @@ impl QUICListener {
                                     ChannelBody::channel(REQUEST_CHUNK_CHANNEL_CAPACITY);
                                 (Some(tx), channel_body.boxed(), false)
                             };
-                            let request = match build_h2_request(
-                                &addr,
+                            let backend_endpoint = match self.backend_endpoints.get(&addr).cloned() {
+                                Some(endpoint) => endpoint,
+                                None => {
+                                    drop(upstream_permit);
+                                    drop(global_permit);
+                                    metrics.inc_failure();
+                                    metrics.record_route(
+                                        &upstream_name,
+                                        request_start.elapsed(),
+                                        RouteOutcome::Failure,
+                                    );
+                                    Self::send_simple_response(
+                                        h3,
+                                        &mut connection.quic,
+                                        stream_id,
+                                        http::StatusCode::BAD_GATEWAY,
+                                        b"unknown backend endpoint\n",
+                                    )?;
+                                    error!("missing parsed backend endpoint for {}", addr);
+                                    resilience
+                                        .adaptive_admission
+                                        .observe(request_start.elapsed(), true);
+                                    continue;
+                                }
+                            };
+                            let request = match build_h2_request_for_endpoint(
+                                &backend_endpoint,
                                 &method,
                                 &path,
                                 &list,
@@ -2244,6 +2282,7 @@ impl QUICListener {
                             let cb = Arc::clone(&resilience.circuit_breakers);
                             let retry_budget = Arc::clone(&resilience.retry_budget);
                             let route_name = upstream_name.clone();
+                            let backend_endpoints = Arc::clone(&self.backend_endpoints);
                             let allow_hedge = bodyless_mode
                                 && resilience.hedging_allowed_for(&method, &upstream_name, true);
                             let hedge_delay = resilience.hedging_delay;
@@ -2300,7 +2339,8 @@ impl QUICListener {
                                             .clone()
                                             .and_then(|(backend, _idx)| {
                                                 let meta = forward_meta.as_ref()?;
-                                                meta.build_bodyless_request(&backend)
+                                                let endpoint = backend_endpoints.get(&backend)?;
+                                                meta.build_bodyless_request(endpoint)
                                                     .ok()
                                                     .map(|req| (backend, req))
                                             });
@@ -2390,8 +2430,10 @@ impl QUICListener {
                                                 } else if let Some((retry_backend, _)) =
                                                         alternate_backend.clone()
                                                     && let Some(meta) = forward_meta.as_ref()
+                                                    && let Some(endpoint) = backend_endpoints
+                                                        .get(&retry_backend)
                                                     && let Ok(retry_request) =
-                                                        meta.build_bodyless_request(&retry_backend)
+                                                        meta.build_bodyless_request(endpoint)
                                                 {
                                                     retry_count = retry_count.saturating_add(1);
                                                     retry_attempt_reason = Some(retry_reason);

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -11,7 +11,7 @@ use std::{
 
 use core::net::SocketAddr;
 
-use bytes::{Bytes, BytesMut};
+use bytes::Bytes;
 use http::{Request, Response, StatusCode};
 use http_body_util::{BodyExt, Full, combinators::BoxBody};
 use hyper::body::Incoming;
@@ -844,6 +844,7 @@ impl QUICListener {
 
         Ok(Self {
             socket,
+            local_addr,
             config,
             quic_config,
             h3_config,
@@ -1107,24 +1108,16 @@ impl QUICListener {
         &mut self,
         peer: SocketAddr,
         local_addr: SocketAddr,
-        packets: &[u8],
+        packet_type: quiche::Type,
+        dcid: &[u8],
+        has_token: bool,
     ) -> Option<(QuicConnection, Arc<[u8]>)> {
-        let mut buf = packets.to_vec();
-        let header = match quiche::Header::from_slice(&mut buf, quiche::MAX_CONN_ID_LEN) {
-            Ok(hdr) => hdr,
-            Err(_) => {
-                error!("Failed to parse QUIC packet header");
-                self.metrics.inc_ingress_bad_header();
-                return None;
-            }
-        };
-
-        let dcid_bytes: Arc<[u8]> = Arc::from(header.dcid.as_ref());
+        let dcid_bytes: Arc<[u8]> = Arc::from(dcid);
         debug!(
             "Packet DCID (len={}): {:02x?}, type: {:?}, active connections: {}",
             dcid_bytes.len(),
             &dcid_bytes,
-            header.ty,
+            packet_type,
             self.connections.len()
         );
 
@@ -1138,7 +1131,7 @@ impl QUICListener {
 
         // For Short packets, try prefix match (client may append bytes to our SCID)
         // This handles cases where client uses longer DCIDs based on server's SCID
-        if header.ty == quiche::Type::Short
+        if packet_type == quiche::Type::Short
             && dcid_bytes.len() > MIN_SCID_LEN_BYTES
             && let Some(primary_cid) = resolve_primary_from_radix_prefix(
                 &dcid_bytes,
@@ -1164,14 +1157,14 @@ impl QUICListener {
         }
 
         // Only create new connections for Initial packets
-        if header.ty != quiche::Type::Initial {
+        if packet_type != quiche::Type::Initial {
             debug!("Non-Initial packet for unknown connection, ignoring");
             self.metrics.inc_ingress_unroutable();
             return None;
         }
 
         // If this is a 0-RTT packet without a valid token, we need to reject it
-        if header.token.is_some() {
+        if has_token {
             debug!("Received 0-RTT attempt, will negotiate fresh connection");
             // return None;
         }
@@ -1397,14 +1390,7 @@ impl QUICListener {
         };
 
         debug!("Received UDP datagram ({} bytes)", len);
-
-        let local_addr = match self.socket.local_addr() {
-            Ok(addr) => addr,
-            Err(_) => return,
-        };
-
-        let packet = self.recv_buf[..len].to_vec();
-        self.process_datagram_inner(peer, local_addr, &packet);
+        self.process_datagram_inner(peer, self.local_addr, &mut self.recv_buf[..len]);
     }
 
     pub fn poll_idle(&mut self) {
@@ -1414,18 +1400,27 @@ impl QUICListener {
         self.handle_timeouts();
     }
 
-    pub fn process_datagram(&mut self, peer: SocketAddr, local_addr: SocketAddr, packet: &[u8]) {
+    pub fn process_datagram(
+        &mut self,
+        peer: SocketAddr,
+        local_addr: SocketAddr,
+        packet: &mut [u8],
+    ) {
         if !self.poll_preamble() {
             return;
         }
         self.process_datagram_inner(peer, local_addr, packet);
     }
 
-    fn process_datagram_inner(&mut self, peer: SocketAddr, local_addr: SocketAddr, packet: &[u8]) {
+    fn process_datagram_inner(
+        &mut self,
+        peer: SocketAddr,
+        local_addr: SocketAddr,
+        packet: &mut [u8],
+    ) {
         self.metrics.inc_ingress_packet();
 
-        let mut recv_data = BytesMut::from(packet);
-        let header = match quiche::Header::from_slice(&mut recv_data, quiche::MAX_CONN_ID_LEN) {
+        let header = match quiche::Header::from_slice(packet, quiche::MAX_CONN_ID_LEN) {
             Ok(hdr) => hdr,
             Err(_) => {
                 error!("Failed to parse QUIC packet header");
@@ -1433,8 +1428,11 @@ impl QUICListener {
                 return;
             }
         };
+        let packet_type = header.ty;
+        let header_has_token = header.token.is_some();
+        let lookup_key: Arc<[u8]> = Arc::from(header.dcid.as_ref());
 
-        if header.ty == quiche::Type::VersionNegotiation {
+        if packet_type == quiche::Type::VersionNegotiation {
             let len =
                 match quiche::negotiate_version(&header.scid, &header.dcid, &mut self.send_buf) {
                     Ok(len) => len,
@@ -1454,7 +1452,6 @@ impl QUICListener {
         let h2_pool = self.h2_pool.clone();
 
         // First, try to find existing connection by DCID
-        let lookup_key: Arc<[u8]> = Arc::from(header.dcid.as_ref());
         debug!(
             "Looking up connection with DCID: {:?}",
             hex::encode(&lookup_key)
@@ -1478,7 +1475,13 @@ impl QUICListener {
                 } else {
                     // Stale alias entry.
                     self.cid_routes.remove(lookup_key.as_ref());
-                    match self.take_or_create_connection(peer, local_addr, &recv_data) {
+                    match self.take_or_create_connection(
+                        peer,
+                        local_addr,
+                        packet_type,
+                        lookup_key.as_ref(),
+                        header_has_token,
+                    ) {
                         Some(conn) => {
                             debug!("Created new connection for {}", peer);
                             conn
@@ -1506,7 +1509,13 @@ impl QUICListener {
                 } else {
                     // Stale peer map entry.
                     self.peer_routes.remove(&peer);
-                    match self.take_or_create_connection(peer, local_addr, &recv_data) {
+                    match self.take_or_create_connection(
+                        peer,
+                        local_addr,
+                        packet_type,
+                        lookup_key.as_ref(),
+                        header_has_token,
+                    ) {
                         Some(conn_pair) => {
                             debug!("Created new connection for {}", peer);
                             conn_pair
@@ -1523,7 +1532,13 @@ impl QUICListener {
                 }
             } else {
                 // No existing connection found, try to create new one.
-                match self.take_or_create_connection(peer, local_addr, &recv_data) {
+                match self.take_or_create_connection(
+                    peer,
+                    local_addr,
+                    packet_type,
+                    lookup_key.as_ref(),
+                    header_has_token,
+                ) {
                     Some(conn_pair) => {
                         debug!("Created new connection for {}", peer);
                         conn_pair
@@ -1544,7 +1559,7 @@ impl QUICListener {
             to: local_addr,
         };
 
-        if let Err(e) = connection.quic.recv(&mut recv_data, recv_info) {
+        if let Err(e) = connection.quic.recv(packet, recv_info) {
             error!("QUIC recv failed: {:?}", e);
             Self::release_connection_streams(&mut connection, &self.metrics);
             self.remove_connection_routes(&connection);

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -1470,10 +1470,7 @@ impl QUICListener {
         let h2_pool = self.h2_pool.clone();
 
         // First, try to find existing connection by DCID
-        debug!(
-            "Looking up connection with DCID: {:?}",
-            hex::encode(dcid)
-        );
+        debug!("Looking up connection with DCID: {:?}", hex::encode(dcid));
         let (mut connection, current_primary) =
             if let Some(mut conn) = self.connections.remove(dcid) {
                 let primary = Arc::clone(&conn.primary_scid);
@@ -3124,7 +3121,8 @@ impl QUICListener {
                                 for (name, value) in &owned_h3_headers {
                                     h3_headers.push(quiche::h3::Header::new(name, value));
                                 }
-                                if let Err(err) = h3.send_response(quic, stream_id, &h3_headers, true)
+                                if let Err(err) =
+                                    h3.send_response(quic, stream_id, &h3_headers, true)
                                 {
                                     if let Some(req) = streams.get(&stream_id) {
                                         let protocol = ProxyError::Protocol(format!(
@@ -3201,7 +3199,8 @@ impl QUICListener {
                                             .saturating_duration_since(now)
                                             .min(backend_body_idle_timeout)
                                     };
-                                    let result = tokio::time::timeout(wait_timeout, frame_fut).await;
+                                    let result =
+                                        tokio::time::timeout(wait_timeout, frame_fut).await;
                                     match result {
                                         Err(_elapsed) => {
                                             // Body read idle timeout — signal timeout to flush loop.
@@ -3216,9 +3215,11 @@ impl QUICListener {
                                                     saw_body_progress = true;
                                                 }
                                                 if defer_headers_until_body_validated {
-                                                    response_bytes_received = response_bytes_received
-                                                        .saturating_add(data.len());
-                                                    if response_bytes_received > max_response_body_bytes
+                                                    response_bytes_received =
+                                                        response_bytes_received
+                                                            .saturating_add(data.len());
+                                                    if response_bytes_received
+                                                        > max_response_body_bytes
                                                     {
                                                         let _ = chunk_tx
                                                             .send(ResponseChunk::Error(ProxyError::Pool(
@@ -3245,18 +3246,23 @@ impl QUICListener {
                                                     for start in (0..data.len())
                                                         .step_by(RESPONSE_CHUNK_BYTES_LIMIT)
                                                     {
-                                                        let end = (start + RESPONSE_CHUNK_BYTES_LIMIT)
+                                                        let end = (start
+                                                            + RESPONSE_CHUNK_BYTES_LIMIT)
                                                             .min(data.len());
-                                                        buffered_chunks.push(data.slice(start..end));
+                                                        buffered_chunks
+                                                            .push(data.slice(start..end));
                                                     }
                                                 } else {
                                                     for start in (0..data.len())
                                                         .step_by(RESPONSE_CHUNK_BYTES_LIMIT)
                                                     {
-                                                        let end = (start + RESPONSE_CHUNK_BYTES_LIMIT)
+                                                        let end = (start
+                                                            + RESPONSE_CHUNK_BYTES_LIMIT)
                                                             .min(data.len());
                                                         if chunk_tx
-                                                            .send(ResponseChunk::Data(data.slice(start..end)))
+                                                            .send(ResponseChunk::Data(
+                                                                data.slice(start..end),
+                                                            ))
                                                             .await
                                                             .is_err()
                                                         {
@@ -3311,9 +3317,9 @@ impl QUICListener {
                                 None => spawn_async_task(fut, "body-pump"),
                             };
                             if !spawned {
-                                let _ = fail_tx.try_send(ResponseChunk::Error(ProxyError::Transport(
-                                    "runtime unavailable".into(),
-                                )));
+                                let _ = fail_tx.try_send(ResponseChunk::Error(
+                                    ProxyError::Transport("runtime unavailable".into()),
+                                ));
                             }
 
                             if let Some(req) = streams.get_mut(&stream_id) {
@@ -3695,8 +3701,9 @@ impl QUICListener {
                 let fast_pick = pool
                     .pick_readonly(key)
                     .and_then(|idx| pool.pool.address(idx).map(|addr| (idx, addr.to_string())));
-                let fast_selected = fast_pick
-                    .and_then(|(idx, addr)| pool.begin_request_if_healthy(idx).then_some((idx, addr)));
+                let fast_selected = fast_pick.and_then(|(idx, addr)| {
+                    pool.begin_request_if_healthy(idx).then_some((idx, addr))
+                });
                 (lb_type, fast_selected)
             };
 

--- a/crates/lb/src/lib.rs
+++ b/crates/lb/src/lib.rs
@@ -341,11 +341,12 @@ impl BackendPool {
             return;
         };
 
-        let _ = backend.active_requests.fetch_update(
-            Ordering::Relaxed,
-            Ordering::Relaxed,
-            |current| Some(current.saturating_sub(1)),
-        );
+        let _ =
+            backend
+                .active_requests
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                    Some(current.saturating_sub(1))
+                });
 
         if status.is_some_and(|code| (500..=599).contains(&code)) {
             return;
@@ -926,7 +927,7 @@ mod tests {
 
     #[test]
     fn least_connections_picks_lowest_active() {
-        let mut pool = BackendPool::new_from_states(vec![
+        let pool = BackendPool::new_from_states(vec![
             create_backend_state("10.0.0.1:1", 1),
             create_backend_state("10.0.0.2:1", 1),
             create_backend_state("10.0.0.3:1", 1),

--- a/crates/lb/src/lib.rs
+++ b/crates/lb/src/lib.rs
@@ -1,6 +1,9 @@
 use std::{
     cell::RefCell,
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
     time::{Duration, Instant},
 };
 
@@ -31,7 +34,7 @@ pub struct BackendState {
     health_check: HealthCheck,
     consecutive_failures: u32,
     health_state: HealthState,
-    active_requests: usize,
+    active_requests: Arc<AtomicUsize>,
     ewma_latency_ms: Option<f64>,
 }
 
@@ -60,7 +63,7 @@ impl BackendState {
             health_check: backend.health_check.clone(),
             consecutive_failures: 0,
             health_state: HealthState::Healthy,
-            active_requests: 0,
+            active_requests: Arc::new(AtomicUsize::new(0)),
             ewma_latency_ms: None,
         }
     }
@@ -89,7 +92,7 @@ impl BackendState {
     }
 
     pub fn active_requests(&self) -> usize {
-        self.active_requests
+        self.active_requests.load(Ordering::Relaxed)
     }
 
     pub fn ewma_latency_ms(&self) -> Option<f64> {
@@ -172,7 +175,7 @@ impl UpstreamPool {
         self.load_balancer.pick_readonly(key, &self.pool)
     }
 
-    pub fn begin_request_if_healthy(&mut self, index: usize) -> bool {
+    pub fn begin_request_if_healthy(&self, index: usize) -> bool {
         if self.pool.is_healthy_index(index) {
             self.pool.begin_request(index);
             true
@@ -327,9 +330,9 @@ impl BackendPool {
         self.healthy_pos.get(index).copied().flatten().is_some()
     }
 
-    pub fn begin_request(&mut self, index: usize) {
-        if let Some(backend) = self.backends.get_mut(index) {
-            backend.active_requests = backend.active_requests.saturating_add(1);
+    pub fn begin_request(&self, index: usize) {
+        if let Some(backend) = self.backends.get(index) {
+            backend.active_requests.fetch_add(1, Ordering::Relaxed);
         }
     }
 
@@ -338,9 +341,11 @@ impl BackendPool {
             return;
         };
 
-        if backend.active_requests > 0 {
-            backend.active_requests -= 1;
-        }
+        let _ = backend.active_requests.fetch_update(
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+            |current| Some(current.saturating_sub(1)),
+        );
 
         if status.is_some_and(|code| (500..=599).contains(&code)) {
             return;

--- a/spooky/src/main.rs
+++ b/spooky/src/main.rs
@@ -355,12 +355,12 @@ fn run_sharded_listener_worker(
                 let idle_timeout = Duration::from_millis(10);
                 while !shard_shutdown.load(Ordering::Relaxed) {
                     match rx.recv_timeout(idle_timeout) {
-                        Ok(packet) => {
+                        Ok(mut packet) => {
                             let packet_bytes = packet.bytes.len();
                             listener.process_datagram(
                                 packet.peer,
                                 packet.local_addr,
-                                &packet.bytes,
+                                &mut packet.bytes,
                             );
                             release_shard_queue_bytes(
                                 shard_queue_bytes_counter.as_ref(),

--- a/spooky/src/main.rs
+++ b/spooky/src/main.rs
@@ -304,6 +304,8 @@ fn run_sharded_listener_worker(
     worker_shutdown: Arc<AtomicBool>,
 ) -> Result<(), String> {
     maybe_pin_worker(worker_idx, pin_workers);
+    let dispatcher_slot = worker_idx.saturating_mul(shard_count);
+    worker_shared.bind_metrics_worker_slot(dispatcher_slot);
 
     let local_addr = socket
         .local_addr()
@@ -337,6 +339,7 @@ fn run_sharded_listener_worker(
             .name(shard_name)
             .spawn(move || -> Result<(), String> {
                 maybe_pin_worker(shard_thread_idx, pin_workers);
+                shard_shared.bind_metrics_worker_slot(shard_thread_idx);
                 let mut listener = QUICListener::new_with_socket_and_shared_state(
                     shard_config,
                     shard_socket,
@@ -493,6 +496,7 @@ fn run_single_listener_worker(
     worker_shutdown: Arc<AtomicBool>,
 ) -> Result<(), String> {
     maybe_pin_worker(worker_idx, pin_workers);
+    worker_shared.bind_metrics_worker_slot(worker_idx);
     let mut listener =
         QUICListener::new_with_socket_and_shared_state(worker_config, socket, worker_shared)
             .map_err(|err| format!("worker {} listener init failed: {}", worker_idx, err))?;


### PR DESCRIPTION
This PR improves spooky throughput by removing multiple hot-path synchronization and allocation costs in the edge data plane.

### What changed
- Replaced per-request worker metrics mutex/string path with fixed worker-slot atomics.
- Replaced per-request route metrics mutex updates with pre-registered route labels + atomic counters/histograms.
- Cached listener local address once and stopped calling `socket.local_addr()` per datagram.
- Removed extra datagram copy/allocation in ingress processing (in-place packet handling).
- Cached parsed backend endpoints and reused them for primary/hedge/retry H2 request construction.
- Removed per-request CID lookup-key allocation by using borrowed lookups.
- Added fast path for guaranteed empty upstream responses (`Content-Length: 0`, `204`, `304`) to skip body-pump channel/task creation.
- Reduced upstream pool write-lock pressure:
  - moved `active_requests` tracking to atomics
  - fast readonly backend picks can reserve request slots under read lock.

### Why
These changes target lock contention, avoidable allocations/copies, and task/channel overhead on the critical request path to increase single-node RPS and reduce latency under load.

### Validation
- `cargo check -p spooky-edge --quiet` passes.