### PR TITLE
refactor(edge): name resolved backend fields and fix forwarding telemetry semantics

### DIFF
--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -91,6 +91,7 @@ mod tests {
         let metrics = Metrics::default();
         metrics.inc_overload_shed_reason(OverloadShedReason::GlobalInflight);
         metrics.inc_overload_shed_reason(OverloadShedReason::BackendInflight);
+        metrics.inc_overload_shed_reason(OverloadShedReason::CircuitOpen);
         metrics.set_active_connections(7);
         metrics.inc_connection_cap_reject();
         metrics.inc_hedge_triggered();
@@ -107,6 +108,7 @@ mod tests {
         assert!(
             output.contains("spooky_overload_shed_by_reason_total{reason=\"backend_inflight\"} 1")
         );
+        assert!(output.contains("spooky_overload_shed_by_reason_total{reason=\"circuit_open\"} 1"));
         assert!(output.contains("spooky_active_connections 7"));
         assert!(output.contains("spooky_connection_cap_rejects 1"));
         assert!(output.contains("spooky_hedge_triggered_total 1"));

--- a/crates/edge/src/metrics/mod.rs
+++ b/crates/edge/src/metrics/mod.rs
@@ -29,6 +29,7 @@ pub struct Metrics {
     pub overload_shed_global_inflight: AtomicU64,
     pub overload_shed_upstream_inflight: AtomicU64,
     pub overload_shed_backend_inflight: AtomicU64,
+    pub overload_shed_circuit_open: AtomicU64,
     pub overload_shed_request_buffer: AtomicU64,
     pub overload_shed_response_prebuffer: AtomicU64,
     pub overload_shed_connection_cap: AtomicU64,
@@ -200,6 +201,7 @@ pub enum OverloadShedReason {
     GlobalInflight,
     UpstreamInflight,
     BackendInflight,
+    CircuitOpen,
     RequestBufferCap,
     ResponsePrebufferCap,
     ConnectionCap,
@@ -287,6 +289,7 @@ impl Metrics {
             overload_shed_global_inflight: AtomicU64::new(0),
             overload_shed_upstream_inflight: AtomicU64::new(0),
             overload_shed_backend_inflight: AtomicU64::new(0),
+            overload_shed_circuit_open: AtomicU64::new(0),
             overload_shed_request_buffer: AtomicU64::new(0),
             overload_shed_response_prebuffer: AtomicU64::new(0),
             overload_shed_connection_cap: AtomicU64::new(0),
@@ -427,6 +430,10 @@ impl Metrics {
             }
             OverloadShedReason::BackendInflight => {
                 self.overload_shed_backend_inflight
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            OverloadShedReason::CircuitOpen => {
+                self.overload_shed_circuit_open
                     .fetch_add(1, Ordering::Relaxed);
             }
             OverloadShedReason::RequestBufferCap => {

--- a/crates/edge/src/metrics/prometheus.rs
+++ b/crates/edge/src/metrics/prometheus.rs
@@ -135,6 +135,10 @@ impl Metrics {
             self.overload_shed_backend_inflight.load(Ordering::Relaxed)
         ));
         out.push_str(&format!(
+            "spooky_overload_shed_by_reason_total{{reason=\"circuit_open\"}} {}\n",
+            self.overload_shed_circuit_open.load(Ordering::Relaxed)
+        ));
+        out.push_str(&format!(
             "spooky_overload_shed_by_reason_total{{reason=\"request_buffer_cap\"}} {}\n",
             self.overload_shed_request_buffer.load(Ordering::Relaxed)
         ));

--- a/crates/edge/src/quic_listener/forwarding.rs
+++ b/crates/edge/src/quic_listener/forwarding.rs
@@ -265,7 +265,7 @@ impl QUICListener {
             Err(ProxyError::Pool(PoolError::CircuitOpen(_))) => {
                 metrics.inc_failure();
                 metrics.inc_circuit_breaker_rejected();
-                metrics.inc_overload_shed_reason(OverloadShedReason::BackendInflight);
+                metrics.inc_overload_shed_reason(OverloadShedReason::CircuitOpen);
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::OverloadShed);
                 Self::log_access(req, 503);
                 Self::send_overload_response(

--- a/crates/edge/src/quic_listener/forwarding.rs
+++ b/crates/edge/src/quic_listener/forwarding.rs
@@ -65,6 +65,10 @@ pub(crate) fn abort_stream(req: &mut RequestEnvelope, metrics: &Metrics) -> Stre
 }
 
 impl QUICListener {
+    fn send_error_health_failure_reason() -> Option<HealthFailureReason> {
+        None
+    }
+
     fn is_internal_pool_control_error(error: &PoolError) -> bool {
         matches!(
             error,
@@ -279,13 +283,15 @@ impl QUICListener {
             Err(ProxyError::Pool(PoolError::Send(ref send_err))) => {
                 // Log the full inner error — commonly exposes TLS/cert/SNI mismatches
                 // that look like transport failures but are actually local config errors.
-                // Do NOT mark the backend unhealthy: the backend may be fully operational;
-                // the connection failure is a proxy-side config issue.
+                // Do NOT mark backend health as failed: the backend may be fully operational;
+                // this path is usually a local proxy configuration/runtime issue.
                 error!(
                     "Upstream send failed for {} (possible TLS/cert/SNI misconfiguration): {}",
                     backend_addr, send_err
                 );
-                metrics.inc_health_failure(HealthFailureReason::Tls);
+                if let Some(reason) = Self::send_error_health_failure_reason() {
+                    metrics.inc_health_failure(reason);
+                }
                 metrics.inc_failure();
                 metrics.inc_backend_error();
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::BackendError);
@@ -508,5 +514,10 @@ mod tests {
         assert!(!QUICListener::is_internal_pool_control_error(
             &PoolError::CircuitOpen("open".to_string())
         ));
+    }
+
+    #[test]
+    fn send_error_does_not_map_to_backend_health_failure_reason() {
+        assert_eq!(QUICListener::send_error_health_failure_reason(), None);
     }
 }

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -307,16 +307,16 @@ fn boxed_full(body: Bytes) -> http_body_util::combinators::BoxBody<Bytes, Infall
     Full::new(body).map_err(|never| match never {}).boxed()
 }
 
-type ResolvedBackend = (
-    String,
-    String,
-    usize,
-    Arc<RwLock<UpstreamPool>>,
-    String,
-    usize,
-    bool,
-    RouteDecisionReason,
-);
+struct ResolvedBackend {
+    upstream_name: String,
+    backend_addr: String,
+    backend_index: usize,
+    upstream_pool: Arc<RwLock<UpstreamPool>>,
+    backend_lb: String,
+    route_path_len: usize,
+    route_host_specific: bool,
+    route_reason: RouteDecisionReason,
+}
 
 impl QUICListener {
     pub fn new(config: SpookyConfig) -> Result<Self, ProxyError> {
@@ -1754,16 +1754,16 @@ impl QUICListener {
                         trace_span,
                         request_id,
                     ) = match resolved {
-                        Ok((
+                        Ok(ResolvedBackend {
                             upstream_name,
-                            addr,
-                            idx,
+                            backend_addr: addr,
+                            backend_index: idx,
                             upstream_pool,
                             backend_lb,
                             route_path_len,
                             route_host_specific,
                             route_reason,
-                        )) => {
+                        }) => {
                             resilience.brownout.observe_admission_pressure(
                                 resilience.adaptive_admission.inflight_percent(),
                             );
@@ -3528,16 +3528,16 @@ impl QUICListener {
             route_decision.host_specific,
             route_decision.reason
         );
-        Ok((
-            upstream_name.to_string(),
+        Ok(ResolvedBackend {
+            upstream_name: upstream_name.to_string(),
             backend_addr,
             backend_index,
             upstream_pool,
-            lb_type.to_string(),
-            route_decision.matched_path_len,
-            route_decision.host_specific,
-            route_decision.reason,
-        ))
+            backend_lb: lb_type.to_string(),
+            route_path_len: route_decision.matched_path_len,
+            route_host_specific: route_decision.host_specific,
+            route_reason: route_decision.reason,
+        })
     }
 
     fn resolve_lb_key_from_spec(
@@ -4076,17 +4076,8 @@ impl QUICListener {
                                     &routing_index,
                                     Some(&lb_header_lookup),
                                 );
-                                let (
-                                    _upstream_name,
-                                    backend_addr,
-                                    _backend_index,
-                                    _pool,
-                                    _lb,
-                                    _,
-                                    _,
-                                    _,
-                                ) = match resolved {
-                                    Ok(value) => value,
+                                let backend_addr = match resolved {
+                                    Ok(value) => value.backend_addr,
                                     Err(ProxyError::Transport(reason)) => {
                                         let (status, body) =
                                             bootstrap_resolution_error_response(&reason);
@@ -4795,7 +4786,7 @@ mod tests {
 
         let mut picks = Vec::new();
         for _ in 0..4 {
-            let (_upstream, backend, _, _, _, _, _, _) = super::QUICListener::resolve_backend(
+            let resolved = super::QUICListener::resolve_backend(
                 "GET",
                 "/api/items",
                 None,
@@ -4805,7 +4796,7 @@ mod tests {
                 None,
             )
             .expect("resolve backend");
-            picks.push(backend);
+            picks.push(resolved.backend_addr);
         }
 
         assert!(
@@ -4826,7 +4817,7 @@ mod tests {
             guard.pool.mark_failure(0);
         }
 
-        let (_upstream, backend, _, _, _, _, _, _) = super::QUICListener::resolve_backend(
+        let resolved = super::QUICListener::resolve_backend(
             "GET",
             "/api/items",
             None,
@@ -4838,7 +4829,7 @@ mod tests {
         .expect("resolve backend");
 
         assert_eq!(
-            backend, "127.0.0.1:7002",
+            resolved.backend_addr, "127.0.0.1:7002",
             "unhealthy backend must be excluded from bootstrap backend selection"
         );
     }
@@ -4852,7 +4843,7 @@ mod tests {
             guard.pool.begin_request(0);
         }
 
-        let (_upstream, backend, _, _, _, _, _, _) = super::QUICListener::resolve_backend(
+        let resolved = super::QUICListener::resolve_backend(
             "GET",
             "/api/items",
             None,
@@ -4864,7 +4855,7 @@ mod tests {
         .expect("resolve backend");
 
         assert_eq!(
-            backend, "127.0.0.1:7002",
+            resolved.backend_addr, "127.0.0.1:7002",
             "least-connections should prefer lower in-flight backend in bootstrap selection"
         );
     }
@@ -4892,7 +4883,7 @@ mod tests {
             upstream_pools.insert(name.clone(), Arc::new(RwLock::new(pool)));
         }
 
-        let (upstream, _, _, _, _, _, _, _) = super::QUICListener::resolve_backend(
+        let resolved = super::QUICListener::resolve_backend(
             "GET",
             "/api/items",
             None,
@@ -4902,9 +4893,9 @@ mod tests {
             None,
         )
         .expect("GET resolve");
-        assert_eq!(upstream, "all_methods");
+        assert_eq!(resolved.upstream_name, "all_methods");
 
-        let (upstream, backend, _, _, _, _, _, _) = super::QUICListener::resolve_backend(
+        let resolved = super::QUICListener::resolve_backend(
             "POST",
             "/api/items",
             None,
@@ -4914,8 +4905,8 @@ mod tests {
             None,
         )
         .expect("POST resolve");
-        assert_eq!(upstream, "post_only");
-        assert_eq!(backend, "127.0.0.1:7010");
+        assert_eq!(resolved.upstream_name, "post_only");
+        assert_eq!(resolved.backend_addr, "127.0.0.1:7010");
     }
 
     #[test]
@@ -4944,7 +4935,7 @@ mod tests {
             }
         };
 
-        let (_, first_backend, _, _, _, _, _, _) = super::QUICListener::resolve_backend(
+        let first = super::QUICListener::resolve_backend(
             "GET",
             "/api/items",
             None,
@@ -4954,7 +4945,7 @@ mod tests {
             Some(&header_lookup),
         )
         .expect("first resolve");
-        let (_, second_backend, _, _, _, _, _, _) = super::QUICListener::resolve_backend(
+        let second = super::QUICListener::resolve_backend(
             "GET",
             "/api/items",
             None,
@@ -4966,7 +4957,7 @@ mod tests {
         .expect("second resolve");
 
         assert_eq!(
-            first_backend, second_backend,
+            first.backend_addr, second.backend_addr,
             "consistent-hash should remain stable when configured header key is constant"
         );
     }


### PR DESCRIPTION
Ref: #156 , #157 , #158 

## Summary
- replace positional `ResolvedBackend` tuple alias with a named struct for explicit routing/LB fields
- classify circuit-breaker-open rejections under a dedicated overload shed reason (`circuit_open`) instead of `backend_inflight`
- stop counting `PoolError::Send` as TLS health-failure for backend health telemetry, matching non-degradation intent
- add/update tests for new telemetry semantics and struct-based routing resolution usage

## Why
- tuple positional semantics reduced readability and made refactors riskier
- circuit-open traffic was misattributed as backend inflight saturation, skewing overload dashboards
- send-error comments explicitly describe proxy-side config/runtime issues; incrementing backend TLS health-failure counters was misleading

## Validation
- cargo test (workspace)
- cargo fmt --all -- --check
- cargo clippy --workspace --lib --bins -- -D clippy::unwrap_used -D clippy::expect_used
- cargo clippy --workspace --all-targets --all-features -- -D warnings