### PR TITLE
feat(edge): add wildcard host routing support in RouteIndex

### DIFF
--- a/crates/edge/src/quic_listener/validation.rs
+++ b/crates/edge/src/quic_listener/validation.rs
@@ -261,9 +261,9 @@ fn validate_request_parts(
         && let (Some(authority_value), Some(host_value)) = (authority.as_deref(), host.as_deref())
     {
         let normalized_authority = normalize_host_for_routing(authority_value)
-            .unwrap_or_else(|| authority_value.to_ascii_lowercase());
+            .unwrap_or_else(|| authority_value.to_ascii_lowercase().into());
         let normalized_host = normalize_host_for_routing(host_value)
-            .unwrap_or_else(|| host_value.to_ascii_lowercase());
+            .unwrap_or_else(|| host_value.to_ascii_lowercase().into());
         if normalized_authority != normalized_host {
             return Err((
                 http::StatusCode::BAD_REQUEST,

--- a/crates/edge/src/route_index.rs
+++ b/crates/edge/src/route_index.rs
@@ -40,6 +40,39 @@ pub(crate) fn normalize_host_for_routing(raw: &str) -> Option<String> {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum ConfiguredHostPattern {
+    Exact(String),
+    WildcardSuffix(String),
+}
+
+fn parse_configured_host_pattern(raw: &str) -> Option<ConfiguredHostPattern> {
+    let normalized = normalize_host_for_routing(raw)?;
+    let Some(wildcard_suffix) = normalized.strip_prefix("*.") else {
+        return Some(ConfiguredHostPattern::Exact(normalized));
+    };
+    if wildcard_suffix.is_empty() || wildcard_suffix.contains('*') {
+        return Some(ConfiguredHostPattern::Exact(format!("*.{wildcard_suffix}")));
+    }
+    Some(ConfiguredHostPattern::WildcardSuffix(
+        wildcard_suffix.to_string(),
+    ))
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+enum HostMatchKind {
+    Default,
+    Wildcard,
+    Exact,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct RouteCandidate {
+    route: IndexedRoute,
+    host_match_kind: HostMatchKind,
+    wildcard_suffix_len: usize,
+}
+
 /// Route precedence (deterministic):
 /// 1) Longest matching path_prefix wins.
 /// 2) On equal path length, host-specific routes win over host-agnostic routes.
@@ -62,6 +95,8 @@ enum RoutePreference {
     KeepCurrent,
     TakeCandidatePathLen,
     TakeCandidateHostSpecific,
+    TakeCandidateExactHost,
+    TakeCandidateWildcardSpecificity,
     TakeCandidateMethodSpecific,
     TakeCandidateLexicalOrder,
 }
@@ -228,6 +263,7 @@ fn prefix_boundary_matches(path: &str, prefix_len: usize) -> bool {
 
 pub(crate) struct RouteIndex {
     host_tries: HashMap<String, RouteTrie>,
+    wildcard_host_tries: HashMap<String, RouteTrie>,
     default_trie: RouteTrie,
     default_max_path_len: usize,
     upstream_names: Vec<String>,
@@ -237,6 +273,7 @@ pub(crate) struct RouteIndex {
 impl RouteIndex {
     pub(crate) fn from_upstreams(upstreams: &HashMap<String, Upstream>) -> Self {
         let mut host_tries = HashMap::new();
+        let mut wildcard_host_tries = HashMap::new();
         let mut default_trie = RouteTrie::default();
         let mut default_max_path_len = 0usize;
         let mut upstream_names = Vec::with_capacity(upstreams.len());
@@ -274,21 +311,17 @@ impl RouteIndex {
             };
 
             match upstream.route.host.as_deref() {
-                Some(host) => {
-                    let normalized_host = parsed_host_for_routing(host)
-                        .map(|value| {
-                            if host_has_uppercase_ascii(value) {
-                                value.to_ascii_lowercase()
-                            } else {
-                                value.to_string()
-                            }
-                        })
-                        .unwrap_or_else(|| host.to_ascii_lowercase());
-                    host_tries
+                Some(host) => match parse_configured_host_pattern(host) {
+                    Some(ConfiguredHostPattern::WildcardSuffix(suffix)) => wildcard_host_tries
+                        .entry(suffix)
+                        .or_insert_with(RouteTrie::default)
+                        .insert(upstream.route.path_prefix.as_deref(), route),
+                    Some(ConfiguredHostPattern::Exact(normalized_host)) => host_tries
                         .entry(normalized_host)
                         .or_insert_with(RouteTrie::default)
-                        .insert(upstream.route.path_prefix.as_deref(), route)
-                }
+                        .insert(upstream.route.path_prefix.as_deref(), route),
+                    None => {}
+                },
                 None => {
                     default_max_path_len = default_max_path_len.max(path_len);
                     default_trie.insert(upstream.route.path_prefix.as_deref(), route);
@@ -298,6 +331,7 @@ impl RouteIndex {
 
         Self {
             host_tries,
+            wildcard_host_tries,
             default_trie,
             default_max_path_len,
             upstream_names,
@@ -315,29 +349,27 @@ impl RouteIndex {
         host: Option<&str>,
         method: Option<&str>,
     ) -> Option<&'a str> {
-        let host_best = host.and_then(|raw_host| {
-            let parsed_host = parsed_host_for_routing(raw_host)?;
-            let host_trie = if host_has_uppercase_ascii(parsed_host) {
-                let normalized = parsed_host.to_ascii_lowercase();
-                self.host_tries.get(normalized.as_str())
-            } else {
-                self.host_tries.get(parsed_host)
-            }?;
-            host_trie.longest_prefix(path, method, &self.upstream_methods)
-        });
+        let host_best = host
+            .and_then(normalize_host_for_routing)
+            .and_then(|normalized_host| self.lookup_host_candidate(path, normalized_host, method));
 
         if let Some(best) = host_best
-            && best.path_len >= self.default_max_path_len
+            && best.route.path_len >= self.default_max_path_len
         {
-            return Some(self.upstream_names[best.upstream_idx].as_str());
+            return Some(self.upstream_names[best.route.upstream_idx].as_str());
         }
 
-        let best = prefer_route(
+        let best = prefer_route_candidate(
             self.default_trie
-                .longest_prefix(path, method, &self.upstream_methods),
+                .longest_prefix(path, method, &self.upstream_methods)
+                .map(|route| RouteCandidate {
+                    route,
+                    host_match_kind: HostMatchKind::Default,
+                    wildcard_suffix_len: 0,
+                }),
             host_best,
         );
-        best.map(|route| self.upstream_names[route.upstream_idx].as_str())
+        best.map(|candidate| self.upstream_names[candidate.route.upstream_idx].as_str())
     }
 
     #[allow(dead_code)]
@@ -438,6 +470,46 @@ impl RouteIndex {
             (None, None) => None,
         }
     }
+
+    fn lookup_host_candidate(
+        &self,
+        path: &str,
+        normalized_host: String,
+        method: Option<&str>,
+    ) -> Option<RouteCandidate> {
+        let exact_best = self
+            .host_tries
+            .get(normalized_host.as_str())
+            .and_then(|host_trie| host_trie.longest_prefix(path, method, &self.upstream_methods))
+            .map(|route| RouteCandidate {
+                route,
+                host_match_kind: HostMatchKind::Exact,
+                wildcard_suffix_len: 0,
+            });
+
+        let mut wildcard_best: Option<RouteCandidate> = None;
+        let mut remaining = normalized_host.as_str();
+        while let Some(dot_idx) = remaining.find('.') {
+            let suffix = &remaining[dot_idx + 1..];
+            if suffix.is_empty() {
+                break;
+            }
+
+            if let Some(trie) = self.wildcard_host_tries.get(suffix) {
+                let candidate = trie
+                    .longest_prefix(path, method, &self.upstream_methods)
+                    .map(|route| RouteCandidate {
+                        route,
+                        host_match_kind: HostMatchKind::Wildcard,
+                        wildcard_suffix_len: suffix.len(),
+                    });
+                wildcard_best = prefer_route_candidate(wildcard_best, candidate);
+            }
+            remaining = suffix;
+        }
+
+        prefer_route_candidate(wildcard_best, exact_best)
+    }
 }
 
 #[inline(always)]
@@ -455,6 +527,62 @@ fn prefer_route(
             | RoutePreference::TakeCandidateMethodSpecific
             | RoutePreference::TakeCandidateLexicalOrder => Some(candidate),
         },
+    }
+}
+
+#[inline(always)]
+fn prefer_route_candidate(
+    current: Option<RouteCandidate>,
+    candidate: Option<RouteCandidate>,
+) -> Option<RouteCandidate> {
+    match (current, candidate) {
+        (None, None) => None,
+        (Some(route), None) | (None, Some(route)) => Some(route),
+        (Some(current), Some(candidate)) => match compare_route_candidate(current, candidate) {
+            RoutePreference::KeepCurrent => Some(current),
+            RoutePreference::TakeCandidatePathLen
+            | RoutePreference::TakeCandidateHostSpecific
+            | RoutePreference::TakeCandidateExactHost
+            | RoutePreference::TakeCandidateWildcardSpecificity
+            | RoutePreference::TakeCandidateMethodSpecific
+            | RoutePreference::TakeCandidateLexicalOrder => Some(candidate),
+        },
+    }
+}
+
+#[inline(always)]
+fn compare_route_candidate(current: RouteCandidate, candidate: RouteCandidate) -> RoutePreference {
+    if candidate.route.path_len > current.route.path_len {
+        RoutePreference::TakeCandidatePathLen
+    } else if candidate.route.path_len == current.route.path_len
+        && candidate.route.host_specific
+        && !current.route.host_specific
+    {
+        RoutePreference::TakeCandidateHostSpecific
+    } else if candidate.route.path_len == current.route.path_len
+        && candidate.host_match_kind > current.host_match_kind
+    {
+        RoutePreference::TakeCandidateExactHost
+    } else if candidate.route.path_len == current.route.path_len
+        && candidate.host_match_kind == HostMatchKind::Wildcard
+        && current.host_match_kind == HostMatchKind::Wildcard
+        && candidate.wildcard_suffix_len > current.wildcard_suffix_len
+    {
+        RoutePreference::TakeCandidateWildcardSpecificity
+    } else if candidate.route.path_len == current.route.path_len
+        && candidate.host_match_kind == current.host_match_kind
+        && candidate.route.method_specific
+        && !current.route.method_specific
+    {
+        RoutePreference::TakeCandidateMethodSpecific
+    } else if candidate.route.path_len == current.route.path_len
+        && candidate.host_match_kind == current.host_match_kind
+        && candidate.route.method_specific == current.route.method_specific
+        && candidate.route.order < current.route.order
+    {
+        RoutePreference::TakeCandidateLexicalOrder
+    } else {
+        RoutePreference::KeepCurrent
     }
 }
 

--- a/crates/edge/src/route_index.rs
+++ b/crates/edge/src/route_index.rs
@@ -1138,7 +1138,7 @@ mod tests {
             index
                 .lookup_with_decision("/api/users", Some("x.a.example.com"))
                 .map(|decision| decision.reason),
-            Some(RouteDecisionReason::WildcardSpecificityTieBreak)
+            Some(RouteDecisionReason::HostPathLongerOrEqual)
         );
     }
 

--- a/crates/edge/src/route_index.rs
+++ b/crates/edge/src/route_index.rs
@@ -1123,6 +1123,7 @@ mod tests {
             "narrow".to_string(),
             test_upstream(Some("*.a.example.com"), Some("/api")),
         );
+        upstreams.insert("default".to_string(), test_upstream(None, Some("/")));
         let index = RouteIndex::from_upstreams(&upstreams);
 
         assert_eq!(

--- a/crates/edge/src/route_index.rs
+++ b/crates/edge/src/route_index.rs
@@ -107,6 +107,8 @@ pub(crate) enum RouteDecisionReason {
     HostPathLongerOrEqual,
     DefaultPathLonger,
     HostSpecificTieBreak,
+    ExactHostTieBreak,
+    WildcardSpecificityTieBreak,
     MethodSpecificTieBreak,
     LexicalTieBreak,
 }
@@ -387,28 +389,32 @@ impl RouteIndex {
         host: Option<&str>,
         method: Option<&str>,
     ) -> Option<RouteDecision<'a>> {
-        let host_best = host.and_then(|raw_host| {
-            let parsed_host = parsed_host_for_routing(raw_host)?;
-            let host_trie = if host_has_uppercase_ascii(parsed_host) {
-                let normalized = parsed_host.to_ascii_lowercase();
-                self.host_tries.get(normalized.as_str())
-            } else {
-                self.host_tries.get(parsed_host)
-            }?;
-            host_trie.longest_prefix(path, method, &self.upstream_methods)
-        });
+        let host_best = host
+            .and_then(normalize_host_for_routing)
+            .and_then(|normalized_host| self.lookup_host_candidate(path, normalized_host, method));
 
         let default_best = self
             .default_trie
-            .longest_prefix(path, method, &self.upstream_methods);
+            .longest_prefix(path, method, &self.upstream_methods)
+            .map(|route| RouteCandidate {
+                route,
+                host_match_kind: HostMatchKind::Default,
+                wildcard_suffix_len: 0,
+            });
         if let Some(best) = host_best
-            && best.path_len >= self.default_max_path_len
+            && best.route.path_len >= self.default_max_path_len
         {
             let reason = match default_best {
                 None => RouteDecisionReason::HostTrieNoDefault,
-                Some(default_route) => match compare_route(default_route, best) {
+                Some(default_route) => match compare_route_candidate(default_route, best) {
                     RoutePreference::TakeCandidateHostSpecific => {
                         RouteDecisionReason::HostSpecificTieBreak
+                    }
+                    RoutePreference::TakeCandidateExactHost => {
+                        RouteDecisionReason::ExactHostTieBreak
+                    }
+                    RoutePreference::TakeCandidateWildcardSpecificity => {
+                        RouteDecisionReason::WildcardSpecificityTieBreak
                     }
                     RoutePreference::TakeCandidateMethodSpecific => {
                         RouteDecisionReason::MethodSpecificTieBreak
@@ -420,33 +426,39 @@ impl RouteIndex {
                 },
             };
             return Some(RouteDecision {
-                upstream: self.upstream_names[best.upstream_idx].as_str(),
-                matched_path_len: best.path_len,
-                host_specific: best.host_specific,
+                upstream: self.upstream_names[best.route.upstream_idx].as_str(),
+                matched_path_len: best.route.path_len,
+                host_specific: best.route.host_specific,
                 reason,
             });
         }
 
         match (default_best, host_best) {
             (Some(default_route), None) => Some(RouteDecision {
-                upstream: self.upstream_names[default_route.upstream_idx].as_str(),
-                matched_path_len: default_route.path_len,
-                host_specific: default_route.host_specific,
+                upstream: self.upstream_names[default_route.route.upstream_idx].as_str(),
+                matched_path_len: default_route.route.path_len,
+                host_specific: default_route.route.host_specific,
                 reason: RouteDecisionReason::DefaultPathLonger,
             }),
             (None, Some(host_route)) => Some(RouteDecision {
-                upstream: self.upstream_names[host_route.upstream_idx].as_str(),
-                matched_path_len: host_route.path_len,
-                host_specific: host_route.host_specific,
+                upstream: self.upstream_names[host_route.route.upstream_idx].as_str(),
+                matched_path_len: host_route.route.path_len,
+                host_specific: host_route.route.host_specific,
                 reason: RouteDecisionReason::HostTrieNoDefault,
             }),
             (Some(current), Some(candidate)) => {
-                let reason = match compare_route(current, candidate) {
+                let reason = match compare_route_candidate(current, candidate) {
                     RoutePreference::TakeCandidatePathLen => {
                         RouteDecisionReason::HostPathLongerOrEqual
                     }
                     RoutePreference::TakeCandidateHostSpecific => {
                         RouteDecisionReason::HostSpecificTieBreak
+                    }
+                    RoutePreference::TakeCandidateExactHost => {
+                        RouteDecisionReason::ExactHostTieBreak
+                    }
+                    RoutePreference::TakeCandidateWildcardSpecificity => {
+                        RouteDecisionReason::WildcardSpecificityTieBreak
                     }
                     RoutePreference::TakeCandidateMethodSpecific => {
                         RouteDecisionReason::MethodSpecificTieBreak
@@ -456,14 +468,14 @@ impl RouteIndex {
                     }
                     RoutePreference::KeepCurrent => RouteDecisionReason::DefaultPathLonger,
                 };
-                let selected = match compare_route(current, candidate) {
+                let selected = match compare_route_candidate(current, candidate) {
                     RoutePreference::KeepCurrent => current,
                     _ => candidate,
                 };
                 Some(RouteDecision {
-                    upstream: self.upstream_names[selected.upstream_idx].as_str(),
-                    matched_path_len: selected.path_len,
-                    host_specific: selected.host_specific,
+                    upstream: self.upstream_names[selected.route.upstream_idx].as_str(),
+                    matched_path_len: selected.route.path_len,
+                    host_specific: selected.route.host_specific,
                     reason,
                 })
             }
@@ -627,8 +639,8 @@ pub(crate) fn scan_lookup_for_method<'a>(
     method: Option<&str>,
 ) -> Option<&'a str> {
     let path_bytes = path.as_bytes();
-    let normalized_request_host = host.and_then(parsed_host_for_routing);
-    let mut best_match: Option<(&str, usize, bool, bool)> = None;
+    let normalized_request_host = host.and_then(normalize_host_for_routing);
+    let mut best_match: Option<(&str, usize, bool, HostMatchKind, usize, bool)> = None;
 
     for (upstream_name, upstream) in upstreams {
         let has_method_match = match (
@@ -645,18 +657,29 @@ pub(crate) fn scan_lookup_for_method<'a>(
             continue;
         }
 
-        let has_host_match = match (&upstream.route.host, normalized_request_host) {
-            (Some(route_host), Some(request_host)) => {
-                if route_host == request_host {
-                    true
-                } else {
-                    parsed_host_for_routing(route_host)
-                        .is_some_and(|route_host| route_host.eq_ignore_ascii_case(request_host))
+        let (has_host_match, host_match_kind, wildcard_suffix_len) =
+            match (&upstream.route.host, normalized_request_host.as_deref()) {
+                (None, _) => (true, HostMatchKind::Default, 0usize),
+                (Some(_), None) => (false, HostMatchKind::Default, 0usize),
+                (Some(route_host), Some(request_host)) => {
+                    match parse_configured_host_pattern(route_host) {
+                        Some(ConfiguredHostPattern::Exact(route_host_exact)) => (
+                            route_host_exact.eq_ignore_ascii_case(request_host),
+                            HostMatchKind::Exact,
+                            0,
+                        ),
+                        Some(ConfiguredHostPattern::WildcardSuffix(suffix)) => (
+                            request_host.len() > suffix.len() + 1
+                                && request_host.ends_with(&suffix)
+                                && request_host.as_bytes()[request_host.len() - suffix.len() - 1]
+                                    == b'.',
+                            HostMatchKind::Wildcard,
+                            suffix.len(),
+                        ),
+                        None => (false, HostMatchKind::Default, 0usize),
+                    }
                 }
-            }
-            (None, _) => true,
-            (Some(_), None) => false,
-        };
+            };
 
         let path_match_len = match &upstream.route.path_prefix {
             Some(path_prefix) => {
@@ -692,15 +715,32 @@ pub(crate) fn scan_lookup_for_method<'a>(
             .is_some_and(|value| !value.trim().is_empty());
 
         match best_match {
-            Some((best_name, best_len, best_host_specific, best_method_specific)) => {
+            Some((
+                best_name,
+                best_len,
+                best_host_specific,
+                best_host_match_kind,
+                best_wildcard_suffix_len,
+                best_method_specific,
+            )) => {
                 if path_match_len > best_len
                     || (path_match_len == best_len && host_specific && !best_host_specific)
                     || (path_match_len == best_len
                         && host_specific == best_host_specific
+                        && host_match_kind > best_host_match_kind)
+                    || (path_match_len == best_len
+                        && host_specific == best_host_specific
+                        && host_match_kind == HostMatchKind::Wildcard
+                        && best_host_match_kind == HostMatchKind::Wildcard
+                        && wildcard_suffix_len > best_wildcard_suffix_len)
+                    || (path_match_len == best_len
+                        && host_specific == best_host_specific
+                        && host_match_kind == best_host_match_kind
                         && method_specific
                         && !best_method_specific)
                     || (path_match_len == best_len
                         && host_specific == best_host_specific
+                        && host_match_kind == best_host_match_kind
                         && method_specific == best_method_specific
                         && upstream_name.as_str() < best_name)
                 {
@@ -708,6 +748,8 @@ pub(crate) fn scan_lookup_for_method<'a>(
                         upstream_name.as_str(),
                         path_match_len,
                         host_specific,
+                        host_match_kind,
+                        wildcard_suffix_len,
                         method_specific,
                     ));
                 }
@@ -717,13 +759,15 @@ pub(crate) fn scan_lookup_for_method<'a>(
                     upstream_name.as_str(),
                     path_match_len,
                     host_specific,
+                    host_match_kind,
+                    wildcard_suffix_len,
                     method_specific,
                 ));
             }
         }
     }
 
-    best_match.map(|(name, _, _, _)| name)
+    best_match.map(|(name, _, _, _, _, _)| name)
 }
 
 #[cfg(test)]

--- a/crates/edge/src/route_index.rs
+++ b/crates/edge/src/route_index.rs
@@ -536,6 +536,8 @@ fn prefer_route(
             RoutePreference::KeepCurrent => Some(current),
             RoutePreference::TakeCandidatePathLen
             | RoutePreference::TakeCandidateHostSpecific
+            | RoutePreference::TakeCandidateExactHost
+            | RoutePreference::TakeCandidateWildcardSpecificity
             | RoutePreference::TakeCandidateMethodSpecific
             | RoutePreference::TakeCandidateLexicalOrder => Some(candidate),
         },

--- a/crates/edge/src/route_index.rs
+++ b/crates/edge/src/route_index.rs
@@ -1063,6 +1063,128 @@ mod tests {
         }
     }
 
+    #[test]
+    fn wildcard_host_route_matches_subdomains() {
+        let mut upstreams = HashMap::new();
+        upstreams.insert(
+            "wildcard".to_string(),
+            test_upstream(Some("*.example.com"), Some("/api")),
+        );
+        upstreams.insert("default".to_string(), test_upstream(None, Some("/")));
+        let index = RouteIndex::from_upstreams(&upstreams);
+
+        assert_eq!(
+            index.lookup("/api/users", Some("tenant.example.com")),
+            Some("wildcard")
+        );
+        assert_eq!(
+            scan_lookup(&upstreams, "/api/users", Some("tenant.example.com")),
+            Some("wildcard")
+        );
+        assert_eq!(
+            index.lookup("/api/users", Some("example.com")),
+            Some("default")
+        );
+    }
+
+    #[test]
+    fn exact_host_route_beats_wildcard_on_tie() {
+        let mut upstreams = HashMap::new();
+        upstreams.insert(
+            "wildcard".to_string(),
+            test_upstream(Some("*.example.com"), Some("/api")),
+        );
+        upstreams.insert(
+            "exact".to_string(),
+            test_upstream(Some("api.example.com"), Some("/api")),
+        );
+        let index = RouteIndex::from_upstreams(&upstreams);
+
+        assert_eq!(
+            index.lookup("/api/users", Some("api.example.com")),
+            Some("exact")
+        );
+        assert_eq!(
+            scan_lookup(&upstreams, "/api/users", Some("api.example.com")),
+            Some("exact")
+        );
+    }
+
+    #[test]
+    fn more_specific_wildcard_beats_less_specific_wildcard() {
+        let mut upstreams = HashMap::new();
+        upstreams.insert(
+            "wide".to_string(),
+            test_upstream(Some("*.example.com"), Some("/api")),
+        );
+        upstreams.insert(
+            "narrow".to_string(),
+            test_upstream(Some("*.a.example.com"), Some("/api")),
+        );
+        let index = RouteIndex::from_upstreams(&upstreams);
+
+        assert_eq!(
+            index.lookup("/api/users", Some("x.a.example.com")),
+            Some("narrow")
+        );
+        assert_eq!(
+            scan_lookup(&upstreams, "/api/users", Some("x.a.example.com")),
+            Some("narrow")
+        );
+        assert_eq!(
+            index
+                .lookup_with_decision("/api/users", Some("x.a.example.com"))
+                .map(|decision| decision.reason),
+            Some(RouteDecisionReason::WildcardSpecificityTieBreak)
+        );
+    }
+
+    #[test]
+    fn wildcard_keeps_method_and_path_precedence() {
+        let mut upstreams = HashMap::new();
+        upstreams.insert(
+            "wildcard-post".to_string(),
+            test_upstream_with_method(Some("*.example.com"), Some("/api"), Some("POST")),
+        );
+        upstreams.insert(
+            "wildcard-all".to_string(),
+            test_upstream_with_method(Some("*.example.com"), Some("/api"), None),
+        );
+        upstreams.insert(
+            "wildcard-deep".to_string(),
+            test_upstream(Some("*.example.com"), Some("/api/v2")),
+        );
+        let index = RouteIndex::from_upstreams(&upstreams);
+
+        assert_eq!(
+            index.lookup_for_method("/api/items", Some("tenant.example.com"), Some("POST")),
+            Some("wildcard-post")
+        );
+        assert_eq!(
+            scan_lookup_for_method(
+                &upstreams,
+                "/api/items",
+                Some("tenant.example.com"),
+                Some("POST")
+            ),
+            Some("wildcard-post")
+        );
+
+        assert_eq!(
+            index.lookup_for_method("/api/v2/items", Some("tenant.example.com"), Some("GET")),
+            Some("wildcard-deep")
+        );
+        assert_eq!(
+            scan_lookup_for_method(
+                &upstreams,
+                "/api/v2/items",
+                Some("tenant.example.com"),
+                Some("GET")
+            ),
+            Some("wildcard-deep")
+        );
+    }
+
     fn build_route_table(route_count: usize) -> HashMap<String, Upstream> {
         let mut upstreams = HashMap::with_capacity(route_count);
         for i in 0..route_count {

--- a/crates/edge/src/route_index.rs
+++ b/crates/edge/src/route_index.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 use spooky_config::config::Upstream;
@@ -31,12 +32,12 @@ fn host_has_uppercase_ascii(host: &str) -> bool {
     host.bytes().any(|byte| byte.is_ascii_uppercase())
 }
 
-pub(crate) fn normalize_host_for_routing(raw: &str) -> Option<String> {
+pub(crate) fn normalize_host_for_routing(raw: &str) -> Option<Cow<'_, str>> {
     let host = parsed_host_for_routing(raw)?;
     if host_has_uppercase_ascii(host) {
-        Some(host.to_ascii_lowercase())
+        Some(Cow::Owned(host.to_ascii_lowercase()))
     } else {
-        Some(host.to_string())
+        Some(Cow::Borrowed(host))
     }
 }
 
@@ -46,17 +47,34 @@ enum ConfiguredHostPattern {
     WildcardSuffix(String),
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ConfiguredHostPatternRef<'a> {
+    Exact(&'a str),
+    WildcardSuffix(&'a str),
+}
+
 fn parse_configured_host_pattern(raw: &str) -> Option<ConfiguredHostPattern> {
     let normalized = normalize_host_for_routing(raw)?;
     let Some(wildcard_suffix) = normalized.strip_prefix("*.") else {
-        return Some(ConfiguredHostPattern::Exact(normalized));
+        return Some(ConfiguredHostPattern::Exact(normalized.into_owned()));
     };
     if wildcard_suffix.is_empty() || wildcard_suffix.contains('*') {
-        return Some(ConfiguredHostPattern::Exact(format!("*.{wildcard_suffix}")));
+        return Some(ConfiguredHostPattern::Exact(normalized.into_owned()));
     }
     Some(ConfiguredHostPattern::WildcardSuffix(
         wildcard_suffix.to_string(),
     ))
+}
+
+fn parse_configured_host_pattern_ref(raw: &str) -> Option<ConfiguredHostPatternRef<'_>> {
+    let host = parsed_host_for_routing(raw)?;
+    let Some(wildcard_suffix) = host.strip_prefix("*.") else {
+        return Some(ConfiguredHostPatternRef::Exact(host));
+    };
+    if wildcard_suffix.is_empty() || wildcard_suffix.contains('*') {
+        return Some(ConfiguredHostPatternRef::Exact(host));
+    }
+    Some(ConfiguredHostPatternRef::WildcardSuffix(wildcard_suffix))
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
@@ -353,7 +371,9 @@ impl RouteIndex {
     ) -> Option<&'a str> {
         let host_best = host
             .and_then(normalize_host_for_routing)
-            .and_then(|normalized_host| self.lookup_host_candidate(path, normalized_host, method));
+            .and_then(|normalized_host| {
+                self.lookup_host_candidate(path, normalized_host.as_ref(), method)
+            });
 
         if let Some(best) = host_best
             && best.route.path_len >= self.default_max_path_len
@@ -391,7 +411,9 @@ impl RouteIndex {
     ) -> Option<RouteDecision<'a>> {
         let host_best = host
             .and_then(normalize_host_for_routing)
-            .and_then(|normalized_host| self.lookup_host_candidate(path, normalized_host, method));
+            .and_then(|normalized_host| {
+                self.lookup_host_candidate(path, normalized_host.as_ref(), method)
+            });
 
         let default_best = self
             .default_trie
@@ -486,12 +508,12 @@ impl RouteIndex {
     fn lookup_host_candidate(
         &self,
         path: &str,
-        normalized_host: String,
+        normalized_host: &str,
         method: Option<&str>,
     ) -> Option<RouteCandidate> {
         let exact_best = self
             .host_tries
-            .get(normalized_host.as_str())
+            .get(normalized_host)
             .and_then(|host_trie| host_trie.longest_prefix(path, method, &self.upstream_methods))
             .map(|route| RouteCandidate {
                 route,
@@ -500,7 +522,7 @@ impl RouteIndex {
             });
 
         let mut wildcard_best: Option<RouteCandidate> = None;
-        let mut remaining = normalized_host.as_str();
+        let mut remaining = normalized_host;
         while let Some(dot_idx) = remaining.find('.') {
             let suffix = &remaining[dot_idx + 1..];
             if suffix.is_empty() {
@@ -664,20 +686,24 @@ pub(crate) fn scan_lookup_for_method<'a>(
                 (None, _) => (true, HostMatchKind::Default, 0usize),
                 (Some(_), None) => (false, HostMatchKind::Default, 0usize),
                 (Some(route_host), Some(request_host)) => {
-                    match parse_configured_host_pattern(route_host) {
-                        Some(ConfiguredHostPattern::Exact(route_host_exact)) => (
+                    match parse_configured_host_pattern_ref(route_host) {
+                        Some(ConfiguredHostPatternRef::Exact(route_host_exact)) => (
                             route_host_exact.eq_ignore_ascii_case(request_host),
                             HostMatchKind::Exact,
                             0,
                         ),
-                        Some(ConfiguredHostPattern::WildcardSuffix(suffix)) => (
-                            request_host.len() > suffix.len() + 1
-                                && request_host.ends_with(&suffix)
-                                && request_host.as_bytes()[request_host.len() - suffix.len() - 1]
-                                    == b'.',
-                            HostMatchKind::Wildcard,
-                            suffix.len(),
-                        ),
+                        Some(ConfiguredHostPatternRef::WildcardSuffix(suffix)) => {
+                            let suffix_start = request_host.len().saturating_sub(suffix.len());
+                            (
+                                request_host.len() > suffix.len() + 1
+                                    && request_host
+                                        .get(suffix_start..)
+                                        .is_some_and(|tail| tail.eq_ignore_ascii_case(suffix))
+                                    && request_host.as_bytes()[suffix_start - 1] == b'.',
+                                HostMatchKind::Wildcard,
+                                suffix.len(),
+                            )
+                        }
                         None => (false, HostMatchKind::Default, 0usize),
                     }
                 }

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -215,17 +215,24 @@ Route matching determines which upstream pool handles a request. Routes are eval
 
 | Property | Type | Required | Default | Description |
 |----------|------|----------|---------|-------------|
-| `host` | string | No | - | Host header to match (e.g., `api.example.com`) |
+| `host` | string | No | - | Host matcher. Supports exact hosts (`api.example.com`) and leading-wildcard suffix patterns (`*.example.com`) |
 | `path_prefix` | string | No | - | Path prefix to match (e.g., `/api`) |
 | `method` | string | No | - | HTTP method to match (case-insensitive, e.g. `GET`, `POST`) |
 
 Route matching rules:
 
-1. If `host` is specified, the request Host header must match exactly
+1. If `host` is specified:
+   - Exact form: request Host must match exactly (case-insensitive after normalization)
+   - Wildcard form: `*.example.com` matches subdomains like `api.example.com`, but not the bare apex `example.com`
 2. If `path_prefix` is specified, the request path must start with the prefix
 3. If both are specified, both conditions must match
 4. Routes are evaluated by longest-prefix matching - the route with the most specific (longest) path prefix is selected
-5. For equal-length prefixes, ties are deterministic: host-specific routes win over host-agnostic routes, then lexicographically smaller upstream name wins
+5. For equal-length prefixes, ties are deterministic:
+   - host-specific routes win over host-agnostic routes
+   - exact-host matches win over wildcard-host matches
+   - among wildcard matches, longer suffixes win (`*.a.example.com` beats `*.example.com`)
+   - method-specific routes win over method-agnostic routes
+   - then lexicographically smaller upstream name wins
 
 #### Route Examples
 
@@ -240,6 +247,14 @@ upstream:
   web_pool:
     route:
       host: "www.example.com"
+    backends: [...]
+
+# Wildcard host routing
+upstream:
+  tenant_pool:
+    route:
+      host: "*.example.com"
+      path_prefix: "/api"
     backends: [...]
 
 # Path-based routing


### PR DESCRIPTION
Ref: #187 
- Adds optional wildcard host matching (for example `*.example.com`) to edge route selection.
- Keeps deterministic precedence across route selection:
  - longest path prefix
  - host-specific over default
  - exact host over wildcard
  - more specific wildcard suffix over less specific wildcard
  - method-specific over method-agnostic
  - lexical fallback tie-break
- Updates indexed lookup, decision-path lookup, and scan lookup for parity.
- Adds tests covering wildcard match behavior and precedence interactions.
- Updates configuration docs with wildcard host examples and matching rules.
