### PR TITLE
fix: log insecure upstream TLS warning

### DIFF
--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -10,6 +10,7 @@ http-body-util.workspace = true
 hyper.workspace = true
 hyper-util.workspace = true
 hyper-rustls.workspace = true
+log.workspace = true
 rustls.workspace = true
 rustls-pemfile.workspace = true
 tokio.workspace = true

--- a/crates/transport/src/h2_client.rs
+++ b/crates/transport/src/h2_client.rs
@@ -13,6 +13,7 @@ use hyper::{Request, rt::Executor};
 use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
 use hyper_util::client::legacy::{Client, connect::HttpConnector};
 
+use log::warn;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
 use rustls::{ClientConfig, DigitallySignedStruct, RootCertStore, SignatureScheme};
@@ -99,7 +100,7 @@ impl H2Client {
 
 fn build_tls_config(tls: &TlsClientConfig) -> Result<ClientConfig, String> {
     if !tls.verify_certificates {
-        eprintln!(
+        warn!(
             "upstream TLS certificate verification is disabled (upstream_tls.verify_certificates=false); this is insecure and should only be used in trusted environments"
         );
         let mut cfg = ClientConfig::builder()


### PR DESCRIPTION
## Summary

Replace the raw stderr warning emitted when `upstream_tls.verify_certificates=false` is used with the project logger. The transport crate now depends on the workspace `log` crate and calls `warn!`, so the warning flows through the same logging configuration as the rest of Spooky instead of bypassing structured/file logging.

This keeps the existing security warning text and TLS behavior unchanged; it only changes how the warning is emitted.

Closes #194

## Verification

- `git diff --check`
- `cargo fmt --check -p spooky-transport`
- `cargo test -p spooky-transport`
