### PR TITLE
fix(upstream_tls): allow verify_certificates=false for backends with self-signed certs

### DIFF
--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -1435,7 +1435,7 @@ upstream:
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.upstream_tls.verify_certificates = false;
-        assert!(!validate(&cfg));
+        assert!(validate(&cfg));
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.upstream_tls.ca_file = Some("/path/does/not/exist.pem".to_string());

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -826,10 +826,9 @@ pub fn validate(config: &Config) -> bool {
 
     // --- Validate upstream TLS trust-store configuration ---
     if !config.upstream_tls.verify_certificates {
-        error!(
-            "upstream_tls.verify_certificates=false is not allowed; certificate verification must remain enabled"
+        warn!(
+            "upstream_tls.verify_certificates=false: upstream TLS certificate verification is disabled; only use in trusted/development environments"
         );
-        return false;
     }
 
     if let Some(ca_file) = config.upstream_tls.ca_file.as_ref() {

--- a/crates/edge/src/quic_listener/forwarding.rs
+++ b/crates/edge/src/quic_listener/forwarding.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::error::Error as StdError;
 
 #[derive(Clone)]
 pub(super) struct ForwardRequestMeta {
@@ -67,6 +68,17 @@ pub(crate) fn abort_stream(req: &mut RequestEnvelope, metrics: &Metrics) -> Stre
 impl QUICListener {
     fn send_error_health_failure_reason() -> Option<HealthFailureReason> {
         None
+    }
+
+    fn format_error_chain(err: &(dyn StdError + 'static)) -> String {
+        let mut detail = err.to_string();
+        let mut source = err.source();
+        while let Some(cause) = source {
+            detail.push_str(": ");
+            detail.push_str(&cause.to_string());
+            source = cause.source();
+        }
+        detail
     }
 
     fn is_internal_pool_control_error(error: &PoolError) -> bool {
@@ -285,9 +297,10 @@ impl QUICListener {
                 // that look like transport failures but are actually local config errors.
                 // Do NOT mark backend health as failed: the backend may be fully operational;
                 // this path is usually a local proxy configuration/runtime issue.
+                let send_err_detail = Self::format_error_chain(send_err);
                 error!(
                     "Upstream send failed for {} (possible TLS/cert/SNI misconfiguration): {}",
-                    backend_addr, send_err
+                    backend_addr, send_err_detail
                 );
                 if let Some(reason) = Self::send_error_health_failure_reason() {
                     metrics.inc_health_failure(reason);
@@ -525,5 +538,37 @@ mod tests {
     #[test]
     fn send_error_does_not_map_to_backend_health_failure_reason() {
         assert_eq!(QUICListener::send_error_health_failure_reason(), None);
+    }
+
+    #[derive(Debug)]
+    struct OuterErr(InnerErr);
+
+    #[derive(Debug)]
+    struct InnerErr;
+
+    impl std::fmt::Display for OuterErr {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "outer")
+        }
+    }
+
+    impl std::fmt::Display for InnerErr {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "inner")
+        }
+    }
+
+    impl StdError for OuterErr {
+        fn source(&self) -> Option<&(dyn StdError + 'static)> {
+            Some(&self.0)
+        }
+    }
+
+    impl StdError for InnerErr {}
+
+    #[test]
+    fn format_error_chain_includes_nested_causes() {
+        let msg = QUICListener::format_error_chain(&OuterErr(InnerErr));
+        assert_eq!(msg, "outer: inner");
     }
 }

--- a/crates/transport/src/h2_client.rs
+++ b/crates/transport/src/h2_client.rs
@@ -4,6 +4,7 @@ use std::fs::File;
 use std::future::Future;
 use std::io::BufReader;
 use std::path::Path;
+use std::sync::Arc;
 use std::time::Duration;
 
 use http_body_util::combinators::BoxBody;
@@ -11,8 +12,10 @@ use hyper::body::Bytes;
 use hyper::{Request, rt::Executor};
 use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
 use hyper_util::client::legacy::{Client, connect::HttpConnector};
-use rustls::pki_types::CertificateDer;
-use rustls::{ClientConfig, RootCertStore};
+
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::{ClientConfig, DigitallySignedStruct, RootCertStore, SignatureScheme};
 
 #[derive(Debug, Clone)]
 pub struct TlsClientConfig {
@@ -96,10 +99,16 @@ impl H2Client {
 
 fn build_tls_config(tls: &TlsClientConfig) -> Result<ClientConfig, String> {
     if !tls.verify_certificates {
-        return Err(
-            "upstream_tls.verify_certificates=false is not allowed; enable certificate verification"
-                .to_string(),
+        eprintln!(
+            "upstream TLS certificate verification is disabled (upstream_tls.verify_certificates=false); this is insecure and should only be used in trusted environments"
         );
+        let mut cfg = ClientConfig::builder()
+            .with_root_certificates(RootCertStore::empty())
+            .with_no_client_auth();
+        cfg.enable_sni = tls.strict_sni;
+        cfg.dangerous()
+            .set_certificate_verifier(Arc::new(InsecureServerCertVerifier));
+        return Ok(cfg);
     }
 
     let mut roots = RootCertStore::empty();
@@ -207,6 +216,54 @@ fn is_pem_like_path(path: &Path) -> bool {
     )
 }
 
+#[derive(Debug)]
+struct InsecureServerCertVerifier;
+
+impl ServerCertVerifier for InsecureServerCertVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        vec![
+            SignatureScheme::RSA_PKCS1_SHA256,
+            SignatureScheme::RSA_PKCS1_SHA384,
+            SignatureScheme::RSA_PKCS1_SHA512,
+            SignatureScheme::ECDSA_NISTP256_SHA256,
+            SignatureScheme::ECDSA_NISTP384_SHA384,
+            SignatureScheme::RSA_PSS_SHA256,
+            SignatureScheme::RSA_PSS_SHA384,
+            SignatureScheme::RSA_PSS_SHA512,
+            SignatureScheme::ED25519,
+        ]
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{H2Client, TlsClientConfig};
@@ -247,7 +304,7 @@ mod tests {
     }
 
     #[test]
-    fn disabling_certificate_verification_is_rejected() {
+    fn disabling_certificate_verification_is_allowed() {
         let client = H2Client::new(
             8,
             Duration::from_secs(5),
@@ -259,6 +316,6 @@ mod tests {
                 ca_dir: None,
             },
         );
-        assert!(client.is_err());
+        assert!(client.is_ok());
     }
 }

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -98,8 +98,8 @@ Copy your certificate and private key into the certs directory and set correct o
 sudo cp /path/to/fullchain.pem /etc/spooky/certs/fullchain.pem
 sudo cp /path/to/privkey.pem   /etc/spooky/certs/privkey.pem
 
-# Set ownership and permissions
-sudo chown spooky:spooky /etc/spooky/certs/fullchain.pem /etc/spooky/certs/privkey.pem
+# Set ownership and permissions (root owns, spooky group can read)
+sudo chown root:spooky /etc/spooky/certs/fullchain.pem /etc/spooky/certs/privkey.pem
 sudo chmod 640 /etc/spooky/certs/fullchain.pem /etc/spooky/certs/privkey.pem
 ```
 
@@ -120,7 +120,7 @@ If you are building from source and want to use the included development certifi
 sudo cp certs/proxy-fullchain.pem /etc/spooky/certs/fullchain.pem
 sudo cp certs/proxy-key-pkcs8.pem /etc/spooky/certs/privkey.pem
 
-sudo chown spooky:spooky /etc/spooky/certs/fullchain.pem /etc/spooky/certs/privkey.pem
+sudo chown root:spooky /etc/spooky/certs/fullchain.pem /etc/spooky/certs/privkey.pem
 sudo chmod 640 /etc/spooky/certs/fullchain.pem /etc/spooky/certs/privkey.pem
 ```
 
@@ -148,7 +148,7 @@ openssl req -x509 -newkey rsa:4096 -nodes \
 
 sudo mv /tmp/fullchain.pem /etc/spooky/certs/fullchain.pem
 sudo mv /tmp/privkey.pem   /etc/spooky/certs/privkey.pem
-sudo chown spooky:spooky /etc/spooky/certs/fullchain.pem /etc/spooky/certs/privkey.pem
+sudo chown root:spooky /etc/spooky/certs/fullchain.pem /etc/spooky/certs/privkey.pem
 sudo chmod 640 /etc/spooky/certs/fullchain.pem /etc/spooky/certs/privkey.pem
 ```
 
@@ -345,7 +345,7 @@ sudo install -m 0640 -o spooky -g spooky packaging/deb/debian/config.yaml /etc/s
 **`Permission denied` on TLS key/cert:**
 The `spooky` user cannot read the certificate files. Fix ownership and permissions:
 ```bash
-sudo chown spooky:spooky /etc/spooky/certs/fullchain.pem /etc/spooky/certs/privkey.pem
+sudo chown root:spooky /etc/spooky/certs/fullchain.pem /etc/spooky/certs/privkey.pem
 sudo chmod 640 /etc/spooky/certs/fullchain.pem /etc/spooky/certs/privkey.pem
 sudo systemctl restart spooky
 ```

--- a/packaging/deb/make-deb.sh
+++ b/packaging/deb/make-deb.sh
@@ -18,7 +18,7 @@ cd "$REPO_ROOT"
 
 # ---- defaults --------------------------------------------------------------
 PKG_NAME="spooky"
-PKG_VERSION="0.1.0-beta"
+PKG_VERSION="0.1.1-beta"
 PKG_ARCH="amd64"
 SKIP_BUILD=0
 


### PR DESCRIPTION
## Summary

- Introduces `InsecureServerCertVerifier` in `h2_client.rs` so that `upstream_tls.verify_certificates: false` skips TLS certificate verification for upstream connections instead of hard-failing at startup
- Downgrades the validator rejection for `verify_certificates: false` from a fatal error to a `warn` log, matching the behavior of Nginx (`proxy_ssl_verify off`) and Envoy (`ACCEPT_UNTRUSTED`)
- Expands the upstream send error log with the full error cause chain via `format_error_chain`, so TLS failures (missing SAN, untrusted root, etc.) surface the underlying rustls reason instead of the opaque `client error (Connect)`