### PR TITLE
fix(config): reject ambiguous route conflicts and invalid backend hostnames at startup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,6 @@ opentelemetry_sdk = { version = "0.28.0", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.28.0", features = ["grpc-tonic", "trace"] }
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "GPLv3"

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -9,6 +9,7 @@ log.workspace = true
 serde.workspace = true
 serde_yml.workspace = true
 rustls-pemfile.workspace = true
+idna = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/config/src/backend_endpoint.rs
+++ b/crates/config/src/backend_endpoint.rs
@@ -1,3 +1,5 @@
+use std::net::IpAddr;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BackendScheme {
     Http,
@@ -98,6 +100,52 @@ fn normalize_authority(authority: &str, scheme: BackendScheme) -> String {
     authority.to_string()
 }
 
+
+fn validate_dns_hostname(host: &str) -> Result<(), String> {
+    let trimmed = host.trim();
+    if trimmed.is_empty() {
+        return Err("backend host is empty".to_string());
+    }
+
+    // Fast-path valid IP literals and localhost aliases.
+    if trimmed.eq_ignore_ascii_case("localhost") || trimmed.parse::<IpAddr>().is_ok() {
+        return Ok(());
+    }
+
+    let without_trailing_dot = trimmed.trim_end_matches('.');
+    if without_trailing_dot.is_empty() {
+        return Err("backend host is invalid".to_string());
+    }
+
+    // Enforce IDNA/UTS#46 conversion and reject malformed Unicode hostnames.
+    let ascii = idna::domain_to_ascii(without_trailing_dot)
+        .map_err(|_| "backend host is not a valid IDNA/DNS hostname".to_string())?;
+
+    if ascii.len() > 253 {
+        return Err("backend host exceeds maximum length (253)".to_string());
+    }
+
+    for label in ascii.split('.') {
+        if label.is_empty() {
+            return Err("backend host contains empty DNS label".to_string());
+        }
+        if label.len() > 63 {
+            return Err("backend host contains DNS label longer than 63 characters".to_string());
+        }
+        if label.starts_with('-') || label.ends_with('-') {
+            return Err("backend host DNS labels must not start or end with '-'".to_string());
+        }
+        if !label
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-')
+        {
+            return Err("backend host contains invalid DNS label characters".to_string());
+        }
+    }
+
+    Ok(())
+}
+
 fn validate_authority(authority: &str) -> Result<(), String> {
     if authority.chars().any(|ch| ch.is_ascii_whitespace()) {
         return Err("backend authority must not contain whitespace".to_string());
@@ -133,6 +181,8 @@ fn validate_authority(authority: &str) -> Result<(), String> {
     if host.is_empty() {
         return Err("backend host is empty".to_string());
     }
+
+    validate_dns_hostname(host)?;
 
     if port_str.is_empty() {
         return Err("backend port is empty".to_string());
@@ -188,6 +238,22 @@ mod tests {
         assert!(BackendEndpoint::parse("127.0.0.1:abc").is_err());
         assert!(BackendEndpoint::parse("::1:443").is_err());
         assert!(BackendEndpoint::parse("https://:443").is_err());
+    }
+
+
+    #[test]
+    fn parse_rejects_malformed_dns_hostnames() {
+        assert!(BackendEndpoint::parse("bad_host:443").is_err());
+        assert!(BackendEndpoint::parse("-bad.example.com:443").is_err());
+        assert!(BackendEndpoint::parse("bad-.example.com:443").is_err());
+        assert!(BackendEndpoint::parse("a..b.example.com:443").is_err());
+    }
+
+    #[test]
+    fn parse_accepts_idna_hostname() {
+        let endpoint = BackendEndpoint::parse("bücher.example:443").expect("idna host");
+        assert_eq!(endpoint.scheme(), BackendScheme::Https);
+        assert_eq!(endpoint.authority(), "bücher.example:443");
     }
 
     #[test]

--- a/crates/config/src/backend_endpoint.rs
+++ b/crates/config/src/backend_endpoint.rs
@@ -100,7 +100,6 @@ fn normalize_authority(authority: &str, scheme: BackendScheme) -> String {
     authority.to_string()
 }
 
-
 fn validate_dns_hostname(host: &str) -> Result<(), String> {
     let trimmed = host.trim();
     if trimmed.is_empty() {
@@ -239,7 +238,6 @@ mod tests {
         assert!(BackendEndpoint::parse("::1:443").is_err());
         assert!(BackendEndpoint::parse("https://:443").is_err());
     }
-
 
     #[test]
     fn parse_rejects_malformed_dns_hostnames() {

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -140,8 +140,6 @@ fn is_valid_http_token(value: &str) -> bool {
         })
 }
 
-
-
 fn normalize_route_host(raw: &str) -> String {
     let trimmed = raw.trim();
     let host = if let Some(rest) = trimmed.strip_prefix('[') {
@@ -1743,7 +1741,6 @@ upstream:
         assert!(!validate(&cfg));
     }
 
-
     #[test]
     fn rejects_ambiguous_route_matchers_with_same_host_path_and_method() {
         let dir = tempdir().expect("tempdir");
@@ -1775,7 +1772,8 @@ upstream:
                 health_check: None,
             }],
         };
-        cfg.upstream.insert("test_upstream_2".to_string(), duplicate);
+        cfg.upstream
+            .insert("test_upstream_2".to_string(), duplicate);
 
         assert!(!validate(&cfg));
     }
@@ -1811,9 +1809,9 @@ upstream:
                 health_check: None,
             }],
         };
-        cfg.upstream.insert("test_upstream_2".to_string(), post_route);
+        cfg.upstream
+            .insert("test_upstream_2".to_string(), post_route);
 
         assert!(validate(&cfg));
     }
-
 }

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -169,6 +169,8 @@ fn normalized_route_method(method: Option<&str>) -> Option<String> {
         .map(|value| value.to_ascii_uppercase())
 }
 
+type RouteMatcherKey = (Option<String>, Option<String>, Option<String>);
+
 pub fn validate(config: &Config) -> bool {
     info!("Starting configuration validation...");
 
@@ -928,8 +930,7 @@ pub fn validate(config: &Config) -> bool {
         return false;
     }
 
-    let mut seen_route_matchers: HashMap<(Option<String>, Option<String>, Option<String>), String> =
-        HashMap::new();
+    let mut seen_route_matchers: HashMap<RouteMatcherKey, String> = HashMap::new();
 
     for (upstream_name, upstream) in &config.upstream {
         let route_key = (

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -1,6 +1,7 @@
 use crate::backend_endpoint::{BackendEndpoint, BackendScheme};
 use crate::config::{CURRENT_CONFIG_VERSION, Config, SUPPORTED_CONFIG_VERSIONS};
 use log::{error, info, warn};
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufReader;
 use std::net::IpAddr;
@@ -137,6 +138,35 @@ fn is_valid_http_token(value: &str) -> bool {
                     | b'~'
             )
         })
+}
+
+
+
+fn normalize_route_host(raw: &str) -> String {
+    let trimmed = raw.trim();
+    let host = if let Some(rest) = trimmed.strip_prefix('[') {
+        if let Some(end) = rest.find(']') {
+            &rest[..end]
+        } else {
+            trimmed
+        }
+    } else if let Some((candidate_host, candidate_port)) = trimmed.rsplit_once(':') {
+        if !candidate_host.contains(':') && candidate_port.chars().all(|c| c.is_ascii_digit()) {
+            candidate_host
+        } else {
+            trimmed
+        }
+    } else {
+        trimmed
+    };
+    host.trim_end_matches('.').to_ascii_lowercase()
+}
+
+fn normalized_route_method(method: Option<&str>) -> Option<String> {
+    method
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| value.to_ascii_uppercase())
 }
 
 pub fn validate(config: &Config) -> bool {
@@ -898,8 +928,28 @@ pub fn validate(config: &Config) -> bool {
         return false;
     }
 
-    let mut seen_backend_origins: std::collections::HashMap<String, (String, String)> =
-        std::collections::HashMap::new();
+    let mut seen_route_matchers: HashMap<(Option<String>, Option<String>, Option<String>), String> =
+        HashMap::new();
+
+    for (upstream_name, upstream) in &config.upstream {
+        let route_key = (
+            upstream.route.host.as_deref().map(normalize_route_host),
+            upstream.route.path_prefix.clone(),
+            normalized_route_method(upstream.route.method.as_deref()),
+        );
+
+        if let Some(existing_upstream) =
+            seen_route_matchers.insert(route_key.clone(), upstream_name.clone())
+        {
+            error!(
+                "Ambiguous route matcher detected: upstream '{}' conflicts with upstream '{}' for host={:?} path_prefix={:?} method={:?}",
+                upstream_name, existing_upstream, route_key.0, route_key.1, route_key.2
+            );
+            return false;
+        }
+    }
+
+    let mut seen_backend_origins: HashMap<String, (String, String)> = HashMap::new();
 
     for (upstream_name, upstream) in &config.upstream {
         if upstream_name.is_empty() {
@@ -1691,4 +1741,78 @@ upstream:
         cfg.security.privileges.group = " ".to_string();
         assert!(!validate(&cfg));
     }
+
+
+    #[test]
+    fn rejects_ambiguous_route_matchers_with_same_host_path_and_method() {
+        let dir = tempdir().expect("tempdir");
+        let (cert, key) = write_test_certs(dir.path());
+
+        let mut cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        {
+            let upstream = cfg.upstream.get_mut("test_upstream").expect("upstream");
+            upstream.route.host = Some("API.EXAMPLE.COM:443".to_string());
+            upstream.route.path_prefix = Some("/api".to_string());
+            upstream.route.method = Some("get".to_string());
+            upstream.backends[0].address = "127.0.0.1:9001".to_string();
+        }
+
+        let duplicate = Upstream {
+            load_balancing: LoadBalancing {
+                lb_type: "round-robin".to_string(),
+                key: None,
+            },
+            route: RouteMatch {
+                host: Some("api.example.com".to_string()),
+                path_prefix: Some("/api".to_string()),
+                method: Some("GET".to_string()),
+            },
+            backends: vec![Backend {
+                id: "backend-2".to_string(),
+                address: "127.0.0.1:9002".to_string(),
+                weight: 1,
+                health_check: None,
+            }],
+        };
+        cfg.upstream.insert("test_upstream_2".to_string(), duplicate);
+
+        assert!(!validate(&cfg));
+    }
+
+    #[test]
+    fn allows_same_host_and_path_when_methods_differ() {
+        let dir = tempdir().expect("tempdir");
+        let (cert, key) = write_test_certs(dir.path());
+
+        let mut cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        {
+            let upstream = cfg.upstream.get_mut("test_upstream").expect("upstream");
+            upstream.route.host = Some("api.example.com".to_string());
+            upstream.route.path_prefix = Some("/api".to_string());
+            upstream.route.method = Some("GET".to_string());
+            upstream.backends[0].address = "127.0.0.1:9001".to_string();
+        }
+
+        let post_route = Upstream {
+            load_balancing: LoadBalancing {
+                lb_type: "round-robin".to_string(),
+                key: None,
+            },
+            route: RouteMatch {
+                host: Some("api.example.com".to_string()),
+                path_prefix: Some("/api".to_string()),
+                method: Some("POST".to_string()),
+            },
+            backends: vec![Backend {
+                id: "backend-2".to_string(),
+                address: "127.0.0.1:9002".to_string(),
+                weight: 1,
+                health_check: None,
+            }],
+        };
+        cfg.upstream.insert("test_upstream_2".to_string(), post_route);
+
+        assert!(validate(&cfg));
+    }
+
 }


### PR DESCRIPTION
## Summary

- **#188** — Config validator now detects and hard-rejects routes with identical
  `(host, path_prefix, method)` specificity instead of silently resolving via
  lexical tie-break. Startup fails with an explicit error naming both conflicting
  upstreams.
- **#197** — `BackendEndpoint::validate_authority` now runs full DNS hostname
  validation: IDNA/UTS#46 via `idna::domain_to_ascii`, label length (≤63),
  alphanumeric+hyphen-only chars, and no leading/trailing hyphens. Invalid
  hostnames are rejected at config load, not at connect time.

## Files changed

- `crates/config/src/validator.rs` — route conflict detection
- `crates/config/src/backend_endpoint.rs` — strict hostname validation
- `crates/config/Cargo.toml` — added `idna` dependency

Closes #188, Closes #197
