### PR TITLE
fix(edge): bootstrap backend selection, retry safety, and streming semantics

### DIFF
--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -1,11 +1,14 @@
 use std::{
     collections::{HashMap, HashSet},
+    convert::Infallible,
     future::Future,
     net::{ToSocketAddrs, UdpSocket},
+    pin::Pin,
     sync::{
         Arc, OnceLock, RwLock,
         atomic::{AtomicUsize, Ordering},
     },
+    task::{Context, Poll},
     time::{Duration, Instant},
 };
 
@@ -14,7 +17,7 @@ use core::net::SocketAddr;
 use bytes::Bytes;
 use http::{Request, Response, StatusCode};
 use http_body_util::{BodyExt, Full, combinators::BoxBody};
-use hyper::body::Incoming;
+use hyper::body::{Body, Frame, Incoming};
 use hyper::server::conn::http1;
 use hyper::server::conn::http2;
 use hyper::service::service_fn;
@@ -144,12 +147,43 @@ type BootstrapServiceFuture = std::pin::Pin<
     Box<
         dyn std::future::Future<
                 Output = Result<
-                    hyper::Response<http_body_util::Full<hyper::body::Bytes>>,
+                    hyper::Response<http_body_util::combinators::BoxBody<hyper::body::Bytes, Infallible>>,
                     hyper::Error,
                 >,
             > + Send,
     >,
 >;
+
+struct BootstrapStreamingBody {
+    inner: Incoming,
+}
+
+impl BootstrapStreamingBody {
+    fn new(inner: Incoming) -> Self {
+        Self { inner }
+    }
+}
+
+impl Body for BootstrapStreamingBody {
+    type Data = Bytes;
+    type Error = Infallible;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        match Pin::new(&mut self.inner).poll_frame(cx) {
+            Poll::Ready(Some(Ok(frame))) => Poll::Ready(Some(Ok(frame))),
+            Poll::Ready(Some(Err(_))) => Poll::Ready(None),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+fn boxed_full(body: Bytes) -> http_body_util::combinators::BoxBody<Bytes, Infallible> {
+    Full::new(body).map_err(|never| match never {}).boxed()
+}
 
 type ResolvedBackend = (
     String,
@@ -3620,6 +3654,8 @@ impl QUICListener {
         let bind = format!("{}:{}", config.listen.address, config.listen.port);
         let alt_svc_value = format!("h3=\":{}\"; ma=86400", config.listen.port);
         let backend_timeout = Duration::from_millis(config.performance.backend_timeout_ms);
+        let max_request_body_bytes = config.performance.max_request_body_bytes;
+        let max_response_body_bytes = config.performance.max_response_body_bytes;
         let max_connections = config.performance.max_active_connections.max(1);
         let connection_timeout =
             Duration::from_millis(config.performance.client_body_idle_timeout_ms.max(1));
@@ -3702,6 +3738,8 @@ impl QUICListener {
                 let resilience = Arc::clone(&resilience);
                 let upstream_pools = upstream_pools.clone();
                 let routing_index = Arc::clone(&routing_index);
+                let max_request_body_bytes = max_request_body_bytes;
+                let max_response_body_bytes = max_response_body_bytes;
                 let timeout = connection_timeout;
 
                 tokio::spawn(async move {
@@ -3728,6 +3766,8 @@ impl QUICListener {
                         let resilience = Arc::clone(&resilience);
                         let upstream_pools = upstream_pools.clone();
                         let routing_index = Arc::clone(&routing_index);
+                        let max_request_body_bytes = max_request_body_bytes;
+                        let max_response_body_bytes = max_response_body_bytes;
 
                         Box::pin(async move {
                             let request = match validate_http_request(&req, &resilience) {
@@ -3746,10 +3786,8 @@ impl QUICListener {
                                     return Ok(Response::builder()
                                         .status(status)
                                         .header("alt-svc", &alt)
-                                        .body(Full::new(Bytes::copy_from_slice(body)))
-                                        .unwrap_or_else(|_| {
-                                            Response::new(Full::new(Bytes::new()))
-                                        }));
+                                        .body(boxed_full(Bytes::copy_from_slice(body)))
+                                        .unwrap_or_else(|_| Response::new(boxed_full(Bytes::new()))));
                                 }
                             };
                             let method = request.method;
@@ -3760,9 +3798,9 @@ impl QUICListener {
                                 Ok(Response::builder()
                                     .status(status)
                                     .header("alt-svc", &alt)
-                                    .body(Full::new(Bytes::from_static(body)))
+                                    .body(boxed_full(Bytes::from_static(body)))
                                     .unwrap_or_else(|_| {
-                                        Response::new(Full::new(Bytes::from_static(b"error\n")))
+                                        Response::new(boxed_full(Bytes::from_static(b"error\n")))
                                     }))
                             };
 
@@ -3807,9 +3845,9 @@ impl QUICListener {
                                     return Ok(Response::builder()
                                         .status(StatusCode::BAD_GATEWAY)
                                         .header("alt-svc", &alt)
-                                        .body(Full::new(Bytes::from_static(b"no endpoint\n")))
+                                        .body(boxed_full(Bytes::from_static(b"no endpoint\n")))
                                         .unwrap_or_else(|_| {
-                                            Response::new(Full::new(Bytes::from_static(b"error\n")))
+                                            Response::new(boxed_full(Bytes::from_static(b"error\n")))
                                         }));
                                 }
                             };
@@ -3823,9 +3861,9 @@ impl QUICListener {
                                         return Ok(Response::builder()
                                             .status(StatusCode::BAD_GATEWAY)
                                             .header("alt-svc", &alt)
-                                            .body(Full::new(Bytes::from_static(b"bad uri\n")))
+                                            .body(boxed_full(Bytes::from_static(b"bad uri\n")))
                                             .unwrap_or_else(|_| {
-                                                Response::new(Full::new(Bytes::from_static(
+                                                Response::new(boxed_full(Bytes::from_static(
                                                     b"error\n",
                                                 )))
                                             }));
@@ -3855,87 +3893,87 @@ impl QUICListener {
                                 ),
                             );
 
-                            let body_bytes = match req.into_body().collect().await {
-                                Ok(collected) => collected.to_bytes(),
-                                Err(_) => Bytes::new(),
-                            };
+                            if let Some(content_length) = req
+                                .headers()
+                                .get(http::header::CONTENT_LENGTH)
+                                .and_then(|v| v.to_str().ok())
+                                .and_then(|s| s.parse::<usize>().ok())
+                                && content_length > max_request_body_bytes
+                            {
+                                return Ok(Response::builder()
+                                    .status(StatusCode::PAYLOAD_TOO_LARGE)
+                                    .header("alt-svc", &alt)
+                                    .body(boxed_full(Bytes::from_static(b"request body too large\n")))
+                                    .unwrap_or_else(|_| {
+                                        Response::new(boxed_full(Bytes::from_static(b"error\n")))
+                                    }));
+                            }
 
-                            // Build a template request (no body) then clone per retry attempt
-                            let template = match upstream_req.body(()) {
+                            let upstream_req = match upstream_req.body(
+                                BootstrapStreamingBody::new(req.into_body())
+                                    .map_err(|never| match never {})
+                                    .boxed(),
+                            ) {
                                 Ok(r) => r,
                                 Err(_) => {
                                     return Ok(Response::builder()
                                         .status(StatusCode::BAD_GATEWAY)
                                         .header("alt-svc", &alt)
-                                        .body(Full::new(Bytes::from_static(
+                                        .body(boxed_full(Bytes::from_static(
                                             b"request build error\n",
                                         )))
                                         .unwrap_or_else(|_| {
-                                            Response::new(Full::new(Bytes::from_static(b"error\n")))
+                                            Response::new(boxed_full(Bytes::from_static(b"error\n")))
                                         }));
                                 }
                             };
-                            let (parts, _) = template.into_parts();
-                            let parts = Arc::new(parts);
-
-                            // Forward to backend — retry on connection errors (pool not yet warm)
-                            const MAX_RETRIES: u32 = 3;
-                            let mut last_err = String::new();
-                            let mut upstream_resp_opt = None;
-                            for attempt in 0..=MAX_RETRIES {
-                                if attempt > 0 {
-                                    tokio::time::sleep(Duration::from_millis(150)).await;
-                                }
-                                let retry_body = http_body_util::Full::new(body_bytes.clone())
-                                    .map_err(|e: std::convert::Infallible| e)
-                                    .boxed();
-                                let retry_req = Request::from_parts((*parts).clone(), retry_body);
-                                match tokio::time::timeout(
-                                    backend_timeout,
-                                    h2_pool.send(&backend_addr, retry_req),
-                                )
-                                .await
-                                {
-                                    Ok(Ok(resp)) => {
-                                        upstream_resp_opt = Some(resp);
-                                        break;
-                                    }
-                                    Ok(Err(err)) => {
-                                        last_err = err.to_string();
-                                    }
-                                    Err(_) => {
-                                        return Ok(Response::builder()
-                                            .status(StatusCode::GATEWAY_TIMEOUT)
-                                            .header("alt-svc", &alt)
-                                            .body(Full::new(Bytes::from_static(
-                                                b"upstream timeout\n",
-                                            )))
-                                            .unwrap_or_else(|_| {
-                                                Response::new(Full::new(Bytes::from_static(
-                                                    b"error\n",
-                                                )))
-                                            }));
-                                    }
-                                }
-                            }
-                            let upstream_resp = match upstream_resp_opt {
-                                Some(r) => r,
-                                None => {
-                                    warn!(
-                                        "Bootstrap proxy upstream error after retries: {}",
-                                        last_err
-                                    );
+                            let upstream_resp = match tokio::time::timeout(
+                                backend_timeout,
+                                h2_pool.send(&backend_addr, upstream_req),
+                            )
+                            .await
+                            {
+                                Ok(Ok(resp)) => resp,
+                                Ok(Err(err)) => {
+                                    warn!("Bootstrap proxy upstream error: {}", err);
                                     return Ok(Response::builder()
                                         .status(StatusCode::BAD_GATEWAY)
                                         .header("alt-svc", &alt)
-                                        .body(Full::new(Bytes::from_static(b"upstream error\n")))
+                                        .body(boxed_full(Bytes::from_static(b"upstream error\n")))
                                         .unwrap_or_else(|_| {
-                                            Response::new(Full::new(Bytes::from_static(b"error\n")))
+                                            Response::new(boxed_full(Bytes::from_static(b"error\n")))
+                                        }));
+                                }
+                                Err(_) => {
+                                    return Ok(Response::builder()
+                                        .status(StatusCode::GATEWAY_TIMEOUT)
+                                        .header("alt-svc", &alt)
+                                        .body(boxed_full(Bytes::from_static(b"upstream timeout\n")))
+                                        .unwrap_or_else(|_| {
+                                            Response::new(boxed_full(Bytes::from_static(b"error\n")))
                                         }));
                                 }
                             };
 
                             // Build downstream response with Alt-Svc injected
+                            if let Some(content_length) = upstream_resp
+                                .headers()
+                                .get(http::header::CONTENT_LENGTH)
+                                .and_then(|v| v.to_str().ok())
+                                .and_then(|s| s.parse::<usize>().ok())
+                                && content_length > max_response_body_bytes
+                            {
+                                return Ok(Response::builder()
+                                    .status(StatusCode::SERVICE_UNAVAILABLE)
+                                    .header("alt-svc", &alt)
+                                    .body(boxed_full(Bytes::from_static(
+                                        b"upstream response body too large\n",
+                                    )))
+                                    .unwrap_or_else(|_| {
+                                        Response::new(boxed_full(Bytes::from_static(b"error\n")))
+                                    }));
+                            }
+
                             let status = upstream_resp.status();
                             let mut resp_builder = Response::builder().status(status);
                             for (name, value) in upstream_resp.headers() {
@@ -3949,15 +3987,13 @@ impl QUICListener {
                                 resp_builder = resp_builder.header(name, value);
                             }
                             resp_builder = resp_builder.header("alt-svc", &alt);
-
-                            let resp_body = match upstream_resp.into_body().collect().await {
-                                Ok(collected) => collected.to_bytes(),
-                                Err(_) => Bytes::new(),
-                            };
+                            let resp_body = BootstrapStreamingBody::new(upstream_resp.into_body())
+                                .map_err(|never| match never {})
+                                .boxed();
 
                             Ok(resp_builder
-                                .body(Full::new(resp_body))
-                                .unwrap_or_else(|_| Response::new(Full::new(Bytes::new()))))
+                                .body(resp_body)
+                                .unwrap_or_else(|_| Response::new(boxed_full(Bytes::new()))))
                         })
                     });
 

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -18,9 +18,11 @@ use bytes::Bytes;
 use http::{Request, Response, StatusCode};
 use http_body_util::{BodyExt, Full, combinators::BoxBody};
 use hyper::body::{Body, Frame, Incoming};
+use hyper::client::conn::http1 as client_http1;
 use hyper::server::conn::http1;
 use hyper::server::conn::http2;
 use hyper::service::service_fn;
+use hyper::upgrade;
 use hyper_util::rt::TokioIo;
 use log::{debug, error, info, warn};
 use quiche::Config;
@@ -43,7 +45,10 @@ use tokio::sync::{
 use tokio_rustls::TlsAcceptor;
 use tracing::{Instrument, info_span};
 
-use spooky_config::{backend_endpoint::BackendEndpoint, config::Config as SpookyConfig};
+use spooky_config::{
+    backend_endpoint::{BackendEndpoint, BackendScheme},
+    config::Config as SpookyConfig,
+};
 
 use crate::{
     ChannelBody, ForwardResult, HealthClassification, Metrics, OverloadShedReason, QUICListener,
@@ -113,6 +118,37 @@ fn should_strip_bootstrap_request_header(name: &http::header::HeaderName) -> boo
     false
 }
 
+fn header_has_token(value: &http::HeaderValue, token: &str) -> bool {
+    value
+        .to_str()
+        .ok()
+        .map(|raw| {
+            raw.split(',')
+                .any(|part| part.trim().eq_ignore_ascii_case(token))
+        })
+        .unwrap_or(false)
+}
+
+fn is_websocket_upgrade_request(req: &Request<Incoming>, use_h2: bool) -> bool {
+    if use_h2 || req.method() != http::Method::GET {
+        return false;
+    }
+    let Some(upgrade_header) = req.headers().get(http::header::UPGRADE) else {
+        return false;
+    };
+    if !upgrade_header
+        .to_str()
+        .map(|v| v.eq_ignore_ascii_case("websocket"))
+        .unwrap_or(false)
+    {
+        return false;
+    }
+    req.headers()
+        .get(http::header::CONNECTION)
+        .map(|v| header_has_token(v, "upgrade"))
+        .unwrap_or(false)
+}
+
 fn bootstrap_forwarded_for_value(ip: std::net::IpAddr) -> String {
     match ip {
         std::net::IpAddr::V4(v4) => v4.to_string(),
@@ -147,7 +183,9 @@ type BootstrapServiceFuture = std::pin::Pin<
     Box<
         dyn std::future::Future<
                 Output = Result<
-                    hyper::Response<http_body_util::combinators::BoxBody<hyper::body::Bytes, Infallible>>,
+                    hyper::Response<
+                        http_body_util::combinators::BoxBody<hyper::body::Bytes, Infallible>,
+                    >,
                     hyper::Error,
                 >,
             > + Send,
@@ -3758,64 +3796,85 @@ impl QUICListener {
                     let io = TokioIo::new(tls_stream);
                     let alt_svc_conn = alt_svc.clone();
 
-                    let svc = service_fn(move |req: Request<Incoming>| -> BootstrapServiceFuture {
-                        let alt = alt_svc_conn.clone();
-                        let h2_pool = Arc::clone(&h2_pool);
-                        let backend_endpoints = Arc::clone(&backend_endpoints);
-                        let metrics = Arc::clone(&metrics);
-                        let resilience = Arc::clone(&resilience);
-                        let upstream_pools = upstream_pools.clone();
-                        let routing_index = Arc::clone(&routing_index);
-                        let max_request_body_bytes = max_request_body_bytes;
-                        let max_response_body_bytes = max_response_body_bytes;
+                    let svc = service_fn(
+                        move |mut req: Request<Incoming>| -> BootstrapServiceFuture {
+                            let alt = alt_svc_conn.clone();
+                            let h2_pool = Arc::clone(&h2_pool);
+                            let backend_endpoints = Arc::clone(&backend_endpoints);
+                            let metrics = Arc::clone(&metrics);
+                            let resilience = Arc::clone(&resilience);
+                            let upstream_pools = upstream_pools.clone();
+                            let routing_index = Arc::clone(&routing_index);
+                            let max_request_body_bytes = max_request_body_bytes;
+                            let max_response_body_bytes = max_response_body_bytes;
 
-                        Box::pin(async move {
-                            let request = match validate_http_request(&req, &resilience) {
-                                Ok(request) => request,
-                                Err((status, body, is_policy)) => {
-                                    metrics.inc_failure();
-                                    metrics.inc_request_validation_reject();
-                                    if is_policy {
-                                        metrics.inc_policy_denied();
+                            Box::pin(async move {
+                                let is_websocket_upgrade =
+                                    is_websocket_upgrade_request(&req, use_h2);
+                                let client_upgrade = if is_websocket_upgrade {
+                                    Some(upgrade::on(&mut req))
+                                } else {
+                                    None
+                                };
+
+                                let request = match validate_http_request(&req, &resilience) {
+                                    Ok(request) => request,
+                                    Err((status, body, is_policy)) => {
+                                        metrics.inc_failure();
+                                        metrics.inc_request_validation_reject();
+                                        if is_policy {
+                                            metrics.inc_policy_denied();
+                                        }
+                                        metrics.record_route(
+                                            "unrouted",
+                                            Duration::from_millis(0),
+                                            RouteOutcome::Failure,
+                                        );
+                                        return Ok(Response::builder()
+                                            .status(status)
+                                            .header("alt-svc", &alt)
+                                            .body(boxed_full(Bytes::copy_from_slice(body)))
+                                            .unwrap_or_else(|_| {
+                                                Response::new(boxed_full(Bytes::new()))
+                                            }));
                                     }
-                                    metrics.record_route(
-                                        "unrouted",
-                                        Duration::from_millis(0),
-                                        RouteOutcome::Failure,
-                                    );
-                                    return Ok(Response::builder()
+                                };
+                                let method = request.method;
+                                let path = request.path;
+                                let authority = request.authority;
+
+                                let bootstrap_error = |status: StatusCode, body: &'static [u8]| {
+                                    Ok(Response::builder()
                                         .status(status)
                                         .header("alt-svc", &alt)
-                                        .body(boxed_full(Bytes::copy_from_slice(body)))
-                                        .unwrap_or_else(|_| Response::new(boxed_full(Bytes::new()))));
-                                }
-                            };
-                            let method = request.method;
-                            let path = request.path;
-                            let authority = request.authority;
+                                        .body(boxed_full(Bytes::from_static(body)))
+                                        .unwrap_or_else(|_| {
+                                            Response::new(boxed_full(Bytes::from_static(
+                                                b"error\n",
+                                            )))
+                                        }))
+                                };
 
-                            let bootstrap_error = |status: StatusCode, body: &'static [u8]| {
-                                Ok(Response::builder()
-                                    .status(status)
-                                    .header("alt-svc", &alt)
-                                    .body(boxed_full(Bytes::from_static(body)))
-                                    .unwrap_or_else(|_| {
-                                        Response::new(boxed_full(Bytes::from_static(b"error\n")))
-                                    }))
-                            };
-
-                            // Preserve the same route-lookup + tie-break semantics as the QUIC
-                            // data plane by delegating bootstrap backend resolution here.
-                            let resolved = Self::resolve_backend(
-                                &method,
-                                &path,
-                                authority.as_deref(),
-                                None,
-                                &upstream_pools,
-                                &routing_index,
-                            );
-                            let (_upstream_name, backend_addr, _backend_index, _pool, _lb, _, _, _) =
-                                match resolved {
+                                // Preserve the same route-lookup + tie-break semantics as the QUIC
+                                // data plane by delegating bootstrap backend resolution here.
+                                let resolved = Self::resolve_backend(
+                                    &method,
+                                    &path,
+                                    authority.as_deref(),
+                                    None,
+                                    &upstream_pools,
+                                    &routing_index,
+                                );
+                                let (
+                                    _upstream_name,
+                                    backend_addr,
+                                    _backend_index,
+                                    _pool,
+                                    _lb,
+                                    _,
+                                    _,
+                                    _,
+                                ) = match resolved {
                                     Ok(value) => value,
                                     Err(ProxyError::Transport(reason)) => {
                                         let (status, body) =
@@ -3839,23 +3898,26 @@ impl QUICListener {
                                     }
                                 };
 
-                            let endpoint = match backend_endpoints.get(&backend_addr) {
-                                Some(ep) => ep.clone(),
-                                None => {
-                                    return Ok(Response::builder()
-                                        .status(StatusCode::BAD_GATEWAY)
-                                        .header("alt-svc", &alt)
-                                        .body(boxed_full(Bytes::from_static(b"no endpoint\n")))
-                                        .unwrap_or_else(|_| {
-                                            Response::new(boxed_full(Bytes::from_static(b"error\n")))
-                                        }));
-                                }
-                            };
+                                let endpoint = match backend_endpoints.get(&backend_addr) {
+                                    Some(ep) => ep.clone(),
+                                    None => {
+                                        return Ok(Response::builder()
+                                            .status(StatusCode::BAD_GATEWAY)
+                                            .header("alt-svc", &alt)
+                                            .body(boxed_full(Bytes::from_static(b"no endpoint\n")))
+                                            .unwrap_or_else(|_| {
+                                                Response::new(boxed_full(Bytes::from_static(
+                                                    b"error\n",
+                                                )))
+                                            }));
+                                    }
+                                };
 
-                            // Build upstream request
-                            let request_path = if path.is_empty() { "/" } else { &path };
-                            let upstream_uri =
-                                match http::Uri::try_from(endpoint.uri_for_path(request_path)) {
+                                // Build upstream request
+                                let request_path = if path.is_empty() { "/" } else { &path };
+                                let upstream_uri = match http::Uri::try_from(
+                                    endpoint.uri_for_path(request_path),
+                                ) {
                                     Ok(u) => u,
                                     Err(_) => {
                                         return Ok(Response::builder()
@@ -3870,132 +3932,356 @@ impl QUICListener {
                                     }
                                 };
 
-                            let mut upstream_req =
-                                Request::builder().method(method.as_str()).uri(upstream_uri);
+                                let mut upstream_req =
+                                    Request::builder().method(method.as_str()).uri(upstream_uri);
 
-                            for (name, value) in req.headers() {
-                                if name == http::header::HOST
-                                    || should_strip_bootstrap_request_header(name)
-                                {
-                                    continue;
+                                for (name, value) in req.headers() {
+                                    if name == http::header::HOST {
+                                        continue;
+                                    }
+                                    if !is_websocket_upgrade
+                                        && should_strip_bootstrap_request_header(name)
+                                    {
+                                        continue;
+                                    }
+                                    if is_websocket_upgrade
+                                        && (name == http::header::PROXY_AUTHORIZATION
+                                            || name == http::header::PROXY_AUTHENTICATE
+                                            || name
+                                                .as_str()
+                                                .eq_ignore_ascii_case("proxy-connection")
+                                            || name.as_str().eq_ignore_ascii_case("forwarded")
+                                            || name
+                                                .as_str()
+                                                .eq_ignore_ascii_case("x-forwarded-for")
+                                            || name
+                                                .as_str()
+                                                .eq_ignore_ascii_case("x-forwarded-proto")
+                                            || name
+                                                .as_str()
+                                                .eq_ignore_ascii_case("x-forwarded-host"))
+                                    {
+                                        continue;
+                                    }
+                                    upstream_req = upstream_req.header(name, value);
                                 }
-                                upstream_req = upstream_req.header(name, value);
-                            }
-                            upstream_req = upstream_req.header(
-                                http::header::HOST,
-                                authority.as_deref().unwrap_or(endpoint.authority()),
-                            );
-                            upstream_req = upstream_req.header(
-                                "forwarded",
-                                format!(
-                                    "for={};proto=https",
-                                    bootstrap_forwarded_for_value(peer.ip())
-                                ),
-                            );
+                                upstream_req = upstream_req.header(
+                                    http::header::HOST,
+                                    authority.as_deref().unwrap_or(endpoint.authority()),
+                                );
+                                upstream_req = upstream_req.header(
+                                    "forwarded",
+                                    format!(
+                                        "for={};proto=https",
+                                        bootstrap_forwarded_for_value(peer.ip())
+                                    ),
+                                );
 
-                            if let Some(content_length) = req
-                                .headers()
-                                .get(http::header::CONTENT_LENGTH)
-                                .and_then(|v| v.to_str().ok())
-                                .and_then(|s| s.parse::<usize>().ok())
-                                && content_length > max_request_body_bytes
-                            {
-                                return Ok(Response::builder()
-                                    .status(StatusCode::PAYLOAD_TOO_LARGE)
-                                    .header("alt-svc", &alt)
-                                    .body(boxed_full(Bytes::from_static(b"request body too large\n")))
-                                    .unwrap_or_else(|_| {
-                                        Response::new(boxed_full(Bytes::from_static(b"error\n")))
-                                    }));
-                            }
-
-                            let upstream_req = match upstream_req.body(
-                                BootstrapStreamingBody::new(req.into_body())
-                                    .map_err(|never| match never {})
-                                    .boxed(),
-                            ) {
-                                Ok(r) => r,
-                                Err(_) => {
+                                if !is_websocket_upgrade
+                                    && let Some(content_length) = req
+                                        .headers()
+                                        .get(http::header::CONTENT_LENGTH)
+                                        .and_then(|v| v.to_str().ok())
+                                        .and_then(|s| s.parse::<usize>().ok())
+                                    && content_length > max_request_body_bytes
+                                {
                                     return Ok(Response::builder()
-                                        .status(StatusCode::BAD_GATEWAY)
+                                        .status(StatusCode::PAYLOAD_TOO_LARGE)
                                         .header("alt-svc", &alt)
                                         .body(boxed_full(Bytes::from_static(
-                                            b"request build error\n",
+                                            b"request body too large\n",
                                         )))
                                         .unwrap_or_else(|_| {
-                                            Response::new(boxed_full(Bytes::from_static(b"error\n")))
+                                            Response::new(boxed_full(Bytes::from_static(
+                                                b"error\n",
+                                            )))
                                         }));
                                 }
-                            };
-                            let upstream_resp = match tokio::time::timeout(
-                                backend_timeout,
-                                h2_pool.send(&backend_addr, upstream_req),
-                            )
-                            .await
-                            {
-                                Ok(Ok(resp)) => resp,
-                                Ok(Err(err)) => {
-                                    warn!("Bootstrap proxy upstream error: {}", err);
-                                    return Ok(Response::builder()
-                                        .status(StatusCode::BAD_GATEWAY)
-                                        .header("alt-svc", &alt)
-                                        .body(boxed_full(Bytes::from_static(b"upstream error\n")))
-                                        .unwrap_or_else(|_| {
-                                            Response::new(boxed_full(Bytes::from_static(b"error\n")))
-                                        }));
-                                }
-                                Err(_) => {
-                                    return Ok(Response::builder()
-                                        .status(StatusCode::GATEWAY_TIMEOUT)
-                                        .header("alt-svc", &alt)
-                                        .body(boxed_full(Bytes::from_static(b"upstream timeout\n")))
-                                        .unwrap_or_else(|_| {
-                                            Response::new(boxed_full(Bytes::from_static(b"error\n")))
-                                        }));
-                                }
-                            };
 
-                            // Build downstream response with Alt-Svc injected
-                            if let Some(content_length) = upstream_resp
-                                .headers()
-                                .get(http::header::CONTENT_LENGTH)
-                                .and_then(|v| v.to_str().ok())
-                                .and_then(|s| s.parse::<usize>().ok())
-                                && content_length > max_response_body_bytes
-                            {
-                                return Ok(Response::builder()
-                                    .status(StatusCode::SERVICE_UNAVAILABLE)
-                                    .header("alt-svc", &alt)
-                                    .body(boxed_full(Bytes::from_static(
-                                        b"upstream response body too large\n",
-                                    )))
-                                    .unwrap_or_else(|_| {
-                                        Response::new(boxed_full(Bytes::from_static(b"error\n")))
-                                    }));
-                            }
+                                let upstream_req = match if is_websocket_upgrade {
+                                    upstream_req.body(boxed_full(Bytes::new()))
+                                } else {
+                                    upstream_req.body(
+                                        BootstrapStreamingBody::new(req.into_body())
+                                            .map_err(|never| match never {})
+                                            .boxed(),
+                                    )
+                                } {
+                                    Ok(r) => r,
+                                    Err(_) => {
+                                        return Ok(Response::builder()
+                                            .status(StatusCode::BAD_GATEWAY)
+                                            .header("alt-svc", &alt)
+                                            .body(boxed_full(Bytes::from_static(
+                                                b"request build error\n",
+                                            )))
+                                            .unwrap_or_else(|_| {
+                                                Response::new(boxed_full(Bytes::from_static(
+                                                    b"error\n",
+                                                )))
+                                            }));
+                                    }
+                                };
+                                let mut upstream_resp = if is_websocket_upgrade {
+                                    if endpoint.scheme() != BackendScheme::Http {
+                                        return Ok(Response::builder()
+                                            .status(StatusCode::BAD_GATEWAY)
+                                            .header("alt-svc", &alt)
+                                            .body(boxed_full(Bytes::from_static(
+                                                b"websocket bootstrap requires http upstream\n",
+                                            )))
+                                            .unwrap_or_else(|_| {
+                                                Response::new(boxed_full(Bytes::from_static(
+                                                    b"error\n",
+                                                )))
+                                            }));
+                                    }
+                                    let backend_target = endpoint.authority().to_string();
+                                    let upstream_path_uri = match http::Uri::try_from(request_path)
+                                    {
+                                        Ok(uri) => uri,
+                                        Err(_) => {
+                                            return Ok(Response::builder()
+                                                .status(StatusCode::BAD_GATEWAY)
+                                                .header("alt-svc", &alt)
+                                                .body(boxed_full(Bytes::from_static(b"bad uri\n")))
+                                                .unwrap_or_else(|_| {
+                                                    Response::new(boxed_full(Bytes::from_static(
+                                                        b"error\n",
+                                                    )))
+                                                }));
+                                        }
+                                    };
+                                    let (mut parts, body) = upstream_req.into_parts();
+                                    parts.uri = upstream_path_uri;
+                                    let upstream_req = Request::from_parts(parts, body);
 
-                            let status = upstream_resp.status();
-                            let mut resp_builder = Response::builder().status(status);
-                            for (name, value) in upstream_resp.headers() {
-                                if name == http::header::CONNECTION
-                                    || name.as_str() == "keep-alive"
-                                    || name.as_str() == "transfer-encoding"
-                                    || name.as_str() == "alt-svc"
+                                    let stream = match tokio::time::timeout(
+                                        backend_timeout,
+                                        tokio::net::TcpStream::connect(&backend_target),
+                                    )
+                                    .await
+                                    {
+                                        Ok(Ok(s)) => s,
+                                        Ok(Err(err)) => {
+                                            warn!("Bootstrap WebSocket connect error: {}", err);
+                                            return Ok(Response::builder()
+                                                .status(StatusCode::BAD_GATEWAY)
+                                                .header("alt-svc", &alt)
+                                                .body(boxed_full(Bytes::from_static(
+                                                    b"upstream error\n",
+                                                )))
+                                                .unwrap_or_else(|_| {
+                                                    Response::new(boxed_full(Bytes::from_static(
+                                                        b"error\n",
+                                                    )))
+                                                }));
+                                        }
+                                        Err(_) => {
+                                            return Ok(Response::builder()
+                                                .status(StatusCode::GATEWAY_TIMEOUT)
+                                                .header("alt-svc", &alt)
+                                                .body(boxed_full(Bytes::from_static(
+                                                    b"upstream timeout\n",
+                                                )))
+                                                .unwrap_or_else(|_| {
+                                                    Response::new(boxed_full(Bytes::from_static(
+                                                        b"error\n",
+                                                    )))
+                                                }));
+                                        }
+                                    };
+                                    let io = TokioIo::new(stream);
+                                    let (mut sender, conn) = match client_http1::handshake(io).await
+                                    {
+                                        Ok(v) => v,
+                                        Err(err) => {
+                                            warn!(
+                                                "Bootstrap WebSocket handshake setup failed: {}",
+                                                err
+                                            );
+                                            return Ok(Response::builder()
+                                                .status(StatusCode::BAD_GATEWAY)
+                                                .header("alt-svc", &alt)
+                                                .body(boxed_full(Bytes::from_static(
+                                                    b"upstream error\n",
+                                                )))
+                                                .unwrap_or_else(|_| {
+                                                    Response::new(boxed_full(Bytes::from_static(
+                                                        b"error\n",
+                                                    )))
+                                                }));
+                                        }
+                                    };
+                                    tokio::spawn(async move {
+                                        let _ = conn.with_upgrades().await;
+                                    });
+                                    match tokio::time::timeout(
+                                        backend_timeout,
+                                        sender.send_request(upstream_req),
+                                    )
+                                    .await
+                                    {
+                                        Ok(Ok(resp)) => resp,
+                                        Ok(Err(err)) => {
+                                            warn!("Bootstrap WebSocket upstream error: {}", err);
+                                            return Ok(Response::builder()
+                                                .status(StatusCode::BAD_GATEWAY)
+                                                .header("alt-svc", &alt)
+                                                .body(boxed_full(Bytes::from_static(
+                                                    b"upstream error\n",
+                                                )))
+                                                .unwrap_or_else(|_| {
+                                                    Response::new(boxed_full(Bytes::from_static(
+                                                        b"error\n",
+                                                    )))
+                                                }));
+                                        }
+                                        Err(_) => {
+                                            return Ok(Response::builder()
+                                                .status(StatusCode::GATEWAY_TIMEOUT)
+                                                .header("alt-svc", &alt)
+                                                .body(boxed_full(Bytes::from_static(
+                                                    b"upstream timeout\n",
+                                                )))
+                                                .unwrap_or_else(|_| {
+                                                    Response::new(boxed_full(Bytes::from_static(
+                                                        b"error\n",
+                                                    )))
+                                                }));
+                                        }
+                                    }
+                                } else {
+                                    match tokio::time::timeout(
+                                        backend_timeout,
+                                        h2_pool.send(&backend_addr, upstream_req),
+                                    )
+                                    .await
+                                    {
+                                        Ok(Ok(resp)) => resp,
+                                        Ok(Err(err)) => {
+                                            warn!("Bootstrap proxy upstream error: {}", err);
+                                            return Ok(Response::builder()
+                                                .status(StatusCode::BAD_GATEWAY)
+                                                .header("alt-svc", &alt)
+                                                .body(boxed_full(Bytes::from_static(
+                                                    b"upstream error\n",
+                                                )))
+                                                .unwrap_or_else(|_| {
+                                                    Response::new(boxed_full(Bytes::from_static(
+                                                        b"error\n",
+                                                    )))
+                                                }));
+                                        }
+                                        Err(_) => {
+                                            return Ok(Response::builder()
+                                                .status(StatusCode::GATEWAY_TIMEOUT)
+                                                .header("alt-svc", &alt)
+                                                .body(boxed_full(Bytes::from_static(
+                                                    b"upstream timeout\n",
+                                                )))
+                                                .unwrap_or_else(|_| {
+                                                    Response::new(boxed_full(Bytes::from_static(
+                                                        b"error\n",
+                                                    )))
+                                                }));
+                                        }
+                                    }
+                                };
+
+                                // Build downstream response with Alt-Svc injected
+                                if let Some(content_length) = upstream_resp
+                                    .headers()
+                                    .get(http::header::CONTENT_LENGTH)
+                                    .and_then(|v| v.to_str().ok())
+                                    .and_then(|s| s.parse::<usize>().ok())
+                                    && content_length > max_response_body_bytes
                                 {
-                                    continue;
+                                    return Ok(Response::builder()
+                                        .status(StatusCode::SERVICE_UNAVAILABLE)
+                                        .header("alt-svc", &alt)
+                                        .body(boxed_full(Bytes::from_static(
+                                            b"upstream response body too large\n",
+                                        )))
+                                        .unwrap_or_else(|_| {
+                                            Response::new(boxed_full(Bytes::from_static(
+                                                b"error\n",
+                                            )))
+                                        }));
                                 }
-                                resp_builder = resp_builder.header(name, value);
-                            }
-                            resp_builder = resp_builder.header("alt-svc", &alt);
-                            let resp_body = BootstrapStreamingBody::new(upstream_resp.into_body())
-                                .map_err(|never| match never {})
-                                .boxed();
 
-                            Ok(resp_builder
-                                .body(resp_body)
-                                .unwrap_or_else(|_| Response::new(boxed_full(Bytes::new()))))
-                        })
-                    });
+                                let status = upstream_resp.status();
+                                let mut resp_builder = Response::builder().status(status);
+                                for (name, value) in upstream_resp.headers() {
+                                    if name == http::header::CONNECTION
+                                        || name.as_str() == "keep-alive"
+                                        || name.as_str() == "transfer-encoding"
+                                        || name.as_str() == "alt-svc"
+                                    {
+                                        continue;
+                                    }
+                                    resp_builder = resp_builder.header(name, value);
+                                }
+                                resp_builder = resp_builder.header("alt-svc", &alt);
+                                if is_websocket_upgrade
+                                    && upstream_resp.status() == StatusCode::SWITCHING_PROTOCOLS
+                                {
+                                    let client_upgrade = match client_upgrade {
+                                        Some(u) => u,
+                                        None => {
+                                            return Ok(Response::builder()
+                                                .status(StatusCode::BAD_GATEWAY)
+                                                .header("alt-svc", &alt)
+                                                .body(boxed_full(Bytes::from_static(
+                                                    b"upgrade setup error\n",
+                                                )))
+                                                .unwrap_or_else(|_| {
+                                                    Response::new(boxed_full(Bytes::from_static(
+                                                        b"error\n",
+                                                    )))
+                                                }));
+                                        }
+                                    };
+                                    let upstream_upgrade = upgrade::on(&mut upstream_resp);
+                                    tokio::spawn(async move {
+                                        let (client, upstream) = match tokio::try_join!(
+                                            client_upgrade,
+                                            upstream_upgrade
+                                        ) {
+                                            Ok(v) => v,
+                                            Err(err) => {
+                                                debug!(
+                                                    "Bootstrap WebSocket upgrade join failed: {}",
+                                                    err
+                                                );
+                                                return;
+                                            }
+                                        };
+                                        let mut client = TokioIo::new(client);
+                                        let mut upstream = TokioIo::new(upstream);
+                                        let _ = tokio::io::copy_bidirectional(
+                                            &mut client,
+                                            &mut upstream,
+                                        )
+                                        .await;
+                                    });
+                                    return Ok(resp_builder
+                                        .body(boxed_full(Bytes::new()))
+                                        .unwrap_or_else(|_| {
+                                            Response::new(boxed_full(Bytes::new()))
+                                        }));
+                                }
+                                let resp_body =
+                                    BootstrapStreamingBody::new(upstream_resp.into_body())
+                                        .map_err(|never| match never {})
+                                        .boxed();
+
+                                Ok(resp_builder
+                                    .body(resp_body)
+                                    .unwrap_or_else(|_| Response::new(boxed_full(Bytes::new()))))
+                            })
+                        },
+                    );
 
                     if use_h2 {
                         let executor = hyper_util::rt::TokioExecutor::new();
@@ -4010,7 +4296,9 @@ impl QUICListener {
                             }
                         }
                     } else {
-                        let serve = http1::Builder::new().serve_connection(io, svc);
+                        let serve = http1::Builder::new()
+                            .serve_connection(io, svc)
+                            .with_upgrades();
                         match tokio::time::timeout(timeout, serve).await {
                             Ok(Ok(())) => {}
                             Ok(Err(err)) => {


### PR DESCRIPTION
## Summary

Three correctness gaps in the bootstrap TCP/TLS forwarding path — unbounded body buffering, unconditional retries on non-idempotent requests, and missing WebSocket support.

- **Streaming bodies, no buffering (closes #114):** The bootstrap path was calling `.collect().await` on both request and response bodies, loading entire payloads into memory with no size cap. Request bodies are now forwarded via `BootstrapStreamingBody` — a proper `hyper::body::Body` impl that delegates `poll_frame` directly for back-pressure and zero-copy streaming. Response bodies are streamed the same way. `Content-Length` is checked upfront against `max_request_body_bytes` / `max_response_body_bytes` from config to reject oversized payloads before any data flows.

- **Non-idempotent retry removed (closes #116):** The old path retried all upstream errors up to 3 times regardless of HTTP method, risking duplicate execution of `POST`, `DELETE`, and `PATCH` requests on flaky connections. The retry loop is gone entirely — the switch to streaming bodies makes per-attempt body cloning impossible by design, so the fix is structural rather than a method gate.

- **WebSocket upgrade support (closes #127):** The bootstrap path stripped `Connection` and `Upgrade` headers unconditionally, breaking WebSocket handshakes for HTTP/1.1 clients. The path now detects `Upgrade: websocket` + `Connection: upgrade` on HTTP/1.1 GET requests, preserves the upgrade headers, opens a direct `TcpStream` to the backend bypassing the H2 pool, and performs the HTTP/1.1 upgrade handshake. On `101 Switching Protocols`, both ends are upgraded via `hyper::upgrade::on` and connected with `tokio::io::copy_bidirectional` for a transparent bidirectional tunnel.
