### PR TITLE
fix(runtime): make control_plane_threads configure the primary Tokio runtime

### DIFF
--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -68,7 +68,7 @@ log:
 
 performance:
     worker_threads: 1
-    control_plane_threads: 2
+    control_plane_threads: 2  # Tokio worker threads for control-plane async tasks (startup, health checks, metrics)
     packet_shards_per_worker: 1
     packet_shard_queue_capacity: 2048
     packet_shard_queue_max_bytes: 67108864    # max queued UDP datagram bytes per shard dispatch queue (64 MiB)

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -294,6 +294,7 @@ pub struct Performance {
     #[serde(default = "perf_default_worker_threads")]
     pub worker_threads: usize,
 
+    /// Tokio worker threads used by the control-plane runtime.
     #[serde(default = "perf_default_control_plane_threads")]
     pub control_plane_threads: usize,
 

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -549,7 +549,7 @@ Controls resource limits, tuning knobs, and connection-flood protection. All fie
 | Property | Type | Required | Default | Description |
 |----------|------|----------|---------|-------------|
 | `worker_threads` | integer | No | `1` | Number of polling worker threads |
-| `control_plane_threads` | integer | No | `2` | Threads for background tasks (health checks, metrics) |
+| `control_plane_threads` | integer | No | `2` | Tokio worker threads for the control-plane runtime (startup, health checks, metrics, and other async control tasks) |
 | `reuseport` | bool | No | `true` | Enable `SO_REUSEPORT`; required when `worker_threads > 1` |
 | `pin_workers` | bool | No | `false` | Pin each worker thread to a dedicated CPU core |
 | `global_inflight_limit` | integer | No | `4096` | Maximum concurrent in-flight requests across all upstreams |

--- a/spooky/src/main.rs
+++ b/spooky/src/main.rs
@@ -5,6 +5,7 @@ use std::sync::mpsc::{self, RecvTimeoutError, SyncSender, TrySendError};
 mod privilege_drop;
 mod runtime_guard;
 
+use spooky_config::config::Config;
 use std::sync::{
     Arc,
     atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -59,8 +60,7 @@ async fn wait_for_shutdown_signal() {
     let _ = tokio::signal::ctrl_c().await;
 }
 
-#[tokio::main]
-async fn main() {
+fn main() {
     // Parse CLI arguments
     let cli = Cli::parse();
 
@@ -109,8 +109,29 @@ Use a port >= 1024 for unprivileged startup.",
         std::process::exit(1);
     }
 
-    configure_async_runtime(config_yaml.performance.control_plane_threads.max(1));
+    let control_plane_threads = config_yaml.performance.control_plane_threads.max(1);
+    configure_async_runtime(control_plane_threads);
 
+    let runtime = match tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .worker_threads(control_plane_threads)
+        .thread_name("spooky-control-plane")
+        .build()
+    {
+        Ok(runtime) => runtime,
+        Err(err) => {
+            error!(
+                "Failed to initialize Tokio control-plane runtime (threads={}): {}",
+                control_plane_threads, err
+            );
+            std::process::exit(1);
+        }
+    };
+
+    runtime.block_on(run(config_yaml, uid));
+}
+
+async fn run(config_yaml: Config, uid: libc::uid_t) {
     let shared_state = match QUICListener::build_shared_state(&config_yaml) {
         Ok(shared_state) => Arc::new(shared_state),
         Err(e) => {


### PR DESCRIPTION
Fixes: #121 

## Summary
This PR fixes a runtime configuration gap where `performance.control_plane_threads` was not applied to normal startup runtime creation.

## Problem
`spooky/src/main.rs` used `#[tokio::main]`, which creates the primary runtime with Tokio defaults (CPU-core based).  
As a result, `performance.control_plane_threads` only affected the fallback runtime path and not the main control-plane runtime, despite documentation implying otherwise.

## Changes
- Replaced `#[tokio::main]` startup with an explicit Tokio runtime builder in `spooky/src/main.rs`.
- Wired `performance.control_plane_threads` into `.worker_threads(...)` for the primary control-plane runtime.
- Kept `configure_async_runtime(...)` call so fallback runtime thread configuration remains aligned.
- Updated config/docs text to reflect actual behavior:
  - `docs/configuration/reference.md`
  - `config/config.sample.yaml`
  - `crates/config/src/config.rs`

## Impact
- `performance.control_plane_threads` now works as expected for normal startup.
- Operator tuning and capacity planning based on this setting are now accurate.
- Documentation now matches runtime behavior.

## Validation
- `cargo fmt --all`
- `cargo test` (full suite passes)