### PR TITLE
fix(edge): harden bootstrap listener availability and connection admission

### DIFF
--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -3616,6 +3616,9 @@ impl QUICListener {
         let bind = format!("{}:{}", config.listen.address, config.listen.port);
         let alt_svc_value = format!("h3=\":{}\"; ma=86400", config.listen.port);
         let backend_timeout = Duration::from_millis(config.performance.backend_timeout_ms);
+        let max_connections = config.performance.max_active_connections.max(1);
+        let connection_timeout =
+            Duration::from_millis(config.performance.client_body_idle_timeout_ms.max(1));
 
         let h2_pool = Arc::clone(&shared_state.h2_pool);
         let backend_endpoints = Arc::clone(&shared_state.backend_endpoints);
@@ -3665,14 +3668,29 @@ impl QUICListener {
                 }
             };
             info!(
-                "Bootstrap TLS listener on https://{} (TCP+TLS) — advertising Alt-Svc: {}",
-                bind, alt_svc_value
+                "Bootstrap TLS listener on https://{} (TCP+TLS) — advertising Alt-Svc: {} (max_connections={}, connection_timeout_ms={})",
+                bind,
+                alt_svc_value,
+                max_connections,
+                connection_timeout.as_millis()
             );
+            let connection_limiter = Arc::new(Semaphore::new(max_connections));
             loop {
                 let (stream, peer) = match listener.accept().await {
                     Ok(v) => v,
                     Err(err) => {
                         error!("Bootstrap TLS listener accept failed: {}", err);
+                        continue;
+                    }
+                };
+                let permit = match Arc::clone(&connection_limiter).try_acquire_owned() {
+                    Ok(permit) => permit,
+                    Err(_) => {
+                        metrics.inc_connection_cap_reject();
+                        debug!(
+                            "Bootstrap TLS listener dropped connection from {}: max_connections reached",
+                            peer
+                        );
                         continue;
                     }
                 };
@@ -3685,8 +3703,10 @@ impl QUICListener {
                 let resilience = Arc::clone(&resilience);
                 let upstream_pools = upstream_pools.clone();
                 let routing_index = Arc::clone(&routing_index);
+                let timeout = connection_timeout;
 
                 tokio::spawn(async move {
+                    let _permit = permit;
                     let tls_stream = match acceptor.accept(stream).await {
                         Ok(s) => s,
                         Err(err) => {
@@ -3944,14 +3964,27 @@ impl QUICListener {
 
                     if use_h2 {
                         let executor = hyper_util::rt::TokioExecutor::new();
-                        if let Err(err) = http2::Builder::new(executor)
-                            .serve_connection(io, svc)
-                            .await
-                        {
-                            debug!("Bootstrap h2 connection from {} closed: {}", peer, err);
+                        let serve = http2::Builder::new(executor).serve_connection(io, svc);
+                        match tokio::time::timeout(timeout, serve).await {
+                            Ok(Ok(())) => {}
+                            Ok(Err(err)) => {
+                                debug!("Bootstrap h2 connection from {} closed: {}", peer, err);
+                            }
+                            Err(_) => {
+                                debug!("Bootstrap h2 connection from {} timed out", peer);
+                            }
                         }
-                    } else if let Err(err) = http1::Builder::new().serve_connection(io, svc).await {
-                        debug!("Bootstrap h1 connection from {} closed: {}", peer, err);
+                    } else {
+                        let serve = http1::Builder::new().serve_connection(io, svc);
+                        match tokio::time::timeout(timeout, serve).await {
+                            Ok(Ok(())) => {}
+                            Ok(Err(err)) => {
+                                debug!("Bootstrap h1 connection from {} closed: {}", peer, err);
+                            }
+                            Err(_) => {
+                                debug!("Bootstrap h1 connection from {} timed out", peer);
+                            }
+                        }
                     }
                 });
             }

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -3602,16 +3602,12 @@ impl QUICListener {
         config: &SpookyConfig,
         shared_state: &SharedRuntimeState,
     ) -> Result<(), ProxyError> {
-        let acceptor = match Self::build_bootstrap_tls_acceptor(config) {
-            Ok(a) => a,
-            Err(err) => {
-                warn!(
-                    "Bootstrap TLS listener disabled (could not build TLS config): {}",
-                    err
-                );
-                return Ok(());
-            }
-        };
+        let acceptor = Self::build_bootstrap_tls_acceptor(config).map_err(|err| {
+            ProxyError::Tls(format!(
+                "failed to initialize bootstrap TLS listener config: {}",
+                err
+            ))
+        })?;
 
         let bind = format!("{}:{}", config.listen.address, config.listen.port);
         let alt_svc_value = format!("h3=\":{}\"; ma=86400", config.listen.port);
@@ -3630,43 +3626,35 @@ impl QUICListener {
         let handle = match runtime_handle() {
             Some(h) => h,
             None => {
-                warn!("Bootstrap TLS listener disabled (no Tokio runtime available)");
-                return Ok(());
+                return Err(ProxyError::Transport(
+                    "failed to start bootstrap TLS listener: no Tokio runtime available"
+                        .to_string(),
+                ));
             }
         };
 
-        let std_listener = match std::net::TcpListener::bind(&bind) {
-            Ok(l) => l,
-            Err(err) => {
-                warn!(
-                    "Bootstrap TLS listener could not bind TCP {}: {} \
-                    (browser HTTP/3 discovery will not work; Alt-Svc will only come from QUIC responses)",
-                    bind, err
-                );
-                return Ok(());
-            }
-        };
-        if let Err(err) = std_listener.set_nonblocking(true) {
-            warn!(
-                "Bootstrap TLS listener set_nonblocking failed ({}): {}",
+        let std_listener = std::net::TcpListener::bind(&bind).map_err(|err| {
+            ProxyError::Transport(format!(
+                "failed to bind bootstrap TLS listener on {}: {}",
                 bind, err
-            );
-            return Ok(());
+            ))
+        })?;
+        if let Err(err) = std_listener.set_nonblocking(true) {
+            return Err(ProxyError::Transport(format!(
+                "failed to set bootstrap TLS listener nonblocking ({}): {}",
+                bind, err
+            )));
         }
+        let listener = tokio::net::TcpListener::from_std(std_listener).map_err(|err| {
+            ProxyError::Transport(format!(
+                "failed to register bootstrap TLS listener {}: {}",
+                bind, err
+            ))
+        })?;
 
         let routing_index = Arc::new(routing_index);
 
         spawn_supervised_async_task(&handle, "bootstrap-tls-listener", None, async move {
-            let listener = match tokio::net::TcpListener::from_std(std_listener) {
-                Ok(l) => l,
-                Err(err) => {
-                    warn!(
-                        "Bootstrap TLS listener registration failed ({}): {}",
-                        bind, err
-                    );
-                    return;
-                }
-            };
             info!(
                 "Bootstrap TLS listener on https://{} (TCP+TLS) — advertising Alt-Svc: {} (max_connections={}, connection_timeout_ms={})",
                 bind,

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -3645,12 +3645,15 @@ impl QUICListener {
                 bind, err
             )));
         }
-        let listener = tokio::net::TcpListener::from_std(std_listener).map_err(|err| {
-            ProxyError::Transport(format!(
-                "failed to register bootstrap TLS listener {}: {}",
-                bind, err
-            ))
-        })?;
+        let listener = {
+            let _guard = handle.enter();
+            tokio::net::TcpListener::from_std(std_listener).map_err(|err| {
+                ProxyError::Transport(format!(
+                    "failed to register bootstrap TLS listener {}: {}",
+                    bind, err
+                ))
+            })?
+        };
 
         let routing_index = Arc::new(routing_index);
 


### PR DESCRIPTION
## Summary

Two reliability gaps in the bootstrap TCP/TLS listener that could cause silent failures or resource exhaustion.

- **Connection limiter + per-connection timeout (closes #115):** The bootstrap accept loop was spawning unbounded `tokio::spawn` tasks with no cap. It now acquires a permit from a `Semaphore` sized to `max_active_connections` before spawning — excess connections are dropped immediately. Both the HTTP/1 and HTTP/2 `serve_connection` calls are wrapped in `tokio::time::timeout` using `client_body_idle_timeout_ms`, consistent with the control API and metrics endpoints.

- **Hard failures on listener init (closes #120):** TLS config build failures and TCP bind failures were handled with `warn!` and `return Ok(())`, letting the process start with no bootstrap listener while still advertising `Alt-Svc`. All four init steps — TLS acceptor build, TCP bind, `set_nonblocking`, and `from_std` registration — now propagate `Err(ProxyError::...)` via `?`, making bootstrap failures fatal at startup so operators get an immediate hard signal.
