### PR TITLE
feat(edge): add periodic DNS refresh for upstream backends

### DIFF
--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -100,6 +100,8 @@ performance:
     udp_send_buffer_bytes: 8388608
     h2_pool_max_idle_per_backend: 256
     h2_pool_idle_timeout_ms: 90000
+    backend_dns_refresh_enabled: false        # periodically refresh hostname-based backend DNS in the control plane
+    backend_dns_refresh_interval_ms: 30000   # refresh cadence for hostname-based backends (ms)
     per_backend_inflight_limit: 64
     new_connections_per_sec: 2000   # max new QUIC connections accepted per second (token-bucket refill rate)
     new_connections_burst: 500      # burst capacity above the steady-state rate; must be >= 1

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -19,6 +19,7 @@ use crate::default::{
     observe_default_routing_transparency_include_reason, observe_default_tracing_sample_ratio,
     observe_default_tracing_service_name, perf_default_backend_body_idle_timeout_ms,
     perf_default_backend_body_total_timeout_ms, perf_default_backend_connect_timeout_ms,
+    perf_default_backend_dns_refresh_enabled, perf_default_backend_dns_refresh_interval_ms,
     perf_default_backend_timeout_ms, perf_default_backend_total_request_timeout_ms,
     perf_default_client_body_idle_timeout_ms, perf_default_control_plane_threads,
     perf_default_global_inflight_limit, perf_default_h2_pool_idle_timeout_ms,
@@ -413,6 +414,14 @@ pub struct Performance {
     #[serde(default = "perf_default_h2_pool_idle_timeout_ms")]
     pub h2_pool_idle_timeout_ms: u64,
 
+    /// Enables periodic DNS refresh for hostname-based upstream backends.
+    #[serde(default = "perf_default_backend_dns_refresh_enabled")]
+    pub backend_dns_refresh_enabled: bool,
+
+    /// Control-plane interval for refreshing hostname-based backend DNS records.
+    #[serde(default = "perf_default_backend_dns_refresh_interval_ms")]
+    pub backend_dns_refresh_interval_ms: u64,
+
     #[serde(default = "perf_default_per_backend_inflight_limit")]
     pub per_backend_inflight_limit: usize,
 
@@ -500,6 +509,8 @@ impl Default for Performance {
             udp_send_buffer_bytes: perf_default_udp_send_buffer_bytes(),
             h2_pool_max_idle_per_backend: perf_default_h2_pool_max_idle_per_backend(),
             h2_pool_idle_timeout_ms: perf_default_h2_pool_idle_timeout_ms(),
+            backend_dns_refresh_enabled: perf_default_backend_dns_refresh_enabled(),
+            backend_dns_refresh_interval_ms: perf_default_backend_dns_refresh_interval_ms(),
             per_backend_inflight_limit: perf_default_per_backend_inflight_limit(),
             new_connections_per_sec: perf_default_new_connections_per_sec(),
             new_connections_burst: perf_default_new_connections_burst(),

--- a/crates/config/src/default.rs
+++ b/crates/config/src/default.rs
@@ -159,6 +159,14 @@ pub fn perf_default_h2_pool_idle_timeout_ms() -> u64 {
     90_000
 }
 
+pub fn perf_default_backend_dns_refresh_enabled() -> bool {
+    false
+}
+
+pub fn perf_default_backend_dns_refresh_interval_ms() -> u64 {
+    30_000
+}
+
 pub fn perf_default_per_backend_inflight_limit() -> usize {
     64
 }

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -389,6 +389,11 @@ pub fn validate(config: &Config) -> bool {
         return false;
     }
 
+    if config.performance.backend_dns_refresh_interval_ms == 0 {
+        error!("performance.backend_dns_refresh_interval_ms must be greater than 0");
+        return false;
+    }
+
     if config.performance.per_backend_inflight_limit == 0 {
         error!("performance.per_backend_inflight_limit must be greater than 0");
         return false;
@@ -1399,6 +1404,8 @@ upstream:
         assert_eq!(cfg.performance.udp_send_buffer_bytes, 8 * 1024 * 1024);
         assert_eq!(cfg.performance.h2_pool_max_idle_per_backend, 256);
         assert_eq!(cfg.performance.h2_pool_idle_timeout_ms, 90_000);
+        assert!(!cfg.performance.backend_dns_refresh_enabled);
+        assert_eq!(cfg.performance.backend_dns_refresh_interval_ms, 30_000);
         assert_eq!(cfg.performance.per_backend_inflight_limit, 64);
         assert_eq!(cfg.performance.max_active_connections, 20_000);
         assert_eq!(cfg.performance.max_request_body_bytes, 1_000_000);
@@ -1502,6 +1509,10 @@ upstream:
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.performance.h2_pool_idle_timeout_ms = 0;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.performance.backend_dns_refresh_interval_ms = 0;
         assert!(!validate(&cfg));
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -42,7 +42,7 @@ use spooky_bridge::h3_to_h2::{
 };
 use spooky_errors::{PoolError, ProxyError, is_retryable};
 use spooky_lb::{HealthFailureReason, HealthTransition, UpstreamPool};
-use spooky_transport::h2_client::{H2Client, TlsClientConfig};
+use spooky_transport::h2_client::{H2Client, SharedDnsResolver, TlsClientConfig};
 use spooky_transport::h2_pool::H2Pool;
 use tokio::runtime::Handle;
 use tokio::sync::{
@@ -496,6 +496,7 @@ impl QUICListener {
             }
         }
 
+        let backend_dns_resolver = SharedDnsResolver::new();
         let h2_pool = Arc::new(
             H2Pool::new(
                 backend_addresses,
@@ -504,6 +505,7 @@ impl QUICListener {
                 Duration::from_millis(config.performance.h2_pool_idle_timeout_ms),
                 Duration::from_millis(config.performance.backend_connect_timeout_ms),
                 Self::upstream_tls_client_config(config),
+                backend_dns_resolver.clone(),
             )
             .map_err(ProxyError::Tls)?,
         );
@@ -575,6 +577,7 @@ impl QUICListener {
                     })
                     .collect(),
             ),
+            backend_dns_resolver,
             forwarded_header_policies: Arc::new(
                 config
                     .upstream
@@ -611,6 +614,7 @@ impl QUICListener {
             Duration::from_millis(config.performance.h2_pool_idle_timeout_ms.max(1)),
             Duration::from_millis(config.performance.backend_connect_timeout_ms.max(1)),
             Self::upstream_tls_client_config(config),
+            shared_state.backend_dns_resolver.clone(),
         ) {
             Ok(client) => Arc::new(client),
             Err(err) => {
@@ -711,6 +715,7 @@ impl QUICListener {
             h3_config,
             h2_pool: Arc::clone(&shared_state.h2_pool),
             backend_endpoints: Arc::clone(&shared_state.backend_endpoints),
+            backend_dns_resolver: shared_state.backend_dns_resolver.clone(),
             upstream_host_policies: Arc::clone(&shared_state.upstream_host_policies),
             forwarded_header_policies: Arc::clone(&shared_state.forwarded_header_policies),
             upstream_pools: shared_state.upstream_pools.clone(),

--- a/crates/edge/src/types.rs
+++ b/crates/edge/src/types.rs
@@ -6,7 +6,7 @@ use spooky_config::{
 };
 use spooky_errors::ProxyError;
 use spooky_lb::UpstreamPool;
-use spooky_transport::h2_pool::H2Pool;
+use spooky_transport::{h2_client::SharedDnsResolver, h2_pool::H2Pool};
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     net::UdpSocket,
@@ -27,6 +27,7 @@ use crate::watchdog::WatchdogCoordinator;
 pub struct SharedRuntimeState {
     pub(crate) h2_pool: Arc<H2Pool>,
     pub(crate) backend_endpoints: Arc<HashMap<String, BackendEndpoint>>,
+    pub(crate) backend_dns_resolver: SharedDnsResolver,
     pub(crate) upstream_host_policies: Arc<HashMap<String, UpstreamHostPolicy>>,
     pub(crate) forwarded_header_policies: Arc<HashMap<String, ForwardedHeaderPolicy>>,
     pub(crate) upstream_pools: HashMap<String, Arc<RwLock<UpstreamPool>>>,
@@ -80,6 +81,7 @@ pub struct QUICListener {
     pub h3_config: Arc<quiche::h3::Config>,
     pub h2_pool: Arc<H2Pool>,
     pub backend_endpoints: Arc<HashMap<String, BackendEndpoint>>,
+    pub backend_dns_resolver: SharedDnsResolver,
     pub upstream_host_policies: Arc<HashMap<String, UpstreamHostPolicy>>,
     pub forwarded_header_policies: Arc<HashMap<String, ForwardedHeaderPolicy>>,
     pub upstream_pools: HashMap<String, Arc<RwLock<UpstreamPool>>>,

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -13,5 +13,6 @@ hyper-rustls.workspace = true
 rustls.workspace = true
 rustls-pemfile.workspace = true
 tokio.workspace = true
+tower-service = "0.3"
 webpki-roots.workspace = true
 spooky-errors = { path = "../errors" }

--- a/crates/transport/src/h2_client.rs
+++ b/crates/transport/src/h2_client.rs
@@ -2,15 +2,18 @@ use std::convert::Infallible;
 use std::ffi::OsStr;
 use std::fs::File;
 use std::future::Future;
-use std::io::BufReader;
 use std::io;
+use std::io::BufReader;
 use std::net::SocketAddr;
 use std::path::Path;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::RwLock;
 use std::time::Duration;
-use std::{collections::HashMap, task::{Context, Poll}};
+use std::{
+    collections::HashMap,
+    task::{Context, Poll},
+};
 
 use http_body_util::combinators::BoxBody;
 use hyper::body::Bytes;
@@ -92,6 +95,12 @@ impl SharedDnsResolver {
             .read()
             .ok()
             .and_then(|guard| guard.get(&normalize_dns_cache_host(host)).cloned())
+    }
+}
+
+impl Default for SharedDnsResolver {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/transport/src/h2_client.rs
+++ b/crates/transport/src/h2_client.rs
@@ -3,19 +3,31 @@ use std::ffi::OsStr;
 use std::fs::File;
 use std::future::Future;
 use std::io::BufReader;
+use std::io;
+use std::net::SocketAddr;
 use std::path::Path;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::RwLock;
 use std::time::Duration;
+use std::{collections::HashMap, task::{Context, Poll}};
 
 use http_body_util::combinators::BoxBody;
 use hyper::body::Bytes;
 use hyper::{Request, rt::Executor};
 use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
-use hyper_util::client::legacy::{Client, connect::HttpConnector};
+use hyper_util::client::legacy::{
+    Client,
+    connect::{
+        HttpConnector,
+        dns::{GaiResolver, Name},
+    },
+};
 
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
 use rustls::{ClientConfig, DigitallySignedStruct, RootCertStore, SignatureScheme};
+use tower_service::Service;
 
 #[derive(Debug, Clone)]
 pub struct TlsClientConfig {
@@ -36,8 +48,77 @@ impl Default for TlsClientConfig {
     }
 }
 
+type ResolverResponse = std::vec::IntoIter<SocketAddr>;
+type ResolverFuture =
+    Pin<Box<dyn Future<Output = Result<ResolverResponse, io::Error>> + Send + 'static>>;
+
+#[derive(Clone)]
+pub struct SharedDnsResolver {
+    cache: Arc<RwLock<HashMap<String, Vec<SocketAddr>>>>,
+    fallback: GaiResolver,
+}
+
+impl SharedDnsResolver {
+    pub fn new() -> Self {
+        Self {
+            cache: Arc::new(RwLock::new(HashMap::new())),
+            fallback: GaiResolver::new(),
+        }
+    }
+
+    pub fn set_host_addrs<I>(&self, host: &str, addrs: I)
+    where
+        I: IntoIterator<Item = SocketAddr>,
+    {
+        let normalized = normalize_dns_cache_host(host);
+        let addrs: Vec<SocketAddr> = addrs.into_iter().collect();
+        if addrs.is_empty() {
+            self.remove_host(host);
+            return;
+        }
+        if let Ok(mut guard) = self.cache.write() {
+            guard.insert(normalized, addrs);
+        }
+    }
+
+    pub fn remove_host(&self, host: &str) {
+        if let Ok(mut guard) = self.cache.write() {
+            guard.remove(&normalize_dns_cache_host(host));
+        }
+    }
+
+    pub fn cached_addrs(&self, host: &str) -> Option<Vec<SocketAddr>> {
+        self.cache
+            .read()
+            .ok()
+            .and_then(|guard| guard.get(&normalize_dns_cache_host(host)).cloned())
+    }
+}
+
+impl Service<Name> for SharedDnsResolver {
+    type Response = ResolverResponse;
+    type Error = io::Error;
+    type Future = ResolverFuture;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.fallback.poll_ready(cx)
+    }
+
+    fn call(&mut self, name: Name) -> Self::Future {
+        if let Some(addrs) = self.cached_addrs(name.as_str()) {
+            return Box::pin(async move { Ok(addrs.into_iter()) });
+        }
+
+        let mut fallback = self.fallback.clone();
+        Box::pin(async move {
+            let resolved = fallback.call(name).await?;
+            Ok(resolved.collect::<Vec<_>>().into_iter())
+        })
+    }
+}
+
 pub struct H2Client {
-    client: Client<HttpsConnector<HttpConnector>, BoxBody<Bytes, Infallible>>,
+    client: Client<HttpsConnector<HttpConnector<SharedDnsResolver>>, BoxBody<Bytes, Infallible>>,
 }
 
 #[derive(Clone, Copy)]
@@ -59,8 +140,9 @@ impl H2Client {
         pool_idle_timeout: Duration,
         connect_timeout: Duration,
         tls: TlsClientConfig,
+        dns_resolver: SharedDnsResolver,
     ) -> Result<Self, String> {
-        let mut http = HttpConnector::new();
+        let mut http = HttpConnector::new_with_resolver(dns_resolver);
         http.enforce_http(false);
         http.set_connect_timeout(Some(connect_timeout));
 
@@ -93,8 +175,13 @@ impl H2Client {
             Duration::from_secs(30),
             Duration::from_secs(2),
             TlsClientConfig::default(),
+            SharedDnsResolver::new(),
         )
     }
+}
+
+fn normalize_dns_cache_host(host: &str) -> String {
+    host.trim().trim_end_matches('.').to_ascii_lowercase()
 }
 
 fn build_tls_config(tls: &TlsClientConfig) -> Result<ClientConfig, String> {
@@ -266,8 +353,10 @@ impl ServerCertVerifier for InsecureServerCertVerifier {
 
 #[cfg(test)]
 mod tests {
-    use super::{H2Client, TlsClientConfig};
-    use std::time::Duration;
+    use super::{H2Client, SharedDnsResolver, TlsClientConfig};
+    use hyper_util::client::legacy::connect::dns::Name;
+    use std::{net::SocketAddr, str::FromStr, time::Duration};
+    use tower_service::Service;
 
     #[test]
     fn default_tls_client_config_builds_h2_client() {
@@ -297,6 +386,7 @@ mod tests {
                 ca_file: Some(path.to_string_lossy().to_string()),
                 ca_dir: None,
             },
+            SharedDnsResolver::new(),
         );
         assert!(client.is_err());
 
@@ -315,7 +405,35 @@ mod tests {
                 ca_file: None,
                 ca_dir: None,
             },
+            SharedDnsResolver::new(),
         );
         assert!(client.is_ok());
+    }
+
+    #[tokio::test]
+    async fn shared_dns_resolver_returns_cached_addresses_case_insensitively() {
+        let resolver = SharedDnsResolver::new();
+        resolver.set_host_addrs(
+            "api.example.com",
+            [
+                SocketAddr::from(([127, 0, 0, 10], 0)),
+                SocketAddr::from(([127, 0, 0, 11], 0)),
+            ],
+        );
+
+        let mut service = resolver.clone();
+        let addrs: Vec<_> = service
+            .call(Name::from_str("API.EXAMPLE.COM").expect("name"))
+            .await
+            .expect("resolve")
+            .collect();
+
+        assert_eq!(
+            addrs,
+            vec![
+                SocketAddr::from(([127, 0, 0, 10], 0)),
+                SocketAddr::from(([127, 0, 0, 11], 0))
+            ]
+        );
     }
 }

--- a/crates/transport/src/h2_pool.rs
+++ b/crates/transport/src/h2_pool.rs
@@ -5,7 +5,7 @@ use hyper::Request;
 use hyper::body::{Bytes, Incoming};
 use tokio::sync::{Semaphore, TryAcquireError};
 
-use crate::h2_client::{H2Client, TlsClientConfig};
+use crate::h2_client::{H2Client, SharedDnsResolver, TlsClientConfig};
 pub use spooky_errors::PoolError;
 
 struct BackendHandle {
@@ -25,6 +25,7 @@ impl H2Pool {
         pool_idle_timeout: Duration,
         connect_timeout: Duration,
         tls: TlsClientConfig,
+        dns_resolver: SharedDnsResolver,
     ) -> Result<Self, String>
     where
         I: IntoIterator<Item = String>,
@@ -38,6 +39,7 @@ impl H2Pool {
                 pool_idle_timeout,
                 connect_timeout,
                 tls.clone(),
+                dns_resolver.clone(),
             )?;
             map.insert(
                 backend,

--- a/crates/transport/tests/h2_pool.rs
+++ b/crates/transport/tests/h2_pool.rs
@@ -13,7 +13,7 @@ use hyper_util::rt::{TokioExecutor, TokioIo};
 use tokio::net::TcpListener;
 
 use spooky_transport::{
-    h2_client::TlsClientConfig,
+    h2_client::{SharedDnsResolver, TlsClientConfig},
     h2_pool::{H2Pool, PoolError},
 };
 
@@ -95,6 +95,7 @@ async fn pool_limits_inflight_per_backend() {
             Duration::from_secs(30),
             Duration::from_secs(2),
             TlsClientConfig::default(),
+            SharedDnsResolver::new(),
         )
         .expect("pool"),
     );
@@ -143,6 +144,7 @@ async fn pool_rejects_unknown_backend() {
         Duration::from_secs(30),
         Duration::from_secs(2),
         TlsClientConfig::default(),
+        SharedDnsResolver::new(),
     )
     .expect("pool");
     let req = Request::builder()
@@ -171,6 +173,7 @@ async fn pool_reports_overload_when_inflight_is_exhausted() {
             Duration::from_secs(30),
             Duration::from_secs(2),
             TlsClientConfig::default(),
+            SharedDnsResolver::new(),
         )
         .expect("pool"),
     );

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -131,6 +131,8 @@ The following table lists all default configuration values used when properties 
 | `performance.new_connections_per_sec` | `2000` | Token-bucket refill rate for new QUIC connections (conns/sec) |
 | `performance.new_connections_burst` | `500` | Burst capacity for new QUIC connections |
 | `performance.max_active_connections` | `20000` | Hard cap on concurrently tracked active QUIC connections per worker |
+| `performance.backend_dns_refresh_enabled` | `false` | Enable periodic control-plane DNS refresh for hostname-based upstream backends |
+| `performance.backend_dns_refresh_interval_ms` | `30000` | Refresh interval for hostname-based backend DNS records |
 | `performance.quic_max_idle_timeout_ms` | `5000` | QUIC idle timeout — connection closed after this many ms of inactivity |
 | `performance.quic_initial_max_data` | `10000000` | Connection-level flow control window (bytes) |
 | `performance.quic_initial_max_stream_data` | `1000000` | Per-stream flow control window (bytes) |
@@ -692,6 +694,8 @@ Controls resource limits, tuning knobs, and connection-flood protection. All fie
 | `udp_send_buffer_bytes` | integer | No | `8388608` | UDP socket send buffer size (bytes) |
 | `h2_pool_max_idle_per_backend` | integer | No | `256` | Maximum idle HTTP/2 connections kept open per backend |
 | `h2_pool_idle_timeout_ms` | integer | No | `90000` | How long an idle H2 connection is kept before being closed (ms) |
+| `backend_dns_refresh_enabled` | bool | No | `false` | Enable periodic DNS refresh for hostname-based upstream backends |
+| `backend_dns_refresh_interval_ms` | integer | No | `30000` | Control-plane DNS refresh interval for hostname-based upstream backends (ms) |
 | `new_connections_per_sec` | integer | No | `2000` | Steady-state rate at which new QUIC connections are accepted (token-bucket refill, connections/sec) |
 | `new_connections_burst` | integer | No | `500` | Burst capacity above the steady-state rate; the bucket starts full so the first burst of legitimate connections always succeeds |
 | `max_active_connections` | integer | No | `20000` | Hard cap on active QUIC connections per worker; unknown `Initial` packets are dropped once this cap is reached |


### PR DESCRIPTION
Ref: #193 

## Summary

Add control-plane DNS refresh support for hostname-based upstream backends so backend resolution can change at runtime without requiring a Spooky restart.

## Changes

- add performance config for backend DNS refresh enablement and interval
- add a shared DNS resolver/cache for upstream HTTP/2 clients
- refresh hostname-based backend DNS records periodically in the control plane
- ensure data-plane and health-check upstream connects use refreshed DNS results
- preserve backend authority/SNI behavior while updating connect-time resolution
- add validation, config/docs updates, and regression coverage

## Why

Backend authorities were effectively static for the lifetime of the process, which is a poor fit for Kubernetes, service discovery, and failover IP rotation. This change allows hostname-backed upstreams to follow DNS changes during runtime.

## Notes

- applies to hostname-based backends; literal IP backends remain unchanged
- keeps existing routing, load-balancing, and backend health semantics intact
- avoids swapping request URIs to raw IPs so upstream TLS/SNI validation continues to work correctly