### PR TITLE
fix(control-api): require stronger auth posture and constant-time token verification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ thiserror = "1"
 tokio = { version = "1", features = ["full"] }
 libc = "0.2"
 smallvec = "1"
+subtle = "2"
 socket2 = { version = "0.5", features = ["all"] }
 core_affinity = "0.8"
 tracing = "0.1.41"

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -720,12 +720,9 @@ pub fn validate(config: &Config) -> bool {
             return false;
         }
 
-        if !is_loopback_bind_address(&config.observability.control_api.address)
-            && config.observability.control_api.auth_token.is_none()
-        {
+        if config.observability.control_api.auth_token.is_none() {
             error!(
-                "observability.control_api.auth_token is required when control_api.address is non-loopback ({})",
-                config.observability.control_api.address
+                "observability.control_api.auth_token is required when control_api.enabled=true"
             );
             return false;
         }
@@ -1613,6 +1610,17 @@ upstream:
         let mut cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.observability.control_api.enabled = true;
         cfg.observability.control_api.address = "0.0.0.0".to_string();
+        cfg.observability.control_api.auth_token = None;
+        assert!(!validate(&cfg));
+    }
+
+    #[test]
+    fn rejects_loopback_control_api_without_auth_token() {
+        let dir = tempdir().expect("tempdir");
+        let (cert, key) = write_test_certs(dir.path());
+        let mut cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.observability.control_api.enabled = true;
+        cfg.observability.control_api.address = "127.0.0.1".to_string();
         cfg.observability.control_api.auth_token = None;
         assert!(!validate(&cfg));
     }

--- a/crates/edge/Cargo.toml
+++ b/crates/edge/Cargo.toml
@@ -29,6 +29,7 @@ serde_json.workspace = true
 tokio-rustls.workspace = true
 rustls.workspace = true
 rustls-pemfile.workspace = true
+subtle.workspace = true
 
 [dev-dependencies]
 rand.workspace = true

--- a/crates/edge/src/quic_listener/control_api.rs
+++ b/crates/edge/src/quic_listener/control_api.rs
@@ -1,4 +1,5 @@
 use super::*;
+use subtle::ConstantTimeEq;
 
 #[derive(Clone)]
 pub(super) struct ControlApiPaths {
@@ -371,7 +372,7 @@ impl QUICListener {
         let Some(provided) = raw.strip_prefix("Bearer ") else {
             return false;
         };
-        provided == token
+        bool::from(provided.as_bytes().ct_eq(token.as_bytes()))
     }
 
     pub(super) fn spawn_watchdog(

--- a/crates/edge/src/quic_listener/control_api.rs
+++ b/crates/edge/src/quic_listener/control_api.rs
@@ -51,6 +51,21 @@ impl QUICListener {
         let bind = format!("{}:{}", endpoint.address, endpoint.port);
         let max_connections = endpoint.max_connections.max(1);
         let connection_timeout = Duration::from_millis(endpoint.connection_timeout_ms.max(1));
+        let acceptor = match Self::build_server_tls_acceptor(
+            config,
+            false,
+            vec![b"http/1.1".to_vec()],
+        ) {
+            Ok(acceptor) => acceptor,
+            Err(err) => {
+                let msg = format!("failed to initialize control API TLS config: {err}");
+                if required {
+                    return Err(ProxyError::Tls(msg));
+                }
+                error!("{}", msg);
+                return Ok(());
+            }
+        };
         let paths = ControlApiPaths {
             health_path: endpoint.health_path.clone(),
             ready_path: endpoint.ready_path.clone(),
@@ -101,7 +116,10 @@ impl QUICListener {
             error!("{}", msg);
             return Ok(());
         }
-        let listener = match tokio::net::TcpListener::from_std(std_listener) {
+        let listener = match {
+            let _guard = handle.enter();
+            tokio::net::TcpListener::from_std(std_listener)
+        } {
             Ok(listener) => listener,
             Err(err) => {
                 let msg = format!(
@@ -122,7 +140,7 @@ impl QUICListener {
             Some(Arc::clone(&shared_state.metrics)),
             async move {
                 info!(
-                    "Control API endpoint listening on http://{}{} (ready={}, runtime={}, max_connections={}, connection_timeout_ms={})",
+                    "Control API endpoint listening on https://{}{} (ready={}, runtime={}, max_connections={}, connection_timeout_ms={})",
                     bind,
                     paths.health_path,
                     paths.ready_path,
@@ -133,7 +151,7 @@ impl QUICListener {
                 let connection_limiter = Arc::new(Semaphore::new(max_connections));
 
                 loop {
-                    let (stream, _peer) = match listener.accept().await {
+                    let (stream, peer) = match listener.accept().await {
                         Ok(v) => v,
                         Err(err) => {
                             error!("Control API endpoint accept failed: {}", err);
@@ -147,13 +165,24 @@ impl QUICListener {
                         }
                     };
 
-                    let io = TokioIo::new(stream);
+                    let acceptor = acceptor.clone();
                     let paths = paths.clone();
                     let state = state.clone();
                     let timeout = connection_timeout;
 
                     tokio::spawn(async move {
                         let _permit = permit;
+                        let tls_stream = match acceptor.accept(stream).await {
+                            Ok(stream) => stream,
+                            Err(err) => {
+                                error!(
+                                    "Control API endpoint TLS handshake failed from {}: {}",
+                                    peer, err
+                                );
+                                return;
+                            }
+                        };
+                        let io = TokioIo::new(tls_stream);
                         let service = service_fn(move |req: Request<Incoming>| {
                             let paths = paths.clone();
                             let state = state.clone();
@@ -331,7 +360,7 @@ impl QUICListener {
         state: &ControlApiState,
     ) -> bool {
         let Some(token) = state.auth_token.as_ref() else {
-            return true;
+            return false;
         };
         let Some(header) = req.headers().get(http::header::AUTHORIZATION) else {
             return false;

--- a/crates/edge/src/quic_listener/control_api.rs
+++ b/crates/edge/src/quic_listener/control_api.rs
@@ -117,10 +117,11 @@ impl QUICListener {
             error!("{}", msg);
             return Ok(());
         }
-        let listener = match {
+        let from_std_result = {
             let _guard = handle.enter();
             tokio::net::TcpListener::from_std(std_listener)
-        } {
+        };
+        let listener = match from_std_result {
             Ok(listener) => listener,
             Err(err) => {
                 let msg = format!(

--- a/crates/edge/src/quic_listener/control_api.rs
+++ b/crates/edge/src/quic_listener/control_api.rs
@@ -52,21 +52,18 @@ impl QUICListener {
         let bind = format!("{}:{}", endpoint.address, endpoint.port);
         let max_connections = endpoint.max_connections.max(1);
         let connection_timeout = Duration::from_millis(endpoint.connection_timeout_ms.max(1));
-        let acceptor = match Self::build_server_tls_acceptor(
-            config,
-            false,
-            vec![b"http/1.1".to_vec()],
-        ) {
-            Ok(acceptor) => acceptor,
-            Err(err) => {
-                let msg = format!("failed to initialize control API TLS config: {err}");
-                if required {
-                    return Err(ProxyError::Tls(msg));
+        let acceptor =
+            match Self::build_server_tls_acceptor(config, false, vec![b"http/1.1".to_vec()]) {
+                Ok(acceptor) => acceptor,
+                Err(err) => {
+                    let msg = format!("failed to initialize control API TLS config: {err}");
+                    if required {
+                        return Err(ProxyError::Tls(msg));
+                    }
+                    error!("{}", msg);
+                    return Ok(());
                 }
-                error!("{}", msg);
-                return Ok(());
-            }
-        };
+            };
         let paths = ControlApiPaths {
             health_path: endpoint.health_path.clone(),
             ready_path: endpoint.ready_path.clone(),

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -3485,7 +3485,11 @@ impl QUICListener {
         Ok(())
     }
 
-    fn build_bootstrap_tls_acceptor(config: &SpookyConfig) -> Result<TlsAcceptor, ProxyError> {
+    fn build_server_tls_acceptor(
+        config: &SpookyConfig,
+        enforce_client_auth: bool,
+        alpn_protocols: Vec<Vec<u8>>,
+    ) -> Result<TlsAcceptor, ProxyError> {
         use rustls_pemfile::{certs, pkcs8_private_keys, rsa_private_keys};
         use std::io::BufReader;
 
@@ -3533,7 +3537,7 @@ impl QUICListener {
             }
         };
 
-        let builder = if config.listen.tls.client_auth.enabled {
+        let builder = if enforce_client_auth && config.listen.tls.client_auth.enabled {
             let ca_file = config
                 .listen
                 .tls
@@ -3593,9 +3597,17 @@ impl QUICListener {
             ProxyError::Tls(format!("failed to build rustls ServerConfig: {}", err))
         })?;
 
-        tls_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+        tls_config.alpn_protocols = alpn_protocols;
 
         Ok(TlsAcceptor::from(Arc::new(tls_config)))
+    }
+
+    fn build_bootstrap_tls_acceptor(config: &SpookyConfig) -> Result<TlsAcceptor, ProxyError> {
+        Self::build_server_tls_acceptor(
+            config,
+            true,
+            vec![b"h2".to_vec(), b"http/1.1".to_vec()],
+        )
     }
 
     fn spawn_bootstrap_tls_listener(

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -3603,11 +3603,7 @@ impl QUICListener {
     }
 
     fn build_bootstrap_tls_acceptor(config: &SpookyConfig) -> Result<TlsAcceptor, ProxyError> {
-        Self::build_server_tls_acceptor(
-            config,
-            true,
-            vec![b"h2".to_vec(), b"http/1.1".to_vec()],
-        )
+        Self::build_server_tls_acceptor(config, true, vec![b"h2".to_vec(), b"http/1.1".to_vec()])
     }
 
     fn spawn_bootstrap_tls_listener(


### PR DESCRIPTION
## Summary

Two security fixes for the control API — unauthenticated access on loopback and a timing side-channel on token comparison.

- **TLS + mandatory auth (closes #123):** The control API was plaintext HTTP and skipped authentication for loopback binds. It now uses the same TLS acceptor as the bootstrap listener, so all connections are encrypted. The validator now requires `auth_token` unconditionally when `control_api.enabled=true` — no loopback exemption. The `control_api_is_authorized` function returns `false` when no token is configured, removing the implicit allow.

- **Constant-time token comparison (closes #124):** Bearer token validation used plain `==`, which is vulnerable to timing oracle attacks. The comparison now uses `subtle::ct_eq()` so the comparison takes the same time regardless of where the strings diverge.
