### PR TITLE
fix(edge): strip Connection-nominated hop-by-hop headers in bootstrap forwarding

### DIFF
--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -4995,7 +4995,10 @@ mod tests {
     #[test]
     fn bootstrap_header_filter_keeps_non_nominated_custom_headers() {
         let mut headers = HeaderMap::new();
-        headers.insert(http::header::CONNECTION, HeaderValue::from_static("keep-alive"));
+        headers.insert(
+            http::header::CONNECTION,
+            HeaderValue::from_static("keep-alive"),
+        );
         let tokens = connection_header_tokens(&headers);
 
         let header = http::HeaderName::from_static("x-custom-keep");

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -94,7 +94,31 @@ fn is_hop_header(name: &str) -> bool {
     )
 }
 
-fn should_strip_bootstrap_request_header(name: &http::header::HeaderName) -> bool {
+fn connection_header_tokens(headers: &http::HeaderMap) -> HashSet<String> {
+    let mut tokens = HashSet::new();
+    for value in headers.get_all(http::header::CONNECTION) {
+        let Ok(raw) = value.to_str() else {
+            continue;
+        };
+        for part in raw.split(',') {
+            let token = part.trim().to_ascii_lowercase();
+            if token.is_empty() {
+                continue;
+            }
+            tokens.insert(token);
+        }
+    }
+    tokens
+}
+
+fn should_strip_bootstrap_request_header(
+    name: &http::header::HeaderName,
+    connection_tokens: &HashSet<String>,
+) -> bool {
+    if connection_tokens.contains(name.as_str()) {
+        return true;
+    }
+
     if name == http::header::CONTENT_LENGTH {
         return true;
     }
@@ -4097,12 +4121,17 @@ impl QUICListener {
                                 let mut upstream_req =
                                     Request::builder().method(method.as_str()).uri(upstream_uri);
 
+                                let bootstrap_connection_tokens =
+                                    connection_header_tokens(req.headers());
                                 for (name, value) in req.headers() {
                                     if name == http::header::HOST {
                                         continue;
                                     }
                                     if !is_websocket_upgrade
-                                        && should_strip_bootstrap_request_header(name)
+                                        && should_strip_bootstrap_request_header(
+                                            name,
+                                            &bootstrap_connection_tokens,
+                                        )
                                     {
                                         continue;
                                     }

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -4692,7 +4692,7 @@ mod tests {
 
     use crate::REQUEST_ID_COUNTER;
     use crate::cid_radix::CidRadix;
-    use http::StatusCode;
+    use http::{HeaderMap, HeaderValue, StatusCode};
 
     use std::collections::HashSet;
     use std::net::SocketAddr;
@@ -4700,7 +4700,8 @@ mod tests {
 
     use super::{
         ConnectionRoutes, TokenBucket, abort_stream, classify_active_health_check_response,
-        purge_connection_routes, resolve_primary_from_radix_prefix, sweep_closed_connections,
+        connection_header_tokens, purge_connection_routes, resolve_primary_from_radix_prefix,
+        should_strip_bootstrap_request_header, sweep_closed_connections,
     };
     type RoutingMaps = (
         HashMap<Arc<[u8]>, Arc<[u8]>>,
@@ -4958,6 +4959,47 @@ mod tests {
             classify_active_health_check_response(StatusCode::BAD_GATEWAY),
             crate::HealthClassification::Failure
         ));
+    }
+
+    #[test]
+    fn bootstrap_connection_header_tokens_are_parsed_case_insensitively() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            http::header::CONNECTION,
+            HeaderValue::from_static("keep-alive, X-Secret"),
+        );
+        headers.append(
+            http::header::CONNECTION,
+            HeaderValue::from_static("x-another"),
+        );
+
+        let tokens = connection_header_tokens(&headers);
+        assert!(tokens.contains("keep-alive"));
+        assert!(tokens.contains("x-secret"));
+        assert!(tokens.contains("x-another"));
+    }
+
+    #[test]
+    fn bootstrap_header_filter_strips_connection_nominated_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            http::header::CONNECTION,
+            HeaderValue::from_static("keep-alive, x-secret"),
+        );
+        let tokens = connection_header_tokens(&headers);
+
+        let header = http::HeaderName::from_static("x-secret");
+        assert!(should_strip_bootstrap_request_header(&header, &tokens));
+    }
+
+    #[test]
+    fn bootstrap_header_filter_keeps_non_nominated_custom_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert(http::header::CONNECTION, HeaderValue::from_static("keep-alive"));
+        let tokens = connection_header_tokens(&headers);
+
+        let header = http::HeaderName::from_static("x-custom-keep");
+        assert!(!should_strip_bootstrap_request_header(&header, &tokens));
     }
 
     #[test]


### PR DESCRIPTION
Ref: #144 
## Summary
- parse `Connection` header tokens during bootstrap request forwarding
- strip hop-by-hop headers explicitly nominated by `Connection` (case-insensitive)
- retain existing static deny-list stripping behavior
- add regression tests for token parsing and stripping behavior

## Why
Bootstrap filtering previously only removed a fixed deny-list and could leak hop-by-hop headers named in `Connection`, causing protocol-safety inconsistencies upstream.

## Validation
- cargo test
- cargo fmt --all -- --check
- cargo clippy --workspace --lib --bins -- -D clippy::unwrap_used -D clippy::expect_used
- cargo clippy --workspace --all-targets --all-features -- -D warnings