### PR TITLE
fix(edge): enforce bootstrap ingress security parity (mTLS + request policy + header trust chain)

### DIFF
--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -3566,11 +3566,9 @@ impl QUICListener {
             RustlsServerConfig::builder().with_no_client_auth()
         };
 
-        let mut tls_config = builder
-            .with_single_cert(server_certs, key)
-            .map_err(|err| {
-                ProxyError::Tls(format!("failed to build rustls ServerConfig: {}", err))
-            })?;
+        let mut tls_config = builder.with_single_cert(server_certs, key).map_err(|err| {
+            ProxyError::Tls(format!("failed to build rustls ServerConfig: {}", err))
+        })?;
 
         tls_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
 
@@ -3707,7 +3705,9 @@ impl QUICListener {
                                         .status(status)
                                         .header("alt-svc", &alt)
                                         .body(Full::new(Bytes::copy_from_slice(body)))
-                                        .unwrap_or_else(|_| Response::new(Full::new(Bytes::new()))));
+                                        .unwrap_or_else(|_| {
+                                            Response::new(Full::new(Bytes::new()))
+                                        }));
                                 }
                             };
                             let method = request.method;
@@ -3806,9 +3806,8 @@ impl QUICListener {
                                     }
                                 };
 
-                            let mut upstream_req = Request::builder()
-                                .method(method.as_str())
-                                .uri(upstream_uri);
+                            let mut upstream_req =
+                                Request::builder().method(method.as_str()).uri(upstream_uri);
 
                             for (name, value) in req.headers() {
                                 if name == http::header::HOST

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -110,6 +110,13 @@ fn should_strip_bootstrap_request_header(name: &http::header::HeaderName) -> boo
     false
 }
 
+fn bootstrap_forwarded_for_value(ip: std::net::IpAddr) -> String {
+    match ip {
+        std::net::IpAddr::V4(v4) => v4.to_string(),
+        std::net::IpAddr::V6(v6) => format!("\"[{}]\"", v6),
+    }
+}
+
 type BootstrapServiceFuture = std::pin::Pin<
     Box<
         dyn std::future::Future<
@@ -3815,8 +3822,13 @@ impl QUICListener {
                                 http::header::HOST,
                                 authority.as_deref().unwrap_or(endpoint.authority()),
                             );
-                            upstream_req = upstream_req
-                                .header("forwarded", format!("for={};proto=https", peer.ip()));
+                            upstream_req = upstream_req.header(
+                                "forwarded",
+                                format!(
+                                    "for={};proto=https",
+                                    bootstrap_forwarded_for_value(peer.ip())
+                                ),
+                            );
 
                             let body_bytes = match req.into_body().collect().await {
                                 Ok(collected) => collected.to_bytes(),

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -75,7 +75,7 @@ use health_check::classify_active_health_check_response;
 pub(crate) use token_bucket::TokenBucket;
 use validation::{
     RequestBufferError, extract_header_value, generated_span_id, generated_trace_id,
-    parse_traceparent, request_content_length, validate_request_headers,
+    parse_traceparent, request_content_length, validate_http_request, validate_request_headers,
 };
 
 fn is_hop_header(name: &str) -> bool {
@@ -3566,6 +3566,8 @@ impl QUICListener {
 
         let h2_pool = Arc::clone(&shared_state.h2_pool);
         let backend_endpoints = Arc::clone(&shared_state.backend_endpoints);
+        let metrics = Arc::clone(&shared_state.metrics);
+        let resilience = Arc::clone(&shared_state.resilience);
         let upstream_pools = shared_state.upstream_pools.clone();
         let routing_index = RouteIndex::from_upstreams(&config.upstream);
 
@@ -3626,6 +3628,8 @@ impl QUICListener {
                 let alt_svc = alt_svc_value.clone();
                 let h2_pool = Arc::clone(&h2_pool);
                 let backend_endpoints = Arc::clone(&backend_endpoints);
+                let metrics = Arc::clone(&metrics);
+                let resilience = Arc::clone(&resilience);
                 let upstream_pools = upstream_pools.clone();
                 let routing_index = Arc::clone(&routing_index);
 
@@ -3648,26 +3652,35 @@ impl QUICListener {
                         let alt = alt_svc_conn.clone();
                         let h2_pool = Arc::clone(&h2_pool);
                         let backend_endpoints = Arc::clone(&backend_endpoints);
+                        let metrics = Arc::clone(&metrics);
+                        let resilience = Arc::clone(&resilience);
                         let upstream_pools = upstream_pools.clone();
                         let routing_index = Arc::clone(&routing_index);
 
                         Box::pin(async move {
-                            let _method = req.method().to_string();
-                            let path = req
-                                .uri()
-                                .path_and_query()
-                                .map(|pq| pq.as_str().to_owned())
-                                .unwrap_or_else(|| "/".to_string());
-                            let authority = req
-                                .uri()
-                                .authority()
-                                .map(|a| a.as_str().to_owned())
-                                .or_else(|| {
-                                    req.headers()
-                                        .get(http::header::HOST)
-                                        .and_then(|v| v.to_str().ok())
-                                        .map(str::to_owned)
-                                });
+                            let request = match validate_http_request(&req, &resilience) {
+                                Ok(request) => request,
+                                Err((status, body, is_policy)) => {
+                                    metrics.inc_failure();
+                                    metrics.inc_request_validation_reject();
+                                    if is_policy {
+                                        metrics.inc_policy_denied();
+                                    }
+                                    metrics.record_route(
+                                        "unrouted",
+                                        Duration::from_millis(0),
+                                        RouteOutcome::Failure,
+                                    );
+                                    return Ok(Response::builder()
+                                        .status(status)
+                                        .header("alt-svc", &alt)
+                                        .body(Full::new(Bytes::copy_from_slice(body)))
+                                        .unwrap_or_else(|_| Response::new(Full::new(Bytes::new()))));
+                                }
+                            };
+                            let method = request.method;
+                            let path = request.path;
+                            let authority = request.authority;
 
                             // Route lookup
                             let upstream_name = routing_index.lookup(&path, authority.as_deref());
@@ -3762,7 +3775,7 @@ impl QUICListener {
                                 };
 
                             let mut upstream_req = Request::builder()
-                                .method(req.method().clone())
+                                .method(method.as_str())
                                 .uri(upstream_uri);
 
                             for (name, value) in req.headers() {

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -85,6 +85,31 @@ fn is_hop_header(name: &str) -> bool {
     )
 }
 
+fn should_strip_bootstrap_request_header(name: &http::header::HeaderName) -> bool {
+    if name == http::header::CONTENT_LENGTH {
+        return true;
+    }
+
+    if name == http::header::CONNECTION
+        || name == http::header::PROXY_AUTHENTICATE
+        || name == http::header::PROXY_AUTHORIZATION
+        || name == http::header::TE
+        || name == http::header::TRAILER
+        || name == http::header::TRANSFER_ENCODING
+        || name == http::header::UPGRADE
+        || name.as_str().eq_ignore_ascii_case("keep-alive")
+        || name.as_str().eq_ignore_ascii_case("proxy-connection")
+        || name.as_str().eq_ignore_ascii_case("forwarded")
+        || name.as_str().eq_ignore_ascii_case("x-forwarded-for")
+        || name.as_str().eq_ignore_ascii_case("x-forwarded-proto")
+        || name.as_str().eq_ignore_ascii_case("x-forwarded-host")
+    {
+        return true;
+    }
+
+    false
+}
+
 type BootstrapServiceFuture = std::pin::Pin<
     Box<
         dyn std::future::Future<
@@ -3780,14 +3805,7 @@ impl QUICListener {
 
                             for (name, value) in req.headers() {
                                 if name == http::header::HOST
-                                    || name == http::header::CONNECTION
-                                    || name == http::header::UPGRADE
-                                    || name == http::header::PROXY_AUTHORIZATION
-                                    || name.as_str() == "keep-alive"
-                                    || name.as_str() == "proxy-connection"
-                                    || name.as_str() == "te"
-                                    || name.as_str() == "trailers"
-                                    || name.as_str() == "transfer-encoding"
+                                    || should_strip_bootstrap_request_header(name)
                                 {
                                     continue;
                                 }

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -23,7 +23,7 @@ use log::{debug, error, info, warn};
 use quiche::Config;
 use quiche::h3::NameValue;
 use rand::RngCore;
-use rustls::ServerConfig as RustlsServerConfig;
+use rustls::{RootCertStore, ServerConfig as RustlsServerConfig, server::WebPkiClientVerifier};
 use serde_json::json;
 use socket2::{Domain, Protocol, Socket, Type};
 use spooky_bridge::h3_to_h2::{ForwardedContext, build_h2_request_for_endpoint};
@@ -3447,7 +3447,7 @@ impl QUICListener {
             ))
         })?;
 
-        let certs: Vec<rustls::pki_types::CertificateDer<'static>> =
+        let server_certs: Vec<rustls::pki_types::CertificateDer<'static>> =
             certs(&mut BufReader::new(cert_bytes.as_slice()))
                 .collect::<Result<_, _>>()
                 .map_err(|err| ProxyError::Tls(format!("failed to parse TLS cert PEM: {}", err)))?;
@@ -3478,9 +3478,64 @@ impl QUICListener {
             }
         };
 
-        let mut tls_config = RustlsServerConfig::builder()
-            .with_no_client_auth()
-            .with_single_cert(certs, key)
+        let builder = if config.listen.tls.client_auth.enabled {
+            let ca_file = config
+                .listen
+                .tls
+                .client_auth
+                .ca_file
+                .as_ref()
+                .ok_or_else(|| {
+                    ProxyError::Tls(
+                        "listen.tls.client_auth.ca_file is required when mTLS is enabled"
+                            .to_string(),
+                    )
+                })?;
+            let ca_bytes = std::fs::read(ca_file).map_err(|err| {
+                ProxyError::Tls(format!(
+                    "failed to read listen.tls.client_auth.ca_file '{}': {}",
+                    ca_file, err
+                ))
+            })?;
+            let client_ca_certs: Vec<rustls::pki_types::CertificateDer<'static>> =
+                certs(&mut BufReader::new(ca_bytes.as_slice()))
+                    .collect::<Result<_, _>>()
+                    .map_err(|err| {
+                        ProxyError::Tls(format!(
+                            "failed to parse listen.tls.client_auth.ca_file PEM: {}",
+                            err
+                        ))
+                    })?;
+            let mut roots = RootCertStore::empty();
+            for cert in client_ca_certs {
+                roots.add(cert).map_err(|err| {
+                    ProxyError::Tls(format!(
+                        "failed to add certificate from listen.tls.client_auth.ca_file '{}': {}",
+                        ca_file, err
+                    ))
+                })?;
+            }
+
+            let verifier_builder = WebPkiClientVerifier::builder(Arc::new(roots));
+            let verifier = if config.listen.tls.client_auth.require_client_cert {
+                verifier_builder.build()
+            } else {
+                verifier_builder.allow_unauthenticated().build()
+            }
+            .map_err(|err| {
+                ProxyError::Tls(format!(
+                    "failed to build downstream client certificate verifier: {}",
+                    err
+                ))
+            })?;
+
+            RustlsServerConfig::builder().with_client_cert_verifier(verifier)
+        } else {
+            RustlsServerConfig::builder().with_no_client_auth()
+        };
+
+        let mut tls_config = builder
+            .with_single_cert(server_certs, key)
             .map_err(|err| {
                 ProxyError::Tls(format!("failed to build rustls ServerConfig: {}", err))
             })?;

--- a/crates/edge/src/quic_listener/validation.rs
+++ b/crates/edge/src/quic_listener/validation.rs
@@ -136,20 +136,91 @@ pub(super) fn validate_request_headers(
         }
     };
 
-    if method.trim().is_empty() || method.as_bytes().iter().any(|b| b.is_ascii_whitespace()) {
+    validate_request_parts(
+        method,
+        path,
+        authority,
+        host,
+        resilience,
+        b"invalid :method header\n",
+        b"invalid :path header\n",
+        b":authority and host headers must match\n",
+    )
+}
+
+pub(super) fn validate_http_request(
+    req: &http::Request<Incoming>,
+    resilience: &RuntimeResilience,
+) -> Result<RequestValidationResult, (http::StatusCode, &'static [u8], bool)> {
+    let header_count = req.headers().len().saturating_add(2);
+    if header_count > resilience.max_headers_count {
         return Err((
-            http::StatusCode::BAD_REQUEST,
-            b"invalid :method header\n",
+            http::StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE,
+            b"too many request headers\n",
             false,
         ));
     }
 
+    let mut header_bytes = req.method().as_str().len() + req.uri().path().len();
+    let authority = req.uri().authority().map(|a| a.as_str().to_owned());
+    let host = req
+        .headers()
+        .get(http::header::HOST)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
+
+    if let Some(authority_value) = authority.as_deref() {
+        header_bytes = header_bytes.saturating_add(authority_value.len());
+    }
+    if let Some(host_value) = host.as_deref() {
+        header_bytes = header_bytes.saturating_add(http::header::HOST.as_str().len() + host_value.len());
+    }
+
+    for (name, value) in req.headers() {
+        header_bytes = header_bytes.saturating_add(name.as_str().len() + value.as_bytes().len());
+        if header_bytes > resilience.max_headers_bytes {
+            return Err((
+                http::StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE,
+                b"request headers exceed size limit\n",
+                false,
+            ));
+        }
+    }
+
+    let path = req
+        .uri()
+        .path_and_query()
+        .map(|pq| pq.as_str())
+        .unwrap_or("/");
+
+    validate_request_parts(
+        req.method().as_str().to_string(),
+        path.to_string(),
+        authority,
+        host,
+        resilience,
+        b"invalid method header\n",
+        b"invalid path header\n",
+        b"authority and host headers must match\n",
+    )
+}
+
+fn validate_request_parts(
+    method: String,
+    path: String,
+    authority: Option<String>,
+    host: Option<String>,
+    resilience: &RuntimeResilience,
+    invalid_method_body: &'static [u8],
+    invalid_path_body: &'static [u8],
+    authority_mismatch_body: &'static [u8],
+) -> Result<RequestValidationResult, (http::StatusCode, &'static [u8], bool)> {
+    if method.trim().is_empty() || method.as_bytes().iter().any(|b| b.is_ascii_whitespace()) {
+        return Err((http::StatusCode::BAD_REQUEST, invalid_method_body, false));
+    }
+
     if path.is_empty() || !path.starts_with('/') {
-        return Err((
-            http::StatusCode::BAD_REQUEST,
-            b"invalid :path header\n",
-            false,
-        ));
+        return Err((http::StatusCode::BAD_REQUEST, invalid_path_body, false));
     }
 
     if resilience.enforce_authority_host_match
@@ -160,11 +231,7 @@ pub(super) fn validate_request_headers(
         let normalized_host = normalize_host_for_routing(host_value)
             .unwrap_or_else(|| host_value.to_ascii_lowercase());
         if normalized_authority != normalized_host {
-            return Err((
-                http::StatusCode::BAD_REQUEST,
-                b":authority and host headers must match\n",
-                false,
-            ));
+            return Err((http::StatusCode::BAD_REQUEST, authority_mismatch_body, false));
         }
     }
 

--- a/crates/edge/src/quic_listener/validation.rs
+++ b/crates/edge/src/quic_listener/validation.rs
@@ -142,9 +142,11 @@ pub(super) fn validate_request_headers(
         authority,
         host,
         resilience,
-        b"invalid :method header\n",
-        b"invalid :path header\n",
-        b":authority and host headers must match\n",
+        RequestPartErrors {
+            invalid_method: b"invalid :method header\n",
+            invalid_path: b"invalid :path header\n",
+            authority_mismatch: b":authority and host headers must match\n",
+        },
     )
 }
 
@@ -173,7 +175,8 @@ pub(super) fn validate_http_request(
         header_bytes = header_bytes.saturating_add(authority_value.len());
     }
     if let Some(host_value) = host.as_deref() {
-        header_bytes = header_bytes.saturating_add(http::header::HOST.as_str().len() + host_value.len());
+        header_bytes =
+            header_bytes.saturating_add(http::header::HOST.as_str().len() + host_value.len());
     }
 
     for (name, value) in req.headers() {
@@ -199,10 +202,18 @@ pub(super) fn validate_http_request(
         authority,
         host,
         resilience,
-        b"invalid method header\n",
-        b"invalid path header\n",
-        b"authority and host headers must match\n",
+        RequestPartErrors {
+            invalid_method: b"invalid method header\n",
+            invalid_path: b"invalid path header\n",
+            authority_mismatch: b"authority and host headers must match\n",
+        },
     )
+}
+
+struct RequestPartErrors {
+    invalid_method: &'static [u8],
+    invalid_path: &'static [u8],
+    authority_mismatch: &'static [u8],
 }
 
 fn validate_request_parts(
@@ -211,16 +222,14 @@ fn validate_request_parts(
     authority: Option<String>,
     host: Option<String>,
     resilience: &RuntimeResilience,
-    invalid_method_body: &'static [u8],
-    invalid_path_body: &'static [u8],
-    authority_mismatch_body: &'static [u8],
+    errors: RequestPartErrors,
 ) -> Result<RequestValidationResult, (http::StatusCode, &'static [u8], bool)> {
     if method.trim().is_empty() || method.as_bytes().iter().any(|b| b.is_ascii_whitespace()) {
-        return Err((http::StatusCode::BAD_REQUEST, invalid_method_body, false));
+        return Err((http::StatusCode::BAD_REQUEST, errors.invalid_method, false));
     }
 
     if path.is_empty() || !path.starts_with('/') {
-        return Err((http::StatusCode::BAD_REQUEST, invalid_path_body, false));
+        return Err((http::StatusCode::BAD_REQUEST, errors.invalid_path, false));
     }
 
     if resilience.enforce_authority_host_match
@@ -231,7 +240,11 @@ fn validate_request_parts(
         let normalized_host = normalize_host_for_routing(host_value)
             .unwrap_or_else(|| host_value.to_ascii_lowercase());
         if normalized_authority != normalized_host {
-            return Err((http::StatusCode::BAD_REQUEST, authority_mismatch_body, false));
+            return Err((
+                http::StatusCode::BAD_REQUEST,
+                errors.authority_mismatch,
+                false,
+            ));
         }
     }
 


### PR DESCRIPTION
## Summary

The bootstrap TCP/TLS ingress (HTTP/1.1 + HTTP/2 fallback) had several security gaps compared to the main QUIC/H3 path. Clients that couldn't use QUIC could bypass mTLS, request policy checks, and forwarded-chain header stripping entirely.

This PR brings the bootstrap path to full parity:

- **mTLS (closes #112):** bootstrap TLS acceptor now enforces `listen.tls.client_auth` instead of always calling `.with_no_client_auth()`
- **Request policy (closes #117):** bootstrap path now runs `validate_http_request()` before forwarding — same method/path/header policy as the QUIC path
- **Header stripping (closes #118):** bootstrap now strips all forwarded-chain headers (`Forwarded`, `X-Forwarded-For`, `X-Forwarded-Proto`, `X-Forwarded-Host`) using case-insensitive matching before setting its own
- **RFC 7239 IPv6 (closes #119):** bootstrap `Forwarded` header now wraps IPv6 addresses in `"[...]"` instead of forwarding bare `::1`
