### PR TITLE
fix: add control-api limiter visibility, enforce upstream TLS verification, and align startup/runtime paths

### DIFF
--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -815,9 +815,10 @@ pub fn validate(config: &Config) -> bool {
 
     // --- Validate upstream TLS trust-store configuration ---
     if !config.upstream_tls.verify_certificates {
-        warn!(
-            "upstream_tls.verify_certificates=false disables TLS certificate validation for HTTPS upstreams"
+        error!(
+            "upstream_tls.verify_certificates=false is not allowed; certificate verification must remain enabled"
         );
+        return false;
     }
 
     if let Some(ca_file) = config.upstream_tls.ca_file.as_ref() {
@@ -1410,6 +1411,10 @@ upstream:
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.listen.tls.client_auth.enabled = true;
         cfg.listen.tls.client_auth.ca_file = None;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.upstream_tls.verify_certificates = false;
         assert!(!validate(&cfg));
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -98,6 +98,7 @@ mod tests {
         metrics.inc_hedge_wasted();
         metrics.inc_hedge_primary_won_after_trigger();
         metrics.observe_hedge_primary_late_ms(42);
+        metrics.inc_control_api_connection_limit_drop();
 
         let output = metrics.render_prometheus();
         assert!(
@@ -121,6 +122,7 @@ mod tests {
         assert!(output.contains("spooky_ingress_draining_drops_total 0\n"));
         assert!(output.contains("spooky_ingress_connection_create_failed_total 0\n"));
         assert!(output.contains("spooky_ingress_version_neg_failed_total 0\n"));
+        assert!(output.contains("spooky_control_api_connection_limit_drops 1\n"));
         assert!(output.contains("spooky_circuit_breaker_rejected_total 0\n"));
         assert!(output.contains("spooky_brownout_active 0\n"));
     }

--- a/crates/edge/src/metrics/mod.rs
+++ b/crates/edge/src/metrics/mod.rs
@@ -55,6 +55,7 @@ pub struct Metrics {
     pub request_buffer_limit_rejects: AtomicU64,
     pub response_prebuffer_limit_rejects: AtomicU64,
     pub scid_rotations: AtomicU64,
+    pub control_api_connection_limit_drops: AtomicU64,
     pub watchdog_restart_requests: AtomicU64,
     pub watchdog_restart_hooks: AtomicU64,
     pub watchdog_degraded_windows: AtomicU64,
@@ -312,6 +313,7 @@ impl Metrics {
             request_buffer_limit_rejects: AtomicU64::new(0),
             response_prebuffer_limit_rejects: AtomicU64::new(0),
             scid_rotations: AtomicU64::new(0),
+            control_api_connection_limit_drops: AtomicU64::new(0),
             watchdog_restart_requests: AtomicU64::new(0),
             watchdog_restart_hooks: AtomicU64::new(0),
             watchdog_degraded_windows: AtomicU64::new(0),
@@ -636,6 +638,11 @@ impl Metrics {
 
     pub fn inc_scid_rotation(&self) {
         self.scid_rotations.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_control_api_connection_limit_drop(&self) {
+        self.control_api_connection_limit_drops
+            .fetch_add(1, Ordering::Relaxed);
     }
 
     pub fn inc_watchdog_restart_request(&self) {

--- a/crates/edge/src/metrics/prometheus.rs
+++ b/crates/edge/src/metrics/prometheus.rs
@@ -353,6 +353,16 @@ impl Metrics {
             self.scid_rotations.load(Ordering::Relaxed)
         ));
 
+        out.push_str(
+            "# HELP spooky_control_api_connection_limit_drops Total control API connections dropped due to max-connection limiter.\n",
+        );
+        out.push_str("# TYPE spooky_control_api_connection_limit_drops counter\n");
+        out.push_str(&format!(
+            "spooky_control_api_connection_limit_drops {}\n",
+            self.control_api_connection_limit_drops
+                .load(Ordering::Relaxed)
+        ));
+
         out.push_str("# HELP spooky_watchdog_restart_requests Total watchdog restart requests.\n");
         out.push_str("# TYPE spooky_watchdog_restart_requests counter\n");
         out.push_str(&format!(

--- a/crates/edge/src/quic_listener/control_api.rs
+++ b/crates/edge/src/quic_listener/control_api.rs
@@ -176,6 +176,11 @@ impl QUICListener {
                     let permit = match Arc::clone(&connection_limiter).try_acquire_owned() {
                         Ok(permit) => permit,
                         Err(_) => {
+                            state.metrics.inc_control_api_connection_limit_drop();
+                            warn!(
+                                "Control API endpoint dropped connection from {} due to max connection limit ({})",
+                                peer, max_connections
+                            );
                             continue;
                         }
                     };

--- a/crates/transport/src/h2_client.rs
+++ b/crates/transport/src/h2_client.rs
@@ -4,7 +4,6 @@ use std::fs::File;
 use std::future::Future;
 use std::io::BufReader;
 use std::path::Path;
-use std::sync::Arc;
 use std::time::Duration;
 
 use http_body_util::combinators::BoxBody;
@@ -12,8 +11,7 @@ use hyper::body::Bytes;
 use hyper::{Request, rt::Executor};
 use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
 use hyper_util::client::legacy::{Client, connect::HttpConnector};
-use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
-use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::pki_types::CertificateDer;
 use rustls::{ClientConfig, RootCertStore};
 
 #[derive(Debug, Clone)]
@@ -49,55 +47,6 @@ where
 {
     fn execute(&self, fut: F) {
         tokio::spawn(fut);
-    }
-}
-
-#[derive(Debug)]
-struct NoVerifier;
-
-impl ServerCertVerifier for NoVerifier {
-    fn verify_server_cert(
-        &self,
-        _end_entity: &CertificateDer<'_>,
-        _intermediates: &[CertificateDer<'_>],
-        _server_name: &ServerName<'_>,
-        _ocsp: &[u8],
-        _now: UnixTime,
-    ) -> Result<ServerCertVerified, rustls::Error> {
-        Ok(ServerCertVerified::assertion())
-    }
-
-    fn verify_tls12_signature(
-        &self,
-        _message: &[u8],
-        _cert: &CertificateDer<'_>,
-        _dss: &rustls::DigitallySignedStruct,
-    ) -> Result<HandshakeSignatureValid, rustls::Error> {
-        Ok(HandshakeSignatureValid::assertion())
-    }
-
-    fn verify_tls13_signature(
-        &self,
-        _message: &[u8],
-        _cert: &CertificateDer<'_>,
-        _dss: &rustls::DigitallySignedStruct,
-    ) -> Result<HandshakeSignatureValid, rustls::Error> {
-        Ok(HandshakeSignatureValid::assertion())
-    }
-
-    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-        vec![
-            rustls::SignatureScheme::RSA_PKCS1_SHA256,
-            rustls::SignatureScheme::RSA_PKCS1_SHA384,
-            rustls::SignatureScheme::RSA_PKCS1_SHA512,
-            rustls::SignatureScheme::RSA_PSS_SHA256,
-            rustls::SignatureScheme::RSA_PSS_SHA384,
-            rustls::SignatureScheme::RSA_PSS_SHA512,
-            rustls::SignatureScheme::ECDSA_NISTP256_SHA256,
-            rustls::SignatureScheme::ECDSA_NISTP384_SHA384,
-            rustls::SignatureScheme::ECDSA_NISTP521_SHA512,
-            rustls::SignatureScheme::ED25519,
-        ]
     }
 }
 
@@ -152,12 +101,10 @@ impl Default for H2Client {
 
 fn build_tls_config(tls: &TlsClientConfig) -> Result<ClientConfig, String> {
     if !tls.verify_certificates {
-        let mut cfg = ClientConfig::builder()
-            .dangerous()
-            .with_custom_certificate_verifier(Arc::new(NoVerifier))
-            .with_no_client_auth();
-        cfg.enable_sni = tls.strict_sni;
-        return Ok(cfg);
+        return Err(
+            "upstream_tls.verify_certificates=false is not allowed; enable certificate verification"
+                .to_string(),
+        );
     }
 
     let mut roots = RootCertStore::empty();
@@ -308,5 +255,21 @@ mod tests {
         assert!(client.is_err());
 
         let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn disabling_certificate_verification_is_rejected() {
+        let client = H2Client::new(
+            8,
+            Duration::from_secs(5),
+            Duration::from_secs(1),
+            TlsClientConfig {
+                verify_certificates: false,
+                strict_sni: true,
+                ca_file: None,
+                ca_dir: None,
+            },
+        );
+        assert!(client.is_err());
     }
 }

--- a/crates/transport/tests/h2_pool.rs
+++ b/crates/transport/tests/h2_pool.rs
@@ -94,10 +94,7 @@ async fn pool_limits_inflight_per_backend() {
             64,
             Duration::from_secs(30),
             Duration::from_secs(2),
-            TlsClientConfig {
-                verify_certificates: false,
-                ..TlsClientConfig::default()
-            },
+            TlsClientConfig::default(),
         )
         .expect("pool"),
     );
@@ -145,10 +142,7 @@ async fn pool_rejects_unknown_backend() {
         64,
         Duration::from_secs(30),
         Duration::from_secs(2),
-        TlsClientConfig {
-            verify_certificates: false,
-            ..TlsClientConfig::default()
-        },
+        TlsClientConfig::default(),
     )
     .expect("pool");
     let req = Request::builder()
@@ -176,10 +170,7 @@ async fn pool_reports_overload_when_inflight_is_exhausted() {
             64,
             Duration::from_secs(30),
             Duration::from_secs(2),
-            TlsClientConfig {
-                verify_certificates: false,
-                ..TlsClientConfig::default()
-            },
+            TlsClientConfig::default(),
         )
         .expect("pool"),
     );

--- a/spooky/src/main.rs
+++ b/spooky/src/main.rs
@@ -61,6 +61,15 @@ async fn wait_for_shutdown_signal() {
     let _ = tokio::signal::ctrl_c().await;
 }
 
+fn fatal_startup_error(message: &str, logger_ready: bool, exit_code: i32) -> ! {
+    if logger_ready {
+        error!("{}", message);
+    } else {
+        eprintln!("Error: {}", message);
+    }
+    std::process::exit(exit_code);
+}
+
 fn main() {
     // Parse CLI arguments
     let cli = Cli::parse();
@@ -70,11 +79,14 @@ fn main() {
         Some(path) => path,
         None if Path::new(DEFAULT_CONFIG_PATH).exists() => DEFAULT_CONFIG_PATH.to_string(),
         None => {
-            eprintln!(
-                "Error: no --config provided and default config '{}' was not found.",
-                DEFAULT_CONFIG_PATH
+            fatal_startup_error(
+                &format!(
+                    "no --config provided and default config '{}' was not found.",
+                    DEFAULT_CONFIG_PATH
+                ),
+                false,
+                2,
             );
-            std::process::exit(2);
         }
     };
 
@@ -82,21 +94,9 @@ fn main() {
     let config_yaml = match spooky_config::loader::read_config(&config_path) {
         Ok(cfg) => cfg,
         Err(err_msg) => {
-            eprintln!("Error loading config: {}", err_msg);
-            std::process::exit(1);
+            fatal_startup_error(&format!("loading config failed: {}", err_msg), false, 1);
         }
     };
-
-    // Require root only when binding a privileged port (< 1024).
-    let uid = unsafe { libc::getuid() };
-    if uid != 0 && config_yaml.listen.port < 1024 {
-        eprintln!(
-            "Binding privileged port {} requires root or CAP_NET_BIND_SERVICE. \
-Use a port >= 1024 for unprivileged startup.",
-            config_yaml.listen.port,
-        );
-        std::process::exit(1);
-    }
 
     // Initialize the Logger
     spooky_utils::logger::init_logger(
@@ -113,10 +113,22 @@ Use a port >= 1024 for unprivileged startup.",
     );
     runtime_guard::install_panic_hook();
 
+    // Require root only when binding a privileged port (< 1024).
+    let uid = unsafe { libc::getuid() };
+    if uid != 0 && config_yaml.listen.port < 1024 {
+        fatal_startup_error(
+            &format!(
+                "binding privileged port {} requires root or CAP_NET_BIND_SERVICE. Use a port >= 1024 for unprivileged startup.",
+                config_yaml.listen.port
+            ),
+            true,
+            1,
+        );
+    }
+
     // Validate Configurations
     if !validate_config(&config_yaml) {
-        error!("Configuration validation failed. Exiting...");
-        std::process::exit(1);
+        fatal_startup_error("Configuration validation failed. Exiting...", true, 1);
     }
 
     let control_plane_threads = config_yaml.performance.control_plane_threads.max(1);
@@ -130,11 +142,14 @@ Use a port >= 1024 for unprivileged startup.",
     {
         Ok(runtime) => runtime,
         Err(err) => {
-            error!(
-                "Failed to initialize Tokio control-plane runtime (threads={}): {}",
-                control_plane_threads, err
+            fatal_startup_error(
+                &format!(
+                    "Failed to initialize Tokio control-plane runtime (threads={}): {}",
+                    control_plane_threads, err
+                ),
+                true,
+                1,
             );
-            std::process::exit(1);
         }
     };
 
@@ -150,17 +165,8 @@ async fn run(config_yaml: Config, uid: libc::uid_t) {
         }
     };
 
-    let requested_workers = config_yaml.performance.worker_threads.max(1);
+    let worker_count = config_yaml.performance.worker_threads.max(1);
     let shard_count = config_yaml.performance.packet_shards_per_worker.max(1);
-    let worker_count = if requested_workers > 1 && !config_yaml.performance.reuseport {
-        warn!(
-            "reuseport disabled while worker_threads={} configured; running a single data-plane worker",
-            requested_workers
-        );
-        1
-    } else {
-        requested_workers
-    };
     let effective_worker_count = worker_count.saturating_mul(shard_count);
     if let Err(err) =
         QUICListener::spawn_control_plane_tasks(&config_yaml, &shared_state, effective_worker_count)


### PR DESCRIPTION
Ref:
#147 , #148, #149, #150 

## Summary
- add observability for Control API connection limiter drops:
  - warning log on drop
  - new Prometheus counter `spooky_control_api_connection_limit_drops`
- hard-block insecure upstream TLS configuration:
  - validator now rejects `upstream_tls.verify_certificates=false`
  - transport `H2Client` construction also rejects verify-disable
- normalize startup failure reporting through a shared helper and structured logging where logger is available
- remove data-plane worker fallback logic that conflicted with validator constraints (`worker_threads > 1` requires `reuseport=true`)

## Why
- limiter drops were previously silent, reducing operational visibility during overload/flood scenarios
- warning-only TLS verify-disable allowed easy insecure production config (MITM risk)
- startup failures were inconsistently emitted (`eprintln!` vs logger)
- runtime fallback duplicated/contradicted validator policy, creating maintenance noise

## Validation
- `cargo test` (workspace)
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --lib --bins -- -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`