### PR TITLE
feat(edge): support SNI-based multi-certificate listener TLS

### DIFF
--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -5,8 +5,15 @@ listen:
     address: "0.0.0.0"
     port: 9889
     tls:
-        cert: certs/proxy-fullchain.pem # path to cert
-        key: certs/proxy-key-pkcs8.pem # path to key
+        cert: certs/proxy-fullchain.pem # default/fallback cert (used when SNI is absent or unmatched)
+        key: certs/proxy-key-pkcs8.pem # default/fallback key
+        certificates:                  # optional SNI certificate mappings
+            - server_name: "api.example.com"
+              cert: certs/api-fullchain.pem
+              key: certs/api-key-pkcs8.pem
+            - server_name: "www.example.com"
+              cert: certs/www-fullchain.pem
+              key: certs/www-key-pkcs8.pem
         client_auth:
             enabled: false              # set true to request/verify client certificates (mTLS)
             require_client_cert: false  # when true, close connections that complete handshake without a client cert

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -138,10 +138,22 @@ pub struct Listen {
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 #[serde(deny_unknown_fields)]
 pub struct Tls {
+    #[serde(default)]
     pub cert: String, // "/path/to/cert"
+    #[serde(default)]
     pub key: String,  // "/path/to/key"
     #[serde(default)]
+    pub certificates: Vec<TlsCertificate>, // SNI keyed certificate set
+    #[serde(default)]
     pub client_auth: ClientAuth,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+#[serde(deny_unknown_fields)]
+pub struct TlsCertificate {
+    pub server_name: String, // "api.example.com"
+    pub cert: String,        // "/path/to/cert"
+    pub key: String,         // "/path/to/key"
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -141,7 +141,7 @@ pub struct Tls {
     #[serde(default)]
     pub cert: String, // "/path/to/cert"
     #[serde(default)]
-    pub key: String,  // "/path/to/key"
+    pub key: String, // "/path/to/key"
     #[serde(default)]
     pub certificates: Vec<TlsCertificate>, // SNI keyed certificate set
     #[serde(default)]

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -169,7 +169,11 @@ fn normalized_route_method(method: Option<&str>) -> Option<String> {
 
 fn normalize_sni_server_name(raw: &str) -> Option<String> {
     let trimmed = raw.trim();
-    if trimmed.is_empty() || trimmed.contains(':') || trimmed.contains('*') {
+    if trimmed.is_empty()
+        || trimmed.contains(':')
+        || trimmed.contains('*')
+        || trimmed.chars().any(char::is_whitespace)
+    {
         return None;
     }
     let without_trailing_dot = trimmed.trim_end_matches('.');

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -167,6 +167,22 @@ fn normalized_route_method(method: Option<&str>) -> Option<String> {
         .map(|value| value.to_ascii_uppercase())
 }
 
+fn normalize_sni_server_name(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed.contains(':') || trimmed.contains('*') {
+        return None;
+    }
+    let without_trailing_dot = trimmed.trim_end_matches('.');
+    if without_trailing_dot.is_empty() {
+        return None;
+    }
+    let ascii = idna::domain_to_ascii(without_trailing_dot).ok()?;
+    if ascii.parse::<IpAddr>().is_ok() {
+        return None;
+    }
+    Some(ascii.to_ascii_lowercase())
+}
+
 type RouteMatcherKey = (Option<String>, Option<String>, Option<String>);
 
 pub fn validate(config: &Config) -> bool {
@@ -826,12 +842,65 @@ pub fn validate(config: &Config) -> bool {
     }
 
     // --- Validate TLS certs ---
-    if !validate_pem_certificates(&config.listen.tls.cert, "listen.tls.cert") {
+    let legacy_cert = config.listen.tls.cert.trim();
+    let legacy_key = config.listen.tls.key.trim();
+    let has_legacy_cert_pair = !legacy_cert.is_empty() || !legacy_key.is_empty();
+    let has_sni_certificates = !config.listen.tls.certificates.is_empty();
+
+    if !has_legacy_cert_pair && !has_sni_certificates {
+        error!("listen.tls requires either cert/key or certificates entries");
         return false;
     }
 
-    if !validate_pem_private_key(&config.listen.tls.key, "listen.tls.key") {
-        return false;
+    if has_legacy_cert_pair {
+        if legacy_cert.is_empty() || legacy_key.is_empty() {
+            error!("listen.tls.cert and listen.tls.key must both be set when either is provided");
+            return false;
+        }
+        if !validate_pem_certificates(legacy_cert, "listen.tls.cert") {
+            return false;
+        }
+        if !validate_pem_private_key(legacy_key, "listen.tls.key") {
+            return false;
+        }
+    }
+
+    let mut seen_sni_names: HashMap<String, usize> = HashMap::new();
+    for (idx, entry) in config.listen.tls.certificates.iter().enumerate() {
+        let field_prefix = format!("listen.tls.certificates[{idx}]");
+        let sni_name = match normalize_sni_server_name(&entry.server_name) {
+            Some(sni) => sni,
+            None => {
+                error!("{field_prefix}.server_name '{}' is not a valid DNS hostname", entry.server_name);
+                return false;
+            }
+        };
+
+        if let Some(first_idx) = seen_sni_names.insert(sni_name.clone(), idx) {
+            error!(
+                "{field_prefix}.server_name '{}' duplicates listen.tls.certificates[{}].server_name",
+                entry.server_name, first_idx
+            );
+            return false;
+        }
+
+        let cert = entry.cert.trim();
+        if cert.is_empty() {
+            error!("{field_prefix}.cert cannot be empty");
+            return false;
+        }
+        if !validate_pem_certificates(cert, &format!("{field_prefix}.cert")) {
+            return false;
+        }
+
+        let key = entry.key.trim();
+        if key.is_empty() {
+            error!("{field_prefix}.key cannot be empty");
+            return false;
+        }
+        if !validate_pem_private_key(key, &format!("{field_prefix}.key")) {
+            return false;
+        }
     }
 
     // --- Validate optional downstream client-auth (mTLS) ---
@@ -1082,7 +1151,7 @@ mod tests {
     use crate::config::{
         Backend, ClientAuth, Config, ControlApi, HealthCheck, Listen, LoadBalancing, Log,
         LogFormat, MetricsEndpoint, Observability, Performance, Resilience, RouteMatch, Security,
-        Tls, Tracing, Upstream, UpstreamTls,
+        Tls, TlsCertificate, Tracing, Upstream, UpstreamTls,
     };
     use rcgen::{Certificate, CertificateParams, SanType};
     use std::collections::HashMap;
@@ -1144,6 +1213,7 @@ mod tests {
                 tls: Tls {
                     cert: cert.to_string(),
                     key: key.to_string(),
+                    certificates: vec![],
                     client_auth: ClientAuth::default(),
                 },
             },
@@ -1548,6 +1618,60 @@ upstream:
         std::fs::write(&key, "not-a-pem-key").expect("write key");
 
         let cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        assert!(!validate(&cfg));
+    }
+
+    #[test]
+    fn accepts_sni_certificates_without_legacy_cert_pair() {
+        let dir = tempdir().expect("tempdir");
+        let (cert, key) = write_test_certs(dir.path());
+
+        let mut cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.listen.tls.cert = String::new();
+        cfg.listen.tls.key = String::new();
+        cfg.listen.tls.certificates = vec![TlsCertificate {
+            server_name: "api.example.com".to_string(),
+            cert: cert.to_string_lossy().to_string(),
+            key: key.to_string_lossy().to_string(),
+        }];
+
+        assert!(validate(&cfg));
+    }
+
+    #[test]
+    fn rejects_duplicate_sni_certificate_server_names() {
+        let dir = tempdir().expect("tempdir");
+        let (cert, key) = write_test_certs(dir.path());
+
+        let mut cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.listen.tls.certificates = vec![
+            TlsCertificate {
+                server_name: "api.example.com".to_string(),
+                cert: cert.to_string_lossy().to_string(),
+                key: key.to_string_lossy().to_string(),
+            },
+            TlsCertificate {
+                server_name: "API.EXAMPLE.COM".to_string(),
+                cert: cert.to_string_lossy().to_string(),
+                key: key.to_string_lossy().to_string(),
+            },
+        ];
+
+        assert!(!validate(&cfg));
+    }
+
+    #[test]
+    fn rejects_invalid_sni_certificate_server_name() {
+        let dir = tempdir().expect("tempdir");
+        let (cert, key) = write_test_certs(dir.path());
+
+        let mut cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.listen.tls.certificates = vec![TlsCertificate {
+            server_name: "not a hostname".to_string(),
+            cert: cert.to_string_lossy().to_string(),
+            key: key.to_string_lossy().to_string(),
+        }];
+
         assert!(!validate(&cfg));
     }
 

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -875,7 +875,10 @@ pub fn validate(config: &Config) -> bool {
         let sni_name = match normalize_sni_server_name(&entry.server_name) {
             Some(sni) => sni,
             None => {
-                error!("{field_prefix}.server_name '{}' is not a valid DNS hostname", entry.server_name);
+                error!(
+                    "{field_prefix}.server_name '{}' is not a valid DNS hostname",
+                    entry.server_name
+                );
                 return false;
             }
         };

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -29,6 +29,11 @@ use quiche::Config;
 use quiche::h3::NameValue;
 use rand::RngCore;
 use rustls::{RootCertStore, ServerConfig as RustlsServerConfig, server::WebPkiClientVerifier};
+use rustls::{
+    pki_types::{CertificateDer, PrivateKeyDer},
+    server::{ClientHello, ResolvesServerCert, ResolvesServerCertUsingSni},
+    sign::CertifiedKey,
+};
 use serde_json::json;
 use socket2::{Domain, Protocol, Socket, Type};
 use spooky_bridge::h3_to_h2::{ForwardedContext, build_h2_request_for_endpoint};
@@ -86,6 +91,20 @@ use validation::{
     RequestBufferError, extract_header_value, generated_span_id, generated_trace_id,
     parse_traceparent, validate_http_request, validate_request_headers,
 };
+
+#[derive(Debug)]
+struct FallbackServerCertResolver {
+    sni_resolver: ResolvesServerCertUsingSni,
+    fallback: Arc<CertifiedKey>,
+}
+
+impl ResolvesServerCert for FallbackServerCertResolver {
+    fn resolve(&self, client_hello: ClientHello<'_>) -> Option<Arc<CertifiedKey>> {
+        self.sni_resolver
+            .resolve(client_hello)
+            .or_else(|| Some(Arc::clone(&self.fallback)))
+    }
+}
 
 fn is_hop_header(name: &str) -> bool {
     matches!(
@@ -772,26 +791,63 @@ impl QUICListener {
         Ok(socket.into())
     }
 
+    fn legacy_tls_cert_pair(config: &SpookyConfig) -> Result<Option<(&str, &str)>, ProxyError> {
+        let cert = config.listen.tls.cert.trim();
+        let key = config.listen.tls.key.trim();
+        let has_pair = !cert.is_empty() || !key.is_empty();
+        if !has_pair {
+            return Ok(None);
+        }
+        if cert.is_empty() || key.is_empty() {
+            return Err(ProxyError::Tls(
+                "listen.tls.cert and listen.tls.key must both be set when either is provided"
+                    .to_string(),
+            ));
+        }
+        Ok(Some((cert, key)))
+    }
+
+    fn default_tls_cert_pair(config: &SpookyConfig) -> Result<(&str, &str), ProxyError> {
+        if let Some(pair) = Self::legacy_tls_cert_pair(config)? {
+            return Ok(pair);
+        }
+        let Some(entry) = config.listen.tls.certificates.first() else {
+            return Err(ProxyError::Tls(
+                "listen.tls requires either cert/key or certificates entries".to_string(),
+            ));
+        };
+        let cert = entry.cert.trim();
+        let key = entry.key.trim();
+        if cert.is_empty() || key.is_empty() {
+            return Err(ProxyError::Tls(
+                "listen.tls.certificates entries must include non-empty cert and key".to_string(),
+            ));
+        }
+        Ok((cert, key))
+    }
+
     fn build_quic_config(config: &SpookyConfig) -> Result<Config, ProxyError> {
         let mut quic_config = Config::new(quiche::PROTOCOL_VERSION)
             .map_err(|err| ProxyError::Transport(format!("failed to create QUIC config: {err}")))?;
 
-        match quic_config.load_cert_chain_from_pem_file(&config.listen.tls.cert) {
+        let (default_cert, default_key) = Self::default_tls_cert_pair(config)?;
+
+        match quic_config.load_cert_chain_from_pem_file(default_cert) {
             Ok(_) => debug!("Certificate loaded successfully"),
             Err(e) => {
                 return Err(ProxyError::Tls(format!(
                     "Failed to load certificate '{}': {}",
-                    config.listen.tls.cert, e
+                    default_cert, e
                 )));
             }
         }
 
-        match quic_config.load_priv_key_from_pem_file(&config.listen.tls.key) {
+        match quic_config.load_priv_key_from_pem_file(default_key) {
             Ok(_) => debug!("Private key loaded successfully"),
             Err(e) => {
                 return Err(ProxyError::Tls(format!(
                     "Failed to load key '{}': {}",
-                    config.listen.tls.key, e
+                    default_key, e
                 )));
             }
         }
@@ -3807,57 +3863,86 @@ impl QUICListener {
         Ok(())
     }
 
+    fn load_tls_cert_chain_from_pem_file(
+        path: &str,
+        field_name: &str,
+    ) -> Result<Vec<CertificateDer<'static>>, ProxyError> {
+        use rustls_pemfile::certs;
+        use std::io::BufReader;
+
+        let cert_bytes = std::fs::read(path).map_err(|err| {
+            ProxyError::Tls(format!("failed to read {field_name} '{}': {}", path, err))
+        })?;
+
+        certs(&mut BufReader::new(cert_bytes.as_slice()))
+            .collect::<Result<_, _>>()
+            .map_err(|err| ProxyError::Tls(format!("failed to parse {field_name} PEM: {err}")))
+    }
+
+    fn load_tls_private_key_from_pem_file(
+        path: &str,
+        field_name: &str,
+    ) -> Result<PrivateKeyDer<'static>, ProxyError> {
+        use rustls_pemfile::{pkcs8_private_keys, rsa_private_keys};
+        use std::io::BufReader;
+
+        let key_bytes = std::fs::read(path).map_err(|err| {
+            ProxyError::Tls(format!("failed to read {field_name} '{}': {}", path, err))
+        })?;
+
+        let mut reader = BufReader::new(key_bytes.as_slice());
+        let pkcs8: Vec<PrivateKeyDer<'static>> = pkcs8_private_keys(&mut reader)
+            .map(|r| r.map(PrivateKeyDer::Pkcs8))
+            .collect::<Result<_, _>>()
+            .map_err(|err| ProxyError::Tls(format!("failed to parse {field_name} PEM: {err}")))?;
+        if let Some(key) = pkcs8.into_iter().next() {
+            return Ok(key);
+        }
+
+        let mut reader2 = BufReader::new(key_bytes.as_slice());
+        let rsa: Vec<PrivateKeyDer<'static>> = rsa_private_keys(&mut reader2)
+            .map(|r| r.map(PrivateKeyDer::Pkcs1))
+            .collect::<Result<_, _>>()
+            .map_err(|err| ProxyError::Tls(format!("failed to parse {field_name} PEM: {err}")))?;
+        rsa.into_iter().next().ok_or_else(|| {
+            ProxyError::Tls(format!(
+                "no supported private key found in {field_name} '{}'",
+                path
+            ))
+        })
+    }
+
+    fn load_certified_key(
+        cert_path: &str,
+        key_path: &str,
+        cert_field: &str,
+        key_field: &str,
+    ) -> Result<CertifiedKey, ProxyError> {
+        let certs = Self::load_tls_cert_chain_from_pem_file(cert_path, cert_field)?;
+        let key = Self::load_tls_private_key_from_pem_file(key_path, key_field)?;
+        let signing_key = rustls::crypto::ring::sign::any_supported_type(&key).map_err(|err| {
+            ProxyError::Tls(format!(
+                "failed to parse private key from {} '{}': {}",
+                key_field, key_path, err
+            ))
+        })?;
+        let certified = CertifiedKey::new(certs, signing_key);
+        certified.keys_match().map_err(|err| {
+            ProxyError::Tls(format!(
+                "certificate/key mismatch for {} '{}' and {} '{}': {}",
+                cert_field, cert_path, key_field, key_path, err
+            ))
+        })?;
+        Ok(certified)
+    }
+
     fn build_server_tls_acceptor(
         config: &SpookyConfig,
         enforce_client_auth: bool,
         alpn_protocols: Vec<Vec<u8>>,
     ) -> Result<TlsAcceptor, ProxyError> {
-        use rustls_pemfile::{certs, pkcs8_private_keys, rsa_private_keys};
+        use rustls_pemfile::certs;
         use std::io::BufReader;
-
-        let cert_bytes = std::fs::read(&config.listen.tls.cert).map_err(|err| {
-            ProxyError::Tls(format!(
-                "failed to read TLS cert '{}': {}",
-                config.listen.tls.cert, err
-            ))
-        })?;
-        let key_bytes = std::fs::read(&config.listen.tls.key).map_err(|err| {
-            ProxyError::Tls(format!(
-                "failed to read TLS key '{}': {}",
-                config.listen.tls.key, err
-            ))
-        })?;
-
-        let server_certs: Vec<rustls::pki_types::CertificateDer<'static>> =
-            certs(&mut BufReader::new(cert_bytes.as_slice()))
-                .collect::<Result<_, _>>()
-                .map_err(|err| ProxyError::Tls(format!("failed to parse TLS cert PEM: {}", err)))?;
-
-        let key = {
-            let mut reader = BufReader::new(key_bytes.as_slice());
-            let pkcs8: Vec<rustls::pki_types::PrivateKeyDer<'static>> =
-                pkcs8_private_keys(&mut reader)
-                    .map(|r| r.map(rustls::pki_types::PrivateKeyDer::Pkcs8))
-                    .collect::<Result<_, _>>()
-                    .map_err(|err| {
-                        ProxyError::Tls(format!("failed to parse PKCS8 key PEM: {}", err))
-                    })?;
-            if let Some(key) = pkcs8.into_iter().next() {
-                key
-            } else {
-                let mut reader2 = BufReader::new(key_bytes.as_slice());
-                let rsa: Vec<rustls::pki_types::PrivateKeyDer<'static>> =
-                    rsa_private_keys(&mut reader2)
-                        .map(|r| r.map(rustls::pki_types::PrivateKeyDer::Pkcs1))
-                        .collect::<Result<_, _>>()
-                        .map_err(|err| {
-                            ProxyError::Tls(format!("failed to parse RSA key PEM: {}", err))
-                        })?;
-                rsa.into_iter().next().ok_or_else(|| {
-                    ProxyError::Tls("no supported private key found in TLS key file".to_string())
-                })?
-            }
-        };
 
         let builder = if enforce_client_auth && config.listen.tls.client_auth.enabled {
             let ca_file = config
@@ -3915,9 +4000,60 @@ impl QUICListener {
             RustlsServerConfig::builder().with_no_client_auth()
         };
 
-        let mut tls_config = builder.with_single_cert(server_certs, key).map_err(|err| {
-            ProxyError::Tls(format!("failed to build rustls ServerConfig: {}", err))
-        })?;
+        let legacy_pair = Self::legacy_tls_cert_pair(config)?;
+        let mut fallback_certified_key = if let Some((cert, key)) = legacy_pair {
+            Some(Self::load_certified_key(
+                cert,
+                key,
+                "listen.tls.cert",
+                "listen.tls.key",
+            )?)
+        } else {
+            None
+        };
+
+        let mut sni_resolver = ResolvesServerCertUsingSni::new();
+        for (idx, entry) in config.listen.tls.certificates.iter().enumerate() {
+            let cert_field = format!("listen.tls.certificates[{idx}].cert");
+            let key_field = format!("listen.tls.certificates[{idx}].key");
+            let certified = Self::load_certified_key(&entry.cert, &entry.key, &cert_field, &key_field)?;
+
+            sni_resolver
+                .add(entry.server_name.as_str(), certified.clone())
+                .map_err(|err| {
+                    ProxyError::Tls(format!(
+                        "failed to add SNI certificate mapping for '{}' in listen.tls.certificates[{idx}]: {}",
+                        entry.server_name, err
+                    ))
+                })?;
+
+            if fallback_certified_key.is_none() {
+                fallback_certified_key = Some(certified);
+            }
+        }
+
+        let Some(fallback) = fallback_certified_key else {
+            return Err(ProxyError::Tls(
+                "listen.tls requires either cert/key or certificates entries".to_string(),
+            ));
+        };
+
+        let mut tls_config = if config.listen.tls.certificates.is_empty() {
+            let certs = fallback.cert.clone();
+            let key = Self::load_tls_private_key_from_pem_file(
+                config.listen.tls.key.as_str(),
+                "listen.tls.key",
+            )?;
+            builder.with_single_cert(certs, key).map_err(|err| {
+                ProxyError::Tls(format!("failed to build rustls ServerConfig: {}", err))
+            })?
+        } else {
+            let resolver = Arc::new(FallbackServerCertResolver {
+                sni_resolver,
+                fallback: Arc::new(fallback),
+            });
+            builder.with_cert_resolver(resolver)
+        };
 
         tls_config.alpn_protocols = alpn_protocols;
 

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -5073,7 +5073,8 @@ mod tests {
             false,
             vec![b"h2".to_vec()],
         )
-        .expect_err("mismatched SNI cert mapping should fail");
+        .err()
+        .expect("mismatched SNI cert mapping should fail");
         assert!(
             err.to_string()
                 .contains("failed to add SNI certificate mapping"),

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -4016,7 +4016,8 @@ impl QUICListener {
         for (idx, entry) in config.listen.tls.certificates.iter().enumerate() {
             let cert_field = format!("listen.tls.certificates[{idx}].cert");
             let key_field = format!("listen.tls.certificates[{idx}].key");
-            let certified = Self::load_certified_key(&entry.cert, &entry.key, &cert_field, &key_field)?;
+            let certified =
+                Self::load_certified_key(&entry.cert, &entry.key, &cert_field, &key_field)?;
 
             sni_resolver
                 .add(entry.server_name.as_str(), certified.clone())
@@ -4952,11 +4953,7 @@ mod tests {
         }
     }
 
-    fn write_test_cert_for_name(
-        dir: &Path,
-        cert_name: &str,
-        dns_name: &str,
-    ) -> (String, String) {
+    fn write_test_cert_for_name(dir: &Path, cert_name: &str, dns_name: &str) -> (String, String) {
         let mut params = CertificateParams::new(vec![dns_name.to_string()]);
         params
             .subject_alt_names
@@ -4975,7 +4972,11 @@ mod tests {
         )
     }
 
-    fn tls_test_config(cert: String, key: String, certificates: Vec<TlsCertificate>) -> SpookyConfigConfig {
+    fn tls_test_config(
+        cert: String,
+        key: String,
+        certificates: Vec<TlsCertificate>,
+    ) -> SpookyConfigConfig {
         let mut upstreams = HashMap::new();
         upstreams.insert("api".to_string(), test_upstream("round-robin"));
         SpookyConfigConfig {
@@ -5046,11 +5047,8 @@ mod tests {
             }],
         );
 
-        let acceptor = super::QUICListener::build_server_tls_acceptor(
-            &config,
-            false,
-            vec![b"h2".to_vec()],
-        );
+        let acceptor =
+            super::QUICListener::build_server_tls_acceptor(&config, false, vec![b"h2".to_vec()]);
         assert!(acceptor.is_ok());
     }
 
@@ -5068,13 +5066,10 @@ mod tests {
             }],
         );
 
-        let err = super::QUICListener::build_server_tls_acceptor(
-            &config,
-            false,
-            vec![b"h2".to_vec()],
-        )
-        .err()
-        .expect("mismatched SNI cert mapping should fail");
+        let err =
+            super::QUICListener::build_server_tls_acceptor(&config, false, vec![b"h2".to_vec()])
+                .err()
+                .expect("mismatched SNI cert mapping should fail");
         assert!(
             err.to_string()
                 .contains("failed to add SNI certificate mapping"),

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -4883,10 +4883,17 @@ static FALLBACK_RT_THREADS: AtomicUsize = AtomicUsize::new(2);
 mod tests {
     use std::{
         collections::HashMap,
+        path::Path,
         sync::{Arc, RwLock},
     };
 
-    use spooky_config::config::{Backend, LoadBalancing, RouteMatch, Upstream};
+    use rcgen::{Certificate, CertificateParams, SanType};
+    use spooky_config::config::{
+        Backend, ClientAuth, Config as SpookyConfigConfig, Listen, LoadBalancing, Log,
+        Observability, Performance, Resilience, RouteMatch, Security, Tls, TlsCertificate,
+        Upstream, UpstreamTls,
+    };
+    use tempfile::tempdir;
 
     use crate::REQUEST_ID_COUNTER;
     use crate::cid_radix::CidRadix;
@@ -4943,6 +4950,135 @@ mod tests {
                 },
             ],
         }
+    }
+
+    fn write_test_cert_for_name(
+        dir: &Path,
+        cert_name: &str,
+        dns_name: &str,
+    ) -> (String, String) {
+        let mut params = CertificateParams::new(vec![dns_name.to_string()]);
+        params
+            .subject_alt_names
+            .push(SanType::DnsName(dns_name.to_string()));
+        let cert = Certificate::from_params(params).expect("failed to build cert");
+
+        let cert_path = dir.join(format!("{cert_name}.pem"));
+        let key_path = dir.join(format!("{cert_name}.key.pem"));
+
+        std::fs::write(&cert_path, cert.serialize_pem().expect("serialize cert"))
+            .expect("write cert");
+        std::fs::write(&key_path, cert.serialize_private_key_pem()).expect("write key");
+        (
+            cert_path.to_string_lossy().to_string(),
+            key_path.to_string_lossy().to_string(),
+        )
+    }
+
+    fn tls_test_config(cert: String, key: String, certificates: Vec<TlsCertificate>) -> SpookyConfigConfig {
+        let mut upstreams = HashMap::new();
+        upstreams.insert("api".to_string(), test_upstream("round-robin"));
+        SpookyConfigConfig {
+            version: 1,
+            listen: Listen {
+                protocol: "http3".to_string(),
+                port: 9889,
+                address: "127.0.0.1".to_string(),
+                tls: Tls {
+                    cert,
+                    key,
+                    certificates,
+                    client_auth: ClientAuth::default(),
+                },
+            },
+            upstream: upstreams,
+            load_balancing: Some(LoadBalancing {
+                lb_type: "round-robin".to_string(),
+                key: None,
+            }),
+            upstream_tls: UpstreamTls::default(),
+            log: Log::default(),
+            performance: Performance::default(),
+            observability: Observability::default(),
+            resilience: Resilience::default(),
+            security: Security::default(),
+        }
+    }
+
+    #[test]
+    fn default_tls_pair_uses_first_sni_entry_when_legacy_pair_is_missing() {
+        let dir = tempdir().expect("tempdir");
+        let (api_cert, api_key) = write_test_cert_for_name(dir.path(), "api", "api.example.com");
+        let (www_cert, www_key) = write_test_cert_for_name(dir.path(), "www", "www.example.com");
+        let config = tls_test_config(
+            String::new(),
+            String::new(),
+            vec![
+                TlsCertificate {
+                    server_name: "api.example.com".to_string(),
+                    cert: api_cert.clone(),
+                    key: api_key.clone(),
+                },
+                TlsCertificate {
+                    server_name: "www.example.com".to_string(),
+                    cert: www_cert,
+                    key: www_key,
+                },
+            ],
+        );
+
+        let pair = super::QUICListener::default_tls_cert_pair(&config).expect("default pair");
+        assert_eq!(pair.0, api_cert);
+        assert_eq!(pair.1, api_key);
+    }
+
+    #[test]
+    fn build_server_tls_acceptor_accepts_sni_certs_without_legacy_pair() {
+        let dir = tempdir().expect("tempdir");
+        let (api_cert, api_key) = write_test_cert_for_name(dir.path(), "api", "api.example.com");
+        let config = tls_test_config(
+            String::new(),
+            String::new(),
+            vec![TlsCertificate {
+                server_name: "api.example.com".to_string(),
+                cert: api_cert,
+                key: api_key,
+            }],
+        );
+
+        let acceptor = super::QUICListener::build_server_tls_acceptor(
+            &config,
+            false,
+            vec![b"h2".to_vec()],
+        );
+        assert!(acceptor.is_ok());
+    }
+
+    #[test]
+    fn build_server_tls_acceptor_rejects_mismatched_sni_certificate_mapping() {
+        let dir = tempdir().expect("tempdir");
+        let (api_cert, api_key) = write_test_cert_for_name(dir.path(), "api", "api.example.com");
+        let config = tls_test_config(
+            String::new(),
+            String::new(),
+            vec![TlsCertificate {
+                server_name: "other.example.com".to_string(),
+                cert: api_cert,
+                key: api_key,
+            }],
+        );
+
+        let err = super::QUICListener::build_server_tls_acceptor(
+            &config,
+            false,
+            vec![b"h2".to_vec()],
+        )
+        .expect_err("mismatched SNI cert mapping should fail");
+        assert!(
+            err.to_string()
+                .contains("failed to add SNI certificate mapping"),
+            "unexpected error: {err}"
+        );
     }
 
     type TestRoutingContext = (

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -102,6 +102,7 @@ fn make_config(port: u32, backend_addr: String, cert: String, key: String) -> Co
             tls: Tls {
                 cert,
                 key,
+                certificates: vec![],
                 client_auth: ClientAuth::default(),
             },
         },

--- a/crates/edge/tests/h3_edge.rs
+++ b/crates/edge/tests/h3_edge.rs
@@ -88,6 +88,7 @@ fn make_config(port: u32, cert: String, key: String, backend_address: String) ->
             tls: Tls {
                 cert,
                 key,
+                certificates: vec![],
                 client_auth: ClientAuth::default(),
             },
         },
@@ -826,6 +827,7 @@ fn make_config_with_rate_limit(
             tls: Tls {
                 cert,
                 key,
+                certificates: vec![],
                 client_auth: ClientAuth::default(),
             },
         },

--- a/crates/edge/tests/lb_integration.rs
+++ b/crates/edge/tests/lb_integration.rs
@@ -112,6 +112,7 @@ fn make_config(
             tls: Tls {
                 cert,
                 key,
+                certificates: vec![],
                 client_auth: ClientAuth::default(),
             },
         },

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -112,8 +112,9 @@ The following table lists all default configuration values used when properties 
 | `listen.protocol` | `"http3"` | Native ingress protocol (HTTP/3 over QUIC); TLS bootstrap ingress for HTTP/1.1/2 compatibility is also active |
 | `listen.port` | `9889` | Listening port |
 | `listen.address` | `"0.0.0.0"` | Listening address |
-| `listen.tls.cert` | Required | TLS certificate file path |
-| `listen.tls.key` | Required | TLS private key file path |
+| `listen.tls.cert` | optional | Legacy/default TLS certificate file path |
+| `listen.tls.key` | optional | Legacy/default TLS private key file path |
+| `listen.tls.certificates` | `[]` | Optional SNI certificate mappings (`server_name` + `cert` + `key`) |
 | `upstream[].route.path_prefix` | none | Path prefix for routing (set explicitly; use `/` for catch-all) |
 | `upstream[].backends[].weight` | `100` | Backend weight for load balancing |
 | `upstream[].backends[].health_check.path` | `"/health"` | Health check endpoint |
@@ -160,8 +161,18 @@ Spooky also exposes a TLS bootstrap ingress for HTTP/1.1 and HTTP/2 clients. Thi
 
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
-| `cert` | string | Yes | Path to TLS certificate file (PEM format) |
-| `key` | string | Yes | Path to TLS private key file (PEM format, PKCS#8 recommended) |
+| `cert` | string | Conditionally | Legacy/default TLS certificate path. Required with `key` when no `certificates` entries are configured |
+| `key` | string | Conditionally | Legacy/default TLS private key path. Required with `cert` when no `certificates` entries are configured |
+| `certificates` | array | No | SNI certificate entries |
+| `certificates[].server_name` | string | Yes | Exact SNI hostname (DNS name) to match |
+| `certificates[].cert` | string | Yes | Certificate path for that SNI hostname |
+| `certificates[].key` | string | Yes | Private key path for that SNI hostname |
+
+Certificate selection order:
+
+1. Exact SNI match in `listen.tls.certificates`.
+2. Fallback to `listen.tls.cert`/`listen.tls.key` when configured.
+3. If legacy pair is not configured, fallback to the first entry in `listen.tls.certificates`.
 
 ### Examples
 
@@ -183,6 +194,22 @@ listen:
   tls:
     cert: "certs/localhost.crt"
     key: "certs/localhost.key"
+
+# Multi-domain SNI certificates with legacy fallback
+listen:
+  protocol: http3
+  address: "0.0.0.0"
+  port: 9889
+  tls:
+    cert: "/etc/spooky/certs/default.crt"
+    key: "/etc/spooky/certs/default.key"
+    certificates:
+      - server_name: "api.example.com"
+        cert: "/etc/spooky/certs/api.crt"
+        key: "/etc/spooky/certs/api.key"
+      - server_name: "www.example.com"
+        cert: "/etc/spooky/certs/www.crt"
+        key: "/etc/spooky/certs/www.key"
 ```
 
 ## Upstream Configuration
@@ -865,7 +892,7 @@ Spooky validates configuration at startup and reports errors before attempting t
 ### Common Validation Errors
 
 1. **Missing required fields**
-   - TLS certificate or key paths not specified
+   - Neither `listen.tls.cert/key` nor `listen.tls.certificates` specified
    - Backend address or ID missing
    - Route configuration empty
 


### PR DESCRIPTION
Ref: #190 

- Adds multi-certificate downstream TLS support with SNI hostname mapping (`listen.tls.certificates`).
- Preserves backward compatibility with existing single-cert `listen.tls.cert/key`.
- Implements deterministic cert selection:
  - exact SNI match in `listen.tls.certificates`
  - fallback to legacy `cert/key` when set
  - otherwise fallback to first certificates entry
- Extends config validation for SNI hostnames, duplicate entries, and per-entry PEM/key correctness.
- Adds unit tests for SNI-only config, fallback selection, and invalid SNI mapping startup failure.
- Updates configuration reference docs with syntax and precedence rules.