### PR TITLE
docs+quic: fix TLS roadmap status and reduce benign QUIC peer-error log noise

### DIFF
--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -216,7 +216,7 @@ pub struct RouteMatch {
     pub path_prefix: Option<String>, // path prefix matching (e.g., "/api")
 
     #[serde(default)]
-    pub method: Option<String>, // 🔮 FUTURE: HTTP method filtering (GET, POST, etc.)
+    pub method: Option<String>, // Optional HTTP method filtering (GET, POST, etc.)
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -247,9 +247,9 @@ pub struct LoadBalancing {
     #[serde(rename = "type")]
     pub lb_type: String, // "random","round_robin","consistent_hash","least_connections","latency_aware","sticky_cid"
 
-    // Add support for consistent hash configuration
+    // Configurable key source for hash-based/sticky load balancing.
     #[serde(default)]
-    pub key: Option<String>, // For consistent hashing (header, cookie, etc.)
+    pub key: Option<String>, // Examples: header:x-user-id, cookie:session_id, query:user_id
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -157,6 +157,39 @@ fn bootstrap_forwarded_for_value(ip: std::net::IpAddr) -> String {
     }
 }
 
+fn extract_cookie_value(cookie_header: &str, cookie_name: &str) -> Option<String> {
+    for pair in cookie_header.split(';') {
+        let part = pair.trim();
+        if part.is_empty() {
+            continue;
+        }
+        let (name, value) = part.split_once('=')?;
+        if name.trim().eq_ignore_ascii_case(cookie_name) {
+            let value = value.trim();
+            if value.is_empty() {
+                return None;
+            }
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+fn extract_query_param(path: &str, param: &str) -> Option<String> {
+    let (_, query) = path.split_once('?')?;
+    for pair in query.split('&') {
+        let entry = pair.trim();
+        if entry.is_empty() {
+            continue;
+        }
+        let (name, value) = entry.split_once('=')?;
+        if name.eq_ignore_ascii_case(param) && !value.is_empty() {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
 fn bootstrap_resolution_error_response(reason: &str) -> (StatusCode, &'static [u8]) {
     if reason.starts_with("no route for ") {
         return (StatusCode::BAD_GATEWAY, b"no route\n");
@@ -192,6 +225,8 @@ type BootstrapServiceFuture = std::pin::Pin<
             > + Send,
     >,
 >;
+
+type LbHeaderLookup<'a> = dyn Fn(&str) -> Option<String> + 'a;
 
 struct BootstrapStreamingBody {
     inner: Incoming,
@@ -1632,6 +1667,12 @@ impl QUICListener {
 
                     // Route lookup — needed to start the H2 request immediately.
                     let sticky_cid_key = hex::encode(connection.primary_scid.as_ref());
+                    let lb_header_lookup = |name: &str| {
+                        list.iter()
+                            .find(|header| header.name().eq_ignore_ascii_case(name.as_bytes()))
+                            .and_then(|header| std::str::from_utf8(header.value()).ok())
+                            .map(str::to_string)
+                    };
                     let resolved = Self::resolve_backend(
                         &method,
                         &path,
@@ -1639,6 +1680,7 @@ impl QUICListener {
                         Some(sticky_cid_key.as_str()),
                         upstream_pools,
                         routing_index,
+                        Some(&lb_header_lookup),
                     );
 
                     let (
@@ -3347,13 +3389,14 @@ impl QUICListener {
         cid_key: Option<&str>,
         upstream_pools: &HashMap<String, Arc<RwLock<UpstreamPool>>>,
         routing_index: &RouteIndex,
+        header_lookup: Option<&LbHeaderLookup<'_>>,
     ) -> Result<ResolvedBackend, ProxyError> {
         if method.is_empty() || path.is_empty() {
             return Err(ProxyError::Transport("empty method or path".into()));
         }
 
         let route_decision = routing_index
-            .lookup_with_decision(path, authority)
+            .lookup_with_decision_for_method(path, authority, Some(method))
             .ok_or_else(|| ProxyError::Transport(format!("no route for {path}")))?;
         let upstream_name = route_decision.upstream;
 
@@ -3361,15 +3404,6 @@ impl QUICListener {
             .get(upstream_name)
             .ok_or_else(|| ProxyError::Transport(format!("pool not found: {upstream_name}")))?
             .clone();
-
-        let request_key = authority.unwrap_or(if !path.is_empty() { path } else { method });
-        let key_for_lb = |lb_type: &str| -> &str {
-            if lb_type == "sticky-cid" {
-                cid_key.unwrap_or(request_key)
-            } else {
-                request_key
-            }
-        };
 
         let (backend_index, lb_type, backend_addr) = {
             let (read_lb_type, read_fast_selected) = {
@@ -3380,9 +3414,17 @@ impl QUICListener {
                     return Err(ProxyError::Transport("no servers in upstream".into()));
                 }
                 let lb_type = pool.lb_name();
-                let key = key_for_lb(lb_type);
+                let key = Self::resolve_lb_request_key(
+                    lb_type,
+                    pool.lb_key(),
+                    method,
+                    path,
+                    authority,
+                    cid_key,
+                    header_lookup,
+                );
                 let fast_pick = pool
-                    .pick_readonly(key)
+                    .pick_readonly(key.as_str())
                     .and_then(|idx| pool.pool.address(idx).map(|addr| (idx, addr.to_string())));
                 let fast_selected = fast_pick.and_then(|(idx, addr)| {
                     pool.begin_request_if_healthy(idx).then_some((idx, addr))
@@ -3400,9 +3442,17 @@ impl QUICListener {
                     return Err(ProxyError::Transport("no servers in upstream".into()));
                 }
                 let lb_type = pool.lb_name();
-                let key = key_for_lb(lb_type);
+                let key = Self::resolve_lb_request_key(
+                    lb_type,
+                    pool.lb_key(),
+                    method,
+                    path,
+                    authority,
+                    cid_key,
+                    header_lookup,
+                );
 
-                let idx = pool.pick(key).ok_or_else(|| {
+                let idx = pool.pick(key.as_str()).ok_or_else(|| {
                     let total = pool.pool.len();
                     let healthy = pool.pool.healthy_len();
                     error!(
@@ -3439,6 +3489,96 @@ impl QUICListener {
             route_decision.host_specific,
             route_decision.reason,
         ))
+    }
+
+    fn resolve_lb_key_from_spec(
+        lb_key_spec: &str,
+        method: &str,
+        path: &str,
+        authority: Option<&str>,
+        cid_key: Option<&str>,
+        header_lookup: Option<&LbHeaderLookup<'_>>,
+    ) -> Option<String> {
+        let spec = lb_key_spec.trim();
+        if spec.is_empty() {
+            return None;
+        }
+
+        if spec.eq_ignore_ascii_case("path") {
+            let path_only = path.split_once('?').map(|(p, _)| p).unwrap_or(path);
+            return Some(path_only.to_string());
+        }
+        if spec.eq_ignore_ascii_case("authority") {
+            return authority.map(str::to_string);
+        }
+        if spec.eq_ignore_ascii_case("method") {
+            return Some(method.to_string());
+        }
+        if spec.eq_ignore_ascii_case("cid") || spec.eq_ignore_ascii_case("sticky-cid") {
+            return cid_key.map(str::to_string);
+        }
+
+        let (source, key_name) = spec.split_once(':')?;
+        let key_name = key_name.trim();
+        if key_name.is_empty() {
+            return None;
+        }
+
+        if source.eq_ignore_ascii_case("header") {
+            return header_lookup.and_then(|lookup| lookup(key_name));
+        }
+
+        if source.eq_ignore_ascii_case("cookie") {
+            let cookie_header =
+                header_lookup.and_then(|lookup| lookup(http::header::COOKIE.as_str()))?;
+            return extract_cookie_value(cookie_header.as_str(), key_name);
+        }
+
+        if source.eq_ignore_ascii_case("query") {
+            return extract_query_param(path, key_name);
+        }
+
+        None
+    }
+
+    fn default_lb_request_key(method: &str, path: &str, authority: Option<&str>) -> String {
+        authority
+            .unwrap_or(if !path.is_empty() { path } else { method })
+            .to_string()
+    }
+
+    fn resolve_lb_request_key(
+        lb_type: &str,
+        lb_key_spec: Option<&str>,
+        method: &str,
+        path: &str,
+        authority: Option<&str>,
+        cid_key: Option<&str>,
+        header_lookup: Option<&LbHeaderLookup<'_>>,
+    ) -> String {
+        let default_key = Self::default_lb_request_key(method, path, authority);
+
+        if let Some(spec) = lb_key_spec
+            && let Some(value) = Self::resolve_lb_key_from_spec(
+                spec,
+                method,
+                path,
+                authority,
+                cid_key,
+                header_lookup,
+            )
+            && !value.is_empty()
+        {
+            return value;
+        }
+
+        if lb_type == "sticky-cid"
+            && let Some(cid_key) = cid_key
+        {
+            return cid_key.to_string();
+        }
+
+        default_key
     }
 
     fn spawn_metrics_endpoint(
@@ -3872,6 +4012,12 @@ impl QUICListener {
 
                                 // Preserve the same route-lookup + tie-break semantics as the QUIC
                                 // data plane by delegating bootstrap backend resolution here.
+                                let lb_header_lookup = |name: &str| {
+                                    req.headers()
+                                        .get(name)
+                                        .and_then(|value| value.to_str().ok())
+                                        .map(str::to_string)
+                                };
                                 let resolved = Self::resolve_backend(
                                     &method,
                                     &path,
@@ -3879,6 +4025,7 @@ impl QUICListener {
                                     None,
                                     &upstream_pools,
                                     &routing_index,
+                                    Some(&lb_header_lookup),
                                 );
                                 let (
                                     _upstream_name,
@@ -4537,15 +4684,19 @@ mod tests {
     }
 
     fn test_upstream(lb_type: &str) -> Upstream {
+        test_upstream_with(lb_type, None, None)
+    }
+
+    fn test_upstream_with(lb_type: &str, lb_key: Option<&str>, method: Option<&str>) -> Upstream {
         Upstream {
             load_balancing: LoadBalancing {
                 lb_type: lb_type.to_string(),
-                key: None,
+                key: lb_key.map(str::to_string),
             },
             route: RouteMatch {
                 host: None,
                 path_prefix: Some("/api".to_string()),
-                method: None,
+                method: method.map(str::to_string),
             },
             backends: vec![
                 Backend {
@@ -4595,6 +4746,7 @@ mod tests {
                 None,
                 &upstream_pools,
                 &routing_index,
+                None,
             )
             .expect("resolve backend");
             picks.push(backend);
@@ -4625,6 +4777,7 @@ mod tests {
             None,
             &upstream_pools,
             &routing_index,
+            None,
         )
         .expect("resolve backend");
 
@@ -4650,12 +4803,115 @@ mod tests {
             None,
             &upstream_pools,
             &routing_index,
+            None,
         )
         .expect("resolve backend");
 
         assert_eq!(
             backend, "127.0.0.1:7002",
             "least-connections should prefer lower in-flight backend in bootstrap selection"
+        );
+    }
+
+    #[test]
+    fn resolve_backend_prefers_method_specific_route() {
+        let mut upstreams = HashMap::new();
+        upstreams.insert(
+            "all_methods".to_string(),
+            test_upstream_with("round-robin", None, None),
+        );
+        let mut post_only = test_upstream_with("round-robin", None, Some("POST"));
+        post_only.backends = vec![Backend {
+            id: "post".to_string(),
+            address: "127.0.0.1:7010".to_string(),
+            weight: 1,
+            health_check: None,
+        }];
+        upstreams.insert("post_only".to_string(), post_only);
+
+        let routing_index = super::RouteIndex::from_upstreams(&upstreams);
+        let mut upstream_pools = HashMap::new();
+        for (name, upstream) in &upstreams {
+            let pool = super::UpstreamPool::from_upstream(upstream).expect("pool");
+            upstream_pools.insert(name.clone(), Arc::new(RwLock::new(pool)));
+        }
+
+        let (upstream, _, _, _, _, _, _, _) = super::QUICListener::resolve_backend(
+            "GET",
+            "/api/items",
+            None,
+            None,
+            &upstream_pools,
+            &routing_index,
+            None,
+        )
+        .expect("GET resolve");
+        assert_eq!(upstream, "all_methods");
+
+        let (upstream, backend, _, _, _, _, _, _) = super::QUICListener::resolve_backend(
+            "POST",
+            "/api/items",
+            None,
+            None,
+            &upstream_pools,
+            &routing_index,
+            None,
+        )
+        .expect("POST resolve");
+        assert_eq!(upstream, "post_only");
+        assert_eq!(backend, "127.0.0.1:7010");
+    }
+
+    #[test]
+    fn resolve_backend_uses_configured_header_lb_key() {
+        let (upstream_pools, routing_index, _pool) = {
+            let mut upstreams = HashMap::new();
+            upstreams.insert(
+                "api_pool".to_string(),
+                test_upstream_with("consistent-hash", Some("header:x-user-id"), None),
+            );
+            let routing_index = super::RouteIndex::from_upstreams(&upstreams);
+            let pool =
+                super::UpstreamPool::from_upstream(upstreams.get("api_pool").expect("upstream"))
+                    .expect("pool");
+            let pool = Arc::new(RwLock::new(pool));
+            let mut upstream_pools = HashMap::new();
+            upstream_pools.insert("api_pool".to_string(), Arc::clone(&pool));
+            (upstream_pools, routing_index, pool)
+        };
+
+        let header_lookup = |name: &str| {
+            if name.eq_ignore_ascii_case("x-user-id") {
+                Some("alice".to_string())
+            } else {
+                None
+            }
+        };
+
+        let (_, first_backend, _, _, _, _, _, _) = super::QUICListener::resolve_backend(
+            "GET",
+            "/api/items",
+            None,
+            None,
+            &upstream_pools,
+            &routing_index,
+            Some(&header_lookup),
+        )
+        .expect("first resolve");
+        let (_, second_backend, _, _, _, _, _, _) = super::QUICListener::resolve_backend(
+            "GET",
+            "/api/items",
+            None,
+            None,
+            &upstream_pools,
+            &routing_index,
+            Some(&header_lookup),
+        )
+        .expect("second resolve");
+
+        assert_eq!(
+            first_backend, second_backend,
+            "consistent-hash should remain stable when configured header key is constant"
         );
     }
 

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -65,6 +65,7 @@ use crate::{
     outcome_from_status,
     resilience::{RouteQueueRejection, RuntimeResilience},
     route_index::{RouteDecisionReason, RouteIndex, normalize_host_for_routing},
+    types::QuicConnectionErrorSnapshot,
     watchdog::{WatchdogCoordinator, WatchdogRuntimeConfig, now_millis},
 };
 
@@ -891,6 +892,8 @@ impl QUICListener {
             routing_scids: HashSet::from([Arc::from(&scid_bytes[..])]),
             packets_since_rotation: 0,
             last_scid_rotation: Instant::now(),
+            last_peer_error_snapshot: None,
+            last_local_error_snapshot: None,
         };
 
         // Store connection using server's SCID (not client's DCID)
@@ -1243,11 +1246,23 @@ impl QUICListener {
         }
 
         if let Some(err) = connection.quic.peer_error() {
-            error!("QUIC peer error: {:?}", err);
+            maybe_log_quic_connection_error(
+                "peer",
+                connection.peer_address,
+                connection.quic.trace_id(),
+                err,
+                &mut connection.last_peer_error_snapshot,
+            );
         }
 
         if let Some(err) = connection.quic.local_error() {
-            error!("QUIC local error: {:?}", err);
+            maybe_log_quic_connection_error(
+                "local",
+                connection.peer_address,
+                connection.quic.trace_id(),
+                err,
+                &mut connection.last_local_error_snapshot,
+            );
         }
 
         connection.last_activity = Instant::now();
@@ -4350,6 +4365,68 @@ fn classify_retry_reason(err: &ProxyError) -> RetryReason {
         ProxyError::Pool(_) => RetryReason::BackendPool,
         _ => RetryReason::BackendTransport,
     }
+}
+
+fn is_benign_quic_close(err: &quiche::ConnectionError) -> bool {
+    !err.is_app && err.error_code == 0 && err.reason.is_empty()
+}
+
+fn log_quic_connection_error(
+    source: &str,
+    peer: SocketAddr,
+    trace_id: &str,
+    err: &quiche::ConnectionError,
+) {
+    if is_benign_quic_close(err) {
+        debug!(
+            "QUIC {} close without error: peer={} trace_id={} is_app={} error_code={} reason_len={}",
+            source,
+            peer,
+            trace_id,
+            err.is_app,
+            err.error_code,
+            err.reason.len()
+        );
+        return;
+    }
+
+    if err.reason.is_empty() {
+        error!(
+            "QUIC {} error: peer={} trace_id={} is_app={} error_code={}",
+            source, peer, trace_id, err.is_app, err.error_code
+        );
+    } else {
+        error!(
+            "QUIC {} error: peer={} trace_id={} is_app={} error_code={} reason={}",
+            source,
+            peer,
+            trace_id,
+            err.is_app,
+            err.error_code,
+            String::from_utf8_lossy(&err.reason)
+        );
+    }
+}
+
+fn maybe_log_quic_connection_error(
+    source: &str,
+    peer: SocketAddr,
+    trace_id: &str,
+    err: &quiche::ConnectionError,
+    last_logged: &mut Option<QuicConnectionErrorSnapshot>,
+) {
+    let snapshot = QuicConnectionErrorSnapshot {
+        is_app: err.is_app,
+        error_code: err.error_code,
+        reason: err.reason.clone(),
+    };
+
+    if last_logged.as_ref() == Some(&snapshot) {
+        return;
+    }
+
+    *last_logged = Some(snapshot);
+    log_quic_connection_error(source, peer, trace_id, err);
 }
 
 pub fn configure_async_runtime(worker_threads: usize) {

--- a/crates/edge/src/route_index.rs
+++ b/crates/edge/src/route_index.rs
@@ -43,7 +43,8 @@ pub(crate) fn normalize_host_for_routing(raw: &str) -> Option<String> {
 /// Route precedence (deterministic):
 /// 1) Longest matching path_prefix wins.
 /// 2) On equal path length, host-specific routes win over host-agnostic routes.
-/// 3) On remaining ties, lexicographically smaller upstream name wins.
+/// 3) On equal host/path match, method-specific routes win over method-agnostic routes.
+/// 4) On remaining ties, lexicographically smaller upstream name wins.
 ///
 /// `order` stores the lexicographic rank of upstream name (smaller rank = smaller name),
 /// so trie updates are independent of HashMap insertion order.
@@ -52,6 +53,7 @@ pub struct IndexedRoute {
     upstream_idx: usize,
     path_len: usize,
     host_specific: bool,
+    method_specific: bool,
     order: usize,
 }
 
@@ -60,6 +62,7 @@ enum RoutePreference {
     KeepCurrent,
     TakeCandidatePathLen,
     TakeCandidateHostSpecific,
+    TakeCandidateMethodSpecific,
     TakeCandidateLexicalOrder,
 }
 
@@ -69,6 +72,7 @@ pub(crate) enum RouteDecisionReason {
     HostPathLongerOrEqual,
     DefaultPathLonger,
     HostSpecificTieBreak,
+    MethodSpecificTieBreak,
     LexicalTieBreak,
 }
 
@@ -82,7 +86,7 @@ pub(crate) struct RouteDecision<'a> {
 
 #[derive(Default)]
 pub struct TrieNode {
-    pub route: Option<IndexedRoute>,
+    pub routes: Vec<IndexedRoute>,
     children: Vec<TrieEdge>,
 }
 
@@ -94,7 +98,15 @@ struct TrieEdge {
 
 impl TrieNode {
     fn update_route(&mut self, candidate: IndexedRoute) {
-        self.route = prefer_route(self.route, Some(candidate));
+        if let Some(existing) = self
+            .routes
+            .iter_mut()
+            .find(|route| route.upstream_idx == candidate.upstream_idx)
+        {
+            *existing = candidate;
+            return;
+        }
+        self.routes.push(candidate);
     }
 
     #[inline(always)]
@@ -145,25 +157,62 @@ impl RouteTrie {
         node.update_route(route);
     }
 
-    fn longest_prefix(&self, path: &str) -> Option<IndexedRoute> {
+    fn longest_prefix(
+        &self,
+        path: &str,
+        method: Option<&str>,
+        upstream_methods: &[Option<String>],
+    ) -> Option<IndexedRoute> {
         let mut node = &self.root;
-        let mut best = node
-            .route
-            .filter(|route| prefix_boundary_matches(path, route.path_len));
+        let mut best = best_matching_route(&node.routes, path, method, upstream_methods, None);
 
         for byte in path.as_bytes() {
             let Some(next) = node.child(*byte) else {
                 break;
             };
             node = next;
-            let candidate = node
-                .route
-                .filter(|route| prefix_boundary_matches(path, route.path_len));
-            best = prefer_route(best, candidate);
+            best = best_matching_route(&node.routes, path, method, upstream_methods, best);
         }
 
         best
     }
+}
+
+fn route_matches_method(
+    route: IndexedRoute,
+    method: Option<&str>,
+    upstream_methods: &[Option<String>],
+) -> bool {
+    let Some(method) = method else {
+        return true;
+    };
+    match upstream_methods
+        .get(route.upstream_idx)
+        .and_then(|value| value.as_deref())
+    {
+        Some(expected) => expected.eq_ignore_ascii_case(method),
+        None => true,
+    }
+}
+
+fn best_matching_route(
+    routes: &[IndexedRoute],
+    path: &str,
+    method: Option<&str>,
+    upstream_methods: &[Option<String>],
+    current: Option<IndexedRoute>,
+) -> Option<IndexedRoute> {
+    let mut best = current;
+    for route in routes.iter().copied() {
+        if !prefix_boundary_matches(path, route.path_len) {
+            continue;
+        }
+        if !route_matches_method(route, method, upstream_methods) {
+            continue;
+        }
+        best = prefer_route(best, Some(route));
+    }
+    best
 }
 
 #[inline(always)]
@@ -182,6 +231,7 @@ pub(crate) struct RouteIndex {
     default_trie: RouteTrie,
     default_max_path_len: usize,
     upstream_names: Vec<String>,
+    upstream_methods: Vec<Option<String>>,
 }
 
 impl RouteIndex {
@@ -190,6 +240,7 @@ impl RouteIndex {
         let mut default_trie = RouteTrie::default();
         let mut default_max_path_len = 0usize;
         let mut upstream_names = Vec::with_capacity(upstreams.len());
+        let mut upstream_methods = Vec::with_capacity(upstreams.len());
         // Build a stable route list first. This keeps tie-breaking deterministic even if
         // upstreams came from a map with non-deterministic iteration order.
         let mut ordered: Vec<(&String, &Upstream)> = upstreams.iter().collect();
@@ -198,6 +249,15 @@ impl RouteIndex {
         for (order, (name, upstream)) in ordered.into_iter().enumerate() {
             let upstream_idx = upstream_names.len();
             upstream_names.push(name.clone());
+            upstream_methods.push(
+                upstream
+                    .route
+                    .method
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(|value| value.to_ascii_uppercase()),
+            );
             let path_len = upstream
                 .route
                 .path_prefix
@@ -209,6 +269,7 @@ impl RouteIndex {
                 upstream_idx,
                 path_len,
                 host_specific: upstream.route.host.is_some(),
+                method_specific: upstream.route.method.is_some(),
                 order,
             };
 
@@ -240,10 +301,20 @@ impl RouteIndex {
             default_trie,
             default_max_path_len,
             upstream_names,
+            upstream_methods,
         }
     }
 
     pub(crate) fn lookup<'a>(&'a self, path: &str, host: Option<&str>) -> Option<&'a str> {
+        self.lookup_for_method(path, host, None)
+    }
+
+    pub(crate) fn lookup_for_method<'a>(
+        &'a self,
+        path: &str,
+        host: Option<&str>,
+        method: Option<&str>,
+    ) -> Option<&'a str> {
         let host_best = host.and_then(|raw_host| {
             let parsed_host = parsed_host_for_routing(raw_host)?;
             let host_trie = if host_has_uppercase_ascii(parsed_host) {
@@ -252,7 +323,7 @@ impl RouteIndex {
             } else {
                 self.host_tries.get(parsed_host)
             }?;
-            host_trie.longest_prefix(path)
+            host_trie.longest_prefix(path, method, &self.upstream_methods)
         });
 
         if let Some(best) = host_best
@@ -261,14 +332,28 @@ impl RouteIndex {
             return Some(self.upstream_names[best.upstream_idx].as_str());
         }
 
-        let best = prefer_route(self.default_trie.longest_prefix(path), host_best);
+        let best = prefer_route(
+            self.default_trie
+                .longest_prefix(path, method, &self.upstream_methods),
+            host_best,
+        );
         best.map(|route| self.upstream_names[route.upstream_idx].as_str())
     }
 
+    #[allow(dead_code)]
     pub(crate) fn lookup_with_decision<'a>(
         &'a self,
         path: &str,
         host: Option<&str>,
+    ) -> Option<RouteDecision<'a>> {
+        self.lookup_with_decision_for_method(path, host, None)
+    }
+
+    pub(crate) fn lookup_with_decision_for_method<'a>(
+        &'a self,
+        path: &str,
+        host: Option<&str>,
+        method: Option<&str>,
     ) -> Option<RouteDecision<'a>> {
         let host_best = host.and_then(|raw_host| {
             let parsed_host = parsed_host_for_routing(raw_host)?;
@@ -278,10 +363,12 @@ impl RouteIndex {
             } else {
                 self.host_tries.get(parsed_host)
             }?;
-            host_trie.longest_prefix(path)
+            host_trie.longest_prefix(path, method, &self.upstream_methods)
         });
 
-        let default_best = self.default_trie.longest_prefix(path);
+        let default_best = self
+            .default_trie
+            .longest_prefix(path, method, &self.upstream_methods);
         if let Some(best) = host_best
             && best.path_len >= self.default_max_path_len
         {
@@ -290,6 +377,9 @@ impl RouteIndex {
                 Some(default_route) => match compare_route(default_route, best) {
                     RoutePreference::TakeCandidateHostSpecific => {
                         RouteDecisionReason::HostSpecificTieBreak
+                    }
+                    RoutePreference::TakeCandidateMethodSpecific => {
+                        RouteDecisionReason::MethodSpecificTieBreak
                     }
                     RoutePreference::TakeCandidateLexicalOrder => {
                         RouteDecisionReason::LexicalTieBreak
@@ -326,6 +416,9 @@ impl RouteIndex {
                     RoutePreference::TakeCandidateHostSpecific => {
                         RouteDecisionReason::HostSpecificTieBreak
                     }
+                    RoutePreference::TakeCandidateMethodSpecific => {
+                        RouteDecisionReason::MethodSpecificTieBreak
+                    }
                     RoutePreference::TakeCandidateLexicalOrder => {
                         RouteDecisionReason::LexicalTieBreak
                     }
@@ -359,6 +452,7 @@ fn prefer_route(
             RoutePreference::KeepCurrent => Some(current),
             RoutePreference::TakeCandidatePathLen
             | RoutePreference::TakeCandidateHostSpecific
+            | RoutePreference::TakeCandidateMethodSpecific
             | RoutePreference::TakeCandidateLexicalOrder => Some(candidate),
         },
     }
@@ -375,6 +469,13 @@ fn compare_route(current: IndexedRoute, candidate: IndexedRoute) -> RoutePrefere
         RoutePreference::TakeCandidateHostSpecific
     } else if candidate.path_len == current.path_len
         && candidate.host_specific == current.host_specific
+        && candidate.method_specific
+        && !current.method_specific
+    {
+        RoutePreference::TakeCandidateMethodSpecific
+    } else if candidate.path_len == current.path_len
+        && candidate.host_specific == current.host_specific
+        && candidate.method_specific == current.method_specific
         && candidate.order < current.order
     {
         RoutePreference::TakeCandidateLexicalOrder
@@ -388,11 +489,35 @@ pub(crate) fn scan_lookup<'a>(
     path: &str,
     host: Option<&str>,
 ) -> Option<&'a str> {
+    scan_lookup_for_method(upstreams, path, host, None)
+}
+
+pub(crate) fn scan_lookup_for_method<'a>(
+    upstreams: &'a HashMap<String, Upstream>,
+    path: &str,
+    host: Option<&str>,
+    method: Option<&str>,
+) -> Option<&'a str> {
     let path_bytes = path.as_bytes();
     let normalized_request_host = host.and_then(parsed_host_for_routing);
-    let mut best_match: Option<(&str, usize, bool)> = None;
+    let mut best_match: Option<(&str, usize, bool, bool)> = None;
 
     for (upstream_name, upstream) in upstreams {
+        let has_method_match = match (
+            upstream.route.method.as_deref().map(str::trim),
+            method.map(str::trim),
+        ) {
+            (Some(""), _) => true,
+            (Some(route_method), Some(request_method)) => {
+                route_method.eq_ignore_ascii_case(request_method)
+            }
+            (Some(_), None) => true,
+            (None, _) => true,
+        };
+        if !has_method_match {
+            continue;
+        }
+
         let has_host_match = match (&upstream.route.host, normalized_request_host) {
             (Some(route_host), Some(request_host)) => {
                 if route_host == request_host {
@@ -433,25 +558,45 @@ pub(crate) fn scan_lookup<'a>(
             continue;
         }
         let host_specific = upstream.route.host.is_some();
+        let method_specific = upstream
+            .route
+            .method
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty());
 
         match best_match {
-            Some((best_name, best_len, best_host_specific)) => {
+            Some((best_name, best_len, best_host_specific, best_method_specific)) => {
                 if path_match_len > best_len
                     || (path_match_len == best_len && host_specific && !best_host_specific)
                     || (path_match_len == best_len
                         && host_specific == best_host_specific
+                        && method_specific
+                        && !best_method_specific)
+                    || (path_match_len == best_len
+                        && host_specific == best_host_specific
+                        && method_specific == best_method_specific
                         && upstream_name.as_str() < best_name)
                 {
-                    best_match = Some((upstream_name.as_str(), path_match_len, host_specific));
+                    best_match = Some((
+                        upstream_name.as_str(),
+                        path_match_len,
+                        host_specific,
+                        method_specific,
+                    ));
                 }
             }
             None => {
-                best_match = Some((upstream_name.as_str(), path_match_len, host_specific));
+                best_match = Some((
+                    upstream_name.as_str(),
+                    path_match_len,
+                    host_specific,
+                    method_specific,
+                ));
             }
         }
     }
 
-    best_match.map(|(name, _, _)| name)
+    best_match.map(|(name, _, _, _)| name)
 }
 
 #[cfg(test)]
@@ -461,6 +606,14 @@ mod tests {
     use std::time::Instant;
 
     fn test_upstream(host: Option<&str>, path_prefix: Option<&str>) -> Upstream {
+        test_upstream_with_method(host, path_prefix, None)
+    }
+
+    fn test_upstream_with_method(
+        host: Option<&str>,
+        path_prefix: Option<&str>,
+        method: Option<&str>,
+    ) -> Upstream {
         Upstream {
             load_balancing: LoadBalancing {
                 lb_type: "random".to_string(),
@@ -469,7 +622,7 @@ mod tests {
             route: RouteMatch {
                 host: host.map(str::to_string),
                 path_prefix: path_prefix.map(str::to_string),
-                method: None,
+                method: method.map(str::to_string),
             },
             backends: vec![],
         }
@@ -625,6 +778,50 @@ mod tests {
             .expect("decision");
         assert_eq!(decision.upstream, "default-api-v2");
         assert_eq!(decision.reason, RouteDecisionReason::DefaultPathLonger);
+    }
+
+    #[test]
+    fn method_specific_route_wins_on_tie() {
+        let mut upstreams = HashMap::new();
+        upstreams.insert(
+            "all-api".to_string(),
+            test_upstream_with_method(None, Some("/api"), None),
+        );
+        upstreams.insert(
+            "post-api".to_string(),
+            test_upstream_with_method(None, Some("/api"), Some("POST")),
+        );
+        let index = RouteIndex::from_upstreams(&upstreams);
+
+        let get = index
+            .lookup_with_decision_for_method("/api/items", None, Some("GET"))
+            .expect("GET route");
+        assert_eq!(get.upstream, "all-api");
+
+        let post = index
+            .lookup_with_decision_for_method("/api/items", None, Some("POST"))
+            .expect("POST route");
+        assert_eq!(post.upstream, "post-api");
+
+        assert_eq!(
+            scan_lookup_for_method(&upstreams, "/api/items", None, Some("POST")),
+            Some("post-api")
+        );
+    }
+
+    #[test]
+    fn method_matching_is_case_insensitive() {
+        let mut upstreams = HashMap::new();
+        upstreams.insert(
+            "post-api".to_string(),
+            test_upstream_with_method(None, Some("/api"), Some("post")),
+        );
+        let index = RouteIndex::from_upstreams(&upstreams);
+
+        assert_eq!(
+            index.lookup_for_method("/api", None, Some("POST")),
+            Some("post-api")
+        );
     }
 
     #[test]

--- a/crates/edge/src/types.rs
+++ b/crates/edge/src/types.rs
@@ -108,6 +108,13 @@ pub struct QUICListener {
     pub(crate) conn_rate_limiter: crate::quic_listener::TokenBucket,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct QuicConnectionErrorSnapshot {
+    pub(crate) is_app: bool,
+    pub(crate) error_code: u64,
+    pub(crate) reason: Vec<u8>,
+}
+
 pub struct QuicConnection {
     pub quic: quiche::Connection,
     pub h3: Option<quiche::h3::Connection>,
@@ -120,6 +127,8 @@ pub struct QuicConnection {
     pub routing_scids: HashSet<Arc<[u8]>>,
     pub packets_since_rotation: u64,
     pub last_scid_rotation: Instant,
+    pub(crate) last_peer_error_snapshot: Option<QuicConnectionErrorSnapshot>,
+    pub(crate) last_local_error_snapshot: Option<QuicConnectionErrorSnapshot>,
 }
 
 /// Result type returned by the in-flight H2 forwarding task.

--- a/crates/lb/src/lib.rs
+++ b/crates/lb/src/lib.rs
@@ -162,6 +162,7 @@ pub struct BackendPool {
 pub struct UpstreamPool {
     pub pool: BackendPool,
     pub load_balancer: LoadBalancing,
+    lb_key: Option<String>,
 }
 
 impl UpstreamPool {
@@ -169,10 +170,18 @@ impl UpstreamPool {
         let backends = upstream.backends.iter().map(BackendState::new).collect();
 
         let load_balancer = LoadBalancing::from_config(&upstream.load_balancing.lb_type)?;
+        let lb_key = upstream
+            .load_balancing
+            .key
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
 
         Ok(Self {
             pool: BackendPool::new_from_states(backends),
             load_balancer,
+            lb_key,
         })
     }
 
@@ -201,6 +210,10 @@ impl UpstreamPool {
 
     pub fn lb_name(&self) -> &'static str {
         self.load_balancer.name()
+    }
+
+    pub fn lb_key(&self) -> Option<&str> {
+        self.lb_key.as_deref()
     }
 }
 

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -27,7 +27,7 @@ upstream:
   api_pool:
     load_balancing:
       type: "consistent-hash"
-      # key: "header:x-user-id"  # Planned feature, not currently supported
+      key: "header:x-user-id"  # Optional key source for consistent-hash/sticky-cid
 
     route:
       host: "api.example.com"
@@ -217,7 +217,7 @@ Route matching determines which upstream pool handles a request. Routes are eval
 |----------|------|----------|---------|-------------|
 | `host` | string | No | - | Host header to match (e.g., `api.example.com`) |
 | `path_prefix` | string | No | - | Path prefix to match (e.g., `/api`) |
-| `method` | string | No | - | HTTP method to match (reserved for future use) |
+| `method` | string | No | - | HTTP method to match (case-insensitive, e.g. `GET`, `POST`) |
 
 Route matching rules:
 
@@ -374,7 +374,7 @@ Load balancing determines how requests are distributed across healthy backends w
 | Property | Type | Required | Default | Description |
 |----------|------|----------|---------|-------------|
 | `type` | string | Yes | - | Load balancing algorithm |
-| `key` | string | No | - | Reserved for future pluggable key extraction (currently ignored) |
+| `key` | string | No | - | Optional key source for `consistent-hash` and `sticky-cid` (`header:<name>`, `cookie:<name>`, `query:<name>`, `path`, `authority`, `method`, `cid`) |
 
 ### Supported Algorithms
 
@@ -402,13 +402,14 @@ upstream:
 
 #### consistent-hash
 
-Routes requests using consistent hashing based on a fixed key derived from the request. Currently uses request authority (if present), otherwise request path, otherwise HTTP method.
+Routes requests using consistent hashing. By default it hashes request authority (if present), otherwise request path, otherwise HTTP method. Set `load_balancing.key` to override key derivation.
 
 ```yaml
 upstream:
   my_pool:
     load_balancing:
       type: "consistent-hash"
+      key: "header:x-user-id"
 ```
 
 #### least-connections

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -169,7 +169,7 @@
 2. **Full body buffering**: High memory usage for large requests/responses
 3. **Configuration hot reload missing**: Runtime config updates still require restart
 4. **Dual-ingress operational complexity**: Runtime serves HTTP/3 (native) plus HTTP/1.1/2 TLS bootstrap, so operators must secure and observe both paths consistently
-5. **Method-based route matching unimplemented**: `route.method` remains reserved for future use
+5. **Method-based route matching constraints**: keep route precedence and method tie-break semantics covered by integration tests as routing rules evolve
 6. **Control/metrics endpoint hardening is operator-dependent**: endpoints should remain network-isolated unless explicitly protected
 
 ### Refactoring Needs

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -14,6 +14,7 @@
 - Per-upstream configuration and routing
 - Connection ID management and QUIC packet routing
 - TLS 1.3 with certificate chain loading
+- Upstream TLS peer verification enabled by default via `upstream_tls.verify_certificates`
 - Downstream mTLS (client certificate authentication) via `listen.tls.client_auth.enabled`, `listen.tls.client_auth.require_client_cert`, and `listen.tls.client_auth.ca_file`
 - Structured logging with multiple levels
 - Configuration validation at startup
@@ -70,7 +71,6 @@
 
 ### Security
 
-- **TLS peer verification**: Enable certificate verification for production
 - **mTLS operational tooling**: Certificate rotation/revocation workflows and deployment guidance
 - **Request validation**: Size limits, header validation
 - **IP allowlist/blocklist**: Simple access control

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -143,7 +143,7 @@
 1. Async data plane - unblock main thread
 2. Configuration hot reload - reduce operational friction
 3. Streaming bodies - reduce memory usage
-4. TLS peer verification - production security
+4. mTLS operational tooling - certificate lifecycle automation
 
 ### Medium Priority (3-6 months)
 

--- a/docs/user-guide/load-balancing.md
+++ b/docs/user-guide/load-balancing.md
@@ -58,7 +58,7 @@ upstream:
   api_pool:
     load_balancing:
       type: "consistent-hash"  # Accepts: consistent-hash, consistent_hash, ch
-      # key: "header:x-user-id"  # Planned feature: configurable hash key source
+      key: "header:x-user-id"   # Optional key source: header/cookie/query/path/authority/method/cid
     route:
       path_prefix: "/api"
     backends:
@@ -86,18 +86,17 @@ upstream:
 
 **Hash Key Sources**:
 
-Currently, the key parameter is configured but hash key extraction must be implemented in the proxy layer. The algorithm accepts any string key.
-
 ```yaml
-# Current behavior: fixed key derivation from request
 load_balancing:
   type: "consistent-hash"
-# Planned configurable key sources (not currently implemented):
-# key: "header:x-user-id"       # User ID from header
+  key: "header:x-user-id"       # User ID from header
 # key: "header:x-session-id"    # Session ID from header
 # key: "cookie:session_id"      # Session cookie
 # key: "query:user_id"          # Query parameter
-# key: "path"                   # Request path
+# key: "path"                   # Request path (without query string)
+# key: "authority"              # Host/authority
+# key: "method"                 # HTTP method
+# key: "cid"                    # QUIC connection ID (same as sticky-cid default)
 ```
 
 **Use Cases**:


### PR DESCRIPTION
## Summary
This PR resolves two follow-up issues:

1. Roadmap drift: TLS peer verification was still listed as future work even though upstream certificate verification is already implemented and default-enabled. #126 
2. QUIC log noise: benign peer/local QUIC close states were being logged as errors repeatedly. #79 

## Changes

### 1) Roadmap accuracy for TLS verification
- Updated `docs/roadmap.md` to reflect that upstream TLS certificate verification is already implemented.
- Removed TLS peer verification from Phase 2 future-security items.
- Replaced stale implementation-priority item with a still-relevant security gap (`mTLS operational tooling`).

### 2) QUIC peer/local error logging behavior
- Updated QUIC listener logging to classify benign transport close (`is_app=false`, `error_code=0`, empty reason) as debug-level instead of error-level.
- Preserved error-level logging for actionable QUIC failures.
- Added per-connection peer/local error snapshots to avoid repeated duplicate logs for unchanged error state.

## Why this matters
- Keeps security posture documentation trustworthy and aligned with runtime defaults.
- Reduces false-positive error logs and alert fatigue while preserving real failure visibility.

## Validation
- `cargo fmt --all`
- `cargo test` (full suite pass)
- `cargo clippy --all-targets --all-features -- -D warnings` (pass)