### PR TITLE
feat(edge): add first-class CONNECT tunnel support for H3->H2 forwarding

### DIFF
--- a/crates/bridge/src/h3_to_h2.rs
+++ b/crates/bridge/src/h3_to_h2.rs
@@ -53,11 +53,8 @@ pub fn build_h2_request_for_endpoint(
     forwarded_ctx: ForwardedContext<'_>,
 ) -> Result<Request<BoxBody<Bytes, Infallible>>, BridgeError> {
     let method = Method::from_bytes(method.as_bytes()).map_err(|_| BridgeError::InvalidMethod)?;
-    let request_path = if path.is_empty() { "/" } else { path };
-    let uri = endpoint.uri_for_path(request_path);
-    let uri = Uri::try_from(uri).map_err(|_| BridgeError::InvalidUri)?;
-
-    let mut builder = Request::builder().method(method).uri(uri);
+    let is_connect = method == Method::CONNECT;
+    let mut builder = Request::builder().method(method.clone());
     let connection_tokens = connection_header_tokens(headers);
     let mut host_from_headers: Option<String> = None;
 
@@ -86,6 +83,15 @@ pub fn build_h2_request_for_endpoint(
         .or(host_from_headers.as_deref())
         .filter(|value| !value.trim().is_empty())
         .unwrap_or(endpoint.authority());
+
+    let uri = if is_connect {
+        Uri::try_from(host_value).map_err(|_| BridgeError::InvalidUri)?
+    } else {
+        let request_path = if path.is_empty() { "/" } else { path };
+        let uri = endpoint.uri_for_path(request_path);
+        Uri::try_from(uri).map_err(|_| BridgeError::InvalidUri)?
+    };
+    builder = builder.uri(uri);
     builder = builder.header(http::header::HOST, host_value);
 
     if let Some(len) = content_length
@@ -360,6 +366,32 @@ mod tests {
         assert_eq!(
             req.headers().get("forwarded").and_then(|h| h.to_str().ok()),
             Some("for=\"[2001:db8::1]\";proto=https;host=\"api.example.com\"")
+        );
+    }
+
+    #[test]
+    fn connect_uses_authority_form_request_target() {
+        let req = build_h2_request(
+            "proxy.internal:8443",
+            "CONNECT",
+            "/",
+            &[],
+            Empty::<Bytes>::new().boxed(),
+            None,
+            ForwardedContext {
+                client_addr: "203.0.113.8:44321".parse().expect("client"),
+                request_authority: Some("target.example.com:443"),
+                request_id: 0,
+                traceparent: None,
+            },
+        )
+        .expect("request");
+
+        assert_eq!(req.method(), http::Method::CONNECT);
+        assert_eq!(req.uri().to_string(), "target.example.com:443");
+        assert_eq!(
+            req.headers().get(HOST).and_then(|h| h.to_str().ok()),
+            Some("target.example.com:443")
         );
     }
 }

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -42,6 +42,7 @@ use crate::default::{
     resilience_default_cb_failure_threshold, resilience_default_cb_half_open_max_probes,
     resilience_default_cb_open_ms, resilience_default_hedging_delay_ms,
     resilience_default_hedging_enabled, resilience_default_protocol_allow_0rtt,
+    resilience_default_protocol_allow_connect,
     resilience_default_protocol_enforce_authority_host_match,
     resilience_default_protocol_max_headers_bytes, resilience_default_protocol_max_headers_count,
     resilience_default_retry_budget_enabled, resilience_default_retry_budget_ratio_percent,
@@ -589,6 +590,8 @@ impl Default for RouteQueue {
 pub struct ProtocolPolicy {
     #[serde(default = "resilience_default_protocol_allow_0rtt")]
     pub allow_0rtt: bool,
+    #[serde(default = "resilience_default_protocol_allow_connect")]
+    pub allow_connect: bool,
     #[serde(default)]
     pub early_data_safe_methods: Vec<String>,
     #[serde(default = "resilience_default_protocol_max_headers_count")]
@@ -601,12 +604,17 @@ pub struct ProtocolPolicy {
     pub allowed_methods: Vec<String>,
     #[serde(default)]
     pub denied_path_prefixes: Vec<String>,
+    #[serde(default)]
+    pub connect_allowed_ports: Vec<u16>,
+    #[serde(default)]
+    pub connect_allowed_authorities: Vec<String>,
 }
 
 impl Default for ProtocolPolicy {
     fn default() -> Self {
         Self {
             allow_0rtt: resilience_default_protocol_allow_0rtt(),
+            allow_connect: resilience_default_protocol_allow_connect(),
             early_data_safe_methods: vec!["GET".to_string(), "HEAD".to_string()],
             max_headers_count: resilience_default_protocol_max_headers_count(),
             max_headers_bytes: resilience_default_protocol_max_headers_bytes(),
@@ -614,6 +622,8 @@ impl Default for ProtocolPolicy {
             ),
             allowed_methods: Vec::new(),
             denied_path_prefixes: Vec::new(),
+            connect_allowed_ports: Vec::new(),
+            connect_allowed_authorities: Vec::new(),
         }
     }
 }

--- a/crates/config/src/default.rs
+++ b/crates/config/src/default.rs
@@ -263,6 +263,10 @@ pub fn resilience_default_protocol_enforce_authority_host_match() -> bool {
     true
 }
 
+pub fn resilience_default_protocol_allow_connect() -> bool {
+    false
+}
+
 pub fn resilience_default_cb_enabled() -> bool {
     true
 }

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -140,6 +140,39 @@ fn is_valid_http_token(value: &str) -> bool {
         })
 }
 
+fn is_valid_connect_authority(value: &str) -> bool {
+    let trimmed = value.trim();
+    if trimmed.is_empty() || trimmed.chars().any(char::is_whitespace) {
+        return false;
+    }
+
+    if let Some(rest) = trimmed.strip_prefix('[') {
+        let Some(end) = rest.find(']') else {
+            return false;
+        };
+        let host = &rest[..end];
+        if host.is_empty() {
+            return false;
+        }
+        let suffix = &rest[end + 1..];
+        if !suffix.starts_with(':') || suffix.len() <= 1 {
+            return false;
+        }
+        return suffix[1..]
+            .parse::<u16>()
+            .ok()
+            .is_some_and(|port| port > 0);
+    }
+
+    let Some((host, port)) = trimmed.rsplit_once(':') else {
+        return false;
+    };
+    if host.is_empty() || host.contains(':') {
+        return false;
+    }
+    port.parse::<u16>().ok().is_some_and(|value| value > 0)
+}
+
 fn normalize_route_host(raw: &str) -> String {
     let trimmed = raw.trim();
     let host = if let Some(rest) = trimmed.strip_prefix('[') {
@@ -596,6 +629,40 @@ pub fn validate(config: &Config) -> bool {
         .any(|prefix| prefix.is_empty() || !prefix.starts_with('/'))
     {
         error!("resilience.protocol.denied_path_prefixes must contain '/'-prefixed paths");
+        return false;
+    }
+
+    if !config.resilience.protocol.allow_connect
+        && (!config.resilience.protocol.connect_allowed_ports.is_empty()
+            || !config.resilience.protocol.connect_allowed_authorities.is_empty())
+    {
+        error!(
+            "resilience.protocol.connect_allowed_ports/connect_allowed_authorities require allow_connect=true"
+        );
+        return false;
+    }
+
+    if config
+        .resilience
+        .protocol
+        .connect_allowed_ports
+        .iter()
+        .any(|port| *port == 0)
+    {
+        error!("resilience.protocol.connect_allowed_ports must contain ports in range 1-65535");
+        return false;
+    }
+
+    if config
+        .resilience
+        .protocol
+        .connect_allowed_authorities
+        .iter()
+        .any(|authority| !is_valid_connect_authority(authority))
+    {
+        error!(
+            "resilience.protocol.connect_allowed_authorities must contain authority-form host:port targets"
+        );
         return false;
     }
 
@@ -1323,9 +1390,16 @@ upstream:
         assert_eq!(cfg.resilience.route_queue.global_cap, 2048);
         assert_eq!(cfg.resilience.route_queue.shed_retry_after_seconds, 1);
         assert!(!cfg.resilience.protocol.allow_0rtt);
+        assert!(!cfg.resilience.protocol.allow_connect);
         assert_eq!(cfg.resilience.protocol.max_headers_count, 128);
         assert_eq!(cfg.resilience.protocol.max_headers_bytes, 16 * 1024);
         assert!(cfg.resilience.protocol.enforce_authority_host_match);
+        assert!(cfg.resilience.protocol.connect_allowed_ports.is_empty());
+        assert!(cfg
+            .resilience
+            .protocol
+            .connect_allowed_authorities
+            .is_empty());
         assert!(!cfg.resilience.watchdog.enabled);
         assert_eq!(cfg.resilience.watchdog.check_interval_ms, 1_000);
         assert_eq!(cfg.observability.control_api.max_connections, 256);
@@ -1516,6 +1590,26 @@ upstream:
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.resilience.protocol.denied_path_prefixes = vec!["admin".to_string()];
         assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.resilience.protocol.connect_allowed_ports = vec![443];
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.resilience.protocol.allow_connect = true;
+        cfg.resilience.protocol.connect_allowed_ports = vec![0];
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.resilience.protocol.allow_connect = true;
+        cfg.resilience.protocol.connect_allowed_authorities = vec!["example.com".to_string()];
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.resilience.protocol.allow_connect = true;
+        cfg.resilience.protocol.connect_allowed_authorities = vec!["example.com:443".to_string()];
+        cfg.resilience.protocol.connect_allowed_ports = vec![443];
+        assert!(validate(&cfg));
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.resilience.protocol.allowed_methods = vec!["".to_string()];

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -158,10 +158,7 @@ fn is_valid_connect_authority(value: &str) -> bool {
         if !suffix.starts_with(':') || suffix.len() <= 1 {
             return false;
         }
-        return suffix[1..]
-            .parse::<u16>()
-            .ok()
-            .is_some_and(|port| port > 0);
+        return suffix[1..].parse::<u16>().ok().is_some_and(|port| port > 0);
     }
 
     let Some((host, port)) = trimmed.rsplit_once(':') else {
@@ -634,7 +631,11 @@ pub fn validate(config: &Config) -> bool {
 
     if !config.resilience.protocol.allow_connect
         && (!config.resilience.protocol.connect_allowed_ports.is_empty()
-            || !config.resilience.protocol.connect_allowed_authorities.is_empty())
+            || !config
+                .resilience
+                .protocol
+                .connect_allowed_authorities
+                .is_empty())
     {
         error!(
             "resilience.protocol.connect_allowed_ports/connect_allowed_authorities require allow_connect=true"
@@ -646,8 +647,7 @@ pub fn validate(config: &Config) -> bool {
         .resilience
         .protocol
         .connect_allowed_ports
-        .iter()
-        .any(|port| *port == 0)
+        .contains(&0)
     {
         error!("resilience.protocol.connect_allowed_ports must contain ports in range 1-65535");
         return false;
@@ -1395,11 +1395,12 @@ upstream:
         assert_eq!(cfg.resilience.protocol.max_headers_bytes, 16 * 1024);
         assert!(cfg.resilience.protocol.enforce_authority_host_match);
         assert!(cfg.resilience.protocol.connect_allowed_ports.is_empty());
-        assert!(cfg
-            .resilience
-            .protocol
-            .connect_allowed_authorities
-            .is_empty());
+        assert!(
+            cfg.resilience
+                .protocol
+                .connect_allowed_authorities
+                .is_empty()
+        );
         assert!(!cfg.resilience.watchdog.enabled);
         assert_eq!(cfg.resilience.watchdog.check_interval_ms, 1_000);
         assert_eq!(cfg.observability.control_api.max_connections, 256);

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -209,6 +209,27 @@ fn response_size_exceeded_after_chunk(
     *response_bytes_received > max_response_body_bytes
 }
 
+fn is_connect_method(method: &str) -> bool {
+    method.eq_ignore_ascii_case("CONNECT")
+}
+
+fn is_connect_tunnel_response(method: &str, status: StatusCode) -> bool {
+    is_connect_method(method) && status.is_success()
+}
+
+fn can_poll_upstream_result(req: &RequestEnvelope) -> bool {
+    if is_connect_method(&req.method)
+        && (req.phase == StreamPhase::ReceivingRequest || req.phase == StreamPhase::AwaitingUpstream)
+    {
+        return true;
+    }
+
+    req.phase == StreamPhase::AwaitingUpstream
+        && req.request_fin_received
+        && req.body_tx.is_none()
+        && req.body_buf.is_empty()
+}
+
 fn header_has_token(value: &http::HeaderValue, token: &str) -> bool {
     value
         .to_str()
@@ -2521,7 +2542,8 @@ impl QUICListener {
                                     // Enforce cap on total bytes received for the stream,
                                     // including chunks already forwarded to the H2 body channel.
                                     let next_total = req.body_bytes_received.saturating_add(read);
-                                    if next_total > max_request_body_bytes {
+                                    let request_is_connect = is_connect_method(&req.method);
+                                    if !request_is_connect && next_total > max_request_body_bytes {
                                         payload_too_large = Some((
                                             req.upstream_name
                                                 .clone()
@@ -2814,13 +2836,10 @@ impl QUICListener {
             // Only transition to response handling once request-body ingestion is
             // complete. This preserves request-size enforcement semantics:
             // oversized requests must still be able to terminate with 413 even if
-            // upstream produced an early response.
-            let can_poll_upstream = streams.get(&stream_id).is_some_and(|req| {
-                req.phase == StreamPhase::AwaitingUpstream
-                    && req.request_fin_received
-                    && req.body_tx.is_none()
-                    && req.body_buf.is_empty()
-            });
+            // upstream produced an early response. CONNECT is the exception:
+            // successful CONNECT establishes a tunnel and must not wait for request FIN.
+            let can_poll_upstream =
+                streams.get(&stream_id).is_some_and(can_poll_upstream_result);
 
             // upstream_ready: Option<UpstreamResult>
             //   None          → oneshot not yet resolved (or not eligible), skip
@@ -2885,13 +2904,18 @@ impl QUICListener {
                 }
                 match forward_result.forward {
                     Ok((status, resp_headers, body)) => {
+                        let connect_tunnel = streams
+                            .get(&stream_id)
+                            .is_some_and(|req| is_connect_tunnel_response(&req.method, status));
                         // If upstream advertised a response length beyond our hard cap,
                         // fail fast with 503 before sending any downstream headers/body.
                         let upstream_content_length = resp_headers
                             .get(http::header::CONTENT_LENGTH)
                             .and_then(|v| v.to_str().ok())
                             .and_then(|v| v.parse::<usize>().ok());
-                        if upstream_content_length.is_some_and(|len| len > max_response_body_bytes)
+                        if !connect_tunnel
+                            && upstream_content_length
+                                .is_some_and(|len| len > max_response_body_bytes)
                         {
                             if let Some(req) = streams.get(&stream_id) {
                                 metrics.inc_failure();
@@ -2946,10 +2970,12 @@ impl QUICListener {
                             format!("h3=\":{}\"; ma=86400", listen_port).into_bytes(),
                         ));
 
-                        let defer_headers_until_body_validated = upstream_content_length.is_none();
-                        let immediate_end = upstream_content_length == Some(0)
-                            || status == http::StatusCode::NO_CONTENT
-                            || status == http::StatusCode::NOT_MODIFIED;
+                        let defer_headers_until_body_validated =
+                            upstream_content_length.is_none() && !connect_tunnel;
+                        let immediate_end = !connect_tunnel
+                            && (upstream_content_length == Some(0)
+                                || status == http::StatusCode::NO_CONTENT
+                                || status == http::StatusCode::NOT_MODIFIED);
                         let mut immediate_terminal = false;
 
                         if !defer_headers_until_body_validated {
@@ -3066,6 +3092,7 @@ impl QUICListener {
                                 tokio::time::Instant::now() + backend_body_total_timeout;
                             let deferred_status = status;
                             let deferred_headers = owned_h3_headers.clone();
+                            let tunnel_mode = connect_tunnel;
                             let fut = async move {
                                 use http_body_util::BodyExt;
                                 let mut body: hyper::body::Incoming = body;
@@ -3103,11 +3130,13 @@ impl QUICListener {
                                                 if !data.is_empty() {
                                                     saw_body_progress = true;
                                                 }
-                                                if response_size_exceeded_after_chunk(
-                                                    &mut response_bytes_received,
-                                                    data.len(),
-                                                    max_response_body_bytes,
-                                                ) {
+                                                if !tunnel_mode
+                                                    && response_size_exceeded_after_chunk(
+                                                        &mut response_bytes_received,
+                                                        data.len(),
+                                                        max_response_body_bytes,
+                                                    )
+                                                {
                                                     let _ = chunk_tx
                                                         .send(ResponseChunk::Error(ProxyError::Pool(
                                                             PoolError::BackendOverloaded(
@@ -4974,7 +5003,8 @@ mod tests {
 
     use super::{
         ConnectionRoutes, TokenBucket, abort_stream, classify_active_health_check_response,
-        collect_h3_trailers, connection_header_tokens, purge_connection_routes,
+        can_poll_upstream_result, collect_h3_trailers, connection_header_tokens,
+        is_connect_tunnel_response, purge_connection_routes,
         resolve_primary_from_radix_prefix, response_size_exceeded_after_chunk,
         should_strip_bootstrap_request_header, should_strip_bootstrap_response_header,
         should_strip_h3_response_header, sweep_closed_connections,
@@ -5546,6 +5576,37 @@ mod tests {
         assert_eq!(received, 10);
         assert!(response_size_exceeded_after_chunk(&mut received, 1, 10));
         assert_eq!(received, 11);
+    }
+
+    #[test]
+    fn connect_tunnel_response_detected_only_for_success_status() {
+        assert!(is_connect_tunnel_response("CONNECT", StatusCode::OK));
+        assert!(is_connect_tunnel_response("connect", StatusCode::NO_CONTENT));
+        assert!(!is_connect_tunnel_response("CONNECT", StatusCode::BAD_GATEWAY));
+        assert!(!is_connect_tunnel_response("GET", StatusCode::OK));
+    }
+
+    #[test]
+    fn connect_can_poll_upstream_before_request_fin() {
+        let (_tx, rx) = oneshot::channel::<crate::UpstreamResult>();
+        let mut req = make_envelope(StreamPhase::ReceivingRequest);
+        req.method = "CONNECT".to_string();
+        req.request_fin_received = false;
+        req.upstream_result_rx = Some(rx);
+        assert!(can_poll_upstream_result(&req));
+    }
+
+    #[test]
+    fn non_connect_requires_request_completion_before_upstream_poll() {
+        let (_tx, rx) = oneshot::channel::<crate::UpstreamResult>();
+        let mut req = make_envelope(StreamPhase::AwaitingUpstream);
+        req.method = "GET".to_string();
+        req.request_fin_received = false;
+        req.upstream_result_rx = Some(rx);
+        assert!(!can_poll_upstream_result(&req));
+
+        req.request_fin_received = true;
+        assert!(can_poll_upstream_result(&req));
     }
 
     #[test]

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -219,7 +219,8 @@ fn is_connect_tunnel_response(method: &str, status: StatusCode) -> bool {
 
 fn can_poll_upstream_result(req: &RequestEnvelope) -> bool {
     if is_connect_method(&req.method)
-        && (req.phase == StreamPhase::ReceivingRequest || req.phase == StreamPhase::AwaitingUpstream)
+        && (req.phase == StreamPhase::ReceivingRequest
+            || req.phase == StreamPhase::AwaitingUpstream)
     {
         return true;
     }
@@ -2838,8 +2839,9 @@ impl QUICListener {
             // oversized requests must still be able to terminate with 413 even if
             // upstream produced an early response. CONNECT is the exception:
             // successful CONNECT establishes a tunnel and must not wait for request FIN.
-            let can_poll_upstream =
-                streams.get(&stream_id).is_some_and(can_poll_upstream_result);
+            let can_poll_upstream = streams
+                .get(&stream_id)
+                .is_some_and(can_poll_upstream_result);
 
             // upstream_ready: Option<UpstreamResult>
             //   None          → oneshot not yet resolved (or not eligible), skip
@@ -5002,12 +5004,12 @@ mod tests {
     use std::sync::atomic::Ordering;
 
     use super::{
-        ConnectionRoutes, TokenBucket, abort_stream, classify_active_health_check_response,
-        can_poll_upstream_result, collect_h3_trailers, connection_header_tokens,
-        is_connect_tunnel_response, purge_connection_routes,
-        resolve_primary_from_radix_prefix, response_size_exceeded_after_chunk,
-        should_strip_bootstrap_request_header, should_strip_bootstrap_response_header,
-        should_strip_h3_response_header, sweep_closed_connections,
+        ConnectionRoutes, TokenBucket, abort_stream, can_poll_upstream_result,
+        classify_active_health_check_response, collect_h3_trailers, connection_header_tokens,
+        is_connect_tunnel_response, purge_connection_routes, resolve_primary_from_radix_prefix,
+        response_size_exceeded_after_chunk, should_strip_bootstrap_request_header,
+        should_strip_bootstrap_response_header, should_strip_h3_response_header,
+        sweep_closed_connections,
     };
     type RoutingMaps = (
         HashMap<Arc<[u8]>, Arc<[u8]>>,
@@ -5581,8 +5583,14 @@ mod tests {
     #[test]
     fn connect_tunnel_response_detected_only_for_success_status() {
         assert!(is_connect_tunnel_response("CONNECT", StatusCode::OK));
-        assert!(is_connect_tunnel_response("connect", StatusCode::NO_CONTENT));
-        assert!(!is_connect_tunnel_response("CONNECT", StatusCode::BAD_GATEWAY));
+        assert!(is_connect_tunnel_response(
+            "connect",
+            StatusCode::NO_CONTENT
+        ));
+        assert!(!is_connect_tunnel_response(
+            "CONNECT",
+            StatusCode::BAD_GATEWAY
+        ));
         assert!(!is_connect_tunnel_response("GET", StatusCode::OK));
     }
 

--- a/crates/edge/src/quic_listener/validation.rs
+++ b/crates/edge/src/quic_listener/validation.rs
@@ -129,9 +129,25 @@ pub(super) fn validate_request_headers(
             ));
         }
     };
-    let path = match path {
-        Some(path) => path,
-        None => {
+    let is_connect = method.eq_ignore_ascii_case("CONNECT");
+    let path = match (is_connect, path) {
+        (true, Some(path)) if path.is_empty() => {
+            return Err((
+                http::StatusCode::BAD_REQUEST,
+                b"invalid CONNECT :path header\n",
+                false,
+            ));
+        }
+        (true, Some(_)) => {
+            return Err((
+                http::StatusCode::BAD_REQUEST,
+                b"invalid CONNECT :path header\n",
+                false,
+            ));
+        }
+        (true, None) => "/".to_string(),
+        (false, Some(path)) => path,
+        (false, None) => {
             return Err((
                 http::StatusCode::BAD_REQUEST,
                 b"missing :path header\n",
@@ -151,6 +167,8 @@ pub(super) fn validate_request_headers(
             invalid_method: b"invalid :method header\n",
             invalid_path: b"invalid :path header\n",
             authority_mismatch: b":authority and host headers must match\n",
+            connect_path_not_allowed: b"invalid CONNECT :path header\n",
+            connect_authority_required: b"CONNECT requires authority host:port\n",
         },
     )
 }
@@ -221,6 +239,8 @@ pub(super) fn validate_http_request(
             invalid_method: b"invalid method header\n",
             invalid_path: b"invalid path header\n",
             authority_mismatch: b"authority and host headers must match\n",
+            connect_path_not_allowed: b"invalid CONNECT path\n",
+            connect_authority_required: b"CONNECT requires authority host:port\n",
         },
     )
 }
@@ -238,6 +258,8 @@ struct RequestPartErrors {
     invalid_method: &'static [u8],
     invalid_path: &'static [u8],
     authority_mismatch: &'static [u8],
+    connect_path_not_allowed: &'static [u8],
+    connect_authority_required: &'static [u8],
 }
 
 fn validate_request_parts(
@@ -249,11 +271,20 @@ fn validate_request_parts(
     resilience: &RuntimeResilience,
     errors: RequestPartErrors,
 ) -> Result<RequestValidationResult, (http::StatusCode, &'static [u8], bool)> {
+    let is_connect = method.eq_ignore_ascii_case("CONNECT");
     if method.trim().is_empty() || method.as_bytes().iter().any(|b| b.is_ascii_whitespace()) {
         return Err((http::StatusCode::BAD_REQUEST, errors.invalid_method, false));
     }
 
-    if path.is_empty() || !path.starts_with('/') {
+    if is_connect {
+        if !path.is_empty() && path != "/" {
+            return Err((
+                http::StatusCode::BAD_REQUEST,
+                errors.connect_path_not_allowed,
+                false,
+            ));
+        }
+    } else if path.is_empty() || !path.starts_with('/') {
         return Err((http::StatusCode::BAD_REQUEST, errors.invalid_path, false));
     }
 
@@ -281,7 +312,20 @@ fn validate_request_parts(
         ));
     }
 
-    if resilience.path_denied(&path) {
+    if is_connect {
+        let connect_authority = authority.as_deref().or(host.as_deref()).ok_or((
+            http::StatusCode::BAD_REQUEST,
+            errors.connect_authority_required,
+            false,
+        ))?;
+        if !resilience.connect_allowed(connect_authority) {
+            return Err((
+                http::StatusCode::FORBIDDEN,
+                b"CONNECT target denied by policy\n",
+                true,
+            ));
+        }
+    } else if resilience.path_denied(&path) {
         return Err((
             http::StatusCode::FORBIDDEN,
             b"request path blocked by policy\n",
@@ -561,5 +605,61 @@ mod tests {
         assert_eq!(err.0, http::StatusCode::BAD_REQUEST);
         assert_eq!(err.1, b"conflicting content-length header\n");
         assert!(!err.2);
+    }
+
+    #[test]
+    fn connect_without_path_is_accepted_when_policy_allows_target() {
+        let mut cfg = Resilience::default();
+        cfg.protocol.allow_connect = true;
+        cfg.protocol.connect_allowed_authorities = vec!["proxy.example.com:443".to_string()];
+        let resilience = RuntimeResilience::from_config(&cfg, 1024);
+        let headers = vec![
+            h3_header(b":method", b"CONNECT"),
+            h3_header(b":authority", b"proxy.example.com:443"),
+        ];
+
+        let request =
+            validate_request_headers(&headers, &resilience).expect("CONNECT request should pass");
+        assert_eq!(request.method, "CONNECT");
+        assert_eq!(request.path, "/");
+        assert_eq!(request.authority.as_deref(), Some("proxy.example.com:443"));
+    }
+
+    #[test]
+    fn connect_missing_authority_is_rejected() {
+        let mut cfg = Resilience::default();
+        cfg.protocol.allow_connect = true;
+        let resilience = RuntimeResilience::from_config(&cfg, 1024);
+        let headers = vec![h3_header(b":method", b"CONNECT")];
+
+        let err = validate_request_headers(&headers, &resilience)
+            .expect_err("CONNECT without authority must be rejected");
+        assert_eq!(err.0, http::StatusCode::BAD_REQUEST);
+        assert_eq!(err.1, b"CONNECT requires authority host:port\n");
+        assert!(!err.2);
+    }
+
+    #[test]
+    fn connect_is_denied_when_policy_disables_or_blocks_target() {
+        let resilience = runtime_resilience();
+        let headers = vec![
+            h3_header(b":method", b"CONNECT"),
+            h3_header(b":authority", b"proxy.example.com:443"),
+        ];
+        let err = validate_request_headers(&headers, &resilience)
+            .expect_err("CONNECT should be denied by default policy");
+        assert_eq!(err.0, http::StatusCode::FORBIDDEN);
+        assert_eq!(err.1, b"CONNECT target denied by policy\n");
+        assert!(err.2);
+
+        let mut cfg = Resilience::default();
+        cfg.protocol.allow_connect = true;
+        cfg.protocol.connect_allowed_ports = vec![8443];
+        let resilience = RuntimeResilience::from_config(&cfg, 1024);
+        let err = validate_request_headers(&headers, &resilience)
+            .expect_err("CONNECT should be denied when port is not allowlisted");
+        assert_eq!(err.0, http::StatusCode::FORBIDDEN);
+        assert_eq!(err.1, b"CONNECT target denied by policy\n");
+        assert!(err.2);
     }
 }

--- a/crates/edge/src/resilience.rs
+++ b/crates/edge/src/resilience.rs
@@ -441,12 +441,15 @@ pub struct RuntimeResilience {
     pub max_headers_count: usize,
     pub max_headers_bytes: usize,
     pub enforce_authority_host_match: bool,
+    pub allow_connect: bool,
     pub hedging_enabled: bool,
     pub hedging_delay: Duration,
     hedge_safe_methods: HashSet<String>,
     early_data_safe_methods: HashSet<String>,
     allowed_methods: HashSet<String>,
     denied_path_prefixes: Vec<String>,
+    connect_allowed_ports: HashSet<u16>,
+    connect_allowed_authorities: HashSet<String>,
     route_allowlist: HashSet<String>,
 }
 
@@ -510,6 +513,18 @@ impl RuntimeResilience {
             .iter()
             .cloned()
             .collect::<HashSet<_>>();
+        let connect_allowed_ports = config
+            .protocol
+            .connect_allowed_ports
+            .iter()
+            .copied()
+            .collect::<HashSet<_>>();
+        let connect_allowed_authorities = config
+            .protocol
+            .connect_allowed_authorities
+            .iter()
+            .filter_map(|authority| normalize_connect_authority(authority))
+            .collect::<HashSet<_>>();
 
         Self {
             adaptive_admission: admission,
@@ -522,12 +537,15 @@ impl RuntimeResilience {
             max_headers_count: config.protocol.max_headers_count.max(1),
             max_headers_bytes: config.protocol.max_headers_bytes.max(1),
             enforce_authority_host_match: config.protocol.enforce_authority_host_match,
+            allow_connect: config.protocol.allow_connect,
             hedging_enabled: config.hedging.enabled,
             hedging_delay: Duration::from_millis(config.hedging.delay_ms),
             hedge_safe_methods,
             early_data_safe_methods,
             allowed_methods,
             denied_path_prefixes: config.protocol.denied_path_prefixes.clone(),
+            connect_allowed_ports,
+            connect_allowed_authorities,
             route_allowlist,
         }
     }
@@ -562,6 +580,73 @@ impl RuntimeResilience {
             .iter()
             .any(|prefix| path.starts_with(prefix))
     }
+
+    pub fn connect_allowed(&self, authority: &str) -> bool {
+        if !self.allow_connect {
+            return false;
+        }
+        let Some(normalized_authority) = normalize_connect_authority(authority) else {
+            return false;
+        };
+        let Some(port) = connect_authority_port(&normalized_authority) else {
+            return false;
+        };
+        if !self.connect_allowed_ports.is_empty() && !self.connect_allowed_ports.contains(&port) {
+            return false;
+        }
+        if self.connect_allowed_authorities.is_empty() {
+            return true;
+        }
+        self.connect_allowed_authorities
+            .contains(&normalized_authority)
+    }
+}
+
+fn normalize_connect_authority(authority: &str) -> Option<String> {
+    let trimmed = authority.trim();
+    if trimmed.is_empty() || trimmed.chars().any(char::is_whitespace) {
+        return None;
+    }
+
+    if let Some(rest) = trimmed.strip_prefix('[') {
+        let end = rest.find(']')?;
+        let host = &rest[..end];
+        if host.is_empty() {
+            return None;
+        }
+        let suffix = &rest[end + 1..];
+        if !suffix.starts_with(':') || suffix.len() <= 1 {
+            return None;
+        }
+        let port = suffix[1..].parse::<u16>().ok().filter(|value| *value > 0)?;
+        return Some(format!(
+            "[{}]:{}",
+            host.trim_end_matches('.').to_ascii_lowercase(),
+            port
+        ));
+    }
+
+    let (host, port) = trimmed.rsplit_once(':')?;
+    if host.is_empty() || host.contains(':') {
+        return None;
+    }
+    let port = port.parse::<u16>().ok().filter(|value| *value > 0)?;
+    Some(format!(
+        "{}:{}",
+        host.trim_end_matches('.').to_ascii_lowercase(),
+        port
+    ))
+}
+
+fn connect_authority_port(normalized_authority: &str) -> Option<u16> {
+    if normalized_authority.starts_with('[') {
+        let end = normalized_authority.find(']')?;
+        let suffix = normalized_authority.get(end + 1..)?;
+        return suffix.strip_prefix(':')?.parse::<u16>().ok();
+    }
+    normalized_authority
+        .rsplit_once(':')
+        .and_then(|(_, port)| port.parse::<u16>().ok())
 }
 
 #[cfg(test)]
@@ -641,6 +726,9 @@ mod tests {
         cfg.protocol.denied_path_prefixes = vec!["/admin".to_string()];
         cfg.protocol.allow_0rtt = true;
         cfg.protocol.early_data_safe_methods = vec!["GET".to_string()];
+        cfg.protocol.allow_connect = true;
+        cfg.protocol.connect_allowed_ports = vec![443];
+        cfg.protocol.connect_allowed_authorities = vec!["proxy.example.com:443".to_string()];
 
         let runtime = RuntimeResilience::from_config(&cfg, 64);
         assert!(runtime.method_allowed("GET"));
@@ -649,5 +737,8 @@ mod tests {
         assert!(!runtime.path_denied("/api"));
         assert!(runtime.early_data_allowed_for("GET"));
         assert!(!runtime.early_data_allowed_for("POST"));
+        assert!(runtime.connect_allowed("proxy.example.com:443"));
+        assert!(!runtime.connect_allowed("proxy.example.com:8443"));
+        assert!(!runtime.connect_allowed("other.example.com:443"));
     }
 }


### PR DESCRIPTION
Ref: #192 
- Adds policy-gated CONNECT support for reverse-proxy tunneling.
- Extends config/runtime resilience with `allow_connect`, port allowlist, and authority allowlist validation.
- Accepts CONNECT request shape (`:authority` required, no `:path`) and denies unauthorized targets with 403 policy response.
- Translates CONNECT upstream requests to HTTP/2 authority-form request target.
- Implements CONNECT tunnel lifecycle in H3 listener:
  - allows upstream response handling before request FIN for CONNECT,
  - bypasses normal request/response body size and unknown-length prebuffer enforcement for successful CONNECT tunnels,
  - preserves existing non-CONNECT enforcement paths.
- Adds/updates tests for config validation, request validation, bridge translation, and CONNECT lifecycle behavior.
- Includes formatting/clippy cleanup required by CI lint gates.