### PR TITLE
feat(reverse-proxy): configurable Host rewrite and X-Forwarded-For forwarding policies

### DIFF
--- a/config/config.production.yaml
+++ b/config/config.production.yaml
@@ -18,6 +18,11 @@ upstream:
       type: round-robin
     route:
       path_prefix: "/"
+    host_policy:
+      mode: pass-through   # pass-through | rewrite | upstream
+      # host: "origin.example.com"  # required when mode: rewrite
+    forwarded_headers:
+      mode: append         # append | preserve | overwrite
     backends:
       - id: "backend1"
         address: "backend.internal.example:8443" # verified HTTPS by default (no scheme needed)

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -33,6 +33,13 @@ upstream:
     route:
       path_prefix: "/api"
 
+    host_policy:
+      mode: pass-through   # pass-through | rewrite | upstream
+      # host: "api.example.com"  # required when mode: rewrite
+
+    forwarded_headers:
+      mode: append         # append | preserve | overwrite
+
     backends:
       - id: "backend1"
         address: "api-backend-1.internal.example:7001"   # verified HTTPS by default; use config.development.yaml for local cleartext

--- a/crates/bench/src/main.rs
+++ b/crates/bench/src/main.rs
@@ -737,6 +737,7 @@ fn build_lb_upstream(scale: usize, lb_type: &str) -> Upstream {
             key: None,
         },
         host_policy: Default::default(),
+        forwarded_headers: Default::default(),
         route: RouteMatch {
             host: None,
             path_prefix: Some("/".to_string()),

--- a/crates/bench/src/main.rs
+++ b/crates/bench/src/main.rs
@@ -736,6 +736,7 @@ fn build_lb_upstream(scale: usize, lb_type: &str) -> Upstream {
             lb_type: lb_type.to_string(),
             key: None,
         },
+        host_policy: Default::default(),
         route: RouteMatch {
             host: None,
             path_prefix: Some("/".to_string()),

--- a/crates/bridge/src/h3_to_h2.rs
+++ b/crates/bridge/src/h3_to_h2.rs
@@ -10,7 +10,7 @@ use http_body_util::combinators::BoxBody;
 use quiche::h3::NameValue;
 use spooky_config::{
     backend_endpoint::BackendEndpoint,
-    config::{UpstreamHostPolicy, UpstreamHostPolicyMode},
+    config::{ForwardedHeaderPolicy, ForwardedHeaderPolicyMode, UpstreamHostPolicy, UpstreamHostPolicyMode},
 };
 
 pub use spooky_errors::BridgeError;
@@ -21,6 +21,23 @@ pub struct ForwardedContext<'a> {
     pub request_id: u64,
     pub traceparent: Option<&'a str>,
 }
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ForwardedHeaderChains<'a> {
+    pub forwarded: &'a [Vec<u8>],
+    pub x_forwarded_for: &'a [Vec<u8>],
+    pub x_forwarded_proto: &'a [Vec<u8>],
+    pub x_forwarded_host: &'a [Vec<u8>],
+}
+
+#[derive(Debug, Default)]
+pub struct ForwardedHeaderValues {
+    pub forwarded: Option<HeaderValue>,
+    pub x_forwarded_for: Option<HeaderValue>,
+    pub x_forwarded_proto: Option<HeaderValue>,
+    pub x_forwarded_host: Option<HeaderValue>,
+}
+
 
 /// Build an HTTP/2 request with a pre-boxed streaming body.
 /// `content_length` is `Some(n)` only when the full length is known upfront
@@ -58,6 +75,7 @@ pub fn build_h2_request_for_endpoint(
     build_h2_request_for_endpoint_with_host_policy(
         endpoint,
         &UpstreamHostPolicy::default(),
+        &ForwardedHeaderPolicy::default(),
         method,
         path,
         headers,
@@ -71,6 +89,7 @@ pub fn build_h2_request_for_endpoint(
 pub fn build_h2_request_for_endpoint_with_host_policy(
     endpoint: &BackendEndpoint,
     host_policy: &UpstreamHostPolicy,
+    forwarded_policy: &ForwardedHeaderPolicy,
     method: &str,
     path: &str,
     headers: &[quiche::h3::Header],
@@ -83,10 +102,30 @@ pub fn build_h2_request_for_endpoint_with_host_policy(
     let mut builder = Request::builder().method(method.clone());
     let connection_tokens = connection_header_tokens(headers);
     let mut host_from_headers: Option<String> = None;
+    let mut forwarded_from_headers: Vec<Vec<u8>> = Vec::new();
+    let mut x_forwarded_for_from_headers: Vec<Vec<u8>> = Vec::new();
+    let mut x_forwarded_proto_from_headers: Vec<Vec<u8>> = Vec::new();
+    let mut x_forwarded_host_from_headers: Vec<Vec<u8>> = Vec::new();
 
     for header in headers {
         let name = header.name();
         if name.starts_with(b":") {
+            continue;
+        }
+        if name.eq_ignore_ascii_case(b"forwarded") {
+            forwarded_from_headers.push(header.value().to_vec());
+            continue;
+        }
+        if name.eq_ignore_ascii_case(b"x-forwarded-for") {
+            x_forwarded_for_from_headers.push(header.value().to_vec());
+            continue;
+        }
+        if name.eq_ignore_ascii_case(b"x-forwarded-proto") {
+            x_forwarded_proto_from_headers.push(header.value().to_vec());
+            continue;
+        }
+        if name.eq_ignore_ascii_case(b"x-forwarded-host") {
+            x_forwarded_host_from_headers.push(header.value().to_vec());
             continue;
         }
 
@@ -148,29 +187,29 @@ pub fn build_h2_request_for_endpoint_with_host_policy(
         );
     }
 
-    let forwarded_value = format!(
-        "for={};proto=https;host=\"{}\"",
-        forwarded_for_value(forwarded_ctx.client_addr.ip()),
-        escape_forwarded_host(host_value),
-    );
-    builder = builder
-        .header(
-            HeaderName::from_static("forwarded"),
-            HeaderValue::from_str(&forwarded_value).map_err(|_| BridgeError::InvalidHeader)?,
-        )
-        .header(
-            HeaderName::from_static("x-forwarded-for"),
-            HeaderValue::from_str(&forwarded_ctx.client_addr.ip().to_string())
-                .map_err(|_| BridgeError::InvalidHeader)?,
-        )
-        .header(
-            HeaderName::from_static("x-forwarded-proto"),
-            HeaderValue::from_static("https"),
-        )
-        .header(
-            HeaderName::from_static("x-forwarded-host"),
-            HeaderValue::from_str(host_value).map_err(|_| BridgeError::InvalidHeader)?,
-        );
+    let forwarded_values = build_forwarded_header_values(
+        forwarded_policy,
+        ForwardedHeaderChains {
+            forwarded: &forwarded_from_headers,
+            x_forwarded_for: &x_forwarded_for_from_headers,
+            x_forwarded_proto: &x_forwarded_proto_from_headers,
+            x_forwarded_host: &x_forwarded_host_from_headers,
+        },
+        forwarded_ctx.client_addr.ip(),
+        host_value,
+    )?;
+    if let Some(value) = forwarded_values.forwarded {
+        builder = builder.header(HeaderName::from_static("forwarded"), value);
+    }
+    if let Some(value) = forwarded_values.x_forwarded_for {
+        builder = builder.header(HeaderName::from_static("x-forwarded-for"), value);
+    }
+    if let Some(value) = forwarded_values.x_forwarded_proto {
+        builder = builder.header(HeaderName::from_static("x-forwarded-proto"), value);
+    }
+    if let Some(value) = forwarded_values.x_forwarded_host {
+        builder = builder.header(HeaderName::from_static("x-forwarded-host"), value);
+    }
 
     builder.body(body).map_err(BridgeError::Build)
 }
@@ -193,6 +232,84 @@ pub fn resolve_upstream_host_value<'a>(
             .ok_or(BridgeError::InvalidHeader),
         UpstreamHostPolicyMode::Upstream => Ok(endpoint.authority()),
     }
+}
+
+pub fn build_forwarded_header_values(
+    policy: &ForwardedHeaderPolicy,
+    inbound: ForwardedHeaderChains<'_>,
+    client_ip: IpAddr,
+    host_value: &str,
+) -> Result<ForwardedHeaderValues, BridgeError> {
+    let forwarded_current = format!(
+        "for={};proto=https;host=\"{}\"",
+        forwarded_for_value(client_ip),
+        escape_forwarded_host(host_value),
+    );
+    let x_forwarded_for_current = client_ip.to_string();
+    let x_forwarded_proto_current = "https";
+    let x_forwarded_host_current = host_value;
+
+    Ok(ForwardedHeaderValues {
+        forwarded: merge_forwarded_chain(
+            policy.mode,
+            inbound.forwarded,
+            Some(forwarded_current.as_bytes()),
+        )?,
+        x_forwarded_for: merge_forwarded_chain(
+            policy.mode,
+            inbound.x_forwarded_for,
+            Some(x_forwarded_for_current.as_bytes()),
+        )?,
+        x_forwarded_proto: merge_forwarded_chain(
+            policy.mode,
+            inbound.x_forwarded_proto,
+            Some(x_forwarded_proto_current.as_bytes()),
+        )?,
+        x_forwarded_host: merge_forwarded_chain(
+            policy.mode,
+            inbound.x_forwarded_host,
+            Some(x_forwarded_host_current.as_bytes()),
+        )?,
+    })
+}
+
+fn merge_forwarded_chain(
+    mode: ForwardedHeaderPolicyMode,
+    inbound: &[Vec<u8>],
+    current: Option<&[u8]>,
+) -> Result<Option<HeaderValue>, BridgeError> {
+    match mode {
+        ForwardedHeaderPolicyMode::Preserve => join_header_chain(inbound),
+        ForwardedHeaderPolicyMode::Append => {
+            let mut values = inbound.to_vec();
+            if let Some(current) = current {
+                values.push(current.to_vec());
+            }
+            join_header_chain(&values)
+        }
+        ForwardedHeaderPolicyMode::Overwrite => current
+            .map(HeaderValue::from_bytes)
+            .transpose()
+            .map_err(|_| BridgeError::InvalidHeader),
+    }
+}
+
+fn join_header_chain(values: &[Vec<u8>]) -> Result<Option<HeaderValue>, BridgeError> {
+    if values.is_empty() {
+        return Ok(None);
+    }
+
+    let mut joined = Vec::new();
+    for (index, value) in values.iter().enumerate() {
+        if index > 0 {
+            joined.extend_from_slice(b", ");
+        }
+        joined.extend_from_slice(value);
+    }
+
+    HeaderValue::from_bytes(&joined)
+        .map(Some)
+        .map_err(|_| BridgeError::InvalidHeader)
 }
 
 fn connection_header_tokens(headers: &[quiche::h3::Header]) -> HashSet<String> {
@@ -262,7 +379,7 @@ mod tests {
     use quiche::h3::Header;
     use spooky_config::{
         backend_endpoint::BackendEndpoint,
-        config::{UpstreamHostPolicy, UpstreamHostPolicyMode},
+        config::{ForwardedHeaderPolicy, ForwardedHeaderPolicyMode, UpstreamHostPolicy, UpstreamHostPolicyMode},
     };
 
     use super::{
@@ -399,6 +516,106 @@ mod tests {
     }
 
     #[test]
+    fn forwarded_header_policy_append_and_preserve_behave_as_expected() {
+        let endpoint = BackendEndpoint::parse("backend.internal:443").expect("endpoint");
+        let headers = vec![
+            Header::new(b"forwarded", b"for=1.2.3.4;proto=http;host=\"old.example\""),
+            Header::new(b"x-forwarded-for", b"1.2.3.4"),
+            Header::new(b"x-forwarded-proto", b"http"),
+            Header::new(b"x-forwarded-host", b"old.example"),
+        ];
+
+        let host_policy = UpstreamHostPolicy::default();
+        let append_policy = ForwardedHeaderPolicy {
+            mode: ForwardedHeaderPolicyMode::Append,
+        };
+        let req = build_h2_request_for_endpoint_with_host_policy(
+            &endpoint,
+            &host_policy,
+            &append_policy,
+            "GET",
+            "/",
+            &headers,
+            Empty::<Bytes>::new().boxed(),
+            None,
+            ForwardedContext {
+                client_addr: "203.0.113.55:43210".parse().expect("client"),
+                request_authority: Some("api.example.com"),
+                request_id: 0,
+                traceparent: None,
+            },
+        )
+        .expect("append request");
+
+        assert_eq!(
+            req.headers().get("forwarded").and_then(|h| h.to_str().ok()),
+            Some("for=1.2.3.4;proto=http;host=\"old.example\", for=203.0.113.55;proto=https;host=\"api.example.com\"")
+        );
+        assert_eq!(
+            req.headers()
+                .get("x-forwarded-for")
+                .and_then(|h| h.to_str().ok()),
+            Some("1.2.3.4, 203.0.113.55")
+        );
+        assert_eq!(
+            req.headers()
+                .get("x-forwarded-proto")
+                .and_then(|h| h.to_str().ok()),
+            Some("http, https")
+        );
+        assert_eq!(
+            req.headers()
+                .get("x-forwarded-host")
+                .and_then(|h| h.to_str().ok()),
+            Some("old.example, api.example.com")
+        );
+
+        let preserve_policy = ForwardedHeaderPolicy {
+            mode: ForwardedHeaderPolicyMode::Preserve,
+        };
+        let req = build_h2_request_for_endpoint_with_host_policy(
+            &endpoint,
+            &host_policy,
+            &preserve_policy,
+            "GET",
+            "/",
+            &headers,
+            Empty::<Bytes>::new().boxed(),
+            None,
+            ForwardedContext {
+                client_addr: "203.0.113.55:43210".parse().expect("client"),
+                request_authority: Some("api.example.com"),
+                request_id: 0,
+                traceparent: None,
+            },
+        )
+        .expect("preserve request");
+
+        assert_eq!(
+            req.headers().get("forwarded").and_then(|h| h.to_str().ok()),
+            Some("for=1.2.3.4;proto=http;host=\"old.example\"")
+        );
+        assert_eq!(
+            req.headers()
+                .get("x-forwarded-for")
+                .and_then(|h| h.to_str().ok()),
+            Some("1.2.3.4")
+        );
+        assert_eq!(
+            req.headers()
+                .get("x-forwarded-proto")
+                .and_then(|h| h.to_str().ok()),
+            Some("http")
+        );
+        assert_eq!(
+            req.headers()
+                .get("x-forwarded-host")
+                .and_then(|h| h.to_str().ok()),
+            Some("old.example")
+        );
+    }
+
+    #[test]
     fn forwarded_header_formats_ipv6_clients() {
         let req = build_h2_request(
             "backend.internal:443",
@@ -432,6 +649,7 @@ mod tests {
         let req = build_h2_request_for_endpoint_with_host_policy(
             &endpoint,
             &policy,
+            &ForwardedHeaderPolicy::default(),
             "GET",
             "/",
             &[],
@@ -468,6 +686,7 @@ mod tests {
         let req = build_h2_request_for_endpoint_with_host_policy(
             &endpoint,
             &policy,
+            &ForwardedHeaderPolicy::default(),
             "GET",
             "/",
             &[],

--- a/crates/bridge/src/h3_to_h2.rs
+++ b/crates/bridge/src/h3_to_h2.rs
@@ -8,7 +8,10 @@ use bytes::Bytes;
 use http::{HeaderName, HeaderValue, Method, Request, Uri};
 use http_body_util::combinators::BoxBody;
 use quiche::h3::NameValue;
-use spooky_config::backend_endpoint::BackendEndpoint;
+use spooky_config::{
+    backend_endpoint::BackendEndpoint,
+    config::{UpstreamHostPolicy, UpstreamHostPolicyMode},
+};
 
 pub use spooky_errors::BridgeError;
 
@@ -52,6 +55,29 @@ pub fn build_h2_request_for_endpoint(
     content_length: Option<usize>,
     forwarded_ctx: ForwardedContext<'_>,
 ) -> Result<Request<BoxBody<Bytes, Infallible>>, BridgeError> {
+    build_h2_request_for_endpoint_with_host_policy(
+        endpoint,
+        &UpstreamHostPolicy::default(),
+        method,
+        path,
+        headers,
+        body,
+        content_length,
+        forwarded_ctx,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn build_h2_request_for_endpoint_with_host_policy(
+    endpoint: &BackendEndpoint,
+    host_policy: &UpstreamHostPolicy,
+    method: &str,
+    path: &str,
+    headers: &[quiche::h3::Header],
+    body: BoxBody<Bytes, Infallible>,
+    content_length: Option<usize>,
+    forwarded_ctx: ForwardedContext<'_>,
+) -> Result<Request<BoxBody<Bytes, Infallible>>, BridgeError> {
     let method = Method::from_bytes(method.as_bytes()).map_err(|_| BridgeError::InvalidMethod)?;
     let is_connect = method == Method::CONNECT;
     let mut builder = Request::builder().method(method.clone());
@@ -78,11 +104,12 @@ pub fn build_h2_request_for_endpoint(
         builder = builder.header(header_name, header_value);
     }
 
-    let host_value = forwarded_ctx
-        .request_authority
-        .or(host_from_headers.as_deref())
-        .filter(|value| !value.trim().is_empty())
-        .unwrap_or(endpoint.authority());
+    let host_value = resolve_upstream_host_value(
+        endpoint,
+        host_policy,
+        forwarded_ctx.request_authority,
+        host_from_headers.as_deref(),
+    )?;
 
     let uri = if is_connect {
         Uri::try_from(host_value).map_err(|_| BridgeError::InvalidUri)?
@@ -146,6 +173,26 @@ pub fn build_h2_request_for_endpoint(
         );
 
     builder.body(body).map_err(BridgeError::Build)
+}
+
+pub fn resolve_upstream_host_value<'a>(
+    endpoint: &'a BackendEndpoint,
+    host_policy: &'a UpstreamHostPolicy,
+    request_authority: Option<&'a str>,
+    host_header: Option<&'a str>,
+) -> Result<&'a str, BridgeError> {
+    match host_policy.mode {
+        UpstreamHostPolicyMode::PassThrough => Ok(request_authority
+            .or(host_header)
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or(endpoint.authority())),
+        UpstreamHostPolicyMode::Rewrite => host_policy
+            .host
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+            .ok_or(BridgeError::InvalidHeader),
+        UpstreamHostPolicyMode::Upstream => Ok(endpoint.authority()),
+    }
 }
 
 fn connection_header_tokens(headers: &[quiche::h3::Header]) -> HashSet<String> {
@@ -213,8 +260,14 @@ mod tests {
     use http::header::HOST;
     use http_body_util::{BodyExt, Empty};
     use quiche::h3::Header;
+    use spooky_config::{
+        backend_endpoint::BackendEndpoint,
+        config::{UpstreamHostPolicy, UpstreamHostPolicyMode},
+    };
 
-    use super::{ForwardedContext, build_h2_request};
+    use super::{
+        ForwardedContext, build_h2_request, build_h2_request_for_endpoint_with_host_policy,
+    };
 
     #[test]
     fn defaults_to_https_origin_for_host_port_backend() {
@@ -366,6 +419,72 @@ mod tests {
         assert_eq!(
             req.headers().get("forwarded").and_then(|h| h.to_str().ok()),
             Some("for=\"[2001:db8::1]\";proto=https;host=\"api.example.com\"")
+        );
+    }
+
+    #[test]
+    fn host_policy_rewrite_uses_configured_host() {
+        let endpoint = BackendEndpoint::parse("backend.internal:443").expect("endpoint");
+        let policy = UpstreamHostPolicy {
+            mode: UpstreamHostPolicyMode::Rewrite,
+            host: Some("origin.example.com".to_string()),
+        };
+        let req = build_h2_request_for_endpoint_with_host_policy(
+            &endpoint,
+            &policy,
+            "GET",
+            "/",
+            &[],
+            Empty::<Bytes>::new().boxed(),
+            None,
+            ForwardedContext {
+                client_addr: "203.0.113.10:44321".parse().expect("client"),
+                request_authority: Some("api.example.com"),
+                request_id: 0,
+                traceparent: None,
+            },
+        )
+        .expect("request");
+
+        assert_eq!(
+            req.headers().get(HOST).and_then(|h| h.to_str().ok()),
+            Some("origin.example.com")
+        );
+        assert_eq!(
+            req.headers()
+                .get("x-forwarded-host")
+                .and_then(|h| h.to_str().ok()),
+            Some("origin.example.com")
+        );
+    }
+
+    #[test]
+    fn host_policy_upstream_uses_backend_authority() {
+        let endpoint = BackendEndpoint::parse("backend.internal:8443").expect("endpoint");
+        let policy = UpstreamHostPolicy {
+            mode: UpstreamHostPolicyMode::Upstream,
+            host: None,
+        };
+        let req = build_h2_request_for_endpoint_with_host_policy(
+            &endpoint,
+            &policy,
+            "GET",
+            "/",
+            &[],
+            Empty::<Bytes>::new().boxed(),
+            None,
+            ForwardedContext {
+                client_addr: "203.0.113.10:44321".parse().expect("client"),
+                request_authority: Some("api.example.com"),
+                request_id: 0,
+                traceparent: None,
+            },
+        )
+        .expect("request");
+
+        assert_eq!(
+            req.headers().get(HOST).and_then(|h| h.to_str().ok()),
+            Some("backend.internal:8443")
         );
     }
 

--- a/crates/bridge/src/h3_to_h2.rs
+++ b/crates/bridge/src/h3_to_h2.rs
@@ -10,7 +10,10 @@ use http_body_util::combinators::BoxBody;
 use quiche::h3::NameValue;
 use spooky_config::{
     backend_endpoint::BackendEndpoint,
-    config::{ForwardedHeaderPolicy, ForwardedHeaderPolicyMode, UpstreamHostPolicy, UpstreamHostPolicyMode},
+    config::{
+        ForwardedHeaderPolicy, ForwardedHeaderPolicyMode, UpstreamHostPolicy,
+        UpstreamHostPolicyMode,
+    },
 };
 
 pub use spooky_errors::BridgeError;
@@ -37,7 +40,6 @@ pub struct ForwardedHeaderValues {
     pub x_forwarded_proto: Option<HeaderValue>,
     pub x_forwarded_host: Option<HeaderValue>,
 }
-
 
 /// Build an HTTP/2 request with a pre-boxed streaming body.
 /// `content_length` is `Some(n)` only when the full length is known upfront
@@ -379,7 +381,10 @@ mod tests {
     use quiche::h3::Header;
     use spooky_config::{
         backend_endpoint::BackendEndpoint,
-        config::{ForwardedHeaderPolicy, ForwardedHeaderPolicyMode, UpstreamHostPolicy, UpstreamHostPolicyMode},
+        config::{
+            ForwardedHeaderPolicy, ForwardedHeaderPolicyMode, UpstreamHostPolicy,
+            UpstreamHostPolicyMode,
+        },
     };
 
     use super::{
@@ -549,7 +554,9 @@ mod tests {
 
         assert_eq!(
             req.headers().get("forwarded").and_then(|h| h.to_str().ok()),
-            Some("for=1.2.3.4;proto=http;host=\"old.example\", for=203.0.113.55;proto=https;host=\"api.example.com\"")
+            Some(
+                "for=1.2.3.4;proto=http;host=\"old.example\", for=203.0.113.55;proto=https;host=\"api.example.com\""
+            )
         );
         assert_eq!(
             req.headers()

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -10,6 +10,7 @@ serde.workspace = true
 serde_yml.workspace = true
 rustls-pemfile.workspace = true
 idna = "1"
+http.workspace = true
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -201,6 +201,9 @@ pub struct Upstream {
     #[serde(default)]
     pub host_policy: UpstreamHostPolicy,
 
+    #[serde(default)]
+    pub forwarded_headers: ForwardedHeaderPolicy,
+
     pub route: RouteMatch, // Route matching criteria for this upstream
 
     pub backends: Vec<Backend>,
@@ -220,6 +223,24 @@ pub enum UpstreamHostPolicyMode {
     )]
     Upstream,
 }
+
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ForwardedHeaderPolicyMode {
+    #[default]
+    #[serde(alias = "overwrite")]
+    Overwrite,
+    Append,
+    Preserve,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ForwardedHeaderPolicy {
+    #[serde(default)]
+    pub mode: ForwardedHeaderPolicyMode,
+}
+
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -198,9 +198,36 @@ pub struct Upstream {
     #[serde(default = "get_default_load_balancing")]
     pub load_balancing: LoadBalancing,
 
+    #[serde(default)]
+    pub host_policy: UpstreamHostPolicy,
+
     pub route: RouteMatch, // Route matching criteria for this upstream
 
     pub backends: Vec<Backend>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum UpstreamHostPolicyMode {
+    #[default]
+    #[serde(alias = "pass-through")]
+    PassThrough,
+    Rewrite,
+    #[serde(
+        alias = "static_upstream",
+        alias = "static-upstream",
+        alias = "upstream-host"
+    )]
+    Upstream,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct UpstreamHostPolicy {
+    #[serde(default)]
+    pub mode: UpstreamHostPolicyMode,
+    #[serde(default)]
+    pub host: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -241,7 +241,6 @@ pub struct ForwardedHeaderPolicy {
     pub mode: ForwardedHeaderPolicyMode,
 }
 
-
 #[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct UpstreamHostPolicy {

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -1292,6 +1292,7 @@ mod tests {
                     key: None,
                 },
                 host_policy: Default::default(),
+        forwarded_headers: Default::default(),
                 route: RouteMatch {
                     host: None,
                     path_prefix: Some("/".to_string()),
@@ -2022,6 +2023,7 @@ upstream:
                 key: None,
             },
             host_policy: Default::default(),
+        forwarded_headers: Default::default(),
             route: RouteMatch {
                 host: Some("api.example.com".to_string()),
                 path_prefix: Some("/api".to_string()),
@@ -2060,6 +2062,7 @@ upstream:
                 key: None,
             },
             host_policy: Default::default(),
+        forwarded_headers: Default::default(),
             route: RouteMatch {
                 host: Some("api.example.com".to_string()),
                 path_prefix: Some("/api".to_string()),

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -1292,7 +1292,7 @@ mod tests {
                     key: None,
                 },
                 host_policy: Default::default(),
-        forwarded_headers: Default::default(),
+                forwarded_headers: Default::default(),
                 route: RouteMatch {
                     host: None,
                     path_prefix: Some("/".to_string()),
@@ -2023,7 +2023,7 @@ upstream:
                 key: None,
             },
             host_policy: Default::default(),
-        forwarded_headers: Default::default(),
+            forwarded_headers: Default::default(),
             route: RouteMatch {
                 host: Some("api.example.com".to_string()),
                 path_prefix: Some("/api".to_string()),
@@ -2062,7 +2062,7 @@ upstream:
                 key: None,
             },
             host_policy: Default::default(),
-        forwarded_headers: Default::default(),
+            forwarded_headers: Default::default(),
             route: RouteMatch {
                 host: Some("api.example.com".to_string()),
                 path_prefix: Some("/api".to_string()),

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -1,5 +1,7 @@
 use crate::backend_endpoint::{BackendEndpoint, BackendScheme};
-use crate::config::{CURRENT_CONFIG_VERSION, Config, SUPPORTED_CONFIG_VERSIONS};
+use crate::config::{
+    CURRENT_CONFIG_VERSION, Config, SUPPORTED_CONFIG_VERSIONS, UpstreamHostPolicyMode,
+};
 use log::{error, info, warn};
 use std::collections::HashMap;
 use std::fs::File;
@@ -195,6 +197,17 @@ fn normalized_route_method(method: Option<&str>) -> Option<String> {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(|value| value.to_ascii_uppercase())
+}
+
+fn valid_static_host_header(value: &str) -> bool {
+    let trimmed = value.trim();
+    !trimmed.is_empty()
+        && trimmed == value
+        && !trimmed.chars().any(|ch| ch.is_ascii_whitespace())
+        && !trimmed.contains('/')
+        && !trimmed.contains('?')
+        && !trimmed.contains('#')
+        && http::HeaderValue::from_str(trimmed).is_ok()
 }
 
 fn normalize_sni_server_name(raw: &str) -> Option<String> {
@@ -1063,6 +1076,27 @@ pub fn validate(config: &Config) -> bool {
                 return false;
             }
         }
+
+        match upstream.host_policy.mode {
+            UpstreamHostPolicyMode::PassThrough | UpstreamHostPolicyMode::Upstream => {
+                if upstream.host_policy.host.is_some() {
+                    warn!(
+                        "upstream {}.host_policy.host is ignored unless mode is rewrite",
+                        upstream_name
+                    );
+                }
+            }
+            UpstreamHostPolicyMode::Rewrite => match upstream.host_policy.host.as_deref() {
+                Some(host) if valid_static_host_header(host) => {}
+                _ => {
+                    error!(
+                        "upstream {}.host_policy.mode=rewrite requires a valid non-empty host_policy.host",
+                        upstream_name
+                    );
+                    return false;
+                }
+            },
+        }
     }
 
     // --- Validate upstreams ---
@@ -1257,6 +1291,7 @@ mod tests {
                     lb_type: "round-robin".to_string(),
                     key: None,
                 },
+                host_policy: Default::default(),
                 route: RouteMatch {
                     host: None,
                     path_prefix: Some("/".to_string()),
@@ -1986,6 +2021,7 @@ upstream:
                 lb_type: "round-robin".to_string(),
                 key: None,
             },
+            host_policy: Default::default(),
             route: RouteMatch {
                 host: Some("api.example.com".to_string()),
                 path_prefix: Some("/api".to_string()),
@@ -2023,6 +2059,7 @@ upstream:
                 lb_type: "round-robin".to_string(),
                 key: None,
             },
+            host_policy: Default::default(),
             route: RouteMatch {
                 host: Some("api.example.com".to_string()),
                 path_prefix: Some("/api".to_string()),

--- a/crates/edge/src/benchmark.rs
+++ b/crates/edge/src/benchmark.rs
@@ -30,6 +30,7 @@ fn build_benchmark_upstream(host: Option<String>, path_prefix: String) -> Upstre
             key: None,
         },
         host_policy: Default::default(),
+        forwarded_headers: Default::default(),
         route: RouteMatch {
             host,
             path_prefix: Some(path_prefix),

--- a/crates/edge/src/benchmark.rs
+++ b/crates/edge/src/benchmark.rs
@@ -29,6 +29,7 @@ fn build_benchmark_upstream(host: Option<String>, path_prefix: String) -> Upstre
             lb_type: "round-robin".to_string(),
             key: None,
         },
+        host_policy: Default::default(),
         route: RouteMatch {
             host,
             path_prefix: Some(path_prefix),

--- a/crates/edge/src/quic_listener/forwarding.rs
+++ b/crates/edge/src/quic_listener/forwarding.rs
@@ -11,6 +11,7 @@ pub(super) struct ForwardRequestMeta {
     pub(super) request_id: u64,
     pub(super) traceparent: Option<Arc<str>>,
     pub(super) host_policy: UpstreamHostPolicy,
+    pub(super) forwarded_header_policy: ForwardedHeaderPolicy,
 }
 
 impl ForwardRequestMeta {
@@ -21,6 +22,7 @@ impl ForwardRequestMeta {
         build_h2_request_for_endpoint_with_host_policy(
             endpoint,
             &self.host_policy,
+            &self.forwarded_header_policy,
             &self.method,
             &self.path,
             self.headers.as_slice(),

--- a/crates/edge/src/quic_listener/forwarding.rs
+++ b/crates/edge/src/quic_listener/forwarding.rs
@@ -10,6 +10,7 @@ pub(super) struct ForwardRequestMeta {
     pub(super) client_addr: SocketAddr,
     pub(super) request_id: u64,
     pub(super) traceparent: Option<Arc<str>>,
+    pub(super) host_policy: UpstreamHostPolicy,
 }
 
 impl ForwardRequestMeta {
@@ -17,8 +18,9 @@ impl ForwardRequestMeta {
         &self,
         endpoint: &BackendEndpoint,
     ) -> Result<Request<BoxBody<Bytes, std::convert::Infallible>>, ProxyError> {
-        build_h2_request_for_endpoint(
+        build_h2_request_for_endpoint_with_host_policy(
             endpoint,
+            &self.host_policy,
             &self.method,
             &self.path,
             self.headers.as_slice(),

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -37,7 +37,7 @@ use rustls::{
 use serde_json::json;
 use socket2::{Domain, Protocol, Socket, Type};
 use spooky_bridge::h3_to_h2::{
-    ForwardedContext, build_h2_request_for_endpoint_with_host_policy, resolve_upstream_host_value,
+    ForwardedContext, ForwardedHeaderChains, build_forwarded_header_values, build_h2_request_for_endpoint_with_host_policy, resolve_upstream_host_value,
 };
 use spooky_errors::{PoolError, ProxyError, is_retryable};
 use spooky_lb::{HealthFailureReason, HealthTransition, UpstreamPool};
@@ -54,7 +54,7 @@ use tracing::{Instrument, info_span};
 
 use spooky_config::{
     backend_endpoint::{BackendEndpoint, BackendScheme},
-    config::{Config as SpookyConfig, UpstreamHostPolicy},
+    config::{Config as SpookyConfig, ForwardedHeaderPolicy, UpstreamHostPolicy},
 };
 
 use crate::{
@@ -262,13 +262,6 @@ fn is_websocket_upgrade_request(req: &Request<Incoming>, use_h2: bool) -> bool {
         .get(http::header::CONNECTION)
         .map(|v| header_has_token(v, "upgrade"))
         .unwrap_or(false)
-}
-
-fn bootstrap_forwarded_for_value(ip: std::net::IpAddr) -> String {
-    match ip {
-        std::net::IpAddr::V4(v4) => v4.to_string(),
-        std::net::IpAddr::V6(v6) => format!("\"[{}]\"", v6),
-    }
 }
 
 fn extract_cookie_value(cookie_header: &str, cookie_name: &str) -> Option<String> {
@@ -581,6 +574,13 @@ impl QUICListener {
                     })
                     .collect(),
             ),
+            forwarded_header_policies: Arc::new(
+                config
+                    .upstream
+                    .iter()
+                    .map(|(name, upstream)| (name.clone(), upstream.forwarded_headers.clone()))
+                    .collect(),
+            ),
             upstream_host_policies: Arc::new(
                 config
                     .upstream
@@ -711,6 +711,7 @@ impl QUICListener {
             h2_pool: Arc::clone(&shared_state.h2_pool),
             backend_endpoints: Arc::clone(&shared_state.backend_endpoints),
             upstream_host_policies: Arc::clone(&shared_state.upstream_host_policies),
+            forwarded_header_policies: Arc::clone(&shared_state.forwarded_header_policies),
             upstream_pools: shared_state.upstream_pools.clone(),
             upstream_inflight: shared_state.upstream_inflight.clone(),
             global_inflight: Arc::clone(&shared_state.global_inflight),
@@ -1525,6 +1526,7 @@ impl QUICListener {
                 Arc::clone(&h2_pool),
                 Arc::clone(&self.backend_endpoints),
                 Arc::clone(&self.upstream_host_policies),
+                Arc::clone(&self.forwarded_header_policies),
                 &self.upstream_pools,
                 &self.upstream_inflight,
                 Arc::clone(&self.global_inflight),
@@ -1771,6 +1773,7 @@ impl QUICListener {
         h2_pool: Arc<H2Pool>,
         backend_endpoints: Arc<HashMap<String, BackendEndpoint>>,
         upstream_host_policies: Arc<HashMap<String, UpstreamHostPolicy>>,
+        forwarded_header_policies: Arc<HashMap<String, ForwardedHeaderPolicy>>,
         upstream_pools: &HashMap<String, Arc<RwLock<UpstreamPool>>>,
         upstream_inflight: &HashMap<String, Arc<Semaphore>>,
         global_inflight: Arc<Semaphore>,
@@ -2162,9 +2165,14 @@ impl QUICListener {
                                 .get(&upstream_name)
                                 .cloned()
                                 .unwrap_or_default();
+                            let forwarded_header_policy = forwarded_header_policies
+                                .get(&upstream_name)
+                                .cloned()
+                                .unwrap_or_default();
                             let request = match build_h2_request_for_endpoint_with_host_policy(
                                 &backend_endpoint,
                                 &host_policy,
+                                &forwarded_header_policy,
                                 &method,
                                 &path,
                                 &list,
@@ -2223,6 +2231,7 @@ impl QUICListener {
                                     request_id,
                                     traceparent: traceparent.as_deref().map(Arc::<str>::from),
                                     host_policy: host_policy.clone(),
+                                    forwarded_header_policy: forwarded_header_policy.clone(),
                                 })
                             });
                             let trace_span_for_upstream = trace_span.clone();
@@ -4205,6 +4214,7 @@ impl QUICListener {
         let h2_pool = Arc::clone(&shared_state.h2_pool);
         let backend_endpoints = Arc::clone(&shared_state.backend_endpoints);
         let upstream_host_policies = Arc::clone(&shared_state.upstream_host_policies);
+        let forwarded_header_policies = Arc::clone(&shared_state.forwarded_header_policies);
         let metrics = Arc::clone(&shared_state.metrics);
         let resilience = Arc::clone(&shared_state.resilience);
         let upstream_pools = shared_state.upstream_pools.clone();
@@ -4278,6 +4288,7 @@ impl QUICListener {
                 let h2_pool = Arc::clone(&h2_pool);
                 let backend_endpoints = Arc::clone(&backend_endpoints);
                 let upstream_host_policies = Arc::clone(&upstream_host_policies);
+                let forwarded_header_policies = Arc::clone(&forwarded_header_policies);
                 let metrics = Arc::clone(&metrics);
                 let resilience = Arc::clone(&resilience);
                 let upstream_pools = upstream_pools.clone();
@@ -4308,6 +4319,7 @@ impl QUICListener {
                             let h2_pool = Arc::clone(&h2_pool);
                             let backend_endpoints = Arc::clone(&backend_endpoints);
                             let upstream_host_policies = Arc::clone(&upstream_host_policies);
+                            let forwarded_header_policies = Arc::clone(&forwarded_header_policies);
                             let metrics = Arc::clone(&metrics);
                             let resilience = Arc::clone(&resilience);
                             let upstream_pools = upstream_pools.clone();
@@ -4473,8 +4485,40 @@ impl QUICListener {
 
                                 let bootstrap_connection_tokens =
                                     connection_header_tokens(req.headers());
+                                let mut forwarded_from_headers: Vec<Vec<u8>> = Vec::new();
+                                let mut x_forwarded_for_from_headers: Vec<Vec<u8>> = Vec::new();
+                                let mut x_forwarded_proto_from_headers: Vec<Vec<u8>> = Vec::new();
+                                let mut x_forwarded_host_from_headers: Vec<Vec<u8>> = Vec::new();
                                 for (name, value) in req.headers() {
                                     if name == http::header::HOST {
+                                        continue;
+                                    }
+                                    if name.as_str().eq_ignore_ascii_case("forwarded") {
+                                        forwarded_from_headers.push(value.as_bytes().to_vec());
+                                        continue;
+                                    }
+                                    if name
+                                        .as_str()
+                                        .eq_ignore_ascii_case("x-forwarded-for")
+                                    {
+                                        x_forwarded_for_from_headers
+                                            .push(value.as_bytes().to_vec());
+                                        continue;
+                                    }
+                                    if name
+                                        .as_str()
+                                        .eq_ignore_ascii_case("x-forwarded-proto")
+                                    {
+                                        x_forwarded_proto_from_headers
+                                            .push(value.as_bytes().to_vec());
+                                        continue;
+                                    }
+                                    if name
+                                        .as_str()
+                                        .eq_ignore_ascii_case("x-forwarded-host")
+                                    {
+                                        x_forwarded_host_from_headers
+                                            .push(value.as_bytes().to_vec());
                                         continue;
                                     }
                                     if !is_websocket_upgrade
@@ -4506,15 +4550,51 @@ impl QUICListener {
                                     }
                                     upstream_req = upstream_req.header(name, value);
                                 }
-                                upstream_req =
-                                    upstream_req.header(http::header::HOST, upstream_host);
-                                upstream_req = upstream_req.header(
-                                    "forwarded",
-                                    format!(
-                                        "for={};proto=https",
-                                        bootstrap_forwarded_for_value(peer.ip())
-                                    ),
-                                );
+                                upstream_req = upstream_req.header(http::header::HOST, upstream_host);
+
+                                let forwarded_policy = forwarded_header_policies
+                                    .get(&upstream_name)
+                                    .cloned()
+                                    .unwrap_or_default();
+                                let forwarded_values = match build_forwarded_header_values(
+                                    &forwarded_policy,
+                                    ForwardedHeaderChains {
+                                        forwarded: &forwarded_from_headers,
+                                        x_forwarded_for: &x_forwarded_for_from_headers,
+                                        x_forwarded_proto: &x_forwarded_proto_from_headers,
+                                        x_forwarded_host: &x_forwarded_host_from_headers,
+                                    },
+                                    peer.ip(),
+                                    upstream_host,
+                                ) {
+                                    Ok(values) => values,
+                                    Err(err) => {
+                                        warn!("Bootstrap forwarded header policy failed: {}", err);
+                                        return Ok(Response::builder()
+                                            .status(StatusCode::BAD_REQUEST)
+                                            .header("alt-svc", &alt)
+                                            .body(boxed_full(Bytes::from_static(
+                                                b"invalid forwarded headers\n",
+                                            )))
+                                            .unwrap_or_else(|_| {
+                                                Response::new(boxed_full(Bytes::from_static(
+                                                    b"error\n",
+                                                )))
+                                            }));
+                                    }
+                                };
+                                if let Some(value) = forwarded_values.forwarded {
+                                    upstream_req = upstream_req.header("forwarded", value);
+                                }
+                                if let Some(value) = forwarded_values.x_forwarded_for {
+                                    upstream_req = upstream_req.header("x-forwarded-for", value);
+                                }
+                                if let Some(value) = forwarded_values.x_forwarded_proto {
+                                    upstream_req = upstream_req.header("x-forwarded-proto", value);
+                                }
+                                if let Some(value) = forwarded_values.x_forwarded_host {
+                                    upstream_req = upstream_req.header("x-forwarded-host", value);
+                                }
 
                                 if !is_websocket_upgrade
                                     && content_length
@@ -5081,6 +5161,7 @@ mod tests {
                 key: lb_key.map(str::to_string),
             },
             host_policy: Default::default(),
+            forwarded_headers: Default::default(),
             route: RouteMatch {
                 host: None,
                 path_prefix: Some("/api".to_string()),

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -37,7 +37,8 @@ use rustls::{
 use serde_json::json;
 use socket2::{Domain, Protocol, Socket, Type};
 use spooky_bridge::h3_to_h2::{
-    ForwardedContext, ForwardedHeaderChains, build_forwarded_header_values, build_h2_request_for_endpoint_with_host_policy, resolve_upstream_host_value,
+    ForwardedContext, ForwardedHeaderChains, build_forwarded_header_values,
+    build_h2_request_for_endpoint_with_host_policy, resolve_upstream_host_value,
 };
 use spooky_errors::{PoolError, ProxyError, is_retryable};
 use spooky_lb::{HealthFailureReason, HealthTransition, UpstreamPool};
@@ -4497,26 +4498,17 @@ impl QUICListener {
                                         forwarded_from_headers.push(value.as_bytes().to_vec());
                                         continue;
                                     }
-                                    if name
-                                        .as_str()
-                                        .eq_ignore_ascii_case("x-forwarded-for")
-                                    {
+                                    if name.as_str().eq_ignore_ascii_case("x-forwarded-for") {
                                         x_forwarded_for_from_headers
                                             .push(value.as_bytes().to_vec());
                                         continue;
                                     }
-                                    if name
-                                        .as_str()
-                                        .eq_ignore_ascii_case("x-forwarded-proto")
-                                    {
+                                    if name.as_str().eq_ignore_ascii_case("x-forwarded-proto") {
                                         x_forwarded_proto_from_headers
                                             .push(value.as_bytes().to_vec());
                                         continue;
                                     }
-                                    if name
-                                        .as_str()
-                                        .eq_ignore_ascii_case("x-forwarded-host")
-                                    {
+                                    if name.as_str().eq_ignore_ascii_case("x-forwarded-host") {
                                         x_forwarded_host_from_headers
                                             .push(value.as_bytes().to_vec());
                                         continue;
@@ -4550,7 +4542,8 @@ impl QUICListener {
                                     }
                                     upstream_req = upstream_req.header(name, value);
                                 }
-                                upstream_req = upstream_req.header(http::header::HOST, upstream_host);
+                                upstream_req =
+                                    upstream_req.header(http::header::HOST, upstream_host);
 
                                 let forwarded_policy = forwarded_header_policies
                                     .get(&upstream_name)

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -36,7 +36,9 @@ use rustls::{
 };
 use serde_json::json;
 use socket2::{Domain, Protocol, Socket, Type};
-use spooky_bridge::h3_to_h2::{ForwardedContext, build_h2_request_for_endpoint};
+use spooky_bridge::h3_to_h2::{
+    ForwardedContext, build_h2_request_for_endpoint_with_host_policy, resolve_upstream_host_value,
+};
 use spooky_errors::{PoolError, ProxyError, is_retryable};
 use spooky_lb::{HealthFailureReason, HealthTransition, UpstreamPool};
 use spooky_transport::h2_client::{H2Client, TlsClientConfig};
@@ -52,7 +54,7 @@ use tracing::{Instrument, info_span};
 
 use spooky_config::{
     backend_endpoint::{BackendEndpoint, BackendScheme},
-    config::Config as SpookyConfig,
+    config::{Config as SpookyConfig, UpstreamHostPolicy},
 };
 
 use crate::{
@@ -579,6 +581,13 @@ impl QUICListener {
                     })
                     .collect(),
             ),
+            upstream_host_policies: Arc::new(
+                config
+                    .upstream
+                    .iter()
+                    .map(|(name, upstream)| (name.clone(), upstream.host_policy.clone()))
+                    .collect(),
+            ),
             upstream_pools,
             upstream_inflight,
             global_inflight: Arc::new(Semaphore::new(global_inflight_limit)),
@@ -701,6 +710,7 @@ impl QUICListener {
             h3_config,
             h2_pool: Arc::clone(&shared_state.h2_pool),
             backend_endpoints: Arc::clone(&shared_state.backend_endpoints),
+            upstream_host_policies: Arc::clone(&shared_state.upstream_host_policies),
             upstream_pools: shared_state.upstream_pools.clone(),
             upstream_inflight: shared_state.upstream_inflight.clone(),
             global_inflight: Arc::clone(&shared_state.global_inflight),
@@ -1514,6 +1524,7 @@ impl QUICListener {
                 &mut connection,
                 Arc::clone(&h2_pool),
                 Arc::clone(&self.backend_endpoints),
+                Arc::clone(&self.upstream_host_policies),
                 &self.upstream_pools,
                 &self.upstream_inflight,
                 Arc::clone(&self.global_inflight),
@@ -1759,6 +1770,7 @@ impl QUICListener {
         connection: &mut QuicConnection,
         h2_pool: Arc<H2Pool>,
         backend_endpoints: Arc<HashMap<String, BackendEndpoint>>,
+        upstream_host_policies: Arc<HashMap<String, UpstreamHostPolicy>>,
         upstream_pools: &HashMap<String, Arc<RwLock<UpstreamPool>>>,
         upstream_inflight: &HashMap<String, Arc<Semaphore>>,
         global_inflight: Arc<Semaphore>,
@@ -2146,8 +2158,13 @@ impl QUICListener {
                                     continue;
                                 }
                             };
-                            let request = match build_h2_request_for_endpoint(
+                            let host_policy = upstream_host_policies
+                                .get(&upstream_name)
+                                .cloned()
+                                .unwrap_or_default();
+                            let request = match build_h2_request_for_endpoint_with_host_policy(
                                 &backend_endpoint,
+                                &host_policy,
                                 &method,
                                 &path,
                                 &list,
@@ -2205,6 +2222,7 @@ impl QUICListener {
                                     client_addr: connection.peer_address,
                                     request_id,
                                     traceparent: traceparent.as_deref().map(Arc::<str>::from),
+                                    host_policy: host_policy.clone(),
                                 })
                             });
                             let trace_span_for_upstream = trace_span.clone();
@@ -4186,6 +4204,7 @@ impl QUICListener {
 
         let h2_pool = Arc::clone(&shared_state.h2_pool);
         let backend_endpoints = Arc::clone(&shared_state.backend_endpoints);
+        let upstream_host_policies = Arc::clone(&shared_state.upstream_host_policies);
         let metrics = Arc::clone(&shared_state.metrics);
         let resilience = Arc::clone(&shared_state.resilience);
         let upstream_pools = shared_state.upstream_pools.clone();
@@ -4258,6 +4277,7 @@ impl QUICListener {
                 let alt_svc = alt_svc_value.clone();
                 let h2_pool = Arc::clone(&h2_pool);
                 let backend_endpoints = Arc::clone(&backend_endpoints);
+                let upstream_host_policies = Arc::clone(&upstream_host_policies);
                 let metrics = Arc::clone(&metrics);
                 let resilience = Arc::clone(&resilience);
                 let upstream_pools = upstream_pools.clone();
@@ -4287,6 +4307,7 @@ impl QUICListener {
                             let alt = alt_svc_conn.clone();
                             let h2_pool = Arc::clone(&h2_pool);
                             let backend_endpoints = Arc::clone(&backend_endpoints);
+                            let upstream_host_policies = Arc::clone(&upstream_host_policies);
                             let metrics = Arc::clone(&metrics);
                             let resilience = Arc::clone(&resilience);
                             let upstream_pools = upstream_pools.clone();
@@ -4359,8 +4380,8 @@ impl QUICListener {
                                     &routing_index,
                                     Some(&lb_header_lookup),
                                 );
-                                let backend_addr = match resolved {
-                                    Ok(value) => value.backend_addr,
+                                let (backend_addr, upstream_name) = match resolved {
+                                    Ok(value) => (value.backend_addr, value.upstream_name),
                                     Err(ProxyError::Transport(reason)) => {
                                         let (status, body) =
                                             bootstrap_resolution_error_response(&reason);
@@ -4417,6 +4438,36 @@ impl QUICListener {
                                     }
                                 };
 
+                                let host_policy = upstream_host_policies
+                                    .get(&upstream_name)
+                                    .cloned()
+                                    .unwrap_or_default();
+                                let request_host = req
+                                    .headers()
+                                    .get(http::header::HOST)
+                                    .and_then(|value| value.to_str().ok());
+                                let upstream_host = match resolve_upstream_host_value(
+                                    &endpoint,
+                                    &host_policy,
+                                    authority.as_deref(),
+                                    request_host,
+                                ) {
+                                    Ok(host) => host,
+                                    Err(_) => {
+                                        return Ok(Response::builder()
+                                            .status(StatusCode::BAD_REQUEST)
+                                            .header("alt-svc", &alt)
+                                            .body(boxed_full(Bytes::from_static(
+                                                b"invalid host policy\n",
+                                            )))
+                                            .unwrap_or_else(|_| {
+                                                Response::new(boxed_full(Bytes::from_static(
+                                                    b"error\n",
+                                                )))
+                                            }));
+                                    }
+                                };
+
                                 let mut upstream_req =
                                     Request::builder().method(method.as_str()).uri(upstream_uri);
 
@@ -4455,10 +4506,8 @@ impl QUICListener {
                                     }
                                     upstream_req = upstream_req.header(name, value);
                                 }
-                                upstream_req = upstream_req.header(
-                                    http::header::HOST,
-                                    authority.as_deref().unwrap_or(endpoint.authority()),
-                                );
+                                upstream_req =
+                                    upstream_req.header(http::header::HOST, upstream_host);
                                 upstream_req = upstream_req.header(
                                     "forwarded",
                                     format!(
@@ -5031,6 +5080,7 @@ mod tests {
                 lb_type: lb_type.to_string(),
                 key: lb_key.map(str::to_string),
             },
+            host_policy: Default::default(),
             route: RouteMatch {
                 host: None,
                 path_prefix: Some("/api".to_string()),

--- a/crates/edge/src/route_index.rs
+++ b/crates/edge/src/route_index.rs
@@ -819,6 +819,7 @@ mod tests {
                 key: None,
             },
             host_policy: Default::default(),
+        forwarded_headers: Default::default(),
             route: RouteMatch {
                 host: host.map(str::to_string),
                 path_prefix: path_prefix.map(str::to_string),

--- a/crates/edge/src/route_index.rs
+++ b/crates/edge/src/route_index.rs
@@ -818,6 +818,7 @@ mod tests {
                 lb_type: "random".to_string(),
                 key: None,
             },
+            host_policy: Default::default(),
             route: RouteMatch {
                 host: host.map(str::to_string),
                 path_prefix: path_prefix.map(str::to_string),

--- a/crates/edge/src/route_index.rs
+++ b/crates/edge/src/route_index.rs
@@ -819,7 +819,7 @@ mod tests {
                 key: None,
             },
             host_policy: Default::default(),
-        forwarded_headers: Default::default(),
+            forwarded_headers: Default::default(),
             route: RouteMatch {
                 host: host.map(str::to_string),
                 path_prefix: path_prefix.map(str::to_string),

--- a/crates/edge/src/types.rs
+++ b/crates/edge/src/types.rs
@@ -2,7 +2,7 @@ use bytes::Bytes;
 use core::net::SocketAddr;
 use spooky_config::{
     backend_endpoint::BackendEndpoint,
-    config::{Config, UpstreamHostPolicy},
+    config::{Config, ForwardedHeaderPolicy, UpstreamHostPolicy},
 };
 use spooky_errors::ProxyError;
 use spooky_lb::UpstreamPool;
@@ -28,6 +28,7 @@ pub struct SharedRuntimeState {
     pub(crate) h2_pool: Arc<H2Pool>,
     pub(crate) backend_endpoints: Arc<HashMap<String, BackendEndpoint>>,
     pub(crate) upstream_host_policies: Arc<HashMap<String, UpstreamHostPolicy>>,
+    pub(crate) forwarded_header_policies: Arc<HashMap<String, ForwardedHeaderPolicy>>,
     pub(crate) upstream_pools: HashMap<String, Arc<RwLock<UpstreamPool>>>,
     pub(crate) upstream_inflight: HashMap<String, Arc<Semaphore>>,
     pub(crate) global_inflight: Arc<Semaphore>,
@@ -80,6 +81,7 @@ pub struct QUICListener {
     pub h2_pool: Arc<H2Pool>,
     pub backend_endpoints: Arc<HashMap<String, BackendEndpoint>>,
     pub upstream_host_policies: Arc<HashMap<String, UpstreamHostPolicy>>,
+    pub forwarded_header_policies: Arc<HashMap<String, ForwardedHeaderPolicy>>,
     pub upstream_pools: HashMap<String, Arc<RwLock<UpstreamPool>>>,
     pub upstream_inflight: HashMap<String, Arc<Semaphore>>,
     pub global_inflight: Arc<Semaphore>,

--- a/crates/edge/src/types.rs
+++ b/crates/edge/src/types.rs
@@ -1,6 +1,9 @@
 use bytes::Bytes;
 use core::net::SocketAddr;
-use spooky_config::{backend_endpoint::BackendEndpoint, config::Config};
+use spooky_config::{
+    backend_endpoint::BackendEndpoint,
+    config::{Config, UpstreamHostPolicy},
+};
 use spooky_errors::ProxyError;
 use spooky_lb::UpstreamPool;
 use spooky_transport::h2_pool::H2Pool;
@@ -24,6 +27,7 @@ use crate::watchdog::WatchdogCoordinator;
 pub struct SharedRuntimeState {
     pub(crate) h2_pool: Arc<H2Pool>,
     pub(crate) backend_endpoints: Arc<HashMap<String, BackendEndpoint>>,
+    pub(crate) upstream_host_policies: Arc<HashMap<String, UpstreamHostPolicy>>,
     pub(crate) upstream_pools: HashMap<String, Arc<RwLock<UpstreamPool>>>,
     pub(crate) upstream_inflight: HashMap<String, Arc<Semaphore>>,
     pub(crate) global_inflight: Arc<Semaphore>,
@@ -75,6 +79,7 @@ pub struct QUICListener {
     pub h3_config: Arc<quiche::h3::Config>,
     pub h2_pool: Arc<H2Pool>,
     pub backend_endpoints: Arc<HashMap<String, BackendEndpoint>>,
+    pub upstream_host_policies: Arc<HashMap<String, UpstreamHostPolicy>>,
     pub upstream_pools: HashMap<String, Arc<RwLock<UpstreamPool>>>,
     pub upstream_inflight: HashMap<String, Arc<Semaphore>>,
     pub global_inflight: Arc<Semaphore>,

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -74,6 +74,7 @@ fn make_config(port: u32, backend_addr: String, cert: String, key: String) -> Co
                 key: None,
             },
             host_policy: Default::default(),
+        forwarded_headers: Default::default(),
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -73,6 +73,7 @@ fn make_config(port: u32, backend_addr: String, cert: String, key: String) -> Co
                 lb_type: "random".to_string(),
                 key: None,
             },
+            host_policy: Default::default(),
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -74,7 +74,7 @@ fn make_config(port: u32, backend_addr: String, cert: String, key: String) -> Co
                 key: None,
             },
             host_policy: Default::default(),
-        forwarded_headers: Default::default(),
+            forwarded_headers: Default::default(),
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()

--- a/crates/edge/tests/h3_edge.rs
+++ b/crates/edge/tests/h3_edge.rs
@@ -60,6 +60,7 @@ fn make_config(port: u32, cert: String, key: String, backend_address: String) ->
                 key: None,
             },
             host_policy: Default::default(),
+        forwarded_headers: Default::default(),
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()
@@ -800,6 +801,7 @@ fn make_config_with_rate_limit(
                 key: None,
             },
             host_policy: Default::default(),
+        forwarded_headers: Default::default(),
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()

--- a/crates/edge/tests/h3_edge.rs
+++ b/crates/edge/tests/h3_edge.rs
@@ -59,6 +59,7 @@ fn make_config(port: u32, cert: String, key: String, backend_address: String) ->
                 lb_type: "random".to_string(),
                 key: None,
             },
+            host_policy: Default::default(),
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()
@@ -798,6 +799,7 @@ fn make_config_with_rate_limit(
                 lb_type: "random".to_string(),
                 key: None,
             },
+            host_policy: Default::default(),
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()

--- a/crates/edge/tests/h3_edge.rs
+++ b/crates/edge/tests/h3_edge.rs
@@ -60,7 +60,7 @@ fn make_config(port: u32, cert: String, key: String, backend_address: String) ->
                 key: None,
             },
             host_policy: Default::default(),
-        forwarded_headers: Default::default(),
+            forwarded_headers: Default::default(),
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()
@@ -801,7 +801,7 @@ fn make_config_with_rate_limit(
                 key: None,
             },
             host_policy: Default::default(),
-        forwarded_headers: Default::default(),
+            forwarded_headers: Default::default(),
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()

--- a/crates/edge/tests/lb_integration.rs
+++ b/crates/edge/tests/lb_integration.rs
@@ -90,6 +90,7 @@ fn make_config(
                 key: None,
             },
             host_policy: Default::default(),
+        forwarded_headers: Default::default(),
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()

--- a/crates/edge/tests/lb_integration.rs
+++ b/crates/edge/tests/lb_integration.rs
@@ -90,7 +90,7 @@ fn make_config(
                 key: None,
             },
             host_policy: Default::default(),
-        forwarded_headers: Default::default(),
+            forwarded_headers: Default::default(),
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()

--- a/crates/edge/tests/lb_integration.rs
+++ b/crates/edge/tests/lb_integration.rs
@@ -89,6 +89,7 @@ fn make_config(
                 lb_type: lb_type.to_string(),
                 key: None,
             },
+            host_policy: Default::default(),
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()

--- a/crates/lb/src/lib.rs
+++ b/crates/lb/src/lib.rs
@@ -1025,6 +1025,7 @@ mod tests {
                 key: None,
             },
             host_policy: Default::default(),
+        forwarded_headers: Default::default(),
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()

--- a/crates/lb/src/lib.rs
+++ b/crates/lb/src/lib.rs
@@ -1024,6 +1024,7 @@ mod tests {
                 lb_type: "round-robin".to_string(),
                 key: None,
             },
+            host_policy: Default::default(),
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()

--- a/crates/lb/src/lib.rs
+++ b/crates/lb/src/lib.rs
@@ -1025,7 +1025,7 @@ mod tests {
                 key: None,
             },
             host_policy: Default::default(),
-        forwarded_headers: Default::default(),
+            forwarded_headers: Default::default(),
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -233,6 +233,8 @@ upstream:
 | `load_balancing` | object | No | round-robin | Per-upstream load balancing algorithm configuration |
 | `route` | object | Yes | - | Route matching criteria |
 | `backends` | array | Yes | - | List of backend servers |
+| `host_policy` | object | No | `pass-through` | Controls how the `Host`/`:authority` header is set on upstream requests |
+| `forwarded_headers` | object | No | `overwrite` | Controls `X-Forwarded-For` forwarding behavior |
 
 ### Route Matching
 
@@ -405,6 +407,88 @@ backends:
     health_check:
       path: "/healthz"
       interval: 5000
+```
+
+### Host Policy
+
+Controls how the `Host` / `:authority` header is set on requests forwarded to the upstream.
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `mode` | string | No | `pass-through` | Header rewrite mode: `pass-through`, `rewrite`, or `upstream` |
+| `host` | string | No | - | Static host to use when `mode: rewrite` |
+
+#### Modes
+
+| Mode | Behavior |
+|------|----------|
+| `pass-through` | Forwards the original client `Host`/`:authority` unchanged to the upstream |
+| `rewrite` | Replaces the host with the value of `host` (required when using this mode) |
+| `upstream` | Uses the backend's own authority (hostname from the `address` field) |
+
+#### Examples
+
+```yaml
+upstream:
+  # Pass client host through as-is (default)
+  api_pool:
+    host_policy:
+      mode: pass-through
+    backends: [...]
+
+  # Rewrite to a static host
+  legacy_pool:
+    host_policy:
+      mode: rewrite
+      host: "legacy-origin.internal.example"
+    backends: [...]
+
+  # Use the backend's own hostname
+  direct_pool:
+    host_policy:
+      mode: upstream
+    backends: [...]
+```
+
+### Forwarded Headers Policy
+
+Controls how `X-Forwarded-For` and related forwarding headers are set on upstream requests.
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `mode` | string | No | `overwrite` | Forwarding mode: `append`, `preserve`, or `overwrite` |
+
+#### Modes
+
+| Mode | Behavior |
+|------|----------|
+| `overwrite` | Replaces any inbound `X-Forwarded-For` with the client IP only (default) |
+| `append` | Appends the client IP to the existing `X-Forwarded-For` chain |
+| `preserve` | Passes the inbound `X-Forwarded-For` chain through unchanged without adding the client IP |
+
+Use `append` in multi-hop deployments where the full client IP chain must be preserved. Use `overwrite` (default) when spooky is the first edge and inbound forwarded headers should not be trusted.
+
+#### Examples
+
+```yaml
+upstream:
+  # First edge — overwrite inbound XFF with real client IP (default)
+  public_pool:
+    forwarded_headers:
+      mode: overwrite
+    backends: [...]
+
+  # Behind another trusted proxy — append to the existing chain
+  internal_pool:
+    forwarded_headers:
+      mode: append
+    backends: [...]
+
+  # Pass the inbound chain through unchanged
+  passthrough_pool:
+    forwarded_headers:
+      mode: preserve
+    backends: [...]
 ```
 
 ## Load Balancing Configuration


### PR DESCRIPTION
## Summary

- **#195** — Adds `host_policy` per upstream with three modes:
  - `pass-through` — forwards the original client `:authority`/host unchanged
  - `rewrite` — replaces with a configured static host
  - `upstream` — uses the backend's own authority
- **#196** — Adds `forwarded_headers` policy per upstream with three modes:
  - `append` — appends client IP to the existing `X-Forwarded-For` chain
  - `preserve` — passes the inbound XFF chain through unchanged
  - `overwrite` — replaces with only the current client IP (previous default behavior)

Both policies apply to the H3→H2 forwarding path and the bootstrap path.

## Files changed

- `crates/config/src/config.rs` — `UpstreamHostPolicy`, `UpstreamHostPolicyMode`, `ForwardedHeaderPolicy`, `ForwardedHeaderPolicyMode` structs/enums
- `crates/bridge/src/h3_to_h2.rs` — `build_h2_request_for_endpoint_with_host_policy`, `merge_forwarded_chain`
- `crates/edge/src/quic_listener/mod.rs` — bootstrap path wired to both policies
- `crates/config/src/validator.rs` — validation for new policy fields

Closes #195, Closes #196
