### PR TITLE
docs(roadmap): mark mTLS as implemented and scope future work to mTLS operations

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -14,6 +14,7 @@
 - Per-upstream configuration and routing
 - Connection ID management and QUIC packet routing
 - TLS 1.3 with certificate chain loading
+- Downstream mTLS (client certificate authentication) via `listen.tls.client_auth.enabled`, `listen.tls.client_auth.require_client_cert`, and `listen.tls.client_auth.ca_file`
 - Structured logging with multiple levels
 - Configuration validation at startup
 - Graceful shutdown with connection draining
@@ -70,7 +71,7 @@
 ### Security
 
 - **TLS peer verification**: Enable certificate verification for production
-- **mTLS support**: Client certificate authentication
+- **mTLS operational tooling**: Certificate rotation/revocation workflows and deployment guidance
 - **Request validation**: Size limits, header validation
 - **IP allowlist/blocklist**: Simple access control
 


### PR DESCRIPTION
Fixes #125 
## Summary
Roadmap currently implies mTLS is a future feature, but mTLS is already implemented and configurable.

This PR updates the roadmap to reflect current product state:
- Adds downstream mTLS to **Completed** with explicit config knobs:
  - `listen.tls.client_auth.enabled`
  - `listen.tls.client_auth.require_client_cert`
  - `listen.tls.client_auth.ca_file`
- Replaces the Phase 2 security item from feature delivery ("mTLS support") to follow-on operational work ("mTLS operational tooling": cert rotation/revocation workflows and guidance).

## Why
The previous wording could mislead operators and contributors into thinking mTLS is unavailable today.

## Scope
Docs-only change (`docs/roadmap.md`).

## Validation
- Manual doc review for consistency and clarity.