### PR TITLE
refactor: align datagram/config validation with shared constants and stronger type/safety checks

### DIFF
--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -128,7 +128,7 @@ pub struct Listen {
     pub protocol: String, // "http3"
 
     #[serde(default = "get_default_port")]
-    pub port: u32, // 9889
+    pub port: u16, // 9889
 
     #[serde(default = "get_default_address")]
     pub address: String, // "0.0.0.0"

--- a/crates/config/src/default.rs
+++ b/crates/config/src/default.rs
@@ -9,7 +9,7 @@ pub fn get_default_protocol() -> String {
     String::from("http3")
 }
 
-pub fn get_default_port() -> u32 {
+pub fn get_default_port() -> u16 {
     9889
 }
 

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -113,6 +113,33 @@ fn is_loopback_bind_address(raw: &str) -> bool {
         .unwrap_or(false)
 }
 
+fn is_valid_http_token(value: &str) -> bool {
+    !value.is_empty()
+        && value.as_bytes().iter().all(|byte| {
+            matches!(
+                byte,
+                b'0'..=b'9'
+                    | b'a'..=b'z'
+                    | b'A'..=b'Z'
+                    | b'!'
+                    | b'#'
+                    | b'$'
+                    | b'%'
+                    | b'&'
+                    | b'\''
+                    | b'*'
+                    | b'+'
+                    | b'-'
+                    | b'.'
+                    | b'^'
+                    | b'_'
+                    | b'`'
+                    | b'|'
+                    | b'~'
+            )
+        })
+}
+
 pub fn validate(config: &Config) -> bool {
     info!("Starting configuration validation...");
 
@@ -495,6 +522,17 @@ pub fn validate(config: &Config) -> bool {
         .any(|method| method.trim().is_empty())
     {
         error!("resilience.protocol.allowed_methods must not contain empty values");
+        return false;
+    }
+
+    if config
+        .resilience
+        .protocol
+        .allowed_methods
+        .iter()
+        .any(|method| !is_valid_http_token(method))
+    {
+        error!("resilience.protocol.allowed_methods must contain valid HTTP method tokens");
         return false;
     }
 
@@ -1376,6 +1414,18 @@ upstream:
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.resilience.protocol.allowed_methods = vec!["".to_string()];
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.resilience.protocol.allowed_methods = vec!["GE T".to_string()];
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.resilience.protocol.allowed_methods = vec!["GET/".to_string()];
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.resilience.protocol.allowed_methods = vec!["GE\nT".to_string()];
         assert!(!validate(&cfg));
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -171,11 +171,8 @@ pub fn validate(config: &Config) -> bool {
     }
 
     // --- Validate listen port ---
-    if config.listen.port == 0 || config.listen.port > 65535 {
-        error!(
-            "Invalid listen port: {} (must be between 1 and 65535)",
-            config.listen.port
-        );
+    if config.listen.port == 0 {
+        error!("Invalid listen port: {} (must be between 1 and 65535)", config.listen.port);
         return false;
     }
 

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -616,13 +616,7 @@ pub fn validate(config: &Config) -> bool {
         return false;
     }
 
-    if config
-        .resilience
-        .watchdog
-        .restart_hook
-        .as_ref()
-        .is_some_and(|value| !value.trim().is_empty())
-    {
+    if config.resilience.watchdog.restart_hook.is_some() {
         error!(
             "resilience.watchdog.restart_hook is deprecated and unsupported; use restart_command instead"
         );
@@ -1633,6 +1627,24 @@ upstream:
         let (cert, key) = write_test_certs(dir.path());
         let mut cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.resilience.watchdog.restart_hook = Some("echo legacy".to_string());
+        assert!(!validate(&cfg));
+    }
+
+    #[test]
+    fn rejects_any_provided_legacy_watchdog_restart_hook_value() {
+        let dir = tempdir().expect("tempdir");
+        let (cert, key) = write_test_certs(dir.path());
+
+        let mut cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.resilience.watchdog.restart_hook = None;
+        assert!(validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.resilience.watchdog.restart_hook = Some(String::new());
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.resilience.watchdog.restart_hook = Some("   ".to_string());
         assert!(!validate(&cfg));
     }
 

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -4,7 +4,6 @@ use log::{error, info, warn};
 use std::fs::File;
 use std::io::BufReader;
 use std::net::IpAddr;
-use std::path::Path;
 
 pub const VALID_LOG_LEVELS: &[&str] = &[
     "whisper",
@@ -794,22 +793,6 @@ pub fn validate(config: &Config) -> bool {
     }
 
     // --- Validate TLS certs ---
-    if !Path::new(&config.listen.tls.cert).exists() {
-        error!(
-            "TLS certificate file does not exist: {}",
-            config.listen.tls.cert
-        );
-        return false;
-    }
-
-    if !Path::new(&config.listen.tls.key).exists() {
-        error!(
-            "TLS private key file does not exist: {}",
-            config.listen.tls.key
-        );
-        return false;
-    }
-
     if !validate_pem_certificates(&config.listen.tls.cert, "listen.tls.cert") {
         return false;
     }
@@ -833,10 +816,6 @@ pub fn validate(config: &Config) -> bool {
             error!("listen.tls.client_auth.ca_file cannot be empty");
             return false;
         }
-        if !Path::new(ca_file).exists() {
-            error!("listen.tls.client_auth.ca_file does not exist: {}", ca_file);
-            return false;
-        }
         if !validate_pem_certificates(ca_file, "listen.tls.client_auth.ca_file") {
             return false;
         }
@@ -855,10 +834,6 @@ pub fn validate(config: &Config) -> bool {
             error!("upstream_tls.ca_file cannot be empty when provided");
             return false;
         }
-        if !Path::new(ca_file).exists() {
-            error!("upstream_tls.ca_file does not exist: {}", ca_file);
-            return false;
-        }
         if !validate_pem_certificates(ca_file, "upstream_tls.ca_file") {
             return false;
         }
@@ -869,12 +844,14 @@ pub fn validate(config: &Config) -> bool {
             error!("upstream_tls.ca_dir cannot be empty when provided");
             return false;
         }
-        let ca_path = Path::new(ca_dir);
-        if !ca_path.exists() {
-            error!("upstream_tls.ca_dir does not exist: {}", ca_dir);
-            return false;
-        }
-        if !ca_path.is_dir() {
+        let metadata = match std::fs::metadata(ca_dir) {
+            Ok(metadata) => metadata,
+            Err(err) => {
+                error!("Cannot stat upstream_tls.ca_dir '{}': {}", ca_dir, err);
+                return false;
+            }
+        };
+        if !metadata.is_dir() {
             error!("upstream_tls.ca_dir must be a directory: {}", ca_dir);
             return false;
         }

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -198,7 +198,10 @@ pub fn validate(config: &Config) -> bool {
 
     // --- Validate listen port ---
     if config.listen.port == 0 {
-        error!("Invalid listen port: {} (must be between 1 and 65535)", config.listen.port);
+        error!(
+            "Invalid listen port: {} (must be between 1 and 65535)",
+            config.listen.port
+        );
         return false;
     }
 

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -1617,7 +1617,7 @@ impl QUICListener {
         tracing_enabled: bool,
         routing_transparency_enabled: bool,
         routing_transparency_include_reason: bool,
-        listen_port: u32,
+        listen_port: u16,
     ) -> Result<(), quiche::h3::Error> {
         let mut body_buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
 
@@ -2601,7 +2601,7 @@ impl QUICListener {
         max_response_body_bytes: usize,
         unknown_length_response_prebuffer_bytes: usize,
         client_body_idle_timeout: Duration,
-        listen_port: u32,
+        listen_port: u16,
     ) -> Result<(), quiche::h3::Error> {
         let stream_ids: Vec<u64> = streams.keys().copied().collect();
 

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -97,7 +97,7 @@ fn make_config(port: u32, backend_addr: String, cert: String, key: String) -> Co
         version: 1,
         listen: Listen {
             protocol: "http3".to_string(),
-            port,
+            port: port as u16,
             address: "127.0.0.1".to_string(),
             tls: Tls {
                 cert,

--- a/crates/edge/tests/h3_edge.rs
+++ b/crates/edge/tests/h3_edge.rs
@@ -83,7 +83,7 @@ fn make_config(port: u32, cert: String, key: String, backend_address: String) ->
         version: 1,
         listen: Listen {
             protocol: "http3".to_string(),
-            port,
+            port: port as u16,
             address: "127.0.0.1".to_string(),
             tls: Tls {
                 cert,
@@ -821,7 +821,7 @@ fn make_config_with_rate_limit(
         version: 1,
         listen: Listen {
             protocol: "http3".to_string(),
-            port,
+            port: port as u16,
             address: "127.0.0.1".to_string(),
             tls: Tls {
                 cert,

--- a/crates/edge/tests/lb_integration.rs
+++ b/crates/edge/tests/lb_integration.rs
@@ -107,7 +107,7 @@ fn make_config(
         version: 1,
         listen: Listen {
             protocol: "http3".to_string(),
-            port,
+            port: port as u16,
             address: "127.0.0.1".to_string(),
             tls: Tls {
                 cert,

--- a/spooky/src/main.rs
+++ b/spooky/src/main.rs
@@ -18,7 +18,8 @@ use log::{error, info, warn};
 
 use spooky_config::validator::validate as validate_config;
 use spooky_edge::{
-    QUICListener, SharedRuntimeState, configure_async_runtime, stable_hash_socket_addr,
+    QUICListener, SharedRuntimeState, configure_async_runtime,
+    constants::MAX_DATAGRAM_SIZE_BYTES, stable_hash_socket_addr,
 };
 
 #[derive(Parser)]
@@ -431,7 +432,7 @@ fn run_sharded_listener_worker(
         shard_handles.push(shard_handle);
     }
 
-    let mut recv_buf = [0u8; 65_535];
+    let mut recv_buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
     while !worker_shutdown.load(Ordering::Relaxed) {
         match socket.recv_from(&mut recv_buf) {
             Ok((len, peer)) => {

--- a/spooky/src/main.rs
+++ b/spooky/src/main.rs
@@ -18,8 +18,8 @@ use log::{error, info, warn};
 
 use spooky_config::validator::validate as validate_config;
 use spooky_edge::{
-    QUICListener, SharedRuntimeState, configure_async_runtime,
-    constants::MAX_DATAGRAM_SIZE_BYTES, stable_hash_socket_addr,
+    QUICListener, SharedRuntimeState, configure_async_runtime, constants::MAX_DATAGRAM_SIZE_BYTES,
+    stable_hash_socket_addr,
 };
 
 #[derive(Parser)]


### PR DESCRIPTION
Ref: #151, #152 , #153 , #154 , #155 

## Summary
- replace hardcoded datagram recv buffer literal in `spooky/main.rs` with `MAX_DATAGRAM_SIZE_BYTES`
- change `listen.port` config type from `u32` to `u16` and align runtime/test call sites
- make deprecated `resilience.watchdog.restart_hook` unambiguously unsupported for any provided value (`Some(...)`)
- validate `resilience.protocol.allowed_methods` as legal HTTP method tokens (not just non-empty)
- remove TLS pre-`exists()` checks in validator and rely on direct open/parse + metadata checks

## Why
- reduces config/runtime drift by using shared constants
- improves type-level safety for ports
- removes ambiguous deprecation behavior for `restart_hook`
- prevents invalid HTTP method policy entries from silently passing
- avoids redundant TOCTOU-prone existence checks in TLS file validation paths

## Validation
- full workspace `cargo test` (including integration suites)
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --lib --bins -- -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`