### PR TITLE
fix(bootstrap): align backend selection with QUIC load-balancing and health logic

### DIFF
--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -4071,7 +4071,12 @@ static FALLBACK_RT_THREADS: AtomicUsize = AtomicUsize::new(2);
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, sync::Arc};
+    use std::{
+        collections::HashMap,
+        sync::{Arc, RwLock},
+    };
+
+    use spooky_config::config::{Backend, LoadBalancing, RouteMatch, Upstream};
 
     use crate::REQUEST_ID_COUNTER;
     use crate::cid_radix::CidRadix;
@@ -4093,6 +4098,129 @@ mod tests {
 
     fn cid(bytes: &[u8]) -> Arc<[u8]> {
         Arc::from(bytes)
+    }
+
+    fn test_upstream(lb_type: &str) -> Upstream {
+        Upstream {
+            load_balancing: LoadBalancing {
+                lb_type: lb_type.to_string(),
+                key: None,
+            },
+            route: RouteMatch {
+                host: None,
+                path_prefix: Some("/api".to_string()),
+                method: None,
+            },
+            backends: vec![
+                Backend {
+                    id: "b1".to_string(),
+                    address: "127.0.0.1:7001".to_string(),
+                    weight: 1,
+                    health_check: None,
+                },
+                Backend {
+                    id: "b2".to_string(),
+                    address: "127.0.0.1:7002".to_string(),
+                    weight: 1,
+                    health_check: None,
+                },
+            ],
+        }
+    }
+
+    fn test_routing_context(
+        lb_type: &str,
+    ) -> (
+        HashMap<String, Arc<RwLock<super::UpstreamPool>>>,
+        super::RouteIndex,
+        Arc<RwLock<super::UpstreamPool>>,
+    ) {
+        let mut upstreams = HashMap::new();
+        upstreams.insert("api_pool".to_string(), test_upstream(lb_type));
+        let routing_index = super::RouteIndex::from_upstreams(&upstreams);
+        let pool = super::UpstreamPool::from_upstream(upstreams.get("api_pool").expect("upstream"))
+            .expect("pool");
+        let pool = Arc::new(RwLock::new(pool));
+        let mut upstream_pools = HashMap::new();
+        upstream_pools.insert("api_pool".to_string(), Arc::clone(&pool));
+        (upstream_pools, routing_index, pool)
+    }
+
+    #[test]
+    fn resolve_backend_round_robin_is_not_pinned_to_first_backend() {
+        let (upstream_pools, routing_index, _pool) = test_routing_context("round-robin");
+
+        let mut picks = Vec::new();
+        for _ in 0..4 {
+            let (_upstream, backend, _, _, _, _, _, _) = super::QUICListener::resolve_backend(
+                "GET",
+                "/api/items",
+                None,
+                None,
+                &upstream_pools,
+                &routing_index,
+            )
+            .expect("resolve backend");
+            picks.push(backend);
+        }
+
+        assert!(
+            picks.iter().any(|addr| addr == "127.0.0.1:7001")
+                && picks.iter().any(|addr| addr == "127.0.0.1:7002"),
+            "round-robin resolution should not pin all bootstrap picks to the first backend: {:?}",
+            picks
+        );
+    }
+
+    #[test]
+    fn resolve_backend_skips_unhealthy_backends() {
+        let (upstream_pools, routing_index, pool) = test_routing_context("round-robin");
+        {
+            let mut guard = pool.write().expect("pool write");
+            guard.pool.mark_failure(0);
+            guard.pool.mark_failure(0);
+            guard.pool.mark_failure(0);
+        }
+
+        let (_upstream, backend, _, _, _, _, _, _) = super::QUICListener::resolve_backend(
+            "GET",
+            "/api/items",
+            None,
+            None,
+            &upstream_pools,
+            &routing_index,
+        )
+        .expect("resolve backend");
+
+        assert_eq!(
+            backend, "127.0.0.1:7002",
+            "unhealthy backend must be excluded from bootstrap backend selection"
+        );
+    }
+
+    #[test]
+    fn resolve_backend_respects_least_connections_strategy() {
+        let (upstream_pools, routing_index, pool) = test_routing_context("least-connections");
+        {
+            let guard = pool.read().expect("pool read");
+            guard.pool.begin_request(0);
+            guard.pool.begin_request(0);
+        }
+
+        let (_upstream, backend, _, _, _, _, _, _) = super::QUICListener::resolve_backend(
+            "GET",
+            "/api/items",
+            None,
+            None,
+            &upstream_pools,
+            &routing_index,
+        )
+        .expect("resolve backend");
+
+        assert_eq!(
+            backend, "127.0.0.1:7002",
+            "least-connections should prefer lower in-flight backend in bootstrap selection"
+        );
     }
 
     #[test]

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -3714,98 +3714,73 @@ impl QUICListener {
                             let path = request.path;
                             let authority = request.authority;
 
-                            // Route lookup
-                            let upstream_name = routing_index.lookup(&path, authority.as_deref());
-                            let upstream_name = match upstream_name {
-                                Some(name) => name.to_string(),
-                                None => {
-                                    return Ok(Response::builder()
-                                        .status(StatusCode::BAD_GATEWAY)
-                                        .header("alt-svc", &alt)
-                                        .body(Full::new(Bytes::from_static(b"no route\n")))
-                                        .unwrap_or_else(|_| {
-                                            Response::new(Full::new(Bytes::from_static(b"error\n")))
-                                        }));
-                                }
+                            let bootstrap_error = |status: StatusCode, body: &'static [u8]| {
+                                Ok(Response::builder()
+                                    .status(status)
+                                    .header("alt-svc", &alt)
+                                    .body(Full::new(Bytes::from_static(body)))
+                                    .unwrap_or_else(|_| {
+                                        Response::new(Full::new(Bytes::from_static(b"error\n")))
+                                    }))
                             };
 
-                            // Pick backend using configured LB strategy and current health state.
-                            let backend_addr = {
-                                let pool_lock = match upstream_pools.get(&upstream_name) {
-                                    Some(p) => p,
-                                    None => {
-                                        return Ok(Response::builder()
-                                            .status(StatusCode::BAD_GATEWAY)
-                                            .header("alt-svc", &alt)
-                                            .body(Full::new(Bytes::from_static(b"no pool\n")))
-                                            .unwrap_or_else(|_| {
-                                                Response::new(Full::new(Bytes::from_static(
-                                                    b"error\n",
-                                                )))
-                                            }));
-                                    }
-                                };
-                                let mut pool = match pool_lock.write() {
-                                    Ok(p) => p,
-                                    Err(_) => {
-                                        return Ok(Response::builder()
-                                            .status(StatusCode::BAD_GATEWAY)
-                                            .header("alt-svc", &alt)
-                                            .body(Full::new(Bytes::from_static(b"pool error\n")))
-                                            .unwrap_or_else(|_| {
-                                                Response::new(Full::new(Bytes::from_static(
-                                                    b"error\n",
-                                                )))
-                                            }));
-                                    }
-                                };
-                                if pool.pool.is_empty() {
-                                    return Ok(Response::builder()
-                                        .status(StatusCode::SERVICE_UNAVAILABLE)
-                                        .header("alt-svc", &alt)
-                                        .body(Full::new(Bytes::from_static(b"no backends\n")))
-                                        .unwrap_or_else(|_| {
-                                            Response::new(Full::new(Bytes::from_static(
-                                                b"error\n",
-                                            )))
-                                        }));
-                                }
+                            let resolved = Self::resolve_backend(
+                                &method,
+                                &path,
+                                authority.as_deref(),
+                                None,
+                                &upstream_pools,
+                                &routing_index,
+                            );
+                            let (_upstream_name, backend_addr, _backend_index, _pool, _lb, _, _, _) =
+                                match resolved {
+                                    Ok(value) => value,
+                                    Err(ProxyError::Transport(reason)) => {
+                                        if reason.starts_with("no route for ") {
+                                            return bootstrap_error(
+                                                StatusCode::BAD_GATEWAY,
+                                                b"no route\n",
+                                            );
+                                        }
+                                        if reason == "pool not found" || reason.starts_with("pool not found:") {
+                                            return bootstrap_error(
+                                                StatusCode::BAD_GATEWAY,
+                                                b"no pool\n",
+                                            );
+                                        }
+                                        if reason == "upstream pool lock poisoned" {
+                                            return bootstrap_error(
+                                                StatusCode::BAD_GATEWAY,
+                                                b"pool error\n",
+                                            );
+                                        }
+                                        if reason == "no servers in upstream"
+                                            || reason == "no healthy servers"
+                                            || reason == "invalid server address"
+                                        {
+                                            return bootstrap_error(
+                                                StatusCode::SERVICE_UNAVAILABLE,
+                                                b"no backends\n",
+                                            );
+                                        }
 
-                                let request_key =
-                                    authority.as_deref().unwrap_or(if !path.is_empty() {
-                                        path.as_str()
-                                    } else {
-                                        method.as_str()
-                                    });
-                                let Some(backend_index) = pool.pick(request_key) else {
-                                    return Ok(Response::builder()
-                                        .status(StatusCode::SERVICE_UNAVAILABLE)
-                                        .header("alt-svc", &alt)
-                                        .body(Full::new(Bytes::from_static(
-                                            b"no healthy backends\n",
-                                        )))
-                                        .unwrap_or_else(|_| {
-                                            Response::new(Full::new(Bytes::from_static(
-                                                b"error\n",
-                                            )))
-                                        }));
-                                };
-
-                                match pool.pool.address(backend_index).map(str::to_owned) {
-                                    Some(addr) => addr,
-                                    None => {
-                                        return Ok(Response::builder()
-                                            .status(StatusCode::SERVICE_UNAVAILABLE)
-                                            .header("alt-svc", &alt)
-                                            .body(Full::new(Bytes::from_static(b"no backends\n")))
-                                            .unwrap_or_else(|_| {
-                                                Response::new(Full::new(Bytes::from_static(
-                                                    b"error\n",
-                                                )))
-                                            }));
+                                        warn!(
+                                            "Bootstrap route/backend resolution failed: {}",
+                                            reason
+                                        );
+                                        return bootstrap_error(
+                                            StatusCode::BAD_GATEWAY,
+                                            b"route/backend resolution failed\n",
+                                        );
                                     }
-                                }
-                            };
+                                    Err(err) => {
+                                        warn!("Bootstrap route/backend resolution failed: {}", err);
+                                        return bootstrap_error(
+                                            StatusCode::BAD_GATEWAY,
+                                            b"route/backend resolution failed\n",
+                                        );
+                                    }
+                                };
 
                             let endpoint = match backend_endpoints.get(&backend_addr) {
                                 Some(ep) => ep.clone(),

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -134,7 +134,10 @@ fn bootstrap_resolution_error_response(reason: &str) -> (StatusCode, &'static [u
         return (StatusCode::SERVICE_UNAVAILABLE, b"no healthy backends\n");
     }
 
-    (StatusCode::BAD_GATEWAY, b"route/backend resolution failed\n")
+    (
+        StatusCode::BAD_GATEWAY,
+        b"route/backend resolution failed\n",
+    )
 }
 
 type BootstrapServiceFuture = std::pin::Pin<
@@ -4128,13 +4131,13 @@ mod tests {
         }
     }
 
-    fn test_routing_context(
-        lb_type: &str,
-    ) -> (
+    type TestRoutingContext = (
         HashMap<String, Arc<RwLock<super::UpstreamPool>>>,
         super::RouteIndex,
         Arc<RwLock<super::UpstreamPool>>,
-    ) {
+    );
+
+    fn test_routing_context(lb_type: &str) -> TestRoutingContext {
         let mut upstreams = HashMap::new();
         upstreams.insert("api_pool".to_string(), test_upstream(lb_type));
         let routing_index = super::RouteIndex::from_upstreams(&upstreams);

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -3744,6 +3744,8 @@ impl QUICListener {
                                     }))
                             };
 
+                            // Preserve the same route-lookup + tie-break semantics as the QUIC
+                            // data plane by delegating bootstrap backend resolution here.
                             let resolved = Self::resolve_backend(
                                 &method,
                                 &path,

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -3729,7 +3729,7 @@ impl QUICListener {
                                 }
                             };
 
-                            // Pick backend
+                            // Pick backend using configured LB strategy and current health state.
                             let backend_addr = {
                                 let pool_lock = match upstream_pools.get(&upstream_name) {
                                     Some(p) => p,
@@ -3745,7 +3745,7 @@ impl QUICListener {
                                             }));
                                     }
                                 };
-                                let pool = match pool_lock.read() {
+                                let mut pool = match pool_lock.write() {
                                     Ok(p) => p,
                                     Err(_) => {
                                         return Ok(Response::builder()
@@ -3759,7 +3759,39 @@ impl QUICListener {
                                             }));
                                     }
                                 };
-                                match pool.pool.address(0).map(str::to_owned) {
+                                if pool.pool.is_empty() {
+                                    return Ok(Response::builder()
+                                        .status(StatusCode::SERVICE_UNAVAILABLE)
+                                        .header("alt-svc", &alt)
+                                        .body(Full::new(Bytes::from_static(b"no backends\n")))
+                                        .unwrap_or_else(|_| {
+                                            Response::new(Full::new(Bytes::from_static(
+                                                b"error\n",
+                                            )))
+                                        }));
+                                }
+
+                                let request_key =
+                                    authority.as_deref().unwrap_or(if !path.is_empty() {
+                                        path.as_str()
+                                    } else {
+                                        method.as_str()
+                                    });
+                                let Some(backend_index) = pool.pick(request_key) else {
+                                    return Ok(Response::builder()
+                                        .status(StatusCode::SERVICE_UNAVAILABLE)
+                                        .header("alt-svc", &alt)
+                                        .body(Full::new(Bytes::from_static(
+                                            b"no healthy backends\n",
+                                        )))
+                                        .unwrap_or_else(|_| {
+                                            Response::new(Full::new(Bytes::from_static(
+                                                b"error\n",
+                                            )))
+                                        }));
+                                };
+
+                                match pool.pool.address(backend_index).map(str::to_owned) {
                                     Some(addr) => addr,
                                     None => {
                                         return Ok(Response::builder()

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -117,6 +117,26 @@ fn bootstrap_forwarded_for_value(ip: std::net::IpAddr) -> String {
     }
 }
 
+fn bootstrap_resolution_error_response(reason: &str) -> (StatusCode, &'static [u8]) {
+    if reason.starts_with("no route for ") {
+        return (StatusCode::BAD_GATEWAY, b"no route\n");
+    }
+    if reason.starts_with("pool not found:") {
+        return (StatusCode::BAD_GATEWAY, b"no pool\n");
+    }
+    if reason == "upstream pool lock poisoned" {
+        return (StatusCode::BAD_GATEWAY, b"pool error\n");
+    }
+    if reason == "no servers in upstream" || reason == "invalid server address" {
+        return (StatusCode::SERVICE_UNAVAILABLE, b"no backends\n");
+    }
+    if reason == "no healthy servers" {
+        return (StatusCode::SERVICE_UNAVAILABLE, b"no healthy backends\n");
+    }
+
+    (StatusCode::BAD_GATEWAY, b"route/backend resolution failed\n")
+}
+
 type BootstrapServiceFuture = std::pin::Pin<
     Box<
         dyn std::future::Future<
@@ -3736,42 +3756,17 @@ impl QUICListener {
                                 match resolved {
                                     Ok(value) => value,
                                     Err(ProxyError::Transport(reason)) => {
-                                        if reason.starts_with("no route for ") {
-                                            return bootstrap_error(
-                                                StatusCode::BAD_GATEWAY,
-                                                b"no route\n",
-                                            );
-                                        }
-                                        if reason == "pool not found" || reason.starts_with("pool not found:") {
-                                            return bootstrap_error(
-                                                StatusCode::BAD_GATEWAY,
-                                                b"no pool\n",
-                                            );
-                                        }
-                                        if reason == "upstream pool lock poisoned" {
-                                            return bootstrap_error(
-                                                StatusCode::BAD_GATEWAY,
-                                                b"pool error\n",
-                                            );
-                                        }
-                                        if reason == "no servers in upstream"
-                                            || reason == "no healthy servers"
-                                            || reason == "invalid server address"
+                                        let (status, body) =
+                                            bootstrap_resolution_error_response(&reason);
+                                        if status == StatusCode::BAD_GATEWAY
+                                            && body == b"route/backend resolution failed\n"
                                         {
-                                            return bootstrap_error(
-                                                StatusCode::SERVICE_UNAVAILABLE,
-                                                b"no backends\n",
+                                            warn!(
+                                                "Bootstrap route/backend resolution failed: {}",
+                                                reason
                                             );
                                         }
-
-                                        warn!(
-                                            "Bootstrap route/backend resolution failed: {}",
-                                            reason
-                                        );
-                                        return bootstrap_error(
-                                            StatusCode::BAD_GATEWAY,
-                                            b"route/backend resolution failed\n",
-                                        );
+                                        return bootstrap_error(status, body);
                                     }
                                     Err(err) => {
                                         warn!("Bootstrap route/backend resolution failed: {}", err);

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -154,7 +154,7 @@ Configures the listening interface for incoming client connections. HTTP/3 requi
 
 - `http3`: HTTP/3 over QUIC (recommended)
 
-Spooky also exposes a TLS bootstrap ingress for HTTP/1.1 and HTTP/2 clients. This compatibility path is primarily used for browser interoperability and advertising `Alt-Svc` so clients can upgrade to HTTP/3.
+Spooky also exposes a TLS bootstrap ingress for HTTP/1.1 and HTTP/2 clients. This compatibility path is primarily used for browser interoperability and advertising `Alt-Svc` so clients can upgrade to HTTP/3. Backend selection on the bootstrap path uses the same route-resolution, load-balancing strategy, and health-aware eligibility rules as the native QUIC ingress.
 
 ### TLS Configuration
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -14,6 +14,7 @@
 - Per-upstream configuration and routing
 - Connection ID management and QUIC packet routing
 - TLS 1.3 with certificate chain loading
+- Downstream mTLS (client certificate authentication) via `listen.tls.client_auth.enabled`, `listen.tls.client_auth.require_client_cert`, and `listen.tls.client_auth.ca_file`
 - Structured logging with multiple levels
 - Configuration validation at startup
 - Graceful shutdown with connection draining
@@ -70,7 +71,7 @@
 ### Security
 
 - **TLS peer verification**: Enable certificate verification for production
-- **mTLS support**: Client certificate authentication
+- **mTLS operational tooling**: Certificate rotation/revocation workflows and deployment guidance
 - **Request validation**: Size limits, header validation
 - **IP allowlist/blocklist**: Simple access control
 


### PR DESCRIPTION
Fixes : #113 

## Summary

Bootstrap HTTP/1.1+2 forwarding previously selected `pool.pool.address(0)` directly, which pinned traffic to backend index 0 and ignored configured load-balancing strategy and backend health state.

This PR aligns bootstrap backend selection with the QUIC path by reusing shared route/LB resolution logic and adding coverage for the expected behavior.

## What changed

- Replaced bootstrap backend index-0 selection with strategy-based backend pick.
- Reused `resolve_backend(...)` so bootstrap and QUIC share:
  - route lookup semantics
  - load-balancing algorithm behavior
  - health-aware backend eligibility
- Added deterministic bootstrap error mapping for backend-resolution failures:
  - route/pool failures -> `502`
  - no backends/no healthy backends -> `503`
- Added tests covering:
  - bootstrap resolution is not pinned to first backend under round-robin
  - unhealthy backends are skipped
  - least-connections behavior is respected
- Updated docs to clarify bootstrap path now follows the same route/LB/health selection model as QUIC ingress.

## Commits

- `fix(bootstrap): use LB strategy instead of backend index 0`
- `refactor(bootstrap): reuse shared backend resolution logic`
- `fix(bootstrap): enforce deterministic backend resolution errors`
- `docs(bootstrap): document route lookup parity with QUIC`
- `test(bootstrap): cover LB and health-aware backend resolution`
- `docs(bootstrap): clarify LB and health selection parity`
- `style(tests): satisfy clippy type-complexity and formatting`

## Validation

- `cargo test` (full workspace): ✅
- `cargo fmt --all -- --check`: ✅
- `cargo clippy --workspace --lib --bins -- -D clippy::unwrap_used -D clippy::expect_used`: ✅
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: ✅
