### PR TITLE
security: clear inherited env for watchdog restart command

### DIFF
--- a/crates/edge/src/quic_listener/control_api.rs
+++ b/crates/edge/src/quic_listener/control_api.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::ffi::OsString;
 use subtle::ConstantTimeEq;
 
 #[derive(Clone)]
@@ -38,6 +39,18 @@ impl ControlApiState {
 }
 
 impl QUICListener {
+    fn watchdog_restart_env(path: Option<OsString>, restart_reason: &str) -> Vec<(OsString, OsString)> {
+        let mut env_vars = Vec::with_capacity(2);
+        if let Some(path_value) = path {
+            env_vars.push((OsString::from("PATH"), path_value));
+        }
+        env_vars.push((
+            OsString::from("SPOOKY_WATCHDOG_REASON"),
+            OsString::from(restart_reason),
+        ));
+        env_vars
+    }
+
     pub(super) fn spawn_control_api_endpoint(
         config: &SpookyConfig,
         shared_state: &SharedRuntimeState,
@@ -522,11 +535,14 @@ impl QUICListener {
                         .skip(1)
                         .map(String::as_str)
                         .collect();
-                    let status = tokio::process::Command::new(program)
-                        .args(args)
-                        .env("SPOOKY_WATCHDOG_REASON", &restart_reason)
-                        .status()
-                        .await;
+                    let restart_env =
+                        Self::watchdog_restart_env(std::env::var_os("PATH"), &restart_reason);
+                    let mut command = tokio::process::Command::new(program);
+                    command.args(args).env_clear();
+                    for (key, value) in restart_env {
+                        command.env(key, value);
+                    }
+                    let status = command.status().await;
                     match status {
                         Ok(status) => {
                             info!(

--- a/crates/edge/src/quic_listener/control_api.rs
+++ b/crates/edge/src/quic_listener/control_api.rs
@@ -39,7 +39,10 @@ impl ControlApiState {
 }
 
 impl QUICListener {
-    fn watchdog_restart_env(path: Option<OsString>, restart_reason: &str) -> Vec<(OsString, OsString)> {
+    fn watchdog_restart_env(
+        path: Option<OsString>,
+        restart_reason: &str,
+    ) -> Vec<(OsString, OsString)> {
         let mut env_vars = Vec::with_capacity(2);
         if let Some(path_value) = path {
             env_vars.push((OsString::from("PATH"), path_value));

--- a/crates/edge/src/quic_listener/control_api.rs
+++ b/crates/edge/src/quic_listener/control_api.rs
@@ -565,3 +565,39 @@ impl QUICListener {
         );
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn watchdog_restart_env_keeps_path_when_present() {
+        let env = QUICListener::watchdog_restart_env(
+            Some(OsString::from("/usr/bin:/bin")),
+            "timeout_spike",
+        );
+        let map: HashMap<OsString, OsString> = env.into_iter().collect();
+
+        assert_eq!(
+            map.get(&OsString::from("PATH")),
+            Some(&OsString::from("/usr/bin:/bin"))
+        );
+        assert_eq!(
+            map.get(&OsString::from("SPOOKY_WATCHDOG_REASON")),
+            Some(&OsString::from("timeout_spike"))
+        );
+    }
+
+    #[test]
+    fn watchdog_restart_env_omits_path_when_missing() {
+        let env = QUICListener::watchdog_restart_env(None, "poll_stall");
+        let map: HashMap<OsString, OsString> = env.into_iter().collect();
+
+        assert!(!map.contains_key(&OsString::from("PATH")));
+        assert_eq!(
+            map.get(&OsString::from("SPOOKY_WATCHDOG_REASON")),
+            Some(&OsString::from("poll_stall"))
+        );
+    }
+}


### PR DESCRIPTION
Ref: #143 

## Summary
Harden watchdog restart command execution by preventing inherited process environment leakage.

## Problem
The restart command path in `crates/edge/src/quic_listener/control_api.rs` executed child processes without clearing inherited environment variables, allowing potential propagation of sensitive env values to restart hooks/processes.

## Changes
- Added restart env construction helper to define a minimal runtime environment.
- Updated watchdog restart spawn path to:
  - call `env_clear()`
  - re-add only:
    - `PATH` (when present)
    - `SPOOKY_WATCHDOG_REASON`
- Added unit tests for restart env policy:
  - includes `PATH` if provided
  - omits `PATH` when absent
  - always sets `SPOOKY_WATCHDOG_REASON`
- Applied rustfmt formatting adjustments.

## Security Impact
Reduces risk of leaking ambient environment variables/secrets to watchdog restart child processes while preserving required execution context.

## Validation
- `cargo test` (workspace) passed (integration portion run outside sandbox due socket permissions)
- `cargo fmt --all -- --check` passed
- `cargo clippy --workspace --lib --bins -- -D clippy::unwrap_used -D clippy::expect_used` passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` passed