### PR TITLE
Harden listener/runtime safety and request framing validation

### DIFF
--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -627,8 +627,8 @@ impl QUICListener {
             request_buffer_global_cap_bytes,
             unknown_length_response_prebuffer_bytes,
             require_client_cert,
-            recv_buf: [0; MAX_DATAGRAM_SIZE_BYTES],
-            send_buf: [0; MAX_DATAGRAM_SIZE_BYTES],
+            recv_buf: Box::new([0; MAX_DATAGRAM_SIZE_BYTES]),
+            send_buf: Box::new([0; MAX_DATAGRAM_SIZE_BYTES]),
             connections: HashMap::new(),
             cid_routes: HashMap::new(),
             peer_routes: HashMap::new(),
@@ -1135,7 +1135,7 @@ impl QUICListener {
         }
 
         // Read a UDP datagram and feed it into quiche.
-        let (len, peer) = match self.socket.recv_from(&mut self.recv_buf) {
+        let (len, peer) = match self.socket.recv_from(self.recv_buf.as_mut_slice()) {
             Ok(v) => v,
             Err(ref e)
                 if e.kind() == std::io::ErrorKind::WouldBlock
@@ -1197,7 +1197,11 @@ impl QUICListener {
 
         if packet_type == quiche::Type::VersionNegotiation {
             let len =
-                match quiche::negotiate_version(&header.scid, &header.dcid, &mut self.send_buf) {
+                match quiche::negotiate_version(
+                    &header.scid,
+                    &header.dcid,
+                    self.send_buf.as_mut_slice(),
+                ) {
                     Ok(len) => len,
                     Err(e) => {
                         error!("Version negotiation failed: {:?}", e);

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -1196,19 +1196,18 @@ impl QUICListener {
         let dcid = header.dcid.as_ref();
 
         if packet_type == quiche::Type::VersionNegotiation {
-            let len =
-                match quiche::negotiate_version(
-                    &header.scid,
-                    &header.dcid,
-                    self.send_buf.as_mut_slice(),
-                ) {
-                    Ok(len) => len,
-                    Err(e) => {
-                        error!("Version negotiation failed: {:?}", e);
-                        self.metrics.inc_ingress_version_neg_failed();
-                        return;
-                    }
-                };
+            let len = match quiche::negotiate_version(
+                &header.scid,
+                &header.dcid,
+                self.send_buf.as_mut_slice(),
+            ) {
+                Ok(len) => len,
+                Err(e) => {
+                    error!("Version negotiation failed: {:?}", e);
+                    self.metrics.inc_ingress_version_neg_failed();
+                    return;
+                }
+            };
 
             if let Err(e) = self.socket.send_to(&self.send_buf[..len], peer) {
                 error!("Failed to send version negotiation: {:?}", e);

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -84,7 +84,7 @@ use health_check::classify_active_health_check_response;
 pub(crate) use token_bucket::TokenBucket;
 use validation::{
     RequestBufferError, extract_header_value, generated_span_id, generated_trace_id,
-    parse_traceparent, request_content_length, validate_http_request, validate_request_headers,
+    parse_traceparent, validate_http_request, validate_request_headers,
 };
 
 fn is_hop_header(name: &str) -> bool {
@@ -1690,6 +1690,7 @@ impl QUICListener {
                     let method = request.method;
                     let path = request.path;
                     let authority = request.authority;
+                    let content_length = request.content_length;
 
                     metrics.inc_total();
                     let request_start = Instant::now();
@@ -1976,7 +1977,6 @@ impl QUICListener {
                                     )
                                 },
                             );
-                            let content_length = request_content_length(&list);
                             let bodyless_mode = content_length.unwrap_or(0) == 0
                                 && (method.eq_ignore_ascii_case("GET")
                                     || method.eq_ignore_ascii_case("HEAD"));
@@ -4050,6 +4050,7 @@ impl QUICListener {
                                 let method = request.method;
                                 let path = request.path;
                                 let authority = request.authority;
+                                let content_length = request.content_length;
 
                                 let bootstrap_error = |status: StatusCode, body: &'static [u8]| {
                                     Ok(Response::builder()
@@ -4189,12 +4190,8 @@ impl QUICListener {
                                 );
 
                                 if !is_websocket_upgrade
-                                    && let Some(content_length) = req
-                                        .headers()
-                                        .get(http::header::CONTENT_LENGTH)
-                                        .and_then(|v| v.to_str().ok())
-                                        .and_then(|s| s.parse::<usize>().ok())
-                                    && content_length > max_request_body_bytes
+                                    && content_length
+                                        .is_some_and(|value| value > max_request_body_bytes)
                                 {
                                     return Ok(Response::builder()
                                         .status(StatusCode::PAYLOAD_TOO_LARGE)

--- a/crates/edge/src/quic_listener/token_bucket.rs
+++ b/crates/edge/src/quic_listener/token_bucket.rs
@@ -8,8 +8,8 @@ use std::time::Instant;
 pub(crate) struct TokenBucket {
     /// Maximum tokens the bucket can hold (burst capacity).
     burst: f64,
-    /// Tokens added per nanosecond (= rate_per_sec / 1_000_000_000).
-    tokens_per_ns: f64,
+    /// Tokens added per second.
+    rate_per_sec: f64,
     /// Current available tokens.
     tokens: f64,
     /// Last time tokens were refilled.
@@ -22,7 +22,7 @@ impl TokenBucket {
         let rate_per_sec = rate_per_sec.max(1) as f64;
         Self {
             burst,
-            tokens_per_ns: rate_per_sec / 1_000_000_000.0,
+            rate_per_sec,
             tokens: burst,
             last_refill: Instant::now(),
         }
@@ -30,14 +30,49 @@ impl TokenBucket {
 
     pub(super) fn try_consume(&mut self) -> bool {
         let now = Instant::now();
-        let elapsed_ns = now.saturating_duration_since(self.last_refill).as_nanos() as f64;
+        // Refill is intentionally bounded by `burst`: after long idle periods, precision
+        // beyond "enough to fill the bucket" is irrelevant and we clamp to capacity.
+        let refill = now
+            .saturating_duration_since(self.last_refill)
+            .as_secs_f64()
+            * self.rate_per_sec;
         self.last_refill = now;
-        self.tokens = (self.tokens + elapsed_ns * self.tokens_per_ns).min(self.burst);
+
+        if refill.is_finite() && refill > 0.0 {
+            self.tokens = (self.tokens + refill).min(self.burst);
+        } else if !refill.is_finite() {
+            self.tokens = self.burst;
+        }
+
         if self.tokens >= 1.0 {
             self.tokens -= 1.0;
             true
         } else {
             false
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TokenBucket;
+    use std::time::Duration;
+
+    #[test]
+    fn long_idle_refill_is_capped_to_burst() {
+        let mut tb = TokenBucket::new(1_000, 3);
+        assert!(tb.try_consume());
+        assert!(tb.try_consume());
+        assert!(tb.try_consume());
+        assert!(!tb.try_consume());
+
+        tb.last_refill = tb
+            .last_refill
+            .checked_sub(Duration::from_secs(60))
+            .expect("time subtraction");
+
+        assert!(tb.try_consume(), "long idle should refill bucket");
+        assert!(tb.tokens.is_finite());
+        assert!(tb.tokens <= tb.burst);
     }
 }

--- a/crates/edge/src/quic_listener/validation.rs
+++ b/crates/edge/src/quic_listener/validation.rs
@@ -1,27 +1,17 @@
 use super::*;
 
+#[derive(Debug)]
 pub(super) struct RequestValidationResult {
     pub(super) method: String,
     pub(super) path: String,
     pub(super) authority: Option<String>,
+    pub(super) content_length: Option<usize>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum RequestBufferError {
     StreamCap,
     GlobalCap,
-}
-
-pub(super) fn request_content_length(headers: &[quiche::h3::Header]) -> Option<usize> {
-    for header in headers {
-        if !header.name().eq_ignore_ascii_case(b"content-length") {
-            continue;
-        }
-        let value = std::str::from_utf8(header.value()).ok()?;
-        let parsed = value.trim().parse::<usize>().ok()?;
-        return Some(parsed);
-    }
-    None
 }
 
 pub(super) fn validate_request_headers(
@@ -127,6 +117,8 @@ pub(super) fn validate_request_headers(
         }
     }
 
+    let content_length = parse_h3_content_length(list)?;
+
     let method = match method {
         Some(method) => method,
         None => {
@@ -153,6 +145,7 @@ pub(super) fn validate_request_headers(
         path,
         authority,
         host,
+        content_length,
         resilience,
         RequestPartErrors {
             invalid_method: b"invalid :method header\n",
@@ -215,12 +208,14 @@ pub(super) fn validate_http_request(
         .path_and_query()
         .map(|pq| pq.as_str())
         .unwrap_or("/");
+    let content_length = parse_http_content_length(req.headers())?;
 
     validate_request_parts(
         req.method().as_str().to_string(),
         path.to_string(),
         authority,
         host,
+        content_length,
         resilience,
         RequestPartErrors {
             invalid_method: b"invalid method header\n",
@@ -250,6 +245,7 @@ fn validate_request_parts(
     path: String,
     authority: Option<String>,
     host: Option<String>,
+    content_length: Option<usize>,
     resilience: &RuntimeResilience,
     errors: RequestPartErrors,
 ) -> Result<RequestValidationResult, (http::StatusCode, &'static [u8], bool)> {
@@ -297,7 +293,71 @@ fn validate_request_parts(
         method,
         path,
         authority: authority.or(host),
+        content_length,
     })
+}
+
+fn parse_content_length_value(raw: &[u8]) -> Option<usize> {
+    let value = std::str::from_utf8(raw).ok()?.trim();
+    if value.is_empty() || !value.as_bytes().iter().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    value.parse::<usize>().ok()
+}
+
+fn merge_content_length(
+    current: &mut Option<usize>,
+    next: usize,
+) -> Result<(), (http::StatusCode, &'static [u8], bool)> {
+    match *current {
+        None => {
+            *current = Some(next);
+            Ok(())
+        }
+        Some(existing) if existing == next => Ok(()),
+        Some(_) => Err((
+            http::StatusCode::BAD_REQUEST,
+            b"conflicting content-length header\n",
+            false,
+        )),
+    }
+}
+
+fn parse_h3_content_length(
+    headers: &[quiche::h3::Header],
+) -> Result<Option<usize>, (http::StatusCode, &'static [u8], bool)> {
+    let mut content_length = None;
+    for header in headers {
+        if !header.name().eq_ignore_ascii_case(b"content-length") {
+            continue;
+        }
+        let parsed = parse_content_length_value(header.value()).ok_or_else(|| {
+            (
+                http::StatusCode::BAD_REQUEST,
+                b"invalid content-length header\n" as &'static [u8],
+                false,
+            )
+        })?;
+        merge_content_length(&mut content_length, parsed)?;
+    }
+    Ok(content_length)
+}
+
+fn parse_http_content_length(
+    headers: &http::HeaderMap,
+) -> Result<Option<usize>, (http::StatusCode, &'static [u8], bool)> {
+    let mut content_length = None;
+    for value in headers.get_all(http::header::CONTENT_LENGTH) {
+        let parsed = parse_content_length_value(value.as_bytes()).ok_or_else(|| {
+            (
+                http::StatusCode::BAD_REQUEST,
+                b"invalid content-length header\n" as &'static [u8],
+                false,
+            )
+        })?;
+        merge_content_length(&mut content_length, parsed)?;
+    }
+    Ok(content_length)
 }
 
 pub(super) fn extract_header_value<'a>(
@@ -434,6 +494,70 @@ mod tests {
         };
         assert_eq!(err.0, http::StatusCode::BAD_REQUEST);
         assert_eq!(err.1, b"invalid host header\n");
+        assert!(!err.2);
+    }
+
+    #[test]
+    fn accepts_consistent_duplicate_content_length_headers() {
+        let resilience = runtime_resilience();
+        let headers = vec![
+            h3_header(b":method", b"POST"),
+            h3_header(b":path", b"/"),
+            h3_header(b":authority", b"example.com"),
+            h3_header(b"content-length", b"10"),
+            h3_header(b"content-length", b"10"),
+        ];
+
+        let request = validate_request_headers(&headers, &resilience)
+            .expect("consistent duplicate content-length should be accepted");
+        assert_eq!(request.content_length, Some(10));
+    }
+
+    #[test]
+    fn rejects_conflicting_duplicate_content_length_headers() {
+        let resilience = runtime_resilience();
+        let headers = vec![
+            h3_header(b":method", b"POST"),
+            h3_header(b":path", b"/"),
+            h3_header(b":authority", b"example.com"),
+            h3_header(b"content-length", b"10"),
+            h3_header(b"content-length", b"11"),
+        ];
+
+        let err = validate_request_headers(&headers, &resilience)
+            .expect_err("conflicting content-length must be rejected");
+        assert_eq!(err.0, http::StatusCode::BAD_REQUEST);
+        assert_eq!(err.1, b"conflicting content-length header\n");
+        assert!(!err.2);
+    }
+
+    #[test]
+    fn rejects_invalid_content_length_header() {
+        let resilience = runtime_resilience();
+        let headers = vec![
+            h3_header(b":method", b"POST"),
+            h3_header(b":path", b"/"),
+            h3_header(b":authority", b"example.com"),
+            h3_header(b"content-length", b"ten"),
+        ];
+
+        let err = validate_request_headers(&headers, &resilience)
+            .expect_err("invalid content-length must be rejected");
+        assert_eq!(err.0, http::StatusCode::BAD_REQUEST);
+        assert_eq!(err.1, b"invalid content-length header\n");
+        assert!(!err.2);
+    }
+
+    #[test]
+    fn http_header_map_rejects_conflicting_content_length_values() {
+        let mut headers = http::HeaderMap::new();
+        headers.append(http::header::CONTENT_LENGTH, http::HeaderValue::from_static("8"));
+        headers.append(http::header::CONTENT_LENGTH, http::HeaderValue::from_static("9"));
+
+        let err = parse_http_content_length(&headers)
+            .expect_err("conflicting content-length must be rejected");
+        assert_eq!(err.0, http::StatusCode::BAD_REQUEST);
+        assert_eq!(err.1, b"conflicting content-length header\n");
         assert!(!err.2);
     }
 }

--- a/crates/edge/src/quic_listener/validation.rs
+++ b/crates/edge/src/quic_listener/validation.rs
@@ -323,6 +323,12 @@ fn merge_content_length(
     }
 }
 
+const INVALID_CONTENT_LENGTH_ERROR: (http::StatusCode, &[u8], bool) = (
+    http::StatusCode::BAD_REQUEST,
+    b"invalid content-length header\n",
+    false,
+);
+
 fn parse_h3_content_length(
     headers: &[quiche::h3::Header],
 ) -> Result<Option<usize>, (http::StatusCode, &'static [u8], bool)> {
@@ -331,13 +337,8 @@ fn parse_h3_content_length(
         if !header.name().eq_ignore_ascii_case(b"content-length") {
             continue;
         }
-        let parsed = parse_content_length_value(header.value()).ok_or_else(|| {
-            (
-                http::StatusCode::BAD_REQUEST,
-                b"invalid content-length header\n" as &'static [u8],
-                false,
-            )
-        })?;
+        let parsed =
+            parse_content_length_value(header.value()).ok_or(INVALID_CONTENT_LENGTH_ERROR)?;
         merge_content_length(&mut content_length, parsed)?;
     }
     Ok(content_length)
@@ -348,13 +349,8 @@ fn parse_http_content_length(
 ) -> Result<Option<usize>, (http::StatusCode, &'static [u8], bool)> {
     let mut content_length = None;
     for value in headers.get_all(http::header::CONTENT_LENGTH) {
-        let parsed = parse_content_length_value(value.as_bytes()).ok_or_else(|| {
-            (
-                http::StatusCode::BAD_REQUEST,
-                b"invalid content-length header\n" as &'static [u8],
-                false,
-            )
-        })?;
+        let parsed =
+            parse_content_length_value(value.as_bytes()).ok_or(INVALID_CONTENT_LENGTH_ERROR)?;
         merge_content_length(&mut content_length, parsed)?;
     }
     Ok(content_length)
@@ -551,8 +547,14 @@ mod tests {
     #[test]
     fn http_header_map_rejects_conflicting_content_length_values() {
         let mut headers = http::HeaderMap::new();
-        headers.append(http::header::CONTENT_LENGTH, http::HeaderValue::from_static("8"));
-        headers.append(http::header::CONTENT_LENGTH, http::HeaderValue::from_static("9"));
+        headers.append(
+            http::header::CONTENT_LENGTH,
+            http::HeaderValue::from_static("8"),
+        );
+        headers.append(
+            http::header::CONTENT_LENGTH,
+            http::HeaderValue::from_static("9"),
+        );
 
         let err = parse_http_content_length(&headers)
             .expect_err("conflicting content-length must be rejected");

--- a/crates/edge/src/route_index.rs
+++ b/crates/edge/src/route_index.rs
@@ -507,7 +507,6 @@ pub(crate) fn scan_lookup_for_method<'a>(
             upstream.route.method.as_deref().map(str::trim),
             method.map(str::trim),
         ) {
-            (Some(""), _) => true,
             (Some(route_method), Some(request_method)) => {
                 route_method.eq_ignore_ascii_case(request_method)
             }

--- a/crates/edge/src/types.rs
+++ b/crates/edge/src/types.rs
@@ -98,13 +98,13 @@ pub struct QUICListener {
     pub unknown_length_response_prebuffer_bytes: usize,
     pub require_client_cert: bool,
 
-    pub recv_buf: [u8; MAX_DATAGRAM_SIZE_BYTES],
-    pub send_buf: [u8; MAX_DATAGRAM_SIZE_BYTES],
+    pub(crate) recv_buf: Box<[u8; MAX_DATAGRAM_SIZE_BYTES]>,
+    pub(crate) send_buf: Box<[u8; MAX_DATAGRAM_SIZE_BYTES]>,
 
-    pub connections: HashMap<Arc<[u8]>, QuicConnection>, // KEY: SCID(server connection id)
-    pub cid_routes: HashMap<Arc<[u8]>, Arc<[u8]>>,       // KEY: alias SCID, VALUE: primary SCID
-    pub peer_routes: HashMap<SocketAddr, Arc<[u8]>>,     // KEY: peer address, VALUE: primary SCID
-    pub cid_radix: CidRadix,
+    pub(crate) connections: HashMap<Arc<[u8]>, QuicConnection>, // KEY: SCID(server connection id)
+    pub(crate) cid_routes: HashMap<Arc<[u8]>, Arc<[u8]>>, // KEY: alias SCID, VALUE: primary SCID
+    pub(crate) peer_routes: HashMap<SocketAddr, Arc<[u8]>>, // KEY: peer address, VALUE: primary SCID
+    pub(crate) cid_radix: CidRadix,
     pub(crate) conn_rate_limiter: crate::quic_listener::TokenBucket,
 }
 
@@ -244,6 +244,24 @@ pub struct RequestEnvelope {
 impl RequestEnvelope {
     pub fn request_id(&self) -> u64 {
         self.request_id
+    }
+}
+
+impl QUICListener {
+    pub fn connections(&self) -> &HashMap<Arc<[u8]>, QuicConnection> {
+        &self.connections
+    }
+
+    pub fn cid_routes(&self) -> &HashMap<Arc<[u8]>, Arc<[u8]>> {
+        &self.cid_routes
+    }
+
+    pub fn peer_routes(&self) -> &HashMap<SocketAddr, Arc<[u8]>> {
+        &self.peer_routes
+    }
+
+    pub fn cid_radix(&self) -> &CidRadix {
+        &self.cid_radix
     }
 }
 

--- a/crates/edge/tests/h3_edge.rs
+++ b/crates/edge/tests/h3_edge.rs
@@ -432,7 +432,7 @@ fn run_h3_client_multiple_requests(
 }
 
 fn assert_cid_sync_invariants(listener: &QUICListener) {
-    for (primary_key, connection) in &listener.connections {
+    for (primary_key, connection) in listener.connections() {
         assert_eq!(
             primary_key.as_ref(),
             connection.primary_scid.as_ref(),
@@ -441,7 +441,7 @@ fn assert_cid_sync_invariants(listener: &QUICListener) {
 
         for cid in &connection.routing_scids {
             let matched = listener
-                .cid_radix
+                .cid_radix()
                 .longest_prefix_match(cid.as_ref())
                 .unwrap_or_else(|| panic!("missing CID in radix: {}", hex::encode(cid)));
             assert_eq!(
@@ -452,12 +452,12 @@ fn assert_cid_sync_invariants(listener: &QUICListener) {
 
             if cid.as_ref() == connection.primary_scid.as_ref() {
                 assert!(
-                    !listener.cid_routes.contains_key(cid.as_ref()),
+                    !listener.cid_routes().contains_key(cid.as_ref()),
                     "primary SCID must not be present in alias map"
                 );
             } else {
                 let mapped_primary = listener
-                    .cid_routes
+                    .cid_routes()
                     .get(cid.as_ref())
                     .unwrap_or_else(|| panic!("alias CID missing mapping: {}", hex::encode(cid)));
                 assert_eq!(
@@ -469,13 +469,13 @@ fn assert_cid_sync_invariants(listener: &QUICListener) {
         }
     }
 
-    for (alias, primary) in &listener.cid_routes {
+    for (alias, primary) in listener.cid_routes() {
         assert_ne!(
             alias.as_ref(),
             primary.as_ref(),
             "alias route must not map a primary to itself"
         );
-        let connection = listener.connections.get(primary).unwrap_or_else(|| {
+        let connection = listener.connections().get(primary).unwrap_or_else(|| {
             panic!(
                 "alias points to missing primary connection: alias={} primary={}",
                 hex::encode(alias),
@@ -611,19 +611,19 @@ fn send_udp(to: std::net::SocketAddr, payload: &[u8]) {
 
 fn assert_maps_empty(listener: &QUICListener) {
     assert!(
-        listener.connections.is_empty(),
+        listener.connections().is_empty(),
         "connections map must be empty after malformed traffic, had {} entries",
-        listener.connections.len()
+        listener.connections().len()
     );
     assert!(
-        listener.cid_routes.is_empty(),
+        listener.cid_routes().is_empty(),
         "cid_routes must be empty after malformed traffic, had {} entries",
-        listener.cid_routes.len()
+        listener.cid_routes().len()
     );
     assert!(
-        listener.peer_routes.is_empty(),
+        listener.peer_routes().is_empty(),
         "peer_routes must be empty after malformed traffic, had {} entries",
-        listener.peer_routes.len()
+        listener.peer_routes().len()
     );
 }
 
@@ -915,9 +915,9 @@ fn connection_flood_is_rate_limited() {
     // With burst=1 only the very first packet can create a connection.
     // All subsequent ones are dropped by the rate limiter.
     assert!(
-        listener.connections.len() <= 1,
+        listener.connections().len() <= 1,
         "rate limiter must cap connections at burst=1, got {}",
-        listener.connections.len()
+        listener.connections().len()
     );
 }
 
@@ -941,9 +941,9 @@ fn active_connection_cap_rejects_excess_initial_packets() {
     }
 
     assert!(
-        listener.connections.len() <= 1,
+        listener.connections().len() <= 1,
         "active connection cap must keep at most one connection, got {}",
-        listener.connections.len()
+        listener.connections().len()
     );
     assert!(
         listener
@@ -972,7 +972,7 @@ fn draining_mode_rejects_initial_when_no_connections_exist() {
     listener.poll();
 
     assert_eq!(
-        listener.connections.len(),
+        listener.connections().len(),
         0,
         "no new connection should be admitted after drain starts"
     );
@@ -992,12 +992,12 @@ fn draining_mode_rejects_new_initial_after_existing_connection() {
     send_udp(addr, &first);
     listener.poll();
     assert_eq!(
-        listener.connections.len(),
+        listener.connections().len(),
         1,
         "first Initial should create a baseline connection before drain"
     );
     let known_connection_ids: std::collections::HashSet<Vec<u8>> = listener
-        .connections
+        .connections()
         .keys()
         .map(|cid| cid.to_vec())
         .collect();
@@ -1011,7 +1011,7 @@ fn draining_mode_rejects_new_initial_after_existing_connection() {
     }
 
     let post_drain_ids: std::collections::HashSet<Vec<u8>> = listener
-        .connections
+        .connections()
         .keys()
         .map(|cid| cid.to_vec())
         .collect();
@@ -1040,7 +1040,7 @@ fn normal_traffic_below_rate_limit_is_unaffected() {
     }
 
     assert_eq!(
-        listener.connections.len(),
+        listener.connections().len(),
         REQUEST_COUNT,
         "all {} connections should be accepted when below rate limit",
         REQUEST_COUNT
@@ -1234,18 +1234,18 @@ fn lifecycle_churn_leaves_no_orphaned_state() {
     let guard = listener.lock().expect("listener lock");
     assert_cid_sync_invariants(&guard);
     assert!(
-        guard.connections.is_empty(),
+        guard.connections().is_empty(),
         "connections must be empty after churn, found {} entries",
-        guard.connections.len()
+        guard.connections().len()
     );
     assert!(
-        guard.cid_routes.is_empty(),
+        guard.cid_routes().is_empty(),
         "cid_routes must be empty after churn, found {} entries",
-        guard.cid_routes.len()
+        guard.cid_routes().len()
     );
     assert!(
-        guard.peer_routes.is_empty(),
+        guard.peer_routes().is_empty(),
         "peer_routes must be empty after churn, found {} entries",
-        guard.peer_routes.len()
+        guard.peer_routes().len()
     );
 }

--- a/crates/utils/src/logger.rs
+++ b/crates/utils/src/logger.rs
@@ -2,13 +2,53 @@ use std::{
     fs::{OpenOptions, create_dir_all},
     io::Write,
     path::Path,
+    sync::{
+        Mutex, OnceLock,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
 use env_logger::{Builder, Target};
 use log::LevelFilter;
 use serde_json::json;
 
+static LOGGER_INIT_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+static LOGGER_INITIALIZED: AtomicBool = AtomicBool::new(false);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LoggerInitStatus {
+    Initialized,
+    AlreadyInitialized,
+}
+
 pub fn init_logger(log_level: &str, log_enabled: bool, log_file: &str, json: bool) {
+    let _ = try_init_logger(log_level, log_enabled, log_file, json);
+}
+
+pub fn try_init_logger(
+    log_level: &str,
+    log_enabled: bool,
+    log_file: &str,
+    json: bool,
+) -> LoggerInitStatus {
+    let mutex = LOGGER_INIT_MUTEX.get_or_init(|| Mutex::new(()));
+    let _guard = mutex.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    if LOGGER_INITIALIZED.load(Ordering::Acquire) {
+        return LoggerInitStatus::AlreadyInitialized;
+    }
+
+    let status = configure_and_init_logger(log_level, log_enabled, log_file, json);
+    LOGGER_INITIALIZED.store(true, Ordering::Release);
+    status
+}
+
+fn configure_and_init_logger(
+    log_level: &str,
+    log_enabled: bool,
+    log_file: &str,
+    json: bool,
+) -> LoggerInitStatus {
     let level = match log_level.to_lowercase().as_str() {
         "whisper" => LevelFilter::Trace,
         "haunt" => LevelFilter::Debug,
@@ -62,8 +102,7 @@ pub fn init_logger(log_level: &str, log_enabled: bool, log_file: &str, json: boo
                 parent.display(),
                 err
             );
-            builder.init();
-            return;
+            return try_init_builder(builder);
         }
 
         let file = match OpenOptions::new().create(true).append(true).open(log_file) {
@@ -73,8 +112,7 @@ pub fn init_logger(log_level: &str, log_enabled: bool, log_file: &str, json: boo
                     "Failed to open log file '{}': {}. Falling back to stderr logging.",
                     log_file, err
                 );
-                builder.init();
-                return;
+                return try_init_builder(builder);
             }
         };
 
@@ -82,5 +120,25 @@ pub fn init_logger(log_level: &str, log_enabled: bool, log_file: &str, json: boo
     }
     // else → default (stderr)
 
-    builder.init();
+    try_init_builder(builder)
+}
+
+fn try_init_builder(mut builder: Builder) -> LoggerInitStatus {
+    match builder.try_init() {
+        Ok(()) => LoggerInitStatus::Initialized,
+        Err(_) => LoggerInitStatus::AlreadyInitialized,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LoggerInitStatus, try_init_logger};
+
+    #[test]
+    fn logger_init_is_idempotent() {
+        let _first = try_init_logger("info", false, "", false);
+
+        let second = try_init_logger("debug", true, "/tmp/ignored.log", true);
+        assert_eq!(second, LoggerInitStatus::AlreadyInitialized);
+    }
 }

--- a/crates/utils/src/logger.rs
+++ b/crates/utils/src/logger.rs
@@ -32,7 +32,9 @@ pub fn try_init_logger(
     json: bool,
 ) -> LoggerInitStatus {
     let mutex = LOGGER_INIT_MUTEX.get_or_init(|| Mutex::new(()));
-    let _guard = mutex.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _guard = mutex
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
 
     if LOGGER_INITIALIZED.load(Ordering::Acquire) {
         return LoggerInitStatus::AlreadyInitialized;

--- a/spooky/src/privilege_drop.rs
+++ b/spooky/src/privilege_drop.rs
@@ -1,27 +1,103 @@
 #[cfg(unix)]
 pub fn drop_privileges(user: &str, group: &str) -> Result<(), String> {
-    use std::ffi::CString;
+    use std::{ffi::CString, io};
+
+    const DEFAULT_LOOKUP_BUF_LEN: usize = 16 * 1024;
+    const MAX_LOOKUP_BUF_LEN: usize = 1024 * 1024;
+
+    fn initial_lookup_buf_len(selector: libc::c_int) -> usize {
+        let size = unsafe {
+            // SAFETY: sysconf is thread-safe and does not require additional invariants.
+            libc::sysconf(selector)
+        };
+        if size > 0 {
+            size as usize
+        } else {
+            DEFAULT_LOOKUP_BUF_LEN
+        }
+    }
+
+    fn lookup_group_gid(c_group: &CString, group: &str) -> Result<libc::gid_t, String> {
+        let mut buf_len = initial_lookup_buf_len(libc::_SC_GETGR_R_SIZE_MAX);
+        loop {
+            let mut entry = std::mem::MaybeUninit::<libc::group>::uninit();
+            let mut result: *mut libc::group = std::ptr::null_mut();
+            let mut buf = vec![0 as libc::c_char; buf_len];
+            let rc = unsafe {
+                // SAFETY: pointers are valid for the provided buffer and output slots.
+                libc::getgrnam_r(
+                    c_group.as_ptr(),
+                    entry.as_mut_ptr(),
+                    buf.as_mut_ptr(),
+                    buf.len(),
+                    &mut result,
+                )
+            };
+            if rc == 0 {
+                if result.is_null() {
+                    return Err(format!("group '{}' not found", group));
+                }
+                let entry = unsafe {
+                    // SAFETY: successful lookup initializes `entry`.
+                    entry.assume_init()
+                };
+                return Ok(entry.gr_gid);
+            }
+            if rc == libc::ERANGE && buf_len < MAX_LOOKUP_BUF_LEN {
+                buf_len = (buf_len * 2).min(MAX_LOOKUP_BUF_LEN);
+                continue;
+            }
+            return Err(format!(
+                "failed to resolve group '{}': {}",
+                group,
+                io::Error::from_raw_os_error(rc)
+            ));
+        }
+    }
+
+    fn lookup_user_uid(c_user: &CString, user: &str) -> Result<libc::uid_t, String> {
+        let mut buf_len = initial_lookup_buf_len(libc::_SC_GETPW_R_SIZE_MAX);
+        loop {
+            let mut entry = std::mem::MaybeUninit::<libc::passwd>::uninit();
+            let mut result: *mut libc::passwd = std::ptr::null_mut();
+            let mut buf = vec![0 as libc::c_char; buf_len];
+            let rc = unsafe {
+                // SAFETY: pointers are valid for the provided buffer and output slots.
+                libc::getpwnam_r(
+                    c_user.as_ptr(),
+                    entry.as_mut_ptr(),
+                    buf.as_mut_ptr(),
+                    buf.len(),
+                    &mut result,
+                )
+            };
+            if rc == 0 {
+                if result.is_null() {
+                    return Err(format!("user '{}' not found", user));
+                }
+                let entry = unsafe {
+                    // SAFETY: successful lookup initializes `entry`.
+                    entry.assume_init()
+                };
+                return Ok(entry.pw_uid);
+            }
+            if rc == libc::ERANGE && buf_len < MAX_LOOKUP_BUF_LEN {
+                buf_len = (buf_len * 2).min(MAX_LOOKUP_BUF_LEN);
+                continue;
+            }
+            return Err(format!(
+                "failed to resolve user '{}': {}",
+                user,
+                io::Error::from_raw_os_error(rc)
+            ));
+        }
+    }
 
     let c_group = CString::new(group).map_err(|_| "group contains NUL byte".to_string())?;
     let c_user = CString::new(user).map_err(|_| "user contains NUL byte".to_string())?;
 
-    let gid = unsafe {
-        // SAFETY: libc lookup is read-only; pointer is checked for null below.
-        let grp = libc::getgrnam(c_group.as_ptr());
-        if grp.is_null() {
-            return Err(format!("group '{}' not found", group));
-        }
-        (*grp).gr_gid
-    };
-
-    let uid = unsafe {
-        // SAFETY: libc lookup is read-only; pointer is checked for null below.
-        let pwd = libc::getpwnam(c_user.as_ptr());
-        if pwd.is_null() {
-            return Err(format!("user '{}' not found", user));
-        }
-        (*pwd).pw_uid
-    };
+    let gid = lookup_group_gid(&c_group, group)?;
+    let uid = lookup_user_uid(&c_user, user)?;
 
     let clear_groups_rc = unsafe {
         // SAFETY: passing null pointer with length 0 clears supplementary groups.
@@ -32,7 +108,7 @@ pub fn drop_privileges(user: &str, group: &str) -> Result<(), String> {
     }
 
     let setgid_rc = unsafe {
-        // SAFETY: gid resolved from getgrnam above.
+        // SAFETY: gid resolved from getgrnam_r above.
         libc::setgid(gid)
     };
     if setgid_rc != 0 {
@@ -40,7 +116,7 @@ pub fn drop_privileges(user: &str, group: &str) -> Result<(), String> {
     }
 
     let setuid_rc = unsafe {
-        // SAFETY: uid resolved from getpwnam above.
+        // SAFETY: uid resolved from getpwnam_r above.
         libc::setuid(uid)
     };
     if setuid_rc != 0 {


### PR DESCRIPTION
Ref: #164 , #165 , #166 , #167 , #168 , #171 

## Summary
This PR fixes six reliability/safety issues across edge, utils, and spooky runtime code:

- make logger initialization idempotent to avoid repeated-init instability
- remove an unreachable empty-route-method branch in route scanning
- encapsulate QUIC listener routing internals and heap-allocate large datagram buffers
- replace non-reentrant privilege account/group lookups with reentrant libc `_r` variants
- harden token bucket refill math and document precision/cap behavior
- enforce strict duplicate `Content-Length` handling (reject malformed/conflicting duplicates)

## Changes

### 1) Logger init idempotency
- Added guarded one-time initialization flow in `crates/utils/src/logger.rs`.
- Repeated init calls now return controlled `AlreadyInitialized` behavior instead of panicking/failing unpredictably.
- Added regression test for repeated initialization behavior.

### 2) Dead empty-method route branch removal
- Removed unreachable `(Some(\"\"), _)` branch in `crates/edge/src/route_index.rs`.
- Route scan logic remains aligned with validated config assumptions.

### 3) QUICListener surface reduction + buffer ownership cleanup
- In `crates/edge/src/types.rs`:
  - moved large datagram buffers to `Box<[u8; MAX_DATAGRAM_SIZE_BYTES]>`
  - reduced direct exposure of routing state maps (`connections`, `cid_routes`, `peer_routes`, `cid_radix`) to crate visibility
  - added read-only accessors for test/inspection use
- Updated construction/usage call sites in `crates/edge/src/quic_listener/mod.rs`.
- Updated integration test usage in `crates/edge/tests/h3_edge.rs` to use accessors.

### 4) Reentrant privilege lookups
- In `spooky/src/privilege_drop.rs`, replaced `getgrnam/getpwnam` with `getgrnam_r/getpwnam_r`.
- Added robust buffer sizing/retry-on-`ERANGE` handling and preserved existing error semantics.

### 5) Token bucket arithmetic hardening
- In `crates/edge/src/quic_listener/token_bucket.rs`, switched refill math from ns->f64 multiplication to seconds-based refill with explicit finite handling and burst clamping.
- Added long-idle refill regression coverage.

### 6) Strict duplicate `Content-Length` validation
- In `crates/edge/src/quic_listener/validation.rs`:
  - added strict parsing/merge helpers for content-length
  - rejects invalid values
  - rejects conflicting duplicates
  - accepts consistent duplicates
- Extended `RequestValidationResult` to carry normalized `content_length`.
- Wired request setup in `crates/edge/src/quic_listener/mod.rs` to use validated content length for H3 and bootstrap HTTP paths.
- Added targeted unit tests for duplicate/conflicting/invalid cases.