### PR TITLE
feat: browser HTTP/3 support via TCP+TLS bootstrap listener with Alt-Svc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ hyper-util = { version = "0.1", features = ["full"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["http2", "webpki-roots", "ring"] }
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 rustls-pemfile = "2.2"
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
 log = "0.4.28"
 quiche = "0.24.6"
 rand = "0.8"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Spooky
 
-**HTTP/3 edge proxy and load balancer**
-
-Spooky terminates HTTP/3/QUIC connections at the edge and forwards requests to HTTP/2 backends. Built in Rust for production environments requiring HTTP/3 client support without modifying existing infrastructure.
+Spooky lets HAProxy, NGINX, and Apache environments adopt QUIC/HTTP/3 in days instead of quarters.
 
 ## Overview
 

--- a/config/config.development.yaml
+++ b/config/config.development.yaml
@@ -7,21 +7,24 @@ listen:
   tls:
     cert: certs/proxy-fullchain.pem
     key: certs/proxy-key-pkcs8.pem
+    client_auth:
+        enabled: false
+        require_client_cert: false
+        ca_file: null
 
 upstream:
   default:
     route:
       path_prefix: "/"
     backends:
-      - id: "backend1"
-        address: "http://127.0.0.1:8080" # local/dev-only cleartext upstream
-        health_check:
-          path: "/health"
-          interval: 5000
+      - id: "frontend1"
+        address: "https://127.0.0.1:443" # local/dev-only cleartext upstream
+        # health_check is optional — omit it to disable active health checks
 
 upstream_tls:
-  verify_certificates: false # development-only: do not copy into production
-  strict_sni: false
+    verify_certificates: false
+    strict_sni: false
+    ca_file: certs/ca-cert.pem
 
 performance:
   worker_threads: 1

--- a/crates/bench/src/main.rs
+++ b/crates/bench/src/main.rs
@@ -720,14 +720,14 @@ fn build_lb_upstream(scale: usize, lb_type: &str) -> Upstream {
             id: format!("backend-{idx:05}"),
             address: format!("127.0.0.1:{}", 10_000 + (idx % 50_000)),
             weight: 1,
-            health_check: HealthCheck {
+            health_check: Some(HealthCheck {
                 path: "/health".to_string(),
                 interval: 5_000,
                 timeout_ms: 1_000,
                 failure_threshold: 3,
                 success_threshold: 2,
                 cooldown_ms: 5_000,
-            },
+            }),
         })
         .collect();
 

--- a/crates/config/src/backend_endpoint.rs
+++ b/crates/config/src/backend_endpoint.rs
@@ -55,10 +55,7 @@ impl BackendEndpoint {
 
         validate_authority(&authority)?;
 
-        Ok(Self {
-            scheme,
-            authority,
-        })
+        Ok(Self { scheme, authority })
     }
 
     pub fn scheme(&self) -> BackendScheme {

--- a/crates/config/src/backend_endpoint.rs
+++ b/crates/config/src/backend_endpoint.rs
@@ -51,11 +51,13 @@ impl BackendEndpoint {
             return Err("backend address must not include path, query, or fragment".to_string());
         }
 
-        validate_authority(authority)?;
+        let authority = normalize_authority(authority, scheme);
+
+        validate_authority(&authority)?;
 
         Ok(Self {
             scheme,
-            authority: authority.to_string(),
+            authority,
         })
     }
 
@@ -81,6 +83,22 @@ impl BackendEndpoint {
         };
         format!("{}{}", self.origin(), normalized)
     }
+}
+
+fn normalize_authority(authority: &str, scheme: BackendScheme) -> String {
+    if authority.starts_with('[') {
+        // IPv6: always requires explicit port per validate_authority rules
+        return authority.to_string();
+    }
+    if authority.rsplit_once(':').is_none() {
+        // No port — append the scheme default
+        let default_port = match scheme {
+            BackendScheme::Https => 443,
+            BackendScheme::Http => 80,
+        };
+        return format!("{}:{}", authority, default_port);
+    }
+    authority.to_string()
 }
 
 fn validate_authority(authority: &str) -> Result<(), String> {
@@ -170,10 +188,25 @@ mod tests {
 
     #[test]
     fn parse_rejects_invalid_authority() {
-        assert!(BackendEndpoint::parse("127.0.0.1").is_err());
         assert!(BackendEndpoint::parse("127.0.0.1:abc").is_err());
         assert!(BackendEndpoint::parse("::1:443").is_err());
         assert!(BackendEndpoint::parse("https://:443").is_err());
+    }
+
+    #[test]
+    fn parse_defaults_port_from_scheme() {
+        let ep = BackendEndpoint::parse("https://wearebackbenchers.info").expect("https no port");
+        assert_eq!(ep.scheme(), BackendScheme::Https);
+        assert_eq!(ep.authority(), "wearebackbenchers.info:443");
+        assert_eq!(ep.origin(), "https://wearebackbenchers.info:443");
+
+        let ep = BackendEndpoint::parse("http://localhost").expect("http no port");
+        assert_eq!(ep.scheme(), BackendScheme::Http);
+        assert_eq!(ep.authority(), "localhost:80");
+
+        let ep = BackendEndpoint::parse("127.0.0.1").expect("bare host defaults https:443");
+        assert_eq!(ep.scheme(), BackendScheme::Https);
+        assert_eq!(ep.authority(), "127.0.0.1:443");
     }
 
     #[test]

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -202,7 +202,8 @@ pub struct Backend {
 
     #[serde(default = "get_default_weight")]
     pub weight: u32, // 100
-    pub health_check: HealthCheck,
+    #[serde(default)]
+    pub health_check: Option<HealthCheck>,
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -972,47 +972,47 @@ pub fn validate(config: &Config) -> bool {
                 return false;
             }
 
-            // Validate health check
-            let hc = &backend.health_check;
+            // Validate health check (optional — omitting it disables active health checks)
+            if let Some(hc) = &backend.health_check {
+                if hc.interval == 0 {
+                    error!(
+                        "Health check interval is invalid (0) for backend '{}' in upstream '{}'",
+                        backend.id, upstream_name
+                    );
+                    return false;
+                }
 
-            if hc.interval == 0 {
-                error!(
-                    "Health check interval is invalid (0) for backend '{}' in upstream '{}'",
-                    backend.id, upstream_name
-                );
-                return false;
-            }
+                if hc.timeout_ms == 0 {
+                    error!(
+                        "Health check timeout is invalid (0) for backend '{}' in upstream '{}'",
+                        backend.id, upstream_name
+                    );
+                    return false;
+                }
 
-            if hc.timeout_ms == 0 {
-                error!(
-                    "Health check timeout is invalid (0) for backend '{}' in upstream '{}'",
-                    backend.id, upstream_name
-                );
-                return false;
-            }
+                if hc.failure_threshold == 0 {
+                    error!(
+                        "Health check failure threshold is invalid (0) for backend '{}' in upstream '{}'",
+                        backend.id, upstream_name
+                    );
+                    return false;
+                }
 
-            if hc.failure_threshold == 0 {
-                error!(
-                    "Health check failure threshold is invalid (0) for backend '{}' in upstream '{}'",
-                    backend.id, upstream_name
-                );
-                return false;
-            }
+                if hc.success_threshold == 0 {
+                    error!(
+                        "Health check success threshold is invalid (0) for backend '{}' in upstream '{}'",
+                        backend.id, upstream_name
+                    );
+                    return false;
+                }
 
-            if hc.success_threshold == 0 {
-                error!(
-                    "Health check success threshold is invalid (0) for backend '{}' in upstream '{}'",
-                    backend.id, upstream_name
-                );
-                return false;
-            }
-
-            if hc.cooldown_ms == 0 {
-                error!(
-                    "Health check cooldown is invalid (0) for backend '{}' in upstream '{}'",
-                    backend.id, upstream_name
-                );
-                return false;
+                if hc.cooldown_ms == 0 {
+                    error!(
+                        "Health check cooldown is invalid (0) for backend '{}' in upstream '{}'",
+                        backend.id, upstream_name
+                    );
+                    return false;
+                }
             }
         }
     }
@@ -1068,14 +1068,14 @@ mod tests {
                     id: "backend-1".to_string(),
                     address: "127.0.0.1:8080".to_string(),
                     weight: 1,
-                    health_check: HealthCheck {
+                    health_check: Some(HealthCheck {
                         path: "/health".to_string(),
                         interval: 1000,
                         timeout_ms: 1000,
                         failure_threshold: 3,
                         success_threshold: 1,
                         cooldown_ms: 1000,
-                    },
+                    }),
                 }],
             },
         );

--- a/crates/edge/Cargo.toml
+++ b/crates/edge/Cargo.toml
@@ -26,6 +26,9 @@ hex = "0.4"
 socket2.workspace = true
 tracing.workspace = true
 serde_json.workspace = true
+tokio-rustls.workspace = true
+rustls.workspace = true
+rustls-pemfile.workspace = true
 
 [dev-dependencies]
 rand.workspace = true

--- a/crates/edge/src/benchmark.rs
+++ b/crates/edge/src/benchmark.rs
@@ -39,7 +39,7 @@ fn build_benchmark_upstream(host: Option<String>, path_prefix: String) -> Upstre
             id: "placeholder".to_string(),
             address: "127.0.0.1:1".to_string(),
             weight: 1,
-            health_check: default_health_check(),
+            health_check: Some(default_health_check()),
         }],
     }
 }

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -16,8 +16,11 @@ use http::{Request, Response, StatusCode};
 use http_body_util::{BodyExt, Full, combinators::BoxBody};
 use hyper::body::Incoming;
 use hyper::server::conn::http1;
+use hyper::server::conn::http2;
 use hyper::service::service_fn;
 use hyper_util::rt::TokioIo;
+use rustls::ServerConfig as RustlsServerConfig;
+use tokio_rustls::TlsAcceptor;
 use log::{debug, error, info, warn};
 use quiche::Config;
 use quiche::h3::NameValue;
@@ -778,6 +781,7 @@ impl QUICListener {
         );
         Self::spawn_metrics_endpoint(config, Arc::clone(&shared_state.metrics))?;
         Self::spawn_control_api_endpoint(config, shared_state, worker_count)?;
+        Self::spawn_bootstrap_tls_listener(config, shared_state)?;
         Self::spawn_watchdog(
             config,
             Arc::clone(&shared_state.metrics),
@@ -1639,6 +1643,7 @@ impl QUICListener {
                 self.config.observability.tracing.enabled,
                 self.config.observability.routing.enabled,
                 self.config.observability.routing.include_reason,
+                self.config.listen.port,
             )
         {
             error!("HTTP/3 handling failed: {:?}", e);
@@ -1724,6 +1729,7 @@ impl QUICListener {
                     self.max_response_body_bytes,
                     self.unknown_length_response_prebuffer_bytes,
                     self.client_body_idle_timeout,
+                    self.config.listen.port,
                 ) {
                     error!("advance_streams_non_blocking in timeout path: {:?}", e);
                 }
@@ -1882,6 +1888,7 @@ impl QUICListener {
         tracing_enabled: bool,
         routing_transparency_enabled: bool,
         routing_transparency_include_reason: bool,
+        listen_port: u32,
     ) -> Result<(), quiche::h3::Error> {
         let mut body_buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
 
@@ -2819,6 +2826,7 @@ impl QUICListener {
             max_response_body_bytes,
             unknown_length_response_prebuffer_bytes,
             client_body_idle_timeout,
+            listen_port,
         )?;
 
         Ok(())
@@ -2857,6 +2865,7 @@ impl QUICListener {
         max_response_body_bytes: usize,
         unknown_length_response_prebuffer_bytes: usize,
         client_body_idle_timeout: Duration,
+        listen_port: u32,
     ) -> Result<(), quiche::h3::Error> {
         let stream_ids: Vec<u64> = streams.keys().copied().collect();
 
@@ -3057,6 +3066,10 @@ impl QUICListener {
                                 value.as_bytes().to_vec(),
                             ));
                         }
+                        owned_h3_headers.push((
+                            b"alt-svc".to_vec(),
+                            format!("h3=\":{}\"; ma=86400", listen_port).into_bytes(),
+                        ));
 
                         let defer_headers_until_body_validated = upstream_content_length.is_none();
                         let immediate_end = upstream_content_length == Some(0)
@@ -4269,6 +4282,382 @@ impl QUICListener {
                 }
             },
         );
+        Ok(())
+    }
+
+    fn build_bootstrap_tls_acceptor(config: &SpookyConfig) -> Result<TlsAcceptor, ProxyError> {
+        use rustls_pemfile::{certs, pkcs8_private_keys, rsa_private_keys};
+        use std::io::BufReader;
+
+        let cert_bytes = std::fs::read(&config.listen.tls.cert).map_err(|err| {
+            ProxyError::Tls(format!(
+                "failed to read TLS cert '{}': {}",
+                config.listen.tls.cert, err
+            ))
+        })?;
+        let key_bytes = std::fs::read(&config.listen.tls.key).map_err(|err| {
+            ProxyError::Tls(format!(
+                "failed to read TLS key '{}': {}",
+                config.listen.tls.key, err
+            ))
+        })?;
+
+        let certs: Vec<rustls::pki_types::CertificateDer<'static>> =
+            certs(&mut BufReader::new(cert_bytes.as_slice()))
+                .collect::<Result<_, _>>()
+                .map_err(|err| {
+                    ProxyError::Tls(format!("failed to parse TLS cert PEM: {}", err))
+                })?;
+
+        let key = {
+            let mut reader = BufReader::new(key_bytes.as_slice());
+            let pkcs8: Vec<rustls::pki_types::PrivateKeyDer<'static>> =
+                pkcs8_private_keys(&mut reader)
+                    .map(|r| r.map(rustls::pki_types::PrivateKeyDer::Pkcs8))
+                    .collect::<Result<_, _>>()
+                    .map_err(|err| {
+                        ProxyError::Tls(format!("failed to parse PKCS8 key PEM: {}", err))
+                    })?;
+            if !pkcs8.is_empty() {
+                pkcs8.into_iter().next().unwrap()
+            } else {
+                let mut reader2 = BufReader::new(key_bytes.as_slice());
+                let rsa: Vec<rustls::pki_types::PrivateKeyDer<'static>> =
+                    rsa_private_keys(&mut reader2)
+                        .map(|r| r.map(rustls::pki_types::PrivateKeyDer::Pkcs1))
+                        .collect::<Result<_, _>>()
+                        .map_err(|err| {
+                            ProxyError::Tls(format!("failed to parse RSA key PEM: {}", err))
+                        })?;
+                rsa.into_iter().next().ok_or_else(|| {
+                    ProxyError::Tls("no supported private key found in TLS key file".to_string())
+                })?
+            }
+        };
+
+        let mut tls_config = RustlsServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(certs, key)
+            .map_err(|err| ProxyError::Tls(format!("failed to build rustls ServerConfig: {}", err)))?;
+
+        tls_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+
+        Ok(TlsAcceptor::from(Arc::new(tls_config)))
+    }
+
+    fn spawn_bootstrap_tls_listener(
+        config: &SpookyConfig,
+        shared_state: &SharedRuntimeState,
+    ) -> Result<(), ProxyError> {
+        let acceptor = match Self::build_bootstrap_tls_acceptor(config) {
+            Ok(a) => a,
+            Err(err) => {
+                warn!(
+                    "Bootstrap TLS listener disabled (could not build TLS config): {}",
+                    err
+                );
+                return Ok(());
+            }
+        };
+
+        let bind = format!("{}:{}", config.listen.address, config.listen.port);
+        let alt_svc_value = format!("h3=\":{}\"; ma=86400", config.listen.port);
+        let backend_timeout = Duration::from_millis(config.performance.backend_timeout_ms);
+
+        let h2_pool = Arc::clone(&shared_state.h2_pool);
+        let backend_endpoints = Arc::clone(&shared_state.backend_endpoints);
+        let upstream_pools = shared_state.upstream_pools.clone();
+        let routing_index = RouteIndex::from_upstreams(&config.upstream);
+
+        let handle = match runtime_handle() {
+            Some(h) => h,
+            None => {
+                warn!("Bootstrap TLS listener disabled (no Tokio runtime available)");
+                return Ok(());
+            }
+        };
+
+        let std_listener = match std::net::TcpListener::bind(&bind) {
+            Ok(l) => l,
+            Err(err) => {
+                warn!(
+                    "Bootstrap TLS listener could not bind TCP {}: {} \
+                    (browser HTTP/3 discovery will not work; Alt-Svc will only come from QUIC responses)",
+                    bind, err
+                );
+                return Ok(());
+            }
+        };
+        if let Err(err) = std_listener.set_nonblocking(true) {
+            warn!(
+                "Bootstrap TLS listener set_nonblocking failed ({}): {}",
+                bind, err
+            );
+            return Ok(());
+        }
+        let listener = match tokio::net::TcpListener::from_std(std_listener) {
+            Ok(l) => l,
+            Err(err) => {
+                warn!(
+                    "Bootstrap TLS listener registration failed ({}): {}",
+                    bind, err
+                );
+                return Ok(());
+            }
+        };
+
+        let routing_index = Arc::new(routing_index);
+
+        spawn_supervised_async_task(&handle, "bootstrap-tls-listener", None, async move {
+            info!(
+                "Bootstrap TLS listener on https://{} (TCP+TLS) — advertising Alt-Svc: {}",
+                bind, alt_svc_value
+            );
+            loop {
+                let (stream, peer) = match listener.accept().await {
+                    Ok(v) => v,
+                    Err(err) => {
+                        error!("Bootstrap TLS listener accept failed: {}", err);
+                        continue;
+                    }
+                };
+
+                let acceptor = acceptor.clone();
+                let alt_svc = alt_svc_value.clone();
+                let h2_pool = Arc::clone(&h2_pool);
+                let backend_endpoints = Arc::clone(&backend_endpoints);
+                let upstream_pools = upstream_pools.clone();
+                let routing_index = Arc::clone(&routing_index);
+
+                tokio::spawn(async move {
+                    let tls_stream = match acceptor.accept(stream).await {
+                        Ok(s) => s,
+                        Err(err) => {
+                            debug!(
+                                "Bootstrap TLS handshake failed from {}: {}",
+                                peer, err
+                            );
+                            return;
+                        }
+                    };
+
+                    let negotiated = tls_stream
+                        .get_ref()
+                        .1
+                        .alpn_protocol()
+                        .map(|p| p.to_vec());
+                    let use_h2 = negotiated.as_deref() == Some(b"h2");
+
+                    let io = TokioIo::new(tls_stream);
+                    let alt_svc_conn = alt_svc.clone();
+
+                    let svc = service_fn(move |req: Request<Incoming>| -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Response<Full<Bytes>>, hyper::Error>> + Send>> {
+                        let alt = alt_svc_conn.clone();
+                        let h2_pool = Arc::clone(&h2_pool);
+                        let backend_endpoints = Arc::clone(&backend_endpoints);
+                        let upstream_pools = upstream_pools.clone();
+                        let routing_index = Arc::clone(&routing_index);
+
+                        Box::pin(async move {
+                            let _method = req.method().to_string();
+                            let path = req.uri().path_and_query()
+                                .map(|pq| pq.as_str().to_owned())
+                                .unwrap_or_else(|| "/".to_string());
+                            let authority = req.uri().authority()
+                                .map(|a| a.as_str().to_owned())
+                                .or_else(|| {
+                                    req.headers()
+                                        .get(http::header::HOST)
+                                        .and_then(|v| v.to_str().ok())
+                                        .map(str::to_owned)
+                                });
+
+                            // Route lookup
+                            let upstream_name = routing_index
+                                .lookup(&path, authority.as_deref());
+                            let upstream_name = match upstream_name {
+                                Some(name) => name.to_string(),
+                                None => {
+                                    return Ok(Response::builder()
+                                        .status(StatusCode::BAD_GATEWAY)
+                                        .header("alt-svc", &alt)
+                                        .body(Full::new(Bytes::from_static(b"no route\n")))
+                                        .unwrap_or_else(|_| Response::new(Full::new(Bytes::from_static(b"error\n")))));
+                                }
+                            };
+
+                            // Pick backend
+                            let backend_addr = {
+                                let pool_lock = match upstream_pools.get(&upstream_name) {
+                                    Some(p) => p,
+                                    None => {
+                                        return Ok(Response::builder()
+                                            .status(StatusCode::BAD_GATEWAY)
+                                            .header("alt-svc", &alt)
+                                            .body(Full::new(Bytes::from_static(b"no pool\n")))
+                                            .unwrap_or_else(|_| Response::new(Full::new(Bytes::from_static(b"error\n")))));
+                                    }
+                                };
+                                let pool = match pool_lock.read() {
+                                    Ok(p) => p,
+                                    Err(_) => {
+                                        return Ok(Response::builder()
+                                            .status(StatusCode::BAD_GATEWAY)
+                                            .header("alt-svc", &alt)
+                                            .body(Full::new(Bytes::from_static(b"pool error\n")))
+                                            .unwrap_or_else(|_| Response::new(Full::new(Bytes::from_static(b"error\n")))));
+                                    }
+                                };
+                                match pool.pool.address(0).map(str::to_owned) {
+                                    Some(addr) => addr,
+                                    None => {
+                                        return Ok(Response::builder()
+                                            .status(StatusCode::SERVICE_UNAVAILABLE)
+                                            .header("alt-svc", &alt)
+                                            .body(Full::new(Bytes::from_static(b"no backends\n")))
+                                            .unwrap_or_else(|_| Response::new(Full::new(Bytes::from_static(b"error\n")))));
+                                    }
+                                }
+                            };
+
+                            let endpoint = match backend_endpoints.get(&backend_addr) {
+                                Some(ep) => ep.clone(),
+                                None => {
+                                    return Ok(Response::builder()
+                                        .status(StatusCode::BAD_GATEWAY)
+                                        .header("alt-svc", &alt)
+                                        .body(Full::new(Bytes::from_static(b"no endpoint\n")))
+                                        .unwrap_or_else(|_| Response::new(Full::new(Bytes::from_static(b"error\n")))));
+                                }
+                            };
+
+                            // Build upstream request
+                            let request_path = if path.is_empty() { "/" } else { &path };
+                            let upstream_uri = match http::Uri::try_from(endpoint.uri_for_path(request_path)) {
+                                Ok(u) => u,
+                                Err(_) => {
+                                    return Ok(Response::builder()
+                                        .status(StatusCode::BAD_GATEWAY)
+                                        .header("alt-svc", &alt)
+                                        .body(Full::new(Bytes::from_static(b"bad uri\n")))
+                                        .unwrap_or_else(|_| Response::new(Full::new(Bytes::from_static(b"error\n")))));
+                                }
+                            };
+
+                            let mut upstream_req = Request::builder()
+                                .method(req.method().clone())
+                                .uri(upstream_uri);
+
+                            for (name, value) in req.headers() {
+                                if name == http::header::HOST
+                                    || name == http::header::CONNECTION
+                                    || name == http::header::UPGRADE
+                                    || name == http::header::PROXY_AUTHORIZATION
+                                    || name.as_str() == "keep-alive"
+                                    || name.as_str() == "proxy-connection"
+                                    || name.as_str() == "te"
+                                    || name.as_str() == "trailers"
+                                    || name.as_str() == "transfer-encoding"
+                                {
+                                    continue;
+                                }
+                                upstream_req = upstream_req.header(name, value);
+                            }
+                            upstream_req = upstream_req.header(
+                                http::header::HOST,
+                                authority.as_deref().unwrap_or(endpoint.authority()),
+                            );
+                            upstream_req = upstream_req.header(
+                                "forwarded",
+                                format!("for={};proto=https", peer.ip()),
+                            );
+
+                            let body_bytes = match req.into_body().collect().await {
+                                Ok(collected) => collected.to_bytes(),
+                                Err(_) => Bytes::new(),
+                            };
+                            let upstream_body = http_body_util::Full::new(body_bytes.clone())
+                                .map_err(|e: std::convert::Infallible| e)
+                                .boxed();
+
+                            let upstream_request = match upstream_req.body(upstream_body) {
+                                Ok(r) => r,
+                                Err(_) => {
+                                    return Ok(Response::builder()
+                                        .status(StatusCode::BAD_GATEWAY)
+                                        .header("alt-svc", &alt)
+                                        .body(Full::new(Bytes::from_static(b"request build error\n")))
+                                        .unwrap_or_else(|_| Response::new(Full::new(Bytes::from_static(b"error\n")))));
+                                }
+                            };
+
+                            // Forward to backend
+                            let upstream_resp = match tokio::time::timeout(
+                                backend_timeout,
+                                h2_pool.send(&backend_addr, upstream_request),
+                            ).await {
+                                Ok(Ok(resp)) => resp,
+                                Ok(Err(err)) => {
+                                    warn!("Bootstrap proxy upstream error: {}", err);
+                                    return Ok(Response::builder()
+                                        .status(StatusCode::BAD_GATEWAY)
+                                        .header("alt-svc", &alt)
+                                        .body(Full::new(Bytes::from_static(b"upstream error\n")))
+                                        .unwrap_or_else(|_| Response::new(Full::new(Bytes::from_static(b"error\n")))));
+                                }
+                                Err(_) => {
+                                    return Ok(Response::builder()
+                                        .status(StatusCode::GATEWAY_TIMEOUT)
+                                        .header("alt-svc", &alt)
+                                        .body(Full::new(Bytes::from_static(b"upstream timeout\n")))
+                                        .unwrap_or_else(|_| Response::new(Full::new(Bytes::from_static(b"error\n")))));
+                                }
+                            };
+
+                            // Build downstream response with Alt-Svc injected
+                            let status = upstream_resp.status();
+                            let mut resp_builder = Response::builder().status(status);
+                            for (name, value) in upstream_resp.headers() {
+                                if name == http::header::CONNECTION
+                                    || name.as_str() == "keep-alive"
+                                    || name.as_str() == "transfer-encoding"
+                                    || name.as_str() == "alt-svc"
+                                {
+                                    continue;
+                                }
+                                resp_builder = resp_builder.header(name, value);
+                            }
+                            resp_builder = resp_builder.header("alt-svc", &alt);
+
+                            let resp_body = match upstream_resp.into_body().collect().await {
+                                Ok(collected) => collected.to_bytes(),
+                                Err(_) => Bytes::new(),
+                            };
+
+                            Ok(resp_builder
+                                .body(Full::new(resp_body))
+                                .unwrap_or_else(|_| Response::new(Full::new(Bytes::new()))))
+                        })
+                    });
+
+                    if use_h2 {
+                        let executor = hyper_util::rt::TokioExecutor::new();
+                        if let Err(err) =
+                            http2::Builder::new(executor).serve_connection(io, svc).await
+                        {
+                            debug!("Bootstrap h2 connection from {} closed: {}", peer, err);
+                        }
+                    } else {
+                        if let Err(err) =
+                            http1::Builder::new().serve_connection(io, svc).await
+                        {
+                            debug!("Bootstrap h1 connection from {} closed: {}", peer, err);
+                        }
+                    }
+                });
+            }
+        });
+
         Ok(())
     }
 

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -4327,8 +4327,8 @@ impl QUICListener {
                     .map_err(|err| {
                         ProxyError::Tls(format!("failed to parse PKCS8 key PEM: {}", err))
                     })?;
-            if !pkcs8.is_empty() {
-                pkcs8.into_iter().next().unwrap()
+            if let Some(key) = pkcs8.into_iter().next() {
+                key
             } else {
                 let mut reader2 = BufReader::new(key_bytes.as_slice());
                 let rsa: Vec<rustls::pki_types::PrivateKeyDer<'static>> =
@@ -4604,9 +4604,20 @@ impl QUICListener {
                             };
 
                             // Build a template request (no body) then clone per retry attempt
-                            let template = upstream_req
-                                .body(())
-                                .expect("builder cannot fail with unit body");
+                            let template = match upstream_req.body(()) {
+                                Ok(r) => r,
+                                Err(_) => {
+                                    return Ok(Response::builder()
+                                        .status(StatusCode::BAD_GATEWAY)
+                                        .header("alt-svc", &alt)
+                                        .body(Full::new(Bytes::from_static(
+                                            b"request build error\n",
+                                        )))
+                                        .unwrap_or_else(|_| {
+                                            Response::new(Full::new(Bytes::from_static(b"error\n")))
+                                        }));
+                                }
+                            };
                             let (parts, _) = template.into_parts();
                             let parts = Arc::new(parts);
 

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -19,12 +19,11 @@ use hyper::server::conn::http1;
 use hyper::server::conn::http2;
 use hyper::service::service_fn;
 use hyper_util::rt::TokioIo;
-use rustls::ServerConfig as RustlsServerConfig;
-use tokio_rustls::TlsAcceptor;
 use log::{debug, error, info, warn};
 use quiche::Config;
 use quiche::h3::NameValue;
 use rand::RngCore;
+use rustls::ServerConfig as RustlsServerConfig;
 use serde_json::json;
 use socket2::{Domain, Protocol, Socket, Type};
 use spooky_bridge::h3_to_h2::{ForwardedContext, build_h2_request_for_endpoint};
@@ -38,6 +37,7 @@ use tokio::sync::{
     mpsc::error::{TryRecvError, TrySendError},
     oneshot,
 };
+use tokio_rustls::TlsAcceptor;
 use tracing::{Instrument, info_span};
 
 use spooky_config::{backend_endpoint::BackendEndpoint, config::Config as SpookyConfig};
@@ -112,7 +112,14 @@ fn is_hop_header(name: &str) -> bool {
 }
 
 type BootstrapServiceFuture = std::pin::Pin<
-    Box<dyn std::future::Future<Output = Result<hyper::Response<http_body_util::Full<hyper::body::Bytes>>, hyper::Error>> + Send>,
+    Box<
+        dyn std::future::Future<
+                Output = Result<
+                    hyper::Response<http_body_util::Full<hyper::body::Bytes>>,
+                    hyper::Error,
+                >,
+            > + Send,
+    >,
 >;
 
 type ResolvedBackend = (
@@ -4309,9 +4316,7 @@ impl QUICListener {
         let certs: Vec<rustls::pki_types::CertificateDer<'static>> =
             certs(&mut BufReader::new(cert_bytes.as_slice()))
                 .collect::<Result<_, _>>()
-                .map_err(|err| {
-                    ProxyError::Tls(format!("failed to parse TLS cert PEM: {}", err))
-                })?;
+                .map_err(|err| ProxyError::Tls(format!("failed to parse TLS cert PEM: {}", err)))?;
 
         let key = {
             let mut reader = BufReader::new(key_bytes.as_slice());
@@ -4342,7 +4347,9 @@ impl QUICListener {
         let mut tls_config = RustlsServerConfig::builder()
             .with_no_client_auth()
             .with_single_cert(certs, key)
-            .map_err(|err| ProxyError::Tls(format!("failed to build rustls ServerConfig: {}", err)))?;
+            .map_err(|err| {
+                ProxyError::Tls(format!("failed to build rustls ServerConfig: {}", err))
+            })?;
 
         tls_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
 
@@ -4437,19 +4444,12 @@ impl QUICListener {
                     let tls_stream = match acceptor.accept(stream).await {
                         Ok(s) => s,
                         Err(err) => {
-                            debug!(
-                                "Bootstrap TLS handshake failed from {}: {}",
-                                peer, err
-                            );
+                            debug!("Bootstrap TLS handshake failed from {}: {}", peer, err);
                             return;
                         }
                     };
 
-                    let negotiated = tls_stream
-                        .get_ref()
-                        .1
-                        .alpn_protocol()
-                        .map(|p| p.to_vec());
+                    let negotiated = tls_stream.get_ref().1.alpn_protocol().map(|p| p.to_vec());
                     let use_h2 = negotiated.as_deref() == Some(b"h2");
 
                     let io = TokioIo::new(tls_stream);
@@ -4464,10 +4464,14 @@ impl QUICListener {
 
                         Box::pin(async move {
                             let _method = req.method().to_string();
-                            let path = req.uri().path_and_query()
+                            let path = req
+                                .uri()
+                                .path_and_query()
                                 .map(|pq| pq.as_str().to_owned())
                                 .unwrap_or_else(|| "/".to_string());
-                            let authority = req.uri().authority()
+                            let authority = req
+                                .uri()
+                                .authority()
                                 .map(|a| a.as_str().to_owned())
                                 .or_else(|| {
                                     req.headers()
@@ -4477,8 +4481,7 @@ impl QUICListener {
                                 });
 
                             // Route lookup
-                            let upstream_name = routing_index
-                                .lookup(&path, authority.as_deref());
+                            let upstream_name = routing_index.lookup(&path, authority.as_deref());
                             let upstream_name = match upstream_name {
                                 Some(name) => name.to_string(),
                                 None => {
@@ -4486,7 +4489,9 @@ impl QUICListener {
                                         .status(StatusCode::BAD_GATEWAY)
                                         .header("alt-svc", &alt)
                                         .body(Full::new(Bytes::from_static(b"no route\n")))
-                                        .unwrap_or_else(|_| Response::new(Full::new(Bytes::from_static(b"error\n")))));
+                                        .unwrap_or_else(|_| {
+                                            Response::new(Full::new(Bytes::from_static(b"error\n")))
+                                        }));
                                 }
                             };
 
@@ -4499,7 +4504,11 @@ impl QUICListener {
                                             .status(StatusCode::BAD_GATEWAY)
                                             .header("alt-svc", &alt)
                                             .body(Full::new(Bytes::from_static(b"no pool\n")))
-                                            .unwrap_or_else(|_| Response::new(Full::new(Bytes::from_static(b"error\n")))));
+                                            .unwrap_or_else(|_| {
+                                                Response::new(Full::new(Bytes::from_static(
+                                                    b"error\n",
+                                                )))
+                                            }));
                                     }
                                 };
                                 let pool = match pool_lock.read() {
@@ -4509,7 +4518,11 @@ impl QUICListener {
                                             .status(StatusCode::BAD_GATEWAY)
                                             .header("alt-svc", &alt)
                                             .body(Full::new(Bytes::from_static(b"pool error\n")))
-                                            .unwrap_or_else(|_| Response::new(Full::new(Bytes::from_static(b"error\n")))));
+                                            .unwrap_or_else(|_| {
+                                                Response::new(Full::new(Bytes::from_static(
+                                                    b"error\n",
+                                                )))
+                                            }));
                                     }
                                 };
                                 match pool.pool.address(0).map(str::to_owned) {
@@ -4519,7 +4532,11 @@ impl QUICListener {
                                             .status(StatusCode::SERVICE_UNAVAILABLE)
                                             .header("alt-svc", &alt)
                                             .body(Full::new(Bytes::from_static(b"no backends\n")))
-                                            .unwrap_or_else(|_| Response::new(Full::new(Bytes::from_static(b"error\n")))));
+                                            .unwrap_or_else(|_| {
+                                                Response::new(Full::new(Bytes::from_static(
+                                                    b"error\n",
+                                                )))
+                                            }));
                                     }
                                 }
                             };
@@ -4531,22 +4548,29 @@ impl QUICListener {
                                         .status(StatusCode::BAD_GATEWAY)
                                         .header("alt-svc", &alt)
                                         .body(Full::new(Bytes::from_static(b"no endpoint\n")))
-                                        .unwrap_or_else(|_| Response::new(Full::new(Bytes::from_static(b"error\n")))));
+                                        .unwrap_or_else(|_| {
+                                            Response::new(Full::new(Bytes::from_static(b"error\n")))
+                                        }));
                                 }
                             };
 
                             // Build upstream request
                             let request_path = if path.is_empty() { "/" } else { &path };
-                            let upstream_uri = match http::Uri::try_from(endpoint.uri_for_path(request_path)) {
-                                Ok(u) => u,
-                                Err(_) => {
-                                    return Ok(Response::builder()
-                                        .status(StatusCode::BAD_GATEWAY)
-                                        .header("alt-svc", &alt)
-                                        .body(Full::new(Bytes::from_static(b"bad uri\n")))
-                                        .unwrap_or_else(|_| Response::new(Full::new(Bytes::from_static(b"error\n")))));
-                                }
-                            };
+                            let upstream_uri =
+                                match http::Uri::try_from(endpoint.uri_for_path(request_path)) {
+                                    Ok(u) => u,
+                                    Err(_) => {
+                                        return Ok(Response::builder()
+                                            .status(StatusCode::BAD_GATEWAY)
+                                            .header("alt-svc", &alt)
+                                            .body(Full::new(Bytes::from_static(b"bad uri\n")))
+                                            .unwrap_or_else(|_| {
+                                                Response::new(Full::new(Bytes::from_static(
+                                                    b"error\n",
+                                                )))
+                                            }));
+                                    }
+                                };
 
                             let mut upstream_req = Request::builder()
                                 .method(req.method().clone())
@@ -4571,10 +4595,8 @@ impl QUICListener {
                                 http::header::HOST,
                                 authority.as_deref().unwrap_or(endpoint.authority()),
                             );
-                            upstream_req = upstream_req.header(
-                                "forwarded",
-                                format!("for={};proto=https", peer.ip()),
-                            );
+                            upstream_req = upstream_req
+                                .header("forwarded", format!("for={};proto=https", peer.ip()));
 
                             let body_bytes = match req.into_body().collect().await {
                                 Ok(collected) => collected.to_bytes(),
@@ -4582,7 +4604,9 @@ impl QUICListener {
                             };
 
                             // Build a template request (no body) then clone per retry attempt
-                            let template = upstream_req.body(()).expect("builder cannot fail with unit body");
+                            let template = upstream_req
+                                .body(())
+                                .expect("builder cannot fail with unit body");
                             let (parts, _) = template.into_parts();
                             let parts = Arc::new(parts);
 
@@ -4601,7 +4625,9 @@ impl QUICListener {
                                 match tokio::time::timeout(
                                     backend_timeout,
                                     h2_pool.send(&backend_addr, retry_req),
-                                ).await {
+                                )
+                                .await
+                                {
                                     Ok(Ok(resp)) => {
                                         upstream_resp_opt = Some(resp);
                                         break;
@@ -4613,20 +4639,31 @@ impl QUICListener {
                                         return Ok(Response::builder()
                                             .status(StatusCode::GATEWAY_TIMEOUT)
                                             .header("alt-svc", &alt)
-                                            .body(Full::new(Bytes::from_static(b"upstream timeout\n")))
-                                            .unwrap_or_else(|_| Response::new(Full::new(Bytes::from_static(b"error\n")))));
+                                            .body(Full::new(Bytes::from_static(
+                                                b"upstream timeout\n",
+                                            )))
+                                            .unwrap_or_else(|_| {
+                                                Response::new(Full::new(Bytes::from_static(
+                                                    b"error\n",
+                                                )))
+                                            }));
                                     }
                                 }
                             }
                             let upstream_resp = match upstream_resp_opt {
                                 Some(r) => r,
                                 None => {
-                                    warn!("Bootstrap proxy upstream error after retries: {}", last_err);
+                                    warn!(
+                                        "Bootstrap proxy upstream error after retries: {}",
+                                        last_err
+                                    );
                                     return Ok(Response::builder()
                                         .status(StatusCode::BAD_GATEWAY)
                                         .header("alt-svc", &alt)
                                         .body(Full::new(Bytes::from_static(b"upstream error\n")))
-                                        .unwrap_or_else(|_| Response::new(Full::new(Bytes::from_static(b"error\n")))));
+                                        .unwrap_or_else(|_| {
+                                            Response::new(Full::new(Bytes::from_static(b"error\n")))
+                                        }));
                                 }
                             };
 
@@ -4658,14 +4695,13 @@ impl QUICListener {
 
                     if use_h2 {
                         let executor = hyper_util::rt::TokioExecutor::new();
-                        if let Err(err) =
-                            http2::Builder::new(executor).serve_connection(io, svc).await
+                        if let Err(err) = http2::Builder::new(executor)
+                            .serve_connection(io, svc)
+                            .await
                         {
                             debug!("Bootstrap h2 connection from {} closed: {}", peer, err);
                         }
-                    } else if let Err(err) =
-                        http1::Builder::new().serve_connection(io, svc).await
-                    {
+                    } else if let Err(err) = http1::Builder::new().serve_connection(io, svc).await {
                         debug!("Bootstrap h1 connection from {} closed: {}", peer, err);
                     }
                 });

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -4395,20 +4395,20 @@ impl QUICListener {
             );
             return Ok(());
         }
-        let listener = match tokio::net::TcpListener::from_std(std_listener) {
-            Ok(l) => l,
-            Err(err) => {
-                warn!(
-                    "Bootstrap TLS listener registration failed ({}): {}",
-                    bind, err
-                );
-                return Ok(());
-            }
-        };
 
         let routing_index = Arc::new(routing_index);
 
         spawn_supervised_async_task(&handle, "bootstrap-tls-listener", None, async move {
+            let listener = match tokio::net::TcpListener::from_std(std_listener) {
+                Ok(l) => l,
+                Err(err) => {
+                    warn!(
+                        "Bootstrap TLS listener registration failed ({}): {}",
+                        bind, err
+                    );
+                    return;
+                }
+            };
             info!(
                 "Bootstrap TLS listener on https://{} (TCP+TLS) — advertising Alt-Svc: {}",
                 bind, alt_svc_value
@@ -4576,40 +4576,52 @@ impl QUICListener {
                                 Ok(collected) => collected.to_bytes(),
                                 Err(_) => Bytes::new(),
                             };
-                            let upstream_body = http_body_util::Full::new(body_bytes.clone())
-                                .map_err(|e: std::convert::Infallible| e)
-                                .boxed();
 
-                            let upstream_request = match upstream_req.body(upstream_body) {
-                                Ok(r) => r,
-                                Err(_) => {
-                                    return Ok(Response::builder()
-                                        .status(StatusCode::BAD_GATEWAY)
-                                        .header("alt-svc", &alt)
-                                        .body(Full::new(Bytes::from_static(b"request build error\n")))
-                                        .unwrap_or_else(|_| Response::new(Full::new(Bytes::from_static(b"error\n")))));
+                            // Build a template request (no body) then clone per retry attempt
+                            let template = upstream_req.body(()).expect("builder cannot fail with unit body");
+                            let (parts, _) = template.into_parts();
+                            let parts = Arc::new(parts);
+
+                            // Forward to backend — retry on connection errors (pool not yet warm)
+                            const MAX_RETRIES: u32 = 3;
+                            let mut last_err = String::new();
+                            let mut upstream_resp_opt = None;
+                            for attempt in 0..=MAX_RETRIES {
+                                if attempt > 0 {
+                                    tokio::time::sleep(Duration::from_millis(150)).await;
                                 }
-                            };
-
-                            // Forward to backend
-                            let upstream_resp = match tokio::time::timeout(
-                                backend_timeout,
-                                h2_pool.send(&backend_addr, upstream_request),
-                            ).await {
-                                Ok(Ok(resp)) => resp,
-                                Ok(Err(err)) => {
-                                    warn!("Bootstrap proxy upstream error: {}", err);
+                                let retry_body = http_body_util::Full::new(body_bytes.clone())
+                                    .map_err(|e: std::convert::Infallible| e)
+                                    .boxed();
+                                let retry_req = Request::from_parts((*parts).clone(), retry_body);
+                                match tokio::time::timeout(
+                                    backend_timeout,
+                                    h2_pool.send(&backend_addr, retry_req),
+                                ).await {
+                                    Ok(Ok(resp)) => {
+                                        upstream_resp_opt = Some(resp);
+                                        break;
+                                    }
+                                    Ok(Err(err)) => {
+                                        last_err = err.to_string();
+                                    }
+                                    Err(_) => {
+                                        return Ok(Response::builder()
+                                            .status(StatusCode::GATEWAY_TIMEOUT)
+                                            .header("alt-svc", &alt)
+                                            .body(Full::new(Bytes::from_static(b"upstream timeout\n")))
+                                            .unwrap_or_else(|_| Response::new(Full::new(Bytes::from_static(b"error\n")))));
+                                    }
+                                }
+                            }
+                            let upstream_resp = match upstream_resp_opt {
+                                Some(r) => r,
+                                None => {
+                                    warn!("Bootstrap proxy upstream error after retries: {}", last_err);
                                     return Ok(Response::builder()
                                         .status(StatusCode::BAD_GATEWAY)
                                         .header("alt-svc", &alt)
                                         .body(Full::new(Bytes::from_static(b"upstream error\n")))
-                                        .unwrap_or_else(|_| Response::new(Full::new(Bytes::from_static(b"error\n")))));
-                                }
-                                Err(_) => {
-                                    return Ok(Response::builder()
-                                        .status(StatusCode::GATEWAY_TIMEOUT)
-                                        .header("alt-svc", &alt)
-                                        .body(Full::new(Bytes::from_static(b"upstream timeout\n")))
                                         .unwrap_or_else(|_| Response::new(Full::new(Bytes::from_static(b"error\n")))));
                                 }
                             };

--- a/crates/edge/src/quic_listener.rs
+++ b/crates/edge/src/quic_listener.rs
@@ -111,6 +111,10 @@ fn is_hop_header(name: &str) -> bool {
     )
 }
 
+type BootstrapServiceFuture = std::pin::Pin<
+    Box<dyn std::future::Future<Output = Result<hyper::Response<http_body_util::Full<hyper::body::Bytes>>, hyper::Error>> + Send>,
+>;
+
 type ResolvedBackend = (
     String,
     String,
@@ -4451,7 +4455,7 @@ impl QUICListener {
                     let io = TokioIo::new(tls_stream);
                     let alt_svc_conn = alt_svc.clone();
 
-                    let svc = service_fn(move |req: Request<Incoming>| -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Response<Full<Bytes>>, hyper::Error>> + Send>> {
+                    let svc = service_fn(move |req: Request<Incoming>| -> BootstrapServiceFuture {
                         let alt = alt_svc_conn.clone();
                         let h2_pool = Arc::clone(&h2_pool);
                         let backend_endpoints = Arc::clone(&backend_endpoints);
@@ -4659,12 +4663,10 @@ impl QUICListener {
                         {
                             debug!("Bootstrap h2 connection from {} closed: {}", peer, err);
                         }
-                    } else {
-                        if let Err(err) =
-                            http1::Builder::new().serve_connection(io, svc).await
-                        {
-                            debug!("Bootstrap h1 connection from {} closed: {}", peer, err);
-                        }
+                    } else if let Err(err) =
+                        http1::Builder::new().serve_connection(io, svc).await
+                    {
+                        debug!("Bootstrap h1 connection from {} closed: {}", peer, err);
                     }
                 });
             }

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -81,14 +81,14 @@ fn make_config(port: u32, backend_addr: String, cert: String, key: String) -> Co
                 id: "backend1".to_string(),
                 address: normalize_backend_address(backend_addr),
                 weight: 1,
-                health_check: HealthCheck {
+                health_check: Some(HealthCheck {
                     path: "/health".to_string(),
                     interval: 1000,
                     timeout_ms: 1000,
                     failure_threshold: 3,
                     success_threshold: 1,
                     cooldown_ms: 0,
-                },
+                }),
             }],
         },
     );
@@ -2450,27 +2450,27 @@ fn chaos_partial_outage_preserves_some_availability() {
             id: "dead-backend".to_string(),
             address: "127.0.0.1:1".to_string(),
             weight: 1,
-            health_check: HealthCheck {
+            health_check: Some(HealthCheck {
                 path: "/health".to_string(),
                 interval: 1000,
                 timeout_ms: 100,
                 failure_threshold: 1,
                 success_threshold: 1,
                 cooldown_ms: 0,
-            },
+            }),
         },
         Backend {
             id: "healthy-backend".to_string(),
             address: healthy_backend.to_string(),
             weight: 1,
-            health_check: HealthCheck {
+            health_check: Some(HealthCheck {
                 path: "/health".to_string(),
                 interval: 1000,
                 timeout_ms: 1000,
                 failure_threshold: 1,
                 success_threshold: 1,
                 cooldown_ms: 0,
-            },
+            }),
         },
     ];
     let mut config = make_config_with_backends(0, backends, "round-robin", cert, key);

--- a/crates/edge/tests/h3_edge.rs
+++ b/crates/edge/tests/h3_edge.rs
@@ -67,14 +67,14 @@ fn make_config(port: u32, cert: String, key: String, backend_address: String) ->
                 id: "backend1".to_string(),
                 address: normalize_backend_address(backend_address),
                 weight: 1,
-                health_check: HealthCheck {
+                health_check: Some(HealthCheck {
                     path: "/health".to_string(),
                     interval: 1000,
                     timeout_ms: 1000,
                     failure_threshold: 3,
                     success_threshold: 1,
                     cooldown_ms: 0,
-                },
+                }),
             }],
         },
     );
@@ -805,14 +805,14 @@ fn make_config_with_rate_limit(
                 id: "backend1".to_string(),
                 address: normalize_backend_address(backend_address),
                 weight: 1,
-                health_check: HealthCheck {
+                health_check: Some(HealthCheck {
                     path: "/health".to_string(),
                     interval: 1000,
                     timeout_ms: 1000,
                     failure_threshold: 3,
                     success_threshold: 1,
                     cooldown_ms: 0,
-                },
+                }),
             }],
         },
     );

--- a/crates/edge/tests/health_classification_tests.rs
+++ b/crates/edge/tests/health_classification_tests.rs
@@ -9,14 +9,14 @@ fn create_test_backend_pool() -> BackendPool {
         id: "bk-1".to_string(),
         address: "127.0.0.1:8001".to_string(),
         weight: 1,
-        health_check: HealthCheck {
+        health_check: Some(HealthCheck {
             path: "/health".to_string(),
             interval: 1000,
             timeout_ms: 5000,
             failure_threshold: 3,
             success_threshold: 2,
             cooldown_ms: 10000,
-        },
+        }),
     }];
     let backend_states = backends.iter().map(spooky_lb::BackendState::new).collect();
     BackendPool::new_from_states(backend_states)

--- a/crates/edge/tests/lb_integration.rs
+++ b/crates/edge/tests/lb_integration.rs
@@ -286,27 +286,27 @@ fn round_robin_across_backends() {
             id: "a".to_string(),
             address: backend_a.to_string(),
             weight: 1,
-            health_check: HealthCheck {
+            health_check: Some(HealthCheck {
                 path: "/health".to_string(),
                 interval: 1000,
                 timeout_ms: 1000,
                 failure_threshold: 3,
                 success_threshold: 1,
                 cooldown_ms: 0,
-            },
+            }),
         },
         Backend {
             id: "b".to_string(),
             address: backend_b.to_string(),
             weight: 1,
-            health_check: HealthCheck {
+            health_check: Some(HealthCheck {
                 path: "/health".to_string(),
                 interval: 1000,
                 timeout_ms: 1000,
                 failure_threshold: 3,
                 success_threshold: 1,
                 cooldown_ms: 0,
-            },
+            }),
         },
     ];
 
@@ -356,27 +356,27 @@ fn consistent_hash_is_stable_per_authority() {
             id: "a".to_string(),
             address: backend_a.to_string(),
             weight: 1,
-            health_check: HealthCheck {
+            health_check: Some(HealthCheck {
                 path: "/health".to_string(),
                 interval: 1000,
                 timeout_ms: 1000,
                 failure_threshold: 3,
                 success_threshold: 1,
                 cooldown_ms: 0,
-            },
+            }),
         },
         Backend {
             id: "b".to_string(),
             address: backend_b.to_string(),
             weight: 1,
-            health_check: HealthCheck {
+            health_check: Some(HealthCheck {
                 path: "/health".to_string(),
                 interval: 1000,
                 timeout_ms: 1000,
                 failure_threshold: 3,
                 success_threshold: 1,
                 cooldown_ms: 0,
-            },
+            }),
         },
     ];
 

--- a/crates/lb/src/lib.rs
+++ b/crates/lb/src/lib.rs
@@ -31,7 +31,7 @@ const FNV_PRIME: u64 = 0x00000100000001b3;
 pub struct BackendState {
     address: String,
     weight: u32,
-    health_check: HealthCheck,
+    health_check: Option<HealthCheck>,
     consecutive_failures: u32,
     health_state: HealthState,
     active_requests: Arc<AtomicUsize>,
@@ -76,15 +76,15 @@ impl BackendState {
     /// When active checks are present, only the health-check loop should drive
     /// consecutive_failures — request-path failures should not contribute.
     pub fn has_active_health_check(&self) -> bool {
-        self.health_check.interval > 0
+        self.health_check.as_ref().is_some_and(|hc| hc.interval > 0)
     }
 
     pub fn address(&self) -> &str {
         &self.address
     }
 
-    pub fn health_check(&self) -> &HealthCheck {
-        &self.health_check
+    pub fn health_check(&self) -> Option<&HealthCheck> {
+        self.health_check.as_ref()
     }
 
     pub fn weight(&self) -> u32 {
@@ -113,7 +113,8 @@ impl BackendState {
                 }
 
                 *successes += 1;
-                if *successes >= self.health_check.success_threshold {
+                let success_threshold = self.health_check.as_ref().map_or(1, |hc| hc.success_threshold);
+                if *successes >= success_threshold {
                     self.consecutive_failures = 0;
                     self.health_state = HealthState::Healthy;
                     return Some(HealthTransition::BecameHealthy);
@@ -125,13 +126,13 @@ impl BackendState {
 
     pub fn record_failure(&mut self, reason: HealthFailureReason) -> Option<HealthTransition> {
         self.consecutive_failures = self.consecutive_failures.saturating_add(1);
-        let threshold = self.health_check.failure_threshold;
+        let threshold = self.health_check.as_ref().map_or(3, |hc| hc.failure_threshold);
         if self.consecutive_failures < threshold {
             return None;
         }
 
         self.consecutive_failures = 0;
-        let cooldown = Duration::from_millis(self.health_check.cooldown_ms);
+        let cooldown = Duration::from_millis(self.health_check.as_ref().map_or(10_000, |hc| hc.cooldown_ms));
         self.health_state = HealthState::Unhealthy {
             until: Instant::now() + cooldown,
             successes: 0,
@@ -299,7 +300,7 @@ impl BackendPool {
     }
 
     pub fn health_check(&self, index: usize) -> Option<HealthCheck> {
-        self.backends.get(index).map(|b| b.health_check().clone())
+        self.backends.get(index).and_then(|b| b.health_check().cloned())
     }
 
     pub fn healthy_indices(&self) -> Vec<usize> {
@@ -760,14 +761,14 @@ mod tests {
             id: format!("backend-{}", address),
             address: address.to_string(),
             weight,
-            health_check: HealthCheck {
+            health_check: Some(HealthCheck {
                 path: "/health".to_string(),
                 interval: 1000,
                 timeout_ms: 1000,
                 failure_threshold: 3,
                 success_threshold: 1,
                 cooldown_ms: 0,
-            },
+            }),
         };
         BackendState::new(&backend)
     }
@@ -1007,27 +1008,27 @@ mod tests {
                     id: "backend1".to_string(),
                     address: "127.0.0.1:8001".to_string(),
                     weight: 100,
-                    health_check: HealthCheck {
+                    health_check: Some(HealthCheck {
                         path: "/health".to_string(),
                         interval: 5000,
                         timeout_ms: 2000,
                         failure_threshold: 3,
                         success_threshold: 2,
                         cooldown_ms: 10000,
-                    },
+                    }),
                 },
                 Backend {
                     id: "backend2".to_string(),
                     address: "127.0.0.1:8002".to_string(),
                     weight: 200,
-                    health_check: HealthCheck {
+                    health_check: Some(HealthCheck {
                         path: "/health".to_string(),
                         interval: 5000,
                         timeout_ms: 2000,
                         failure_threshold: 3,
                         success_threshold: 2,
                         cooldown_ms: 10000,
-                    },
+                    }),
                 },
             ],
         };

--- a/crates/lb/src/lib.rs
+++ b/crates/lb/src/lib.rs
@@ -113,7 +113,10 @@ impl BackendState {
                 }
 
                 *successes += 1;
-                let success_threshold = self.health_check.as_ref().map_or(1, |hc| hc.success_threshold);
+                let success_threshold = self
+                    .health_check
+                    .as_ref()
+                    .map_or(1, |hc| hc.success_threshold);
                 if *successes >= success_threshold {
                     self.consecutive_failures = 0;
                     self.health_state = HealthState::Healthy;
@@ -126,13 +129,20 @@ impl BackendState {
 
     pub fn record_failure(&mut self, reason: HealthFailureReason) -> Option<HealthTransition> {
         self.consecutive_failures = self.consecutive_failures.saturating_add(1);
-        let threshold = self.health_check.as_ref().map_or(3, |hc| hc.failure_threshold);
+        let threshold = self
+            .health_check
+            .as_ref()
+            .map_or(3, |hc| hc.failure_threshold);
         if self.consecutive_failures < threshold {
             return None;
         }
 
         self.consecutive_failures = 0;
-        let cooldown = Duration::from_millis(self.health_check.as_ref().map_or(10_000, |hc| hc.cooldown_ms));
+        let cooldown = Duration::from_millis(
+            self.health_check
+                .as_ref()
+                .map_or(10_000, |hc| hc.cooldown_ms),
+        );
         self.health_state = HealthState::Unhealthy {
             until: Instant::now() + cooldown,
             successes: 0,
@@ -300,7 +310,9 @@ impl BackendPool {
     }
 
     pub fn health_check(&self, index: usize) -> Option<HealthCheck> {
-        self.backends.get(index).and_then(|b| b.health_check().cloned())
+        self.backends
+            .get(index)
+            .and_then(|b| b.health_check().cloned())
     }
 
     pub fn healthy_indices(&self) -> Vec<usize> {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,7 @@
 # Spooky Documentation
 
+Spooky lets HAProxy, NGINX, and Apache environments adopt QUIC/HTTP/3 in days instead of quarters.
+
 Technical documentation for the Spooky HTTP/3 edge proxy and load balancer.
 
 ## Quick Navigation

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -283,14 +283,14 @@ Each backend represents an upstream server that can handle requests.
 | Property | Type | Required | Default | Description |
 |----------|------|----------|---------|-------------|
 | `id` | string | Yes | - | Unique identifier for the backend |
-| `address` | string | Yes | - | Backend server address. Accepted forms: `host:port` (defaults to `https://`), `https://host:port`, `http://host:port` |
+| `address` | string | Yes | - | Backend server address. Accepted forms: `host:port`, `host` (defaults to `https://host:443`), `https://host[:port]`, `http://host[:port]` |
 | `weight` | integer | No | `100` | Load balancing weight (higher values receive more traffic) |
-| `health_check` | object | Yes | - | Health check configuration |
+| `health_check` | object | No | - | Health check configuration. Omit to disable active health polling — backend starts and stays healthy. |
 
 **Address format notes:**
-- `host:port` — shorthand, treated as `https://host:port`
-- `https://host:port` — TLS connection with certificate verification enabled by default (`upstream_tls.verify_certificates=true`)
-- `http://host:port` — plain HTTP/1.1 only; HTTP/2 over cleartext (h2c) is not supported
+- `host:port` or `host` — shorthand, treated as `https://host:port` (port defaults to `443`)
+- `https://host[:port]` — TLS upstream; port defaults to `443` if omitted
+- `http://host[:port]` — cleartext upstream (plain HTTP); port defaults to `80` if omitted
 
 #### Health Check Configuration
 
@@ -316,7 +316,12 @@ Health check behavior:
 #### Backend Examples
 
 ```yaml
-# Minimal backend configuration
+# Minimal backend — no health check (backend stays permanently healthy)
+backends:
+  - id: "backend1"
+    address: "https://example.com"
+
+# Minimal backend with health check
 backends:
   - id: "backend1"
     address: "10.0.1.10:8080"

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -290,7 +290,7 @@ Each backend represents an upstream server that can handle requests.
 **Address format notes:**
 - `host:port` or `host` — shorthand, treated as `https://host:port` (port defaults to `443`)
 - `https://host[:port]` — TLS upstream; port defaults to `443` if omitted
-- `http://host[:port]` — cleartext upstream (plain HTTP); port defaults to `80` if omitted
+- `http://host[:port]` — cleartext upstream over h2c; port defaults to `80` if omitted. HTTP/1.1 upstream is not yet supported.
 
 #### Health Check Configuration
 

--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -49,7 +49,7 @@ You need an HTTP/2 backend for Spooky to forward traffic to. If you don't have o
 cargo run --bin h2_backend -- --port 8080
 ```
 
-This starts an HTTP/2-only server on `127.0.0.1:8080`. Spooky requires HTTP/2 backends - HTTP/1.1 backends are not supported.
+This starts an HTTP/2 test server on `127.0.0.1:8080`. For plain HTTP/1.1 backends (Vite, Express, nginx without h2), use `http://host:port` as the backend address instead.
 
 ## Step 4: Create Configuration File
 
@@ -76,22 +76,17 @@ upstream:
       - id: "local-backend"
         address: "127.0.0.1:8080"
         weight: 100
-        health_check:
-          path: "/"
-          interval: 5000
-          timeout_ms: 2000
-          success_threshold: 2
-          failure_threshold: 3
+        # health_check is optional — omit to disable active health polling
 
 log:
   level: info
 ```
 
 This configuration:
-- Listens for HTTP/3 connections on UDP port 9889
+- Listens for HTTP/3 (QUIC) on UDP port 9889 and HTTP/1.1+HTTP/2 (TLS) on TCP port 9889
 - Uses the generated self-signed certificates
 - Forwards all requests to `127.0.0.1:8080` using random load balancing
-- Performs health checks every 5 seconds on the backend
+- Advertises `Alt-Svc` on every response so browsers upgrade to HTTP/3 automatically
 
 ## Step 5: Start Spooky
 
@@ -143,7 +138,7 @@ Verify HTTP/3 connectivity by forcing HTTP/3-only requests:
 curl -k --http3-only https://localhost:9889/
 ```
 
-If successful, you should receive a response from your backend. HTTP/3 connectivity is confirmed when the request succeeds (Spooky doesn't advertise Alt-Svc headers).
+If successful, you should receive a response from your backend. Spooky advertises `Alt-Svc: h3=":PORT"; ma=86400` on every response, so browsers automatically upgrade to HTTP/3 on subsequent visits. HTTP/3 connectivity is confirmed when the response contains the `alt-svc` header or when you force `--http3-only` and the request succeeds.
 
 ### Using a Custom HTTP/3 Client
 

--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -49,7 +49,7 @@ You need an HTTP/2 backend for Spooky to forward traffic to. If you don't have o
 cargo run --bin h2_backend -- --port 8080
 ```
 
-This starts an HTTP/2 test server on `127.0.0.1:8080`. For plain HTTP/1.1 backends (Vite, Express, nginx without h2), use `http://host:port` as the backend address instead.
+This starts an HTTP/2 test server on `127.0.0.1:8080`. Spooky currently requires HTTP/2 backends — plain HTTP/1.1 upstream support is not yet implemented.
 
 ## Step 4: Create Configuration File
 

--- a/spooky/src/main.rs
+++ b/spooky/src/main.rs
@@ -182,9 +182,10 @@ Use a port >= 1024 for unprivileged startup.",
     }
 
     info!("Spooky is starting");
-    warn!(
-        "Ingress compatibility: Spooky currently accepts HTTP/3/QUIC clients only. \
-Deploy an external HTTP/1.1 or HTTP/2 terminator in front if legacy clients must be supported."
+    info!(
+        "Ingress: HTTP/3 (QUIC) on UDP {}:{}, HTTP/1.1+HTTP/2 bootstrap (TLS) on TCP {}:{} with Alt-Svc upgrade",
+        config_yaml.listen.address, config_yaml.listen.port,
+        config_yaml.listen.address, config_yaml.listen.port,
     );
     info!(
         "Data-plane workers={} packet_shards_per_worker={} reuseport={} pin_workers={}",

--- a/spooky/src/main.rs
+++ b/spooky/src/main.rs
@@ -184,8 +184,10 @@ Use a port >= 1024 for unprivileged startup.",
     info!("Spooky is starting");
     info!(
         "Ingress: HTTP/3 (QUIC) on UDP {}:{}, HTTP/1.1+HTTP/2 bootstrap (TLS) on TCP {}:{} with Alt-Svc upgrade",
-        config_yaml.listen.address, config_yaml.listen.port,
-        config_yaml.listen.address, config_yaml.listen.port,
+        config_yaml.listen.address,
+        config_yaml.listen.port,
+        config_yaml.listen.address,
+        config_yaml.listen.port,
     );
     info!(
         "Data-plane workers={} packet_shards_per_worker={} reuseport={} pin_workers={}",


### PR DESCRIPTION
Closes- #80 

## Summary

Browsers can't initiate an HTTP/3 connection cold — they need a prior HTTPS
response carrying `Alt-Svc: h3=":PORT"; ma=86400` before they will attempt
QUIC. This branch adds everything needed for spooky to work as a browser-
facing proxy, not just a QUIC-only edge.

### TCP+TLS bootstrap listener
A full reverse-proxy TCP+TLS listener binds on the same port as QUIC. On
every response it injects `Alt-Svc` pointing at the QUIC port, so browsers
upgrade to HTTP/3 on the next visit. The listener negotiates `h2` and
`http/1.1` via ALPN. Alt-Svc is also injected on QUIC (HTTP/3) responses
directly, so the header is present on every protocol path.

### Startup race fix
The H2 pool is lazy — no connection exists until the first request arrives.
The bootstrap listener now retries upstream sends up to 3× with 150 ms
backoff, pre-buffering the request body as `Bytes` and cloning
`http::request::Parts` per attempt so no state is consumed on failure.

### `TcpListener::from_std` moved inside the async task
The call was happening during `QUICListener::new`, which integration tests
invoke synchronously outside a Tokio runtime, causing all 32 tests to panic.
Moving it inside the spawned task fixes the regression.

### Optional `health_check` per backend
`Backend.health_check` is now `Option<HealthCheck>` with `#[serde(default)]`.
Omitting it disables active health polling — backends start and stay healthy.
This allows proxying to plain web servers (nginx, Vite, Express) that don't
expose a `/health` endpoint.

### Port-free backend addresses
`BackendEndpoint::parse` now accepts addresses without an explicit port
(`https://example.com`, `http://localhost`) and infers the default from the
scheme (443 / 80). Bare `host:port` form still works as before.
