### PR TITLE
docs: clarify dual-ingress posture (native HTTP/3 + TLS bootstrap HTTP/1.1/2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,11 @@ Repository config templates:
 
 ### Ingress Compatibility Posture
 
-Spooky currently accepts **HTTP/3 over QUIC only** on the ingress listener.
+Spooky uses **HTTP/3 over QUIC** as its native ingress data plane and also runs a **TLS bootstrap ingress** for HTTP/1.1 and HTTP/2 clients.
 
-- HTTP/1.1 and HTTP/2 clients are not accepted directly.
-- If legacy client compatibility is required, deploy an external frontend (CDN/LB/reverse proxy) that terminates HTTP/1.1 or HTTP/2 and forwards to a Spooky HTTP/3 ingress.
+- Native path: HTTP/3 over QUIC on UDP.
+- Compatibility path: HTTP/1.1 + HTTP/2 over TLS on TCP for modern browser compatibility and `Alt-Svc` discovery/upgrade to HTTP/3.
+- External frontends (CDN/LB/reverse proxy) are still supported when you want additional edge policy, WAF, or protocol mediation.
 
 ### Minimal Example
 

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -109,7 +109,7 @@ The following table lists all default configuration values used when properties 
 | Property | Default Value | Description |
 |----------|---------------|-------------|
 | `version` | `1` | Configuration format version |
-| `listen.protocol` | `"http3"` | Ingress protocol (HTTP/3 over QUIC only) |
+| `listen.protocol` | `"http3"` | Native ingress protocol (HTTP/3 over QUIC); TLS bootstrap ingress for HTTP/1.1/2 compatibility is also active |
 | `listen.port` | `9889` | Listening port |
 | `listen.address` | `"0.0.0.0"` | Listening address |
 | `listen.tls.cert_file` | Required | TLS certificate file path |
@@ -145,7 +145,7 @@ Configures the listening interface for incoming client connections. HTTP/3 requi
 
 | Property | Type | Required | Default | Description |
 |----------|------|----------|---------|-------------|
-| `protocol` | string | No | `http3` | Protocol to listen on (HTTP/3 over QUIC only) |
+| `protocol` | string | No | `http3` | Native ingress protocol for the data plane (HTTP/3 over QUIC) |
 | `address` | string | No | `0.0.0.0` | IP address to bind to |
 | `port` | integer | No | `9889` | Port to bind to |
 | `tls` | object | Yes | - | TLS configuration (required for HTTP/3) |
@@ -154,7 +154,7 @@ Configures the listening interface for incoming client connections. HTTP/3 requi
 
 - `http3`: HTTP/3 over QUIC (recommended)
 
-HTTP/1.1 and HTTP/2 ingress are not currently supported directly. If those clients must be supported, place an external frontend that terminates legacy protocols and forwards to Spooky over HTTP/3.
+Spooky also exposes a TLS bootstrap ingress for HTTP/1.1 and HTTP/2 clients. This compatibility path is primarily used for browser interoperability and advertising `Alt-Svc` so clients can upgrade to HTTP/3.
 
 ### TLS Configuration
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -167,7 +167,7 @@
 1. **Blocking backend calls**: Main thread blocks during HTTP/2 requests
 2. **Full body buffering**: High memory usage for large requests/responses
 3. **Configuration hot reload missing**: Runtime config updates still require restart
-4. **HTTP/3-only ingress**: No native HTTP/1.1 or HTTP/2 client ingress support
+4. **Dual-ingress operational complexity**: Runtime serves HTTP/3 (native) plus HTTP/1.1/2 TLS bootstrap, so operators must secure and observe both paths consistently
 5. **Method-based route matching unimplemented**: `route.method` remains reserved for future use
 6. **Control/metrics endpoint hardening is operator-dependent**: endpoints should remain network-isolated unless explicitly protected
 


### PR DESCRIPTION
## Summary
Align documentation with current runtime behavior: Spooky runs native HTTP/3 (QUIC) ingress and a TLS bootstrap ingress for HTTP/1.1 + HTTP/2 compatibility.

## Why
Current runtime includes the bootstrap TLS listener for browser interoperability and Alt-Svc-based upgrade to HTTP/3. Docs should describe this explicitly to avoid operator confusion.

## What changed
- Updated ingress compatibility language in:
  - README
  - docs/configuration/reference.md
  - docs/roadmap.md
- Clarified that:
  - HTTP/3 over QUIC is the native data-plane ingress.
  - HTTP/1.1/HTTP/2 over TLS bootstrap ingress is intentionally active for compatibility and upgrade flow.
  - External frontends are optional and still valid for additional policy/control.

## Scope
- Docs-only change.
- No runtime/code behavior changes.

## Validation
- Manual wording consistency pass across ingress-related sections.
