### PR TITLE
feat(reverse-proxy): multi-listener support and per-upstream TLS policy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,6 @@ opentelemetry_sdk = { version = "0.28.0", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.28.0", features = ["grpc-tonic", "trace"] }
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "GPLv3"

--- a/config/config.production.yaml
+++ b/config/config.production.yaml
@@ -8,6 +8,22 @@ listen:
     cert: "/etc/spooky/certs/fullchain.pem"
     key: "/etc/spooky/certs/privkey.pem"
 
+# listeners: optional multi-listener block; overrides the top-level listen block when set.
+# Use this to bind multiple independent listeners with separate TLS identities.
+# listeners:
+#   - protocol: http3
+#     address: "0.0.0.0"
+#     port: 9889
+#     tls:
+#       cert: "/etc/spooky/certs/public-fullchain.pem"
+#       key: "/etc/spooky/certs/public-privkey.pem"
+#   - protocol: http3
+#     address: "10.0.0.1"
+#     port: 9890
+#     tls:
+#       cert: "/etc/spooky/certs/internal-fullchain.pem"
+#       key: "/etc/spooky/certs/internal-privkey.pem"
+
 upstream_tls:
   verify_certificates: true
   strict_sni: true

--- a/config/config.production.yaml
+++ b/config/config.production.yaml
@@ -18,6 +18,11 @@ upstream:
       type: round-robin
     route:
       path_prefix: "/"
+    host_policy:
+      mode: pass-through   # pass-through | rewrite | upstream
+      # host: "origin.example.com"  # required when mode: rewrite
+    forwarded_headers:
+      mode: append         # append | preserve | overwrite
     backends:
       - id: "backend1"
         address: "backend.internal.example:8443" # verified HTTPS by default (no scheme needed)

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -5,8 +5,15 @@ listen:
     address: "0.0.0.0"
     port: 9889
     tls:
-        cert: certs/proxy-fullchain.pem # path to cert
-        key: certs/proxy-key-pkcs8.pem # path to key
+        cert: certs/proxy-fullchain.pem # default/fallback cert (used when SNI is absent or unmatched)
+        key: certs/proxy-key-pkcs8.pem # default/fallback key
+        certificates:                  # optional SNI certificate mappings
+            - server_name: "api.example.com"
+              cert: certs/api-fullchain.pem
+              key: certs/api-key-pkcs8.pem
+            - server_name: "www.example.com"
+              cert: certs/www-fullchain.pem
+              key: certs/www-key-pkcs8.pem
         client_auth:
             enabled: false              # set true to request/verify client certificates (mTLS)
             require_client_cert: false  # when true, close connections that complete handshake without a client cert

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -100,6 +100,8 @@ performance:
     udp_send_buffer_bytes: 8388608
     h2_pool_max_idle_per_backend: 256
     h2_pool_idle_timeout_ms: 90000
+    backend_dns_refresh_enabled: false        # periodically refresh hostname-based backend DNS in the control plane
+    backend_dns_refresh_interval_ms: 30000   # refresh cadence for hostname-based backends (ms)
     per_backend_inflight_limit: 64
     new_connections_per_sec: 2000   # max new QUIC connections accepted per second (token-bucket refill rate)
     new_connections_burst: 500      # burst capacity above the steady-state rate; must be >= 1

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -33,6 +33,13 @@ upstream:
     route:
       path_prefix: "/api"
 
+    host_policy:
+      mode: pass-through   # pass-through | rewrite | upstream
+      # host: "api.example.com"  # required when mode: rewrite
+
+    forwarded_headers:
+      mode: append         # append | preserve | overwrite
+
     backends:
       - id: "backend1"
         address: "api-backend-1.internal.example:7001"   # verified HTTPS by default; use config.development.yaml for local cleartext

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -19,6 +19,22 @@ listen:
             require_client_cert: false  # when true, close connections that complete handshake without a client cert
             ca_file: null               # PEM CA bundle used to verify client certificates when enabled=true
 
+# listeners: optional multi-listener block; when set, overrides the top-level listen block.
+# Each entry is an independent listener with its own address, port, and TLS identity.
+# listeners:
+#   - protocol: http3
+#     address: "0.0.0.0"
+#     port: 9889
+#     tls:
+#       cert: certs/public-fullchain.pem
+#       key: certs/public-key-pkcs8.pem
+#   - protocol: http3
+#     address: "10.0.0.1"
+#     port: 9890
+#     tls:
+#       cert: certs/internal-fullchain.pem
+#       key: certs/internal-key-pkcs8.pem
+
 upstream_tls:
     verify_certificates: true  # safe-by-default for HTTPS upstreams
     strict_sni: true           # send backend host as SNI for HTTPS upstream connections
@@ -39,6 +55,13 @@ upstream:
 
     forwarded_headers:
       mode: append         # append | preserve | overwrite
+
+    # tls: optional per-upstream TLS override; inherits from upstream_tls when omitted
+    # tls:
+    #   verify_certificates: true
+    #   strict_sni: true
+    #   ca_file: certs/private-ca.pem  # optional custom CA bundle for this upstream only
+    #   ca_dir: null
 
     backends:
       - id: "backend1"

--- a/crates/bench/src/main.rs
+++ b/crates/bench/src/main.rs
@@ -738,6 +738,7 @@ fn build_lb_upstream(scale: usize, lb_type: &str) -> Upstream {
         },
         host_policy: Default::default(),
         forwarded_headers: Default::default(),
+        tls: None,
         route: RouteMatch {
             host: None,
             path_prefix: Some("/".to_string()),

--- a/crates/bench/src/main.rs
+++ b/crates/bench/src/main.rs
@@ -737,6 +737,7 @@ fn build_lb_upstream(scale: usize, lb_type: &str) -> Upstream {
             key: None,
         },
         host_policy: Default::default(),
+        forwarded_headers: Default::default(),
         route: RouteMatch {
             host: None,
             path_prefix: Some("/".to_string()),

--- a/crates/bench/src/main.rs
+++ b/crates/bench/src/main.rs
@@ -736,6 +736,7 @@ fn build_lb_upstream(scale: usize, lb_type: &str) -> Upstream {
             lb_type: lb_type.to_string(),
             key: None,
         },
+        host_policy: Default::default(),
         route: RouteMatch {
             host: None,
             path_prefix: Some("/".to_string()),

--- a/crates/bridge/src/h3_to_h2.rs
+++ b/crates/bridge/src/h3_to_h2.rs
@@ -10,7 +10,7 @@ use http_body_util::combinators::BoxBody;
 use quiche::h3::NameValue;
 use spooky_config::{
     backend_endpoint::BackendEndpoint,
-    config::{UpstreamHostPolicy, UpstreamHostPolicyMode},
+    config::{ForwardedHeaderPolicy, ForwardedHeaderPolicyMode, UpstreamHostPolicy, UpstreamHostPolicyMode},
 };
 
 pub use spooky_errors::BridgeError;
@@ -21,6 +21,23 @@ pub struct ForwardedContext<'a> {
     pub request_id: u64,
     pub traceparent: Option<&'a str>,
 }
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ForwardedHeaderChains<'a> {
+    pub forwarded: &'a [Vec<u8>],
+    pub x_forwarded_for: &'a [Vec<u8>],
+    pub x_forwarded_proto: &'a [Vec<u8>],
+    pub x_forwarded_host: &'a [Vec<u8>],
+}
+
+#[derive(Debug, Default)]
+pub struct ForwardedHeaderValues {
+    pub forwarded: Option<HeaderValue>,
+    pub x_forwarded_for: Option<HeaderValue>,
+    pub x_forwarded_proto: Option<HeaderValue>,
+    pub x_forwarded_host: Option<HeaderValue>,
+}
+
 
 /// Build an HTTP/2 request with a pre-boxed streaming body.
 /// `content_length` is `Some(n)` only when the full length is known upfront
@@ -58,6 +75,7 @@ pub fn build_h2_request_for_endpoint(
     build_h2_request_for_endpoint_with_host_policy(
         endpoint,
         &UpstreamHostPolicy::default(),
+        &ForwardedHeaderPolicy::default(),
         method,
         path,
         headers,
@@ -71,6 +89,7 @@ pub fn build_h2_request_for_endpoint(
 pub fn build_h2_request_for_endpoint_with_host_policy(
     endpoint: &BackendEndpoint,
     host_policy: &UpstreamHostPolicy,
+    forwarded_policy: &ForwardedHeaderPolicy,
     method: &str,
     path: &str,
     headers: &[quiche::h3::Header],
@@ -83,10 +102,30 @@ pub fn build_h2_request_for_endpoint_with_host_policy(
     let mut builder = Request::builder().method(method.clone());
     let connection_tokens = connection_header_tokens(headers);
     let mut host_from_headers: Option<String> = None;
+    let mut forwarded_from_headers: Vec<Vec<u8>> = Vec::new();
+    let mut x_forwarded_for_from_headers: Vec<Vec<u8>> = Vec::new();
+    let mut x_forwarded_proto_from_headers: Vec<Vec<u8>> = Vec::new();
+    let mut x_forwarded_host_from_headers: Vec<Vec<u8>> = Vec::new();
 
     for header in headers {
         let name = header.name();
         if name.starts_with(b":") {
+            continue;
+        }
+        if name.eq_ignore_ascii_case(b"forwarded") {
+            forwarded_from_headers.push(header.value().to_vec());
+            continue;
+        }
+        if name.eq_ignore_ascii_case(b"x-forwarded-for") {
+            x_forwarded_for_from_headers.push(header.value().to_vec());
+            continue;
+        }
+        if name.eq_ignore_ascii_case(b"x-forwarded-proto") {
+            x_forwarded_proto_from_headers.push(header.value().to_vec());
+            continue;
+        }
+        if name.eq_ignore_ascii_case(b"x-forwarded-host") {
+            x_forwarded_host_from_headers.push(header.value().to_vec());
             continue;
         }
 
@@ -148,29 +187,29 @@ pub fn build_h2_request_for_endpoint_with_host_policy(
         );
     }
 
-    let forwarded_value = format!(
-        "for={};proto=https;host=\"{}\"",
-        forwarded_for_value(forwarded_ctx.client_addr.ip()),
-        escape_forwarded_host(host_value),
-    );
-    builder = builder
-        .header(
-            HeaderName::from_static("forwarded"),
-            HeaderValue::from_str(&forwarded_value).map_err(|_| BridgeError::InvalidHeader)?,
-        )
-        .header(
-            HeaderName::from_static("x-forwarded-for"),
-            HeaderValue::from_str(&forwarded_ctx.client_addr.ip().to_string())
-                .map_err(|_| BridgeError::InvalidHeader)?,
-        )
-        .header(
-            HeaderName::from_static("x-forwarded-proto"),
-            HeaderValue::from_static("https"),
-        )
-        .header(
-            HeaderName::from_static("x-forwarded-host"),
-            HeaderValue::from_str(host_value).map_err(|_| BridgeError::InvalidHeader)?,
-        );
+    let forwarded_values = build_forwarded_header_values(
+        forwarded_policy,
+        ForwardedHeaderChains {
+            forwarded: &forwarded_from_headers,
+            x_forwarded_for: &x_forwarded_for_from_headers,
+            x_forwarded_proto: &x_forwarded_proto_from_headers,
+            x_forwarded_host: &x_forwarded_host_from_headers,
+        },
+        forwarded_ctx.client_addr.ip(),
+        host_value,
+    )?;
+    if let Some(value) = forwarded_values.forwarded {
+        builder = builder.header(HeaderName::from_static("forwarded"), value);
+    }
+    if let Some(value) = forwarded_values.x_forwarded_for {
+        builder = builder.header(HeaderName::from_static("x-forwarded-for"), value);
+    }
+    if let Some(value) = forwarded_values.x_forwarded_proto {
+        builder = builder.header(HeaderName::from_static("x-forwarded-proto"), value);
+    }
+    if let Some(value) = forwarded_values.x_forwarded_host {
+        builder = builder.header(HeaderName::from_static("x-forwarded-host"), value);
+    }
 
     builder.body(body).map_err(BridgeError::Build)
 }
@@ -193,6 +232,84 @@ pub fn resolve_upstream_host_value<'a>(
             .ok_or(BridgeError::InvalidHeader),
         UpstreamHostPolicyMode::Upstream => Ok(endpoint.authority()),
     }
+}
+
+pub fn build_forwarded_header_values(
+    policy: &ForwardedHeaderPolicy,
+    inbound: ForwardedHeaderChains<'_>,
+    client_ip: IpAddr,
+    host_value: &str,
+) -> Result<ForwardedHeaderValues, BridgeError> {
+    let forwarded_current = format!(
+        "for={};proto=https;host=\"{}\"",
+        forwarded_for_value(client_ip),
+        escape_forwarded_host(host_value),
+    );
+    let x_forwarded_for_current = client_ip.to_string();
+    let x_forwarded_proto_current = "https";
+    let x_forwarded_host_current = host_value;
+
+    Ok(ForwardedHeaderValues {
+        forwarded: merge_forwarded_chain(
+            policy.mode,
+            inbound.forwarded,
+            Some(forwarded_current.as_bytes()),
+        )?,
+        x_forwarded_for: merge_forwarded_chain(
+            policy.mode,
+            inbound.x_forwarded_for,
+            Some(x_forwarded_for_current.as_bytes()),
+        )?,
+        x_forwarded_proto: merge_forwarded_chain(
+            policy.mode,
+            inbound.x_forwarded_proto,
+            Some(x_forwarded_proto_current.as_bytes()),
+        )?,
+        x_forwarded_host: merge_forwarded_chain(
+            policy.mode,
+            inbound.x_forwarded_host,
+            Some(x_forwarded_host_current.as_bytes()),
+        )?,
+    })
+}
+
+fn merge_forwarded_chain(
+    mode: ForwardedHeaderPolicyMode,
+    inbound: &[Vec<u8>],
+    current: Option<&[u8]>,
+) -> Result<Option<HeaderValue>, BridgeError> {
+    match mode {
+        ForwardedHeaderPolicyMode::Preserve => join_header_chain(inbound),
+        ForwardedHeaderPolicyMode::Append => {
+            let mut values = inbound.to_vec();
+            if let Some(current) = current {
+                values.push(current.to_vec());
+            }
+            join_header_chain(&values)
+        }
+        ForwardedHeaderPolicyMode::Overwrite => current
+            .map(HeaderValue::from_bytes)
+            .transpose()
+            .map_err(|_| BridgeError::InvalidHeader),
+    }
+}
+
+fn join_header_chain(values: &[Vec<u8>]) -> Result<Option<HeaderValue>, BridgeError> {
+    if values.is_empty() {
+        return Ok(None);
+    }
+
+    let mut joined = Vec::new();
+    for (index, value) in values.iter().enumerate() {
+        if index > 0 {
+            joined.extend_from_slice(b", ");
+        }
+        joined.extend_from_slice(value);
+    }
+
+    HeaderValue::from_bytes(&joined)
+        .map(Some)
+        .map_err(|_| BridgeError::InvalidHeader)
 }
 
 fn connection_header_tokens(headers: &[quiche::h3::Header]) -> HashSet<String> {
@@ -262,7 +379,7 @@ mod tests {
     use quiche::h3::Header;
     use spooky_config::{
         backend_endpoint::BackendEndpoint,
-        config::{UpstreamHostPolicy, UpstreamHostPolicyMode},
+        config::{ForwardedHeaderPolicy, ForwardedHeaderPolicyMode, UpstreamHostPolicy, UpstreamHostPolicyMode},
     };
 
     use super::{
@@ -399,6 +516,106 @@ mod tests {
     }
 
     #[test]
+    fn forwarded_header_policy_append_and_preserve_behave_as_expected() {
+        let endpoint = BackendEndpoint::parse("backend.internal:443").expect("endpoint");
+        let headers = vec![
+            Header::new(b"forwarded", b"for=1.2.3.4;proto=http;host=\"old.example\""),
+            Header::new(b"x-forwarded-for", b"1.2.3.4"),
+            Header::new(b"x-forwarded-proto", b"http"),
+            Header::new(b"x-forwarded-host", b"old.example"),
+        ];
+
+        let host_policy = UpstreamHostPolicy::default();
+        let append_policy = ForwardedHeaderPolicy {
+            mode: ForwardedHeaderPolicyMode::Append,
+        };
+        let req = build_h2_request_for_endpoint_with_host_policy(
+            &endpoint,
+            &host_policy,
+            &append_policy,
+            "GET",
+            "/",
+            &headers,
+            Empty::<Bytes>::new().boxed(),
+            None,
+            ForwardedContext {
+                client_addr: "203.0.113.55:43210".parse().expect("client"),
+                request_authority: Some("api.example.com"),
+                request_id: 0,
+                traceparent: None,
+            },
+        )
+        .expect("append request");
+
+        assert_eq!(
+            req.headers().get("forwarded").and_then(|h| h.to_str().ok()),
+            Some("for=1.2.3.4;proto=http;host=\"old.example\", for=203.0.113.55;proto=https;host=\"api.example.com\"")
+        );
+        assert_eq!(
+            req.headers()
+                .get("x-forwarded-for")
+                .and_then(|h| h.to_str().ok()),
+            Some("1.2.3.4, 203.0.113.55")
+        );
+        assert_eq!(
+            req.headers()
+                .get("x-forwarded-proto")
+                .and_then(|h| h.to_str().ok()),
+            Some("http, https")
+        );
+        assert_eq!(
+            req.headers()
+                .get("x-forwarded-host")
+                .and_then(|h| h.to_str().ok()),
+            Some("old.example, api.example.com")
+        );
+
+        let preserve_policy = ForwardedHeaderPolicy {
+            mode: ForwardedHeaderPolicyMode::Preserve,
+        };
+        let req = build_h2_request_for_endpoint_with_host_policy(
+            &endpoint,
+            &host_policy,
+            &preserve_policy,
+            "GET",
+            "/",
+            &headers,
+            Empty::<Bytes>::new().boxed(),
+            None,
+            ForwardedContext {
+                client_addr: "203.0.113.55:43210".parse().expect("client"),
+                request_authority: Some("api.example.com"),
+                request_id: 0,
+                traceparent: None,
+            },
+        )
+        .expect("preserve request");
+
+        assert_eq!(
+            req.headers().get("forwarded").and_then(|h| h.to_str().ok()),
+            Some("for=1.2.3.4;proto=http;host=\"old.example\"")
+        );
+        assert_eq!(
+            req.headers()
+                .get("x-forwarded-for")
+                .and_then(|h| h.to_str().ok()),
+            Some("1.2.3.4")
+        );
+        assert_eq!(
+            req.headers()
+                .get("x-forwarded-proto")
+                .and_then(|h| h.to_str().ok()),
+            Some("http")
+        );
+        assert_eq!(
+            req.headers()
+                .get("x-forwarded-host")
+                .and_then(|h| h.to_str().ok()),
+            Some("old.example")
+        );
+    }
+
+    #[test]
     fn forwarded_header_formats_ipv6_clients() {
         let req = build_h2_request(
             "backend.internal:443",
@@ -432,6 +649,7 @@ mod tests {
         let req = build_h2_request_for_endpoint_with_host_policy(
             &endpoint,
             &policy,
+            &ForwardedHeaderPolicy::default(),
             "GET",
             "/",
             &[],
@@ -468,6 +686,7 @@ mod tests {
         let req = build_h2_request_for_endpoint_with_host_policy(
             &endpoint,
             &policy,
+            &ForwardedHeaderPolicy::default(),
             "GET",
             "/",
             &[],

--- a/crates/bridge/src/h3_to_h2.rs
+++ b/crates/bridge/src/h3_to_h2.rs
@@ -8,7 +8,10 @@ use bytes::Bytes;
 use http::{HeaderName, HeaderValue, Method, Request, Uri};
 use http_body_util::combinators::BoxBody;
 use quiche::h3::NameValue;
-use spooky_config::backend_endpoint::BackendEndpoint;
+use spooky_config::{
+    backend_endpoint::BackendEndpoint,
+    config::{UpstreamHostPolicy, UpstreamHostPolicyMode},
+};
 
 pub use spooky_errors::BridgeError;
 
@@ -52,6 +55,29 @@ pub fn build_h2_request_for_endpoint(
     content_length: Option<usize>,
     forwarded_ctx: ForwardedContext<'_>,
 ) -> Result<Request<BoxBody<Bytes, Infallible>>, BridgeError> {
+    build_h2_request_for_endpoint_with_host_policy(
+        endpoint,
+        &UpstreamHostPolicy::default(),
+        method,
+        path,
+        headers,
+        body,
+        content_length,
+        forwarded_ctx,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn build_h2_request_for_endpoint_with_host_policy(
+    endpoint: &BackendEndpoint,
+    host_policy: &UpstreamHostPolicy,
+    method: &str,
+    path: &str,
+    headers: &[quiche::h3::Header],
+    body: BoxBody<Bytes, Infallible>,
+    content_length: Option<usize>,
+    forwarded_ctx: ForwardedContext<'_>,
+) -> Result<Request<BoxBody<Bytes, Infallible>>, BridgeError> {
     let method = Method::from_bytes(method.as_bytes()).map_err(|_| BridgeError::InvalidMethod)?;
     let is_connect = method == Method::CONNECT;
     let mut builder = Request::builder().method(method.clone());
@@ -78,11 +104,12 @@ pub fn build_h2_request_for_endpoint(
         builder = builder.header(header_name, header_value);
     }
 
-    let host_value = forwarded_ctx
-        .request_authority
-        .or(host_from_headers.as_deref())
-        .filter(|value| !value.trim().is_empty())
-        .unwrap_or(endpoint.authority());
+    let host_value = resolve_upstream_host_value(
+        endpoint,
+        host_policy,
+        forwarded_ctx.request_authority,
+        host_from_headers.as_deref(),
+    )?;
 
     let uri = if is_connect {
         Uri::try_from(host_value).map_err(|_| BridgeError::InvalidUri)?
@@ -146,6 +173,26 @@ pub fn build_h2_request_for_endpoint(
         );
 
     builder.body(body).map_err(BridgeError::Build)
+}
+
+pub fn resolve_upstream_host_value<'a>(
+    endpoint: &'a BackendEndpoint,
+    host_policy: &'a UpstreamHostPolicy,
+    request_authority: Option<&'a str>,
+    host_header: Option<&'a str>,
+) -> Result<&'a str, BridgeError> {
+    match host_policy.mode {
+        UpstreamHostPolicyMode::PassThrough => Ok(request_authority
+            .or(host_header)
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or(endpoint.authority())),
+        UpstreamHostPolicyMode::Rewrite => host_policy
+            .host
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+            .ok_or(BridgeError::InvalidHeader),
+        UpstreamHostPolicyMode::Upstream => Ok(endpoint.authority()),
+    }
 }
 
 fn connection_header_tokens(headers: &[quiche::h3::Header]) -> HashSet<String> {
@@ -213,8 +260,14 @@ mod tests {
     use http::header::HOST;
     use http_body_util::{BodyExt, Empty};
     use quiche::h3::Header;
+    use spooky_config::{
+        backend_endpoint::BackendEndpoint,
+        config::{UpstreamHostPolicy, UpstreamHostPolicyMode},
+    };
 
-    use super::{ForwardedContext, build_h2_request};
+    use super::{
+        ForwardedContext, build_h2_request, build_h2_request_for_endpoint_with_host_policy,
+    };
 
     #[test]
     fn defaults_to_https_origin_for_host_port_backend() {
@@ -366,6 +419,72 @@ mod tests {
         assert_eq!(
             req.headers().get("forwarded").and_then(|h| h.to_str().ok()),
             Some("for=\"[2001:db8::1]\";proto=https;host=\"api.example.com\"")
+        );
+    }
+
+    #[test]
+    fn host_policy_rewrite_uses_configured_host() {
+        let endpoint = BackendEndpoint::parse("backend.internal:443").expect("endpoint");
+        let policy = UpstreamHostPolicy {
+            mode: UpstreamHostPolicyMode::Rewrite,
+            host: Some("origin.example.com".to_string()),
+        };
+        let req = build_h2_request_for_endpoint_with_host_policy(
+            &endpoint,
+            &policy,
+            "GET",
+            "/",
+            &[],
+            Empty::<Bytes>::new().boxed(),
+            None,
+            ForwardedContext {
+                client_addr: "203.0.113.10:44321".parse().expect("client"),
+                request_authority: Some("api.example.com"),
+                request_id: 0,
+                traceparent: None,
+            },
+        )
+        .expect("request");
+
+        assert_eq!(
+            req.headers().get(HOST).and_then(|h| h.to_str().ok()),
+            Some("origin.example.com")
+        );
+        assert_eq!(
+            req.headers()
+                .get("x-forwarded-host")
+                .and_then(|h| h.to_str().ok()),
+            Some("origin.example.com")
+        );
+    }
+
+    #[test]
+    fn host_policy_upstream_uses_backend_authority() {
+        let endpoint = BackendEndpoint::parse("backend.internal:8443").expect("endpoint");
+        let policy = UpstreamHostPolicy {
+            mode: UpstreamHostPolicyMode::Upstream,
+            host: None,
+        };
+        let req = build_h2_request_for_endpoint_with_host_policy(
+            &endpoint,
+            &policy,
+            "GET",
+            "/",
+            &[],
+            Empty::<Bytes>::new().boxed(),
+            None,
+            ForwardedContext {
+                client_addr: "203.0.113.10:44321".parse().expect("client"),
+                request_authority: Some("api.example.com"),
+                request_id: 0,
+                traceparent: None,
+            },
+        )
+        .expect("request");
+
+        assert_eq!(
+            req.headers().get(HOST).and_then(|h| h.to_str().ok()),
+            Some("backend.internal:8443")
         );
     }
 

--- a/crates/bridge/src/h3_to_h2.rs
+++ b/crates/bridge/src/h3_to_h2.rs
@@ -10,7 +10,10 @@ use http_body_util::combinators::BoxBody;
 use quiche::h3::NameValue;
 use spooky_config::{
     backend_endpoint::BackendEndpoint,
-    config::{ForwardedHeaderPolicy, ForwardedHeaderPolicyMode, UpstreamHostPolicy, UpstreamHostPolicyMode},
+    config::{
+        ForwardedHeaderPolicy, ForwardedHeaderPolicyMode, UpstreamHostPolicy,
+        UpstreamHostPolicyMode,
+    },
 };
 
 pub use spooky_errors::BridgeError;
@@ -37,7 +40,6 @@ pub struct ForwardedHeaderValues {
     pub x_forwarded_proto: Option<HeaderValue>,
     pub x_forwarded_host: Option<HeaderValue>,
 }
-
 
 /// Build an HTTP/2 request with a pre-boxed streaming body.
 /// `content_length` is `Some(n)` only when the full length is known upfront
@@ -379,7 +381,10 @@ mod tests {
     use quiche::h3::Header;
     use spooky_config::{
         backend_endpoint::BackendEndpoint,
-        config::{ForwardedHeaderPolicy, ForwardedHeaderPolicyMode, UpstreamHostPolicy, UpstreamHostPolicyMode},
+        config::{
+            ForwardedHeaderPolicy, ForwardedHeaderPolicyMode, UpstreamHostPolicy,
+            UpstreamHostPolicyMode,
+        },
     };
 
     use super::{
@@ -549,7 +554,9 @@ mod tests {
 
         assert_eq!(
             req.headers().get("forwarded").and_then(|h| h.to_str().ok()),
-            Some("for=1.2.3.4;proto=http;host=\"old.example\", for=203.0.113.55;proto=https;host=\"api.example.com\"")
+            Some(
+                "for=1.2.3.4;proto=http;host=\"old.example\", for=203.0.113.55;proto=https;host=\"api.example.com\""
+            )
         );
         assert_eq!(
             req.headers()

--- a/crates/bridge/src/h3_to_h2.rs
+++ b/crates/bridge/src/h3_to_h2.rs
@@ -53,11 +53,8 @@ pub fn build_h2_request_for_endpoint(
     forwarded_ctx: ForwardedContext<'_>,
 ) -> Result<Request<BoxBody<Bytes, Infallible>>, BridgeError> {
     let method = Method::from_bytes(method.as_bytes()).map_err(|_| BridgeError::InvalidMethod)?;
-    let request_path = if path.is_empty() { "/" } else { path };
-    let uri = endpoint.uri_for_path(request_path);
-    let uri = Uri::try_from(uri).map_err(|_| BridgeError::InvalidUri)?;
-
-    let mut builder = Request::builder().method(method).uri(uri);
+    let is_connect = method == Method::CONNECT;
+    let mut builder = Request::builder().method(method.clone());
     let connection_tokens = connection_header_tokens(headers);
     let mut host_from_headers: Option<String> = None;
 
@@ -86,6 +83,15 @@ pub fn build_h2_request_for_endpoint(
         .or(host_from_headers.as_deref())
         .filter(|value| !value.trim().is_empty())
         .unwrap_or(endpoint.authority());
+
+    let uri = if is_connect {
+        Uri::try_from(host_value).map_err(|_| BridgeError::InvalidUri)?
+    } else {
+        let request_path = if path.is_empty() { "/" } else { path };
+        let uri = endpoint.uri_for_path(request_path);
+        Uri::try_from(uri).map_err(|_| BridgeError::InvalidUri)?
+    };
+    builder = builder.uri(uri);
     builder = builder.header(http::header::HOST, host_value);
 
     if let Some(len) = content_length
@@ -360,6 +366,32 @@ mod tests {
         assert_eq!(
             req.headers().get("forwarded").and_then(|h| h.to_str().ok()),
             Some("for=\"[2001:db8::1]\";proto=https;host=\"api.example.com\"")
+        );
+    }
+
+    #[test]
+    fn connect_uses_authority_form_request_target() {
+        let req = build_h2_request(
+            "proxy.internal:8443",
+            "CONNECT",
+            "/",
+            &[],
+            Empty::<Bytes>::new().boxed(),
+            None,
+            ForwardedContext {
+                client_addr: "203.0.113.8:44321".parse().expect("client"),
+                request_authority: Some("target.example.com:443"),
+                request_id: 0,
+                traceparent: None,
+            },
+        )
+        .expect("request");
+
+        assert_eq!(req.method(), http::Method::CONNECT);
+        assert_eq!(req.uri().to_string(), "target.example.com:443");
+        assert_eq!(
+            req.headers().get(HOST).and_then(|h| h.to_str().ok()),
+            Some("target.example.com:443")
         );
     }
 }

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -10,6 +10,7 @@ serde.workspace = true
 serde_yml.workspace = true
 rustls-pemfile.workspace = true
 idna = "1"
+http.workspace = true
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -9,6 +9,7 @@ log.workspace = true
 serde.workspace = true
 serde_yml.workspace = true
 rustls-pemfile.workspace = true
+idna = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/config/src/backend_endpoint.rs
+++ b/crates/config/src/backend_endpoint.rs
@@ -1,3 +1,5 @@
+use std::net::IpAddr;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BackendScheme {
     Http,
@@ -98,6 +100,52 @@ fn normalize_authority(authority: &str, scheme: BackendScheme) -> String {
     authority.to_string()
 }
 
+
+fn validate_dns_hostname(host: &str) -> Result<(), String> {
+    let trimmed = host.trim();
+    if trimmed.is_empty() {
+        return Err("backend host is empty".to_string());
+    }
+
+    // Fast-path valid IP literals and localhost aliases.
+    if trimmed.eq_ignore_ascii_case("localhost") || trimmed.parse::<IpAddr>().is_ok() {
+        return Ok(());
+    }
+
+    let without_trailing_dot = trimmed.trim_end_matches('.');
+    if without_trailing_dot.is_empty() {
+        return Err("backend host is invalid".to_string());
+    }
+
+    // Enforce IDNA/UTS#46 conversion and reject malformed Unicode hostnames.
+    let ascii = idna::domain_to_ascii(without_trailing_dot)
+        .map_err(|_| "backend host is not a valid IDNA/DNS hostname".to_string())?;
+
+    if ascii.len() > 253 {
+        return Err("backend host exceeds maximum length (253)".to_string());
+    }
+
+    for label in ascii.split('.') {
+        if label.is_empty() {
+            return Err("backend host contains empty DNS label".to_string());
+        }
+        if label.len() > 63 {
+            return Err("backend host contains DNS label longer than 63 characters".to_string());
+        }
+        if label.starts_with('-') || label.ends_with('-') {
+            return Err("backend host DNS labels must not start or end with '-'".to_string());
+        }
+        if !label
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-')
+        {
+            return Err("backend host contains invalid DNS label characters".to_string());
+        }
+    }
+
+    Ok(())
+}
+
 fn validate_authority(authority: &str) -> Result<(), String> {
     if authority.chars().any(|ch| ch.is_ascii_whitespace()) {
         return Err("backend authority must not contain whitespace".to_string());
@@ -133,6 +181,8 @@ fn validate_authority(authority: &str) -> Result<(), String> {
     if host.is_empty() {
         return Err("backend host is empty".to_string());
     }
+
+    validate_dns_hostname(host)?;
 
     if port_str.is_empty() {
         return Err("backend port is empty".to_string());
@@ -188,6 +238,22 @@ mod tests {
         assert!(BackendEndpoint::parse("127.0.0.1:abc").is_err());
         assert!(BackendEndpoint::parse("::1:443").is_err());
         assert!(BackendEndpoint::parse("https://:443").is_err());
+    }
+
+
+    #[test]
+    fn parse_rejects_malformed_dns_hostnames() {
+        assert!(BackendEndpoint::parse("bad_host:443").is_err());
+        assert!(BackendEndpoint::parse("-bad.example.com:443").is_err());
+        assert!(BackendEndpoint::parse("bad-.example.com:443").is_err());
+        assert!(BackendEndpoint::parse("a..b.example.com:443").is_err());
+    }
+
+    #[test]
+    fn parse_accepts_idna_hostname() {
+        let endpoint = BackendEndpoint::parse("bücher.example:443").expect("idna host");
+        assert_eq!(endpoint.scheme(), BackendScheme::Https);
+        assert_eq!(endpoint.authority(), "bücher.example:443");
     }
 
     #[test]

--- a/crates/config/src/backend_endpoint.rs
+++ b/crates/config/src/backend_endpoint.rs
@@ -100,7 +100,6 @@ fn normalize_authority(authority: &str, scheme: BackendScheme) -> String {
     authority.to_string()
 }
 
-
 fn validate_dns_hostname(host: &str) -> Result<(), String> {
     let trimmed = host.trim();
     if trimmed.is_empty() {
@@ -239,7 +238,6 @@ mod tests {
         assert!(BackendEndpoint::parse("::1:443").is_err());
         assert!(BackendEndpoint::parse("https://:443").is_err());
     }
-
 
     #[test]
     fn parse_rejects_malformed_dns_hostnames() {

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -201,6 +201,9 @@ pub struct Upstream {
     #[serde(default)]
     pub host_policy: UpstreamHostPolicy,
 
+    #[serde(default)]
+    pub forwarded_headers: ForwardedHeaderPolicy,
+
     pub route: RouteMatch, // Route matching criteria for this upstream
 
     pub backends: Vec<Backend>,
@@ -220,6 +223,24 @@ pub enum UpstreamHostPolicyMode {
     )]
     Upstream,
 }
+
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ForwardedHeaderPolicyMode {
+    #[default]
+    #[serde(alias = "overwrite")]
+    Overwrite,
+    Append,
+    Preserve,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ForwardedHeaderPolicy {
+    #[serde(default)]
+    pub mode: ForwardedHeaderPolicyMode,
+}
+
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -71,6 +71,9 @@ pub struct Config {
 
     pub listen: Listen,
 
+    #[serde(default)]
+    pub listeners: Vec<Listen>,
+
     pub upstream: HashMap<String, Upstream>,
 
     #[serde(default)]
@@ -120,6 +123,14 @@ impl Default for PrivilegeDrop {
             user: security_default_user(),
             group: security_default_group(),
         }
+    }
+}
+
+pub fn effective_listens(config: &Config) -> Vec<Listen> {
+    if config.listeners.is_empty() {
+        vec![config.listen.clone()]
+    } else {
+        config.listeners.clone()
     }
 }
 
@@ -204,6 +215,9 @@ pub struct Upstream {
 
     #[serde(default)]
     pub forwarded_headers: ForwardedHeaderPolicy,
+
+    #[serde(default)]
+    pub tls: Option<UpstreamTls>,
 
     pub route: RouteMatch, // Route matching criteria for this upstream
 

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -138,10 +138,22 @@ pub struct Listen {
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 #[serde(deny_unknown_fields)]
 pub struct Tls {
+    #[serde(default)]
     pub cert: String, // "/path/to/cert"
+    #[serde(default)]
     pub key: String,  // "/path/to/key"
     #[serde(default)]
+    pub certificates: Vec<TlsCertificate>, // SNI keyed certificate set
+    #[serde(default)]
     pub client_auth: ClientAuth,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+#[serde(deny_unknown_fields)]
+pub struct TlsCertificate {
+    pub server_name: String, // "api.example.com"
+    pub cert: String,        // "/path/to/cert"
+    pub key: String,         // "/path/to/key"
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -19,6 +19,7 @@ use crate::default::{
     observe_default_routing_transparency_include_reason, observe_default_tracing_sample_ratio,
     observe_default_tracing_service_name, perf_default_backend_body_idle_timeout_ms,
     perf_default_backend_body_total_timeout_ms, perf_default_backend_connect_timeout_ms,
+    perf_default_backend_dns_refresh_enabled, perf_default_backend_dns_refresh_interval_ms,
     perf_default_backend_timeout_ms, perf_default_backend_total_request_timeout_ms,
     perf_default_client_body_idle_timeout_ms, perf_default_control_plane_threads,
     perf_default_global_inflight_limit, perf_default_h2_pool_idle_timeout_ms,
@@ -413,6 +414,14 @@ pub struct Performance {
     #[serde(default = "perf_default_h2_pool_idle_timeout_ms")]
     pub h2_pool_idle_timeout_ms: u64,
 
+    /// Enables periodic DNS refresh for hostname-based upstream backends.
+    #[serde(default = "perf_default_backend_dns_refresh_enabled")]
+    pub backend_dns_refresh_enabled: bool,
+
+    /// Control-plane interval for refreshing hostname-based backend DNS records.
+    #[serde(default = "perf_default_backend_dns_refresh_interval_ms")]
+    pub backend_dns_refresh_interval_ms: u64,
+
     #[serde(default = "perf_default_per_backend_inflight_limit")]
     pub per_backend_inflight_limit: usize,
 
@@ -500,6 +509,8 @@ impl Default for Performance {
             udp_send_buffer_bytes: perf_default_udp_send_buffer_bytes(),
             h2_pool_max_idle_per_backend: perf_default_h2_pool_max_idle_per_backend(),
             h2_pool_idle_timeout_ms: perf_default_h2_pool_idle_timeout_ms(),
+            backend_dns_refresh_enabled: perf_default_backend_dns_refresh_enabled(),
+            backend_dns_refresh_interval_ms: perf_default_backend_dns_refresh_interval_ms(),
             per_backend_inflight_limit: perf_default_per_backend_inflight_limit(),
             new_connections_per_sec: perf_default_new_connections_per_sec(),
             new_connections_burst: perf_default_new_connections_burst(),

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -198,9 +198,36 @@ pub struct Upstream {
     #[serde(default = "get_default_load_balancing")]
     pub load_balancing: LoadBalancing,
 
+    #[serde(default)]
+    pub host_policy: UpstreamHostPolicy,
+
     pub route: RouteMatch, // Route matching criteria for this upstream
 
     pub backends: Vec<Backend>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum UpstreamHostPolicyMode {
+    #[default]
+    #[serde(alias = "pass-through")]
+    PassThrough,
+    Rewrite,
+    #[serde(
+        alias = "static_upstream",
+        alias = "static-upstream",
+        alias = "upstream-host"
+    )]
+    Upstream,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct UpstreamHostPolicy {
+    #[serde(default)]
+    pub mode: UpstreamHostPolicyMode,
+    #[serde(default)]
+    pub host: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -241,7 +241,6 @@ pub struct ForwardedHeaderPolicy {
     pub mode: ForwardedHeaderPolicyMode,
 }
 
-
 #[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct UpstreamHostPolicy {

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -141,7 +141,7 @@ pub struct Tls {
     #[serde(default)]
     pub cert: String, // "/path/to/cert"
     #[serde(default)]
-    pub key: String,  // "/path/to/key"
+    pub key: String, // "/path/to/key"
     #[serde(default)]
     pub certificates: Vec<TlsCertificate>, // SNI keyed certificate set
     #[serde(default)]

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -42,6 +42,7 @@ use crate::default::{
     resilience_default_cb_failure_threshold, resilience_default_cb_half_open_max_probes,
     resilience_default_cb_open_ms, resilience_default_hedging_delay_ms,
     resilience_default_hedging_enabled, resilience_default_protocol_allow_0rtt,
+    resilience_default_protocol_allow_connect,
     resilience_default_protocol_enforce_authority_host_match,
     resilience_default_protocol_max_headers_bytes, resilience_default_protocol_max_headers_count,
     resilience_default_retry_budget_enabled, resilience_default_retry_budget_ratio_percent,
@@ -589,6 +590,8 @@ impl Default for RouteQueue {
 pub struct ProtocolPolicy {
     #[serde(default = "resilience_default_protocol_allow_0rtt")]
     pub allow_0rtt: bool,
+    #[serde(default = "resilience_default_protocol_allow_connect")]
+    pub allow_connect: bool,
     #[serde(default)]
     pub early_data_safe_methods: Vec<String>,
     #[serde(default = "resilience_default_protocol_max_headers_count")]
@@ -601,12 +604,17 @@ pub struct ProtocolPolicy {
     pub allowed_methods: Vec<String>,
     #[serde(default)]
     pub denied_path_prefixes: Vec<String>,
+    #[serde(default)]
+    pub connect_allowed_ports: Vec<u16>,
+    #[serde(default)]
+    pub connect_allowed_authorities: Vec<String>,
 }
 
 impl Default for ProtocolPolicy {
     fn default() -> Self {
         Self {
             allow_0rtt: resilience_default_protocol_allow_0rtt(),
+            allow_connect: resilience_default_protocol_allow_connect(),
             early_data_safe_methods: vec!["GET".to_string(), "HEAD".to_string()],
             max_headers_count: resilience_default_protocol_max_headers_count(),
             max_headers_bytes: resilience_default_protocol_max_headers_bytes(),
@@ -614,6 +622,8 @@ impl Default for ProtocolPolicy {
             ),
             allowed_methods: Vec::new(),
             denied_path_prefixes: Vec::new(),
+            connect_allowed_ports: Vec::new(),
+            connect_allowed_authorities: Vec::new(),
         }
     }
 }

--- a/crates/config/src/default.rs
+++ b/crates/config/src/default.rs
@@ -159,6 +159,14 @@ pub fn perf_default_h2_pool_idle_timeout_ms() -> u64 {
     90_000
 }
 
+pub fn perf_default_backend_dns_refresh_enabled() -> bool {
+    false
+}
+
+pub fn perf_default_backend_dns_refresh_interval_ms() -> u64 {
+    30_000
+}
+
 pub fn perf_default_per_backend_inflight_limit() -> usize {
     64
 }

--- a/crates/config/src/default.rs
+++ b/crates/config/src/default.rs
@@ -263,6 +263,10 @@ pub fn resilience_default_protocol_enforce_authority_host_match() -> bool {
     true
 }
 
+pub fn resilience_default_protocol_allow_connect() -> bool {
+    false
+}
+
 pub fn resilience_default_cb_enabled() -> bool {
     true
 }

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -389,6 +389,11 @@ pub fn validate(config: &Config) -> bool {
         return false;
     }
 
+    if config.performance.backend_dns_refresh_interval_ms == 0 {
+        error!("performance.backend_dns_refresh_interval_ms must be greater than 0");
+        return false;
+    }
+
     if config.performance.per_backend_inflight_limit == 0 {
         error!("performance.per_backend_inflight_limit must be greater than 0");
         return false;
@@ -1399,6 +1404,8 @@ upstream:
         assert_eq!(cfg.performance.udp_send_buffer_bytes, 8 * 1024 * 1024);
         assert_eq!(cfg.performance.h2_pool_max_idle_per_backend, 256);
         assert_eq!(cfg.performance.h2_pool_idle_timeout_ms, 90_000);
+        assert!(!cfg.performance.backend_dns_refresh_enabled);
+        assert_eq!(cfg.performance.backend_dns_refresh_interval_ms, 30_000);
         assert_eq!(cfg.performance.per_backend_inflight_limit, 64);
         assert_eq!(cfg.performance.max_active_connections, 20_000);
         assert_eq!(cfg.performance.max_request_body_bytes, 1_000_000);
@@ -1502,6 +1509,10 @@ upstream:
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.performance.h2_pool_idle_timeout_ms = 0;
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.performance.backend_dns_refresh_interval_ms = 0;
         assert!(!validate(&cfg));
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -1292,6 +1292,7 @@ mod tests {
                     key: None,
                 },
                 host_policy: Default::default(),
+        forwarded_headers: Default::default(),
                 route: RouteMatch {
                     host: None,
                     path_prefix: Some("/".to_string()),
@@ -2022,6 +2023,7 @@ upstream:
                 key: None,
             },
             host_policy: Default::default(),
+        forwarded_headers: Default::default(),
             route: RouteMatch {
                 host: Some("api.example.com".to_string()),
                 path_prefix: Some("/api".to_string()),
@@ -2060,6 +2062,7 @@ upstream:
                 key: None,
             },
             host_policy: Default::default(),
+        forwarded_headers: Default::default(),
             route: RouteMatch {
                 host: Some("api.example.com".to_string()),
                 path_prefix: Some("/api".to_string()),

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -1,6 +1,7 @@
 use crate::backend_endpoint::{BackendEndpoint, BackendScheme};
 use crate::config::{
-    CURRENT_CONFIG_VERSION, Config, SUPPORTED_CONFIG_VERSIONS, UpstreamHostPolicyMode,
+    CURRENT_CONFIG_VERSION, Config, Listen, SUPPORTED_CONFIG_VERSIONS, UpstreamHostPolicyMode,
+    UpstreamTls,
 };
 use log::{error, info, warn};
 use std::collections::HashMap;
@@ -102,6 +103,166 @@ fn validate_pem_private_key(path: &str, field_name: &str) -> bool {
             false
         }
     }
+}
+
+fn validate_upstream_tls(field_prefix: &str, tls: &UpstreamTls) -> bool {
+    if !tls.verify_certificates {
+        warn!(
+            "{}.verify_certificates=false: upstream TLS certificate verification is disabled; only use in trusted/development environments",
+            field_prefix
+        );
+    }
+
+    if let Some(ca_file) = tls.ca_file.as_ref() {
+        if ca_file.trim().is_empty() {
+            error!("{}.ca_file cannot be empty when provided", field_prefix);
+            return false;
+        }
+        if !validate_pem_certificates(ca_file, &format!("{}.ca_file", field_prefix)) {
+            return false;
+        }
+    }
+
+    if let Some(ca_dir) = tls.ca_dir.as_ref() {
+        if ca_dir.trim().is_empty() {
+            error!("{}.ca_dir cannot be empty when provided", field_prefix);
+            return false;
+        }
+        let metadata = match std::fs::metadata(ca_dir) {
+            Ok(metadata) => metadata,
+            Err(err) => {
+                error!("Cannot stat {}.ca_dir '{}': {}", field_prefix, ca_dir, err);
+                return false;
+            }
+        };
+        if !metadata.is_dir() {
+            error!("{}.ca_dir must be a directory: {}", field_prefix, ca_dir);
+            return false;
+        }
+    }
+
+    true
+}
+
+fn validate_listen_config(listen: &Listen, field_prefix: &str) -> bool {
+    if listen.protocol != "http3" {
+        error!(
+            "{} protocol: expected 'http3', found '{}'",
+            field_prefix, listen.protocol
+        );
+        return false;
+    }
+
+    if listen.address.is_empty() {
+        error!("{} address is empty", field_prefix);
+        return false;
+    }
+
+    if listen.port == 0 {
+        error!(
+            "Invalid {} port: {} (must be between 1 and 65535)",
+            field_prefix, listen.port
+        );
+        return false;
+    }
+
+    let tls_prefix = format!("{}.tls", field_prefix);
+    let legacy_cert = listen.tls.cert.trim();
+    let legacy_key = listen.tls.key.trim();
+    let has_legacy_cert_pair = !legacy_cert.is_empty() || !legacy_key.is_empty();
+    let has_sni_certificates = !listen.tls.certificates.is_empty();
+
+    if !has_legacy_cert_pair && !has_sni_certificates {
+        error!(
+            "{} requires either cert/key or certificates entries",
+            tls_prefix
+        );
+        return false;
+    }
+
+    if has_legacy_cert_pair {
+        if legacy_cert.is_empty() || legacy_key.is_empty() {
+            error!(
+                "{}.cert and {}.key must both be set when either is provided",
+                tls_prefix, tls_prefix
+            );
+            return false;
+        }
+        if !validate_pem_certificates(legacy_cert, &format!("{}.cert", tls_prefix)) {
+            return false;
+        }
+        if !validate_pem_private_key(legacy_key, &format!("{}.key", tls_prefix)) {
+            return false;
+        }
+    }
+
+    let mut seen_sni_names: HashMap<String, usize> = HashMap::new();
+    for (idx, entry) in listen.tls.certificates.iter().enumerate() {
+        let field_prefix = format!("{}.certificates[{idx}]", tls_prefix);
+        let sni_name = match normalize_sni_server_name(&entry.server_name) {
+            Some(sni) => sni,
+            None => {
+                error!(
+                    "{}.server_name '{}' is not a valid DNS hostname",
+                    field_prefix, entry.server_name
+                );
+                return false;
+            }
+        };
+
+        if let Some(first_idx) = seen_sni_names.insert(sni_name.clone(), idx) {
+            error!(
+                "{}.server_name '{}' duplicates {}.certificates[{}].server_name",
+                field_prefix, entry.server_name, tls_prefix, first_idx
+            );
+            return false;
+        }
+
+        let cert = entry.cert.trim();
+        if cert.is_empty() {
+            error!("{}.cert cannot be empty", field_prefix);
+            return false;
+        }
+        if !validate_pem_certificates(cert, &format!("{}.cert", field_prefix)) {
+            return false;
+        }
+
+        let key = entry.key.trim();
+        if key.is_empty() {
+            error!("{}.key cannot be empty", field_prefix);
+            return false;
+        }
+        if !validate_pem_private_key(key, &format!("{}.key", field_prefix)) {
+            return false;
+        }
+    }
+
+    if listen.tls.client_auth.require_client_cert && !listen.tls.client_auth.enabled {
+        error!(
+            "{}.client_auth.require_client_cert requires client_auth.enabled=true",
+            tls_prefix
+        );
+        return false;
+    }
+
+    if listen.tls.client_auth.enabled {
+        let Some(ca_file) = listen.tls.client_auth.ca_file.as_ref() else {
+            error!(
+                "{}.client_auth.ca_file is required when client_auth.enabled=true",
+                tls_prefix
+            );
+            return false;
+        };
+        if ca_file.trim().is_empty() {
+            error!("{}.client_auth.ca_file cannot be empty", tls_prefix);
+            return false;
+        }
+        if !validate_pem_certificates(ca_file, &format!("{}.client_auth.ca_file", tls_prefix)) {
+            return false;
+        }
+    }
+
+    true
 }
 
 fn is_loopback_bind_address(raw: &str) -> bool {
@@ -255,13 +416,29 @@ pub fn validate(config: &Config) -> bool {
         );
     }
 
-    // --- Validate protocol ---
-    if config.listen.protocol != "http3" {
-        error!(
-            "Invalid protocol: expected 'http3', found '{}'",
-            config.listen.protocol
-        );
+    // --- Validate listen blocks ---
+    if !validate_listen_config(&config.listen, "listen") {
         return false;
+    }
+    for (idx, listen) in config.listeners.iter().enumerate() {
+        if !validate_listen_config(listen, &format!("listeners[{idx}]")) {
+            return false;
+        }
+    }
+
+    let mut seen_listener_bindings: HashMap<(String, u16), String> = HashMap::new();
+    let listen_key = (config.listen.address.clone(), config.listen.port);
+    seen_listener_bindings.insert(listen_key, "listen".to_string());
+    for (idx, listen) in config.listeners.iter().enumerate() {
+        let key = (listen.address.clone(), listen.port);
+        let current = format!("listeners[{idx}]");
+        if let Some(existing) = seen_listener_bindings.insert(key, current.clone()) {
+            error!(
+                "listener binding conflict: {} duplicates {} on {}:{}",
+                current, existing, listen.address, listen.port
+            );
+            return false;
+        }
     }
 
     // --- Validate log level ---
@@ -280,21 +457,6 @@ pub fn validate(config: &Config) -> bool {
             .any(|lb_type| lb_type.eq_ignore_ascii_case(&lb.lb_type))
     {
         error!("Invalid global load balancing type: {}", lb.lb_type);
-        return false;
-    }
-
-    // --- Validate listen address ---
-    if config.listen.address.is_empty() {
-        error!("Listen address is empty");
-        return false;
-    }
-
-    // --- Validate listen port ---
-    if config.listen.port == 0 {
-        error!(
-            "Invalid listen port: {} (must be between 1 and 65535)",
-            config.listen.port
-        );
         return false;
     }
 
@@ -930,128 +1092,19 @@ pub fn validate(config: &Config) -> bool {
         }
     }
 
-    // --- Validate TLS certs ---
-    let legacy_cert = config.listen.tls.cert.trim();
-    let legacy_key = config.listen.tls.key.trim();
-    let has_legacy_cert_pair = !legacy_cert.is_empty() || !legacy_key.is_empty();
-    let has_sni_certificates = !config.listen.tls.certificates.is_empty();
-
-    if !has_legacy_cert_pair && !has_sni_certificates {
-        error!("listen.tls requires either cert/key or certificates entries");
-        return false;
-    }
-
-    if has_legacy_cert_pair {
-        if legacy_cert.is_empty() || legacy_key.is_empty() {
-            error!("listen.tls.cert and listen.tls.key must both be set when either is provided");
-            return false;
-        }
-        if !validate_pem_certificates(legacy_cert, "listen.tls.cert") {
-            return false;
-        }
-        if !validate_pem_private_key(legacy_key, "listen.tls.key") {
-            return false;
-        }
-    }
-
-    let mut seen_sni_names: HashMap<String, usize> = HashMap::new();
-    for (idx, entry) in config.listen.tls.certificates.iter().enumerate() {
-        let field_prefix = format!("listen.tls.certificates[{idx}]");
-        let sni_name = match normalize_sni_server_name(&entry.server_name) {
-            Some(sni) => sni,
-            None => {
-                error!(
-                    "{field_prefix}.server_name '{}' is not a valid DNS hostname",
-                    entry.server_name
-                );
-                return false;
-            }
-        };
-
-        if let Some(first_idx) = seen_sni_names.insert(sni_name.clone(), idx) {
-            error!(
-                "{field_prefix}.server_name '{}' duplicates listen.tls.certificates[{}].server_name",
-                entry.server_name, first_idx
-            );
-            return false;
-        }
-
-        let cert = entry.cert.trim();
-        if cert.is_empty() {
-            error!("{field_prefix}.cert cannot be empty");
-            return false;
-        }
-        if !validate_pem_certificates(cert, &format!("{field_prefix}.cert")) {
-            return false;
-        }
-
-        let key = entry.key.trim();
-        if key.is_empty() {
-            error!("{field_prefix}.key cannot be empty");
-            return false;
-        }
-        if !validate_pem_private_key(key, &format!("{field_prefix}.key")) {
-            return false;
-        }
-    }
-
-    // --- Validate optional downstream client-auth (mTLS) ---
-    if config.listen.tls.client_auth.require_client_cert && !config.listen.tls.client_auth.enabled {
-        error!("listen.tls.client_auth.require_client_cert requires client_auth.enabled=true");
-        return false;
-    }
-
-    if config.listen.tls.client_auth.enabled {
-        let Some(ca_file) = config.listen.tls.client_auth.ca_file.as_ref() else {
-            error!("listen.tls.client_auth.ca_file is required when client_auth.enabled=true");
-            return false;
-        };
-        if ca_file.trim().is_empty() {
-            error!("listen.tls.client_auth.ca_file cannot be empty");
-            return false;
-        }
-        if !validate_pem_certificates(ca_file, "listen.tls.client_auth.ca_file") {
-            return false;
-        }
-    }
-
     // --- Validate upstream TLS trust-store configuration ---
-    if !config.upstream_tls.verify_certificates {
-        warn!(
-            "upstream_tls.verify_certificates=false: upstream TLS certificate verification is disabled; only use in trusted/development environments"
-        );
-    }
-
-    if let Some(ca_file) = config.upstream_tls.ca_file.as_ref() {
-        if ca_file.trim().is_empty() {
-            error!("upstream_tls.ca_file cannot be empty when provided");
-            return false;
-        }
-        if !validate_pem_certificates(ca_file, "upstream_tls.ca_file") {
-            return false;
-        }
-    }
-
-    if let Some(ca_dir) = config.upstream_tls.ca_dir.as_ref() {
-        if ca_dir.trim().is_empty() {
-            error!("upstream_tls.ca_dir cannot be empty when provided");
-            return false;
-        }
-        let metadata = match std::fs::metadata(ca_dir) {
-            Ok(metadata) => metadata,
-            Err(err) => {
-                error!("Cannot stat upstream_tls.ca_dir '{}': {}", ca_dir, err);
-                return false;
-            }
-        };
-        if !metadata.is_dir() {
-            error!("upstream_tls.ca_dir must be a directory: {}", ca_dir);
-            return false;
-        }
+    if !validate_upstream_tls("upstream_tls", &config.upstream_tls) {
+        return false;
     }
 
     // --- Validate upstream routes ---
     for (upstream_name, upstream) in &config.upstream {
+        if let Some(tls) = upstream.tls.as_ref()
+            && !validate_upstream_tls(&format!("upstream['{}'].tls", upstream_name), tls)
+        {
+            return false;
+        }
+
         // Validate route matcher has at least one condition
         let has_host = upstream.route.host.is_some();
         let has_path = upstream.route.path_prefix.is_some();
@@ -1298,6 +1351,7 @@ mod tests {
                 },
                 host_policy: Default::default(),
                 forwarded_headers: Default::default(),
+                tls: None,
                 route: RouteMatch {
                     host: None,
                     path_prefix: Some("/".to_string()),
@@ -1332,6 +1386,7 @@ mod tests {
                     client_auth: ClientAuth::default(),
                 },
             },
+            listeners: vec![],
             upstream,
             load_balancing: Some(LoadBalancing {
                 lb_type: "random".to_string(),
@@ -2035,6 +2090,7 @@ upstream:
             },
             host_policy: Default::default(),
             forwarded_headers: Default::default(),
+            tls: None,
             route: RouteMatch {
                 host: Some("api.example.com".to_string()),
                 path_prefix: Some("/api".to_string()),
@@ -2074,6 +2130,7 @@ upstream:
             },
             host_policy: Default::default(),
             forwarded_headers: Default::default(),
+            tls: None,
             route: RouteMatch {
                 host: Some("api.example.com".to_string()),
                 path_prefix: Some("/api".to_string()),

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -169,7 +169,11 @@ fn normalized_route_method(method: Option<&str>) -> Option<String> {
 
 fn normalize_sni_server_name(raw: &str) -> Option<String> {
     let trimmed = raw.trim();
-    if trimmed.is_empty() || trimmed.contains(':') || trimmed.contains('*') {
+    if trimmed.is_empty()
+        || trimmed.contains(':')
+        || trimmed.contains('*')
+        || trimmed.chars().any(char::is_whitespace)
+    {
         return None;
     }
     let without_trailing_dot = trimmed.trim_end_matches('.');

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -167,6 +167,22 @@ fn normalized_route_method(method: Option<&str>) -> Option<String> {
         .map(|value| value.to_ascii_uppercase())
 }
 
+fn normalize_sni_server_name(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed.contains(':') || trimmed.contains('*') {
+        return None;
+    }
+    let without_trailing_dot = trimmed.trim_end_matches('.');
+    if without_trailing_dot.is_empty() {
+        return None;
+    }
+    let ascii = idna::domain_to_ascii(without_trailing_dot).ok()?;
+    if ascii.parse::<IpAddr>().is_ok() {
+        return None;
+    }
+    Some(ascii.to_ascii_lowercase())
+}
+
 type RouteMatcherKey = (Option<String>, Option<String>, Option<String>);
 
 pub fn validate(config: &Config) -> bool {
@@ -826,12 +842,65 @@ pub fn validate(config: &Config) -> bool {
     }
 
     // --- Validate TLS certs ---
-    if !validate_pem_certificates(&config.listen.tls.cert, "listen.tls.cert") {
+    let legacy_cert = config.listen.tls.cert.trim();
+    let legacy_key = config.listen.tls.key.trim();
+    let has_legacy_cert_pair = !legacy_cert.is_empty() || !legacy_key.is_empty();
+    let has_sni_certificates = !config.listen.tls.certificates.is_empty();
+
+    if !has_legacy_cert_pair && !has_sni_certificates {
+        error!("listen.tls requires either cert/key or certificates entries");
         return false;
     }
 
-    if !validate_pem_private_key(&config.listen.tls.key, "listen.tls.key") {
-        return false;
+    if has_legacy_cert_pair {
+        if legacy_cert.is_empty() || legacy_key.is_empty() {
+            error!("listen.tls.cert and listen.tls.key must both be set when either is provided");
+            return false;
+        }
+        if !validate_pem_certificates(legacy_cert, "listen.tls.cert") {
+            return false;
+        }
+        if !validate_pem_private_key(legacy_key, "listen.tls.key") {
+            return false;
+        }
+    }
+
+    let mut seen_sni_names: HashMap<String, usize> = HashMap::new();
+    for (idx, entry) in config.listen.tls.certificates.iter().enumerate() {
+        let field_prefix = format!("listen.tls.certificates[{idx}]");
+        let sni_name = match normalize_sni_server_name(&entry.server_name) {
+            Some(sni) => sni,
+            None => {
+                error!("{field_prefix}.server_name '{}' is not a valid DNS hostname", entry.server_name);
+                return false;
+            }
+        };
+
+        if let Some(first_idx) = seen_sni_names.insert(sni_name.clone(), idx) {
+            error!(
+                "{field_prefix}.server_name '{}' duplicates listen.tls.certificates[{}].server_name",
+                entry.server_name, first_idx
+            );
+            return false;
+        }
+
+        let cert = entry.cert.trim();
+        if cert.is_empty() {
+            error!("{field_prefix}.cert cannot be empty");
+            return false;
+        }
+        if !validate_pem_certificates(cert, &format!("{field_prefix}.cert")) {
+            return false;
+        }
+
+        let key = entry.key.trim();
+        if key.is_empty() {
+            error!("{field_prefix}.key cannot be empty");
+            return false;
+        }
+        if !validate_pem_private_key(key, &format!("{field_prefix}.key")) {
+            return false;
+        }
     }
 
     // --- Validate optional downstream client-auth (mTLS) ---
@@ -1082,7 +1151,7 @@ mod tests {
     use crate::config::{
         Backend, ClientAuth, Config, ControlApi, HealthCheck, Listen, LoadBalancing, Log,
         LogFormat, MetricsEndpoint, Observability, Performance, Resilience, RouteMatch, Security,
-        Tls, Tracing, Upstream, UpstreamTls,
+        Tls, TlsCertificate, Tracing, Upstream, UpstreamTls,
     };
     use rcgen::{Certificate, CertificateParams, SanType};
     use std::collections::HashMap;
@@ -1144,6 +1213,7 @@ mod tests {
                 tls: Tls {
                     cert: cert.to_string(),
                     key: key.to_string(),
+                    certificates: vec![],
                     client_auth: ClientAuth::default(),
                 },
             },
@@ -1548,6 +1618,60 @@ upstream:
         std::fs::write(&key, "not-a-pem-key").expect("write key");
 
         let cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        assert!(!validate(&cfg));
+    }
+
+    #[test]
+    fn accepts_sni_certificates_without_legacy_cert_pair() {
+        let dir = tempdir().expect("tempdir");
+        let (cert, key) = write_test_certs(dir.path());
+
+        let mut cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.listen.tls.cert = String::new();
+        cfg.listen.tls.key = String::new();
+        cfg.listen.tls.certificates = vec![TlsCertificate {
+            server_name: "api.example.com".to_string(),
+            cert: cert.to_string_lossy().to_string(),
+            key: key.to_string_lossy().to_string(),
+        }];
+
+        assert!(validate(&cfg));
+    }
+
+    #[test]
+    fn rejects_duplicate_sni_certificate_server_names() {
+        let dir = tempdir().expect("tempdir");
+        let (cert, key) = write_test_certs(dir.path());
+
+        let mut cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.listen.tls.certificates = vec![
+            TlsCertificate {
+                server_name: "api.example.com".to_string(),
+                cert: cert.to_string_lossy().to_string(),
+                key: key.to_string_lossy().to_string(),
+            },
+            TlsCertificate {
+                server_name: "API.EXAMPLE.COM".to_string(),
+                cert: cert.to_string_lossy().to_string(),
+                key: key.to_string_lossy().to_string(),
+            },
+        ];
+
+        assert!(!validate(&cfg));
+    }
+
+    #[test]
+    fn rejects_invalid_sni_certificate_server_name() {
+        let dir = tempdir().expect("tempdir");
+        let (cert, key) = write_test_certs(dir.path());
+
+        let mut cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.listen.tls.certificates = vec![TlsCertificate {
+            server_name: "not a hostname".to_string(),
+            cert: cert.to_string_lossy().to_string(),
+            key: key.to_string_lossy().to_string(),
+        }];
+
         assert!(!validate(&cfg));
     }
 

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -875,7 +875,10 @@ pub fn validate(config: &Config) -> bool {
         let sni_name = match normalize_sni_server_name(&entry.server_name) {
             Some(sni) => sni,
             None => {
-                error!("{field_prefix}.server_name '{}' is not a valid DNS hostname", entry.server_name);
+                error!(
+                    "{field_prefix}.server_name '{}' is not a valid DNS hostname",
+                    entry.server_name
+                );
                 return false;
             }
         };

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -140,6 +140,39 @@ fn is_valid_http_token(value: &str) -> bool {
         })
 }
 
+fn is_valid_connect_authority(value: &str) -> bool {
+    let trimmed = value.trim();
+    if trimmed.is_empty() || trimmed.chars().any(char::is_whitespace) {
+        return false;
+    }
+
+    if let Some(rest) = trimmed.strip_prefix('[') {
+        let Some(end) = rest.find(']') else {
+            return false;
+        };
+        let host = &rest[..end];
+        if host.is_empty() {
+            return false;
+        }
+        let suffix = &rest[end + 1..];
+        if !suffix.starts_with(':') || suffix.len() <= 1 {
+            return false;
+        }
+        return suffix[1..]
+            .parse::<u16>()
+            .ok()
+            .is_some_and(|port| port > 0);
+    }
+
+    let Some((host, port)) = trimmed.rsplit_once(':') else {
+        return false;
+    };
+    if host.is_empty() || host.contains(':') {
+        return false;
+    }
+    port.parse::<u16>().ok().is_some_and(|value| value > 0)
+}
+
 fn normalize_route_host(raw: &str) -> String {
     let trimmed = raw.trim();
     let host = if let Some(rest) = trimmed.strip_prefix('[') {
@@ -596,6 +629,40 @@ pub fn validate(config: &Config) -> bool {
         .any(|prefix| prefix.is_empty() || !prefix.starts_with('/'))
     {
         error!("resilience.protocol.denied_path_prefixes must contain '/'-prefixed paths");
+        return false;
+    }
+
+    if !config.resilience.protocol.allow_connect
+        && (!config.resilience.protocol.connect_allowed_ports.is_empty()
+            || !config.resilience.protocol.connect_allowed_authorities.is_empty())
+    {
+        error!(
+            "resilience.protocol.connect_allowed_ports/connect_allowed_authorities require allow_connect=true"
+        );
+        return false;
+    }
+
+    if config
+        .resilience
+        .protocol
+        .connect_allowed_ports
+        .iter()
+        .any(|port| *port == 0)
+    {
+        error!("resilience.protocol.connect_allowed_ports must contain ports in range 1-65535");
+        return false;
+    }
+
+    if config
+        .resilience
+        .protocol
+        .connect_allowed_authorities
+        .iter()
+        .any(|authority| !is_valid_connect_authority(authority))
+    {
+        error!(
+            "resilience.protocol.connect_allowed_authorities must contain authority-form host:port targets"
+        );
         return false;
     }
 
@@ -1323,9 +1390,16 @@ upstream:
         assert_eq!(cfg.resilience.route_queue.global_cap, 2048);
         assert_eq!(cfg.resilience.route_queue.shed_retry_after_seconds, 1);
         assert!(!cfg.resilience.protocol.allow_0rtt);
+        assert!(!cfg.resilience.protocol.allow_connect);
         assert_eq!(cfg.resilience.protocol.max_headers_count, 128);
         assert_eq!(cfg.resilience.protocol.max_headers_bytes, 16 * 1024);
         assert!(cfg.resilience.protocol.enforce_authority_host_match);
+        assert!(cfg.resilience.protocol.connect_allowed_ports.is_empty());
+        assert!(cfg
+            .resilience
+            .protocol
+            .connect_allowed_authorities
+            .is_empty());
         assert!(!cfg.resilience.watchdog.enabled);
         assert_eq!(cfg.resilience.watchdog.check_interval_ms, 1_000);
         assert_eq!(cfg.observability.control_api.max_connections, 256);
@@ -1516,6 +1590,26 @@ upstream:
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.resilience.protocol.denied_path_prefixes = vec!["admin".to_string()];
         assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.resilience.protocol.connect_allowed_ports = vec![443];
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.resilience.protocol.allow_connect = true;
+        cfg.resilience.protocol.connect_allowed_ports = vec![0];
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.resilience.protocol.allow_connect = true;
+        cfg.resilience.protocol.connect_allowed_authorities = vec!["example.com".to_string()];
+        assert!(!validate(&cfg));
+
+        cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.resilience.protocol.allow_connect = true;
+        cfg.resilience.protocol.connect_allowed_authorities = vec!["example.com:443".to_string()];
+        cfg.resilience.protocol.connect_allowed_ports = vec![443];
+        assert!(validate(&cfg));
 
         cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
         cfg.resilience.protocol.allowed_methods = vec!["".to_string()];

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -1292,7 +1292,7 @@ mod tests {
                     key: None,
                 },
                 host_policy: Default::default(),
-        forwarded_headers: Default::default(),
+                forwarded_headers: Default::default(),
                 route: RouteMatch {
                     host: None,
                     path_prefix: Some("/".to_string()),
@@ -2023,7 +2023,7 @@ upstream:
                 key: None,
             },
             host_policy: Default::default(),
-        forwarded_headers: Default::default(),
+            forwarded_headers: Default::default(),
             route: RouteMatch {
                 host: Some("api.example.com".to_string()),
                 path_prefix: Some("/api".to_string()),
@@ -2062,7 +2062,7 @@ upstream:
                 key: None,
             },
             host_policy: Default::default(),
-        forwarded_headers: Default::default(),
+            forwarded_headers: Default::default(),
             route: RouteMatch {
                 host: Some("api.example.com".to_string()),
                 path_prefix: Some("/api".to_string()),

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -158,10 +158,7 @@ fn is_valid_connect_authority(value: &str) -> bool {
         if !suffix.starts_with(':') || suffix.len() <= 1 {
             return false;
         }
-        return suffix[1..]
-            .parse::<u16>()
-            .ok()
-            .is_some_and(|port| port > 0);
+        return suffix[1..].parse::<u16>().ok().is_some_and(|port| port > 0);
     }
 
     let Some((host, port)) = trimmed.rsplit_once(':') else {
@@ -634,7 +631,11 @@ pub fn validate(config: &Config) -> bool {
 
     if !config.resilience.protocol.allow_connect
         && (!config.resilience.protocol.connect_allowed_ports.is_empty()
-            || !config.resilience.protocol.connect_allowed_authorities.is_empty())
+            || !config
+                .resilience
+                .protocol
+                .connect_allowed_authorities
+                .is_empty())
     {
         error!(
             "resilience.protocol.connect_allowed_ports/connect_allowed_authorities require allow_connect=true"
@@ -646,8 +647,7 @@ pub fn validate(config: &Config) -> bool {
         .resilience
         .protocol
         .connect_allowed_ports
-        .iter()
-        .any(|port| *port == 0)
+        .contains(&0)
     {
         error!("resilience.protocol.connect_allowed_ports must contain ports in range 1-65535");
         return false;
@@ -1395,11 +1395,12 @@ upstream:
         assert_eq!(cfg.resilience.protocol.max_headers_bytes, 16 * 1024);
         assert!(cfg.resilience.protocol.enforce_authority_host_match);
         assert!(cfg.resilience.protocol.connect_allowed_ports.is_empty());
-        assert!(cfg
-            .resilience
-            .protocol
-            .connect_allowed_authorities
-            .is_empty());
+        assert!(
+            cfg.resilience
+                .protocol
+                .connect_allowed_authorities
+                .is_empty()
+        );
         assert!(!cfg.resilience.watchdog.enabled);
         assert_eq!(cfg.resilience.watchdog.check_interval_ms, 1_000);
         assert_eq!(cfg.observability.control_api.max_connections, 256);

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -1,5 +1,7 @@
 use crate::backend_endpoint::{BackendEndpoint, BackendScheme};
-use crate::config::{CURRENT_CONFIG_VERSION, Config, SUPPORTED_CONFIG_VERSIONS};
+use crate::config::{
+    CURRENT_CONFIG_VERSION, Config, SUPPORTED_CONFIG_VERSIONS, UpstreamHostPolicyMode,
+};
 use log::{error, info, warn};
 use std::collections::HashMap;
 use std::fs::File;
@@ -195,6 +197,17 @@ fn normalized_route_method(method: Option<&str>) -> Option<String> {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(|value| value.to_ascii_uppercase())
+}
+
+fn valid_static_host_header(value: &str) -> bool {
+    let trimmed = value.trim();
+    !trimmed.is_empty()
+        && trimmed == value
+        && !trimmed.chars().any(|ch| ch.is_ascii_whitespace())
+        && !trimmed.contains('/')
+        && !trimmed.contains('?')
+        && !trimmed.contains('#')
+        && http::HeaderValue::from_str(trimmed).is_ok()
 }
 
 fn normalize_sni_server_name(raw: &str) -> Option<String> {
@@ -1063,6 +1076,27 @@ pub fn validate(config: &Config) -> bool {
                 return false;
             }
         }
+
+        match upstream.host_policy.mode {
+            UpstreamHostPolicyMode::PassThrough | UpstreamHostPolicyMode::Upstream => {
+                if upstream.host_policy.host.is_some() {
+                    warn!(
+                        "upstream {}.host_policy.host is ignored unless mode is rewrite",
+                        upstream_name
+                    );
+                }
+            }
+            UpstreamHostPolicyMode::Rewrite => match upstream.host_policy.host.as_deref() {
+                Some(host) if valid_static_host_header(host) => {}
+                _ => {
+                    error!(
+                        "upstream {}.host_policy.mode=rewrite requires a valid non-empty host_policy.host",
+                        upstream_name
+                    );
+                    return false;
+                }
+            },
+        }
     }
 
     // --- Validate upstreams ---
@@ -1257,6 +1291,7 @@ mod tests {
                     lb_type: "round-robin".to_string(),
                     key: None,
                 },
+                host_policy: Default::default(),
                 route: RouteMatch {
                     host: None,
                     path_prefix: Some("/".to_string()),
@@ -1986,6 +2021,7 @@ upstream:
                 lb_type: "round-robin".to_string(),
                 key: None,
             },
+            host_policy: Default::default(),
             route: RouteMatch {
                 host: Some("api.example.com".to_string()),
                 path_prefix: Some("/api".to_string()),
@@ -2023,6 +2059,7 @@ upstream:
                 lb_type: "round-robin".to_string(),
                 key: None,
             },
+            host_policy: Default::default(),
             route: RouteMatch {
                 host: Some("api.example.com".to_string()),
                 path_prefix: Some("/api".to_string()),

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -140,8 +140,6 @@ fn is_valid_http_token(value: &str) -> bool {
         })
 }
 
-
-
 fn normalize_route_host(raw: &str) -> String {
     let trimmed = raw.trim();
     let host = if let Some(rest) = trimmed.strip_prefix('[') {
@@ -1743,7 +1741,6 @@ upstream:
         assert!(!validate(&cfg));
     }
 
-
     #[test]
     fn rejects_ambiguous_route_matchers_with_same_host_path_and_method() {
         let dir = tempdir().expect("tempdir");
@@ -1775,7 +1772,8 @@ upstream:
                 health_check: None,
             }],
         };
-        cfg.upstream.insert("test_upstream_2".to_string(), duplicate);
+        cfg.upstream
+            .insert("test_upstream_2".to_string(), duplicate);
 
         assert!(!validate(&cfg));
     }
@@ -1811,9 +1809,9 @@ upstream:
                 health_check: None,
             }],
         };
-        cfg.upstream.insert("test_upstream_2".to_string(), post_route);
+        cfg.upstream
+            .insert("test_upstream_2".to_string(), post_route);
 
         assert!(validate(&cfg));
     }
-
 }

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -169,6 +169,8 @@ fn normalized_route_method(method: Option<&str>) -> Option<String> {
         .map(|value| value.to_ascii_uppercase())
 }
 
+type RouteMatcherKey = (Option<String>, Option<String>, Option<String>);
+
 pub fn validate(config: &Config) -> bool {
     info!("Starting configuration validation...");
 
@@ -928,8 +930,7 @@ pub fn validate(config: &Config) -> bool {
         return false;
     }
 
-    let mut seen_route_matchers: HashMap<(Option<String>, Option<String>, Option<String>), String> =
-        HashMap::new();
+    let mut seen_route_matchers: HashMap<RouteMatcherKey, String> = HashMap::new();
 
     for (upstream_name, upstream) in &config.upstream {
         let route_key = (

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -1,6 +1,7 @@
 use crate::backend_endpoint::{BackendEndpoint, BackendScheme};
 use crate::config::{CURRENT_CONFIG_VERSION, Config, SUPPORTED_CONFIG_VERSIONS};
 use log::{error, info, warn};
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufReader;
 use std::net::IpAddr;
@@ -137,6 +138,35 @@ fn is_valid_http_token(value: &str) -> bool {
                     | b'~'
             )
         })
+}
+
+
+
+fn normalize_route_host(raw: &str) -> String {
+    let trimmed = raw.trim();
+    let host = if let Some(rest) = trimmed.strip_prefix('[') {
+        if let Some(end) = rest.find(']') {
+            &rest[..end]
+        } else {
+            trimmed
+        }
+    } else if let Some((candidate_host, candidate_port)) = trimmed.rsplit_once(':') {
+        if !candidate_host.contains(':') && candidate_port.chars().all(|c| c.is_ascii_digit()) {
+            candidate_host
+        } else {
+            trimmed
+        }
+    } else {
+        trimmed
+    };
+    host.trim_end_matches('.').to_ascii_lowercase()
+}
+
+fn normalized_route_method(method: Option<&str>) -> Option<String> {
+    method
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| value.to_ascii_uppercase())
 }
 
 pub fn validate(config: &Config) -> bool {
@@ -898,8 +928,28 @@ pub fn validate(config: &Config) -> bool {
         return false;
     }
 
-    let mut seen_backend_origins: std::collections::HashMap<String, (String, String)> =
-        std::collections::HashMap::new();
+    let mut seen_route_matchers: HashMap<(Option<String>, Option<String>, Option<String>), String> =
+        HashMap::new();
+
+    for (upstream_name, upstream) in &config.upstream {
+        let route_key = (
+            upstream.route.host.as_deref().map(normalize_route_host),
+            upstream.route.path_prefix.clone(),
+            normalized_route_method(upstream.route.method.as_deref()),
+        );
+
+        if let Some(existing_upstream) =
+            seen_route_matchers.insert(route_key.clone(), upstream_name.clone())
+        {
+            error!(
+                "Ambiguous route matcher detected: upstream '{}' conflicts with upstream '{}' for host={:?} path_prefix={:?} method={:?}",
+                upstream_name, existing_upstream, route_key.0, route_key.1, route_key.2
+            );
+            return false;
+        }
+    }
+
+    let mut seen_backend_origins: HashMap<String, (String, String)> = HashMap::new();
 
     for (upstream_name, upstream) in &config.upstream {
         if upstream_name.is_empty() {
@@ -1691,4 +1741,78 @@ upstream:
         cfg.security.privileges.group = " ".to_string();
         assert!(!validate(&cfg));
     }
+
+
+    #[test]
+    fn rejects_ambiguous_route_matchers_with_same_host_path_and_method() {
+        let dir = tempdir().expect("tempdir");
+        let (cert, key) = write_test_certs(dir.path());
+
+        let mut cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        {
+            let upstream = cfg.upstream.get_mut("test_upstream").expect("upstream");
+            upstream.route.host = Some("API.EXAMPLE.COM:443".to_string());
+            upstream.route.path_prefix = Some("/api".to_string());
+            upstream.route.method = Some("get".to_string());
+            upstream.backends[0].address = "127.0.0.1:9001".to_string();
+        }
+
+        let duplicate = Upstream {
+            load_balancing: LoadBalancing {
+                lb_type: "round-robin".to_string(),
+                key: None,
+            },
+            route: RouteMatch {
+                host: Some("api.example.com".to_string()),
+                path_prefix: Some("/api".to_string()),
+                method: Some("GET".to_string()),
+            },
+            backends: vec![Backend {
+                id: "backend-2".to_string(),
+                address: "127.0.0.1:9002".to_string(),
+                weight: 1,
+                health_check: None,
+            }],
+        };
+        cfg.upstream.insert("test_upstream_2".to_string(), duplicate);
+
+        assert!(!validate(&cfg));
+    }
+
+    #[test]
+    fn allows_same_host_and_path_when_methods_differ() {
+        let dir = tempdir().expect("tempdir");
+        let (cert, key) = write_test_certs(dir.path());
+
+        let mut cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        {
+            let upstream = cfg.upstream.get_mut("test_upstream").expect("upstream");
+            upstream.route.host = Some("api.example.com".to_string());
+            upstream.route.path_prefix = Some("/api".to_string());
+            upstream.route.method = Some("GET".to_string());
+            upstream.backends[0].address = "127.0.0.1:9001".to_string();
+        }
+
+        let post_route = Upstream {
+            load_balancing: LoadBalancing {
+                lb_type: "round-robin".to_string(),
+                key: None,
+            },
+            route: RouteMatch {
+                host: Some("api.example.com".to_string()),
+                path_prefix: Some("/api".to_string()),
+                method: Some("POST".to_string()),
+            },
+            backends: vec![Backend {
+                id: "backend-2".to_string(),
+                address: "127.0.0.1:9002".to_string(),
+                weight: 1,
+                health_check: None,
+            }],
+        };
+        cfg.upstream.insert("test_upstream_2".to_string(), post_route);
+
+        assert!(validate(&cfg));
+    }
+
 }

--- a/crates/edge/src/benchmark.rs
+++ b/crates/edge/src/benchmark.rs
@@ -30,6 +30,7 @@ fn build_benchmark_upstream(host: Option<String>, path_prefix: String) -> Upstre
             key: None,
         },
         host_policy: Default::default(),
+        forwarded_headers: Default::default(),
         route: RouteMatch {
             host,
             path_prefix: Some(path_prefix),

--- a/crates/edge/src/benchmark.rs
+++ b/crates/edge/src/benchmark.rs
@@ -31,6 +31,7 @@ fn build_benchmark_upstream(host: Option<String>, path_prefix: String) -> Upstre
         },
         host_policy: Default::default(),
         forwarded_headers: Default::default(),
+        tls: None,
         route: RouteMatch {
             host,
             path_prefix: Some(path_prefix),

--- a/crates/edge/src/benchmark.rs
+++ b/crates/edge/src/benchmark.rs
@@ -29,6 +29,7 @@ fn build_benchmark_upstream(host: Option<String>, path_prefix: String) -> Upstre
             lb_type: "round-robin".to_string(),
             key: None,
         },
+        host_policy: Default::default(),
         route: RouteMatch {
             host,
             path_prefix: Some(path_prefix),

--- a/crates/edge/src/quic_listener/forwarding.rs
+++ b/crates/edge/src/quic_listener/forwarding.rs
@@ -66,8 +66,36 @@ pub(crate) fn abort_stream(req: &mut RequestEnvelope, metrics: &Metrics) -> Stre
 }
 
 impl QUICListener {
-    fn send_error_health_failure_reason() -> Option<HealthFailureReason> {
-        None
+    fn classify_send_error_detail(is_connect: bool, detail: &str) -> HealthFailureReason {
+        let normalized = detail.to_ascii_lowercase();
+        if normalized.contains("timeout") || normalized.contains("timed out") {
+            return HealthFailureReason::Timeout;
+        }
+
+        if is_connect
+            && (normalized.contains("tls")
+                || normalized.contains("rustls")
+                || normalized.contains("webpki")
+                || normalized.contains("certificate")
+                || normalized.contains("x509")
+                || normalized.contains("hostname")
+                || normalized.contains("dns name")
+                || normalized.contains("subjectaltname")
+                || normalized.contains("unknownissuer")
+                || normalized.contains("invalidcertificate")
+                || normalized.contains("alpn"))
+        {
+            return HealthFailureReason::Tls;
+        }
+
+        HealthFailureReason::Transport
+    }
+
+    fn send_error_health_failure_reason(
+        err: &hyper_util::client::legacy::Error,
+    ) -> HealthFailureReason {
+        let detail = Self::format_error_chain(err);
+        Self::classify_send_error_detail(err.is_connect(), &detail)
     }
 
     fn format_error_chain(err: &(dyn StdError + 'static)) -> String {
@@ -293,17 +321,24 @@ impl QUICListener {
                 )
             }
             Err(ProxyError::Pool(PoolError::Send(ref send_err))) => {
-                // Log the full inner error — commonly exposes TLS/cert/SNI mismatches
-                // that look like transport failures but are actually local config errors.
-                // Do NOT mark backend health as failed: the backend may be fully operational;
-                // this path is usually a local proxy configuration/runtime issue.
+                // Log full upstream send/connect detail and map it into a backend
+                // health failure reason so repeated failures can eject unhealthy backends.
                 let send_err_detail = Self::format_error_chain(send_err);
+                let failure_reason = Self::send_error_health_failure_reason(send_err);
                 error!(
-                    "Upstream send failed for {} (possible TLS/cert/SNI misconfiguration): {}",
-                    backend_addr, send_err_detail
+                    "Upstream send failed for {} (health_reason={:?}): {}",
+                    backend_addr,
+                    failure_reason,
+                    send_err_detail
                 );
-                if let Some(reason) = Self::send_error_health_failure_reason() {
-                    metrics.inc_health_failure(reason);
+                metrics.inc_health_failure(failure_reason);
+                if let Some(pool) = &upstream_pool
+                    && let Some(t) = pool.write().ok().and_then(|mut p| {
+                        p.pool
+                            .mark_request_failure(backend_index, failure_reason)
+                    })
+                {
+                    Self::log_health_transition(backend_addr, t);
                 }
                 metrics.inc_failure();
                 metrics.inc_backend_error();
@@ -536,8 +571,33 @@ mod tests {
     }
 
     #[test]
-    fn send_error_does_not_map_to_backend_health_failure_reason() {
-        assert_eq!(QUICListener::send_error_health_failure_reason(), None);
+    fn send_connect_error_with_tls_details_maps_to_tls_health_failure() {
+        assert_eq!(
+            QUICListener::classify_send_error_detail(
+                true,
+                "client error (Connect): tls handshake failed: invalid certificate"
+            ),
+            HealthFailureReason::Tls
+        );
+    }
+
+    #[test]
+    fn send_connect_error_without_tls_details_maps_to_transport_health_failure() {
+        assert_eq!(
+            QUICListener::classify_send_error_detail(
+                true,
+                "client error (Connect): connection refused"
+            ),
+            HealthFailureReason::Transport
+        );
+    }
+
+    #[test]
+    fn send_error_with_timeout_detail_maps_to_timeout_health_failure() {
+        assert_eq!(
+            QUICListener::classify_send_error_detail(false, "request timed out"),
+            HealthFailureReason::Timeout
+        );
     }
 
     #[derive(Debug)]

--- a/crates/edge/src/quic_listener/forwarding.rs
+++ b/crates/edge/src/quic_listener/forwarding.rs
@@ -11,6 +11,7 @@ pub(super) struct ForwardRequestMeta {
     pub(super) request_id: u64,
     pub(super) traceparent: Option<Arc<str>>,
     pub(super) host_policy: UpstreamHostPolicy,
+    pub(super) forwarded_header_policy: ForwardedHeaderPolicy,
 }
 
 impl ForwardRequestMeta {
@@ -21,6 +22,7 @@ impl ForwardRequestMeta {
         build_h2_request_for_endpoint_with_host_policy(
             endpoint,
             &self.host_policy,
+            &self.forwarded_header_policy,
             &self.method,
             &self.path,
             self.headers.as_slice(),

--- a/crates/edge/src/quic_listener/forwarding.rs
+++ b/crates/edge/src/quic_listener/forwarding.rs
@@ -327,15 +327,12 @@ impl QUICListener {
                 let failure_reason = Self::send_error_health_failure_reason(send_err);
                 error!(
                     "Upstream send failed for {} (health_reason={:?}): {}",
-                    backend_addr,
-                    failure_reason,
-                    send_err_detail
+                    backend_addr, failure_reason, send_err_detail
                 );
                 metrics.inc_health_failure(failure_reason);
                 if let Some(pool) = &upstream_pool
                     && let Some(t) = pool.write().ok().and_then(|mut p| {
-                        p.pool
-                            .mark_request_failure(backend_index, failure_reason)
+                        p.pool.mark_request_failure(backend_index, failure_reason)
                     })
                 {
                     Self::log_health_transition(backend_addr, t);

--- a/crates/edge/src/quic_listener/forwarding.rs
+++ b/crates/edge/src/quic_listener/forwarding.rs
@@ -10,6 +10,7 @@ pub(super) struct ForwardRequestMeta {
     pub(super) client_addr: SocketAddr,
     pub(super) request_id: u64,
     pub(super) traceparent: Option<Arc<str>>,
+    pub(super) host_policy: UpstreamHostPolicy,
 }
 
 impl ForwardRequestMeta {
@@ -17,8 +18,9 @@ impl ForwardRequestMeta {
         &self,
         endpoint: &BackendEndpoint,
     ) -> Result<Request<BoxBody<Bytes, std::convert::Infallible>>, ProxyError> {
-        build_h2_request_for_endpoint(
+        build_h2_request_for_endpoint_with_host_policy(
             endpoint,
+            &self.host_policy,
             &self.method,
             &self.path,
             self.headers.as_slice(),

--- a/crates/edge/src/quic_listener/health_check.rs
+++ b/crates/edge/src/quic_listener/health_check.rs
@@ -3,10 +3,11 @@ use super::*;
 impl QUICListener {
     pub(super) fn spawn_health_checks(
         upstream_pools: HashMap<String, Arc<RwLock<UpstreamPool>>>,
-        health_client: Arc<H2Client>,
+        health_clients: Arc<HashMap<String, Arc<H2Client>>>,
         metrics: Arc<Metrics>,
     ) {
         struct HealthCheckJob {
+            upstream_name: String,
             upstream_pool: Arc<RwLock<UpstreamPool>>,
             index: usize,
             address: String,
@@ -18,7 +19,7 @@ impl QUICListener {
         }
 
         let mut grouped_jobs: HashMap<u64, Vec<HealthCheckJob>> = HashMap::new();
-        for (_upstream_name, upstream_pool) in upstream_pools.iter() {
+        for (upstream_name, upstream_pool) in upstream_pools.iter() {
             let pool = match upstream_pool.read() {
                 Ok(pool) => pool,
                 Err(_) => continue,
@@ -52,6 +53,7 @@ impl QUICListener {
                 };
                 let next_due_at = Instant::now() + Duration::from_millis(initial_jitter_ms);
                 let job = HealthCheckJob {
+                    upstream_name: upstream_name.clone(),
                     upstream_pool: Arc::clone(upstream_pool),
                     index,
                     address,
@@ -78,7 +80,7 @@ impl QUICListener {
         };
 
         for (base_interval_ms, mut jobs) in grouped_jobs {
-            let health_client = Arc::clone(&health_client);
+            let health_clients = Arc::clone(&health_clients);
             let task_metrics = Arc::clone(&metrics);
             let handle = handle.clone();
             let supervise_metrics = Arc::clone(&task_metrics);
@@ -107,6 +109,10 @@ impl QUICListener {
                             {
                                 Ok(req) => req,
                                 Err(_) => continue,
+                            };
+
+                            let Some(health_client) = health_clients.get(&job.upstream_name) else {
+                                continue;
                             };
 
                             let result =

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -37,7 +37,7 @@ use rustls::{
 use serde_json::json;
 use socket2::{Domain, Protocol, Socket, Type};
 use spooky_bridge::h3_to_h2::{
-    ForwardedContext, build_h2_request_for_endpoint_with_host_policy, resolve_upstream_host_value,
+    ForwardedContext, ForwardedHeaderChains, build_forwarded_header_values, build_h2_request_for_endpoint_with_host_policy, resolve_upstream_host_value,
 };
 use spooky_errors::{PoolError, ProxyError, is_retryable};
 use spooky_lb::{HealthFailureReason, HealthTransition, UpstreamPool};
@@ -54,7 +54,7 @@ use tracing::{Instrument, info_span};
 
 use spooky_config::{
     backend_endpoint::{BackendEndpoint, BackendScheme},
-    config::{Config as SpookyConfig, UpstreamHostPolicy},
+    config::{Config as SpookyConfig, ForwardedHeaderPolicy, UpstreamHostPolicy},
 };
 
 use crate::{
@@ -262,13 +262,6 @@ fn is_websocket_upgrade_request(req: &Request<Incoming>, use_h2: bool) -> bool {
         .get(http::header::CONNECTION)
         .map(|v| header_has_token(v, "upgrade"))
         .unwrap_or(false)
-}
-
-fn bootstrap_forwarded_for_value(ip: std::net::IpAddr) -> String {
-    match ip {
-        std::net::IpAddr::V4(v4) => v4.to_string(),
-        std::net::IpAddr::V6(v6) => format!("\"[{}]\"", v6),
-    }
 }
 
 fn extract_cookie_value(cookie_header: &str, cookie_name: &str) -> Option<String> {
@@ -581,6 +574,13 @@ impl QUICListener {
                     })
                     .collect(),
             ),
+            forwarded_header_policies: Arc::new(
+                config
+                    .upstream
+                    .iter()
+                    .map(|(name, upstream)| (name.clone(), upstream.forwarded_headers.clone()))
+                    .collect(),
+            ),
             upstream_host_policies: Arc::new(
                 config
                     .upstream
@@ -711,6 +711,7 @@ impl QUICListener {
             h2_pool: Arc::clone(&shared_state.h2_pool),
             backend_endpoints: Arc::clone(&shared_state.backend_endpoints),
             upstream_host_policies: Arc::clone(&shared_state.upstream_host_policies),
+            forwarded_header_policies: Arc::clone(&shared_state.forwarded_header_policies),
             upstream_pools: shared_state.upstream_pools.clone(),
             upstream_inflight: shared_state.upstream_inflight.clone(),
             global_inflight: Arc::clone(&shared_state.global_inflight),
@@ -1525,6 +1526,7 @@ impl QUICListener {
                 Arc::clone(&h2_pool),
                 Arc::clone(&self.backend_endpoints),
                 Arc::clone(&self.upstream_host_policies),
+                Arc::clone(&self.forwarded_header_policies),
                 &self.upstream_pools,
                 &self.upstream_inflight,
                 Arc::clone(&self.global_inflight),
@@ -1771,6 +1773,7 @@ impl QUICListener {
         h2_pool: Arc<H2Pool>,
         backend_endpoints: Arc<HashMap<String, BackendEndpoint>>,
         upstream_host_policies: Arc<HashMap<String, UpstreamHostPolicy>>,
+        forwarded_header_policies: Arc<HashMap<String, ForwardedHeaderPolicy>>,
         upstream_pools: &HashMap<String, Arc<RwLock<UpstreamPool>>>,
         upstream_inflight: &HashMap<String, Arc<Semaphore>>,
         global_inflight: Arc<Semaphore>,
@@ -2162,9 +2165,14 @@ impl QUICListener {
                                 .get(&upstream_name)
                                 .cloned()
                                 .unwrap_or_default();
+                            let forwarded_header_policy = forwarded_header_policies
+                                .get(&upstream_name)
+                                .cloned()
+                                .unwrap_or_default();
                             let request = match build_h2_request_for_endpoint_with_host_policy(
                                 &backend_endpoint,
                                 &host_policy,
+                                &forwarded_header_policy,
                                 &method,
                                 &path,
                                 &list,
@@ -2223,6 +2231,7 @@ impl QUICListener {
                                     request_id,
                                     traceparent: traceparent.as_deref().map(Arc::<str>::from),
                                     host_policy: host_policy.clone(),
+                                    forwarded_header_policy: forwarded_header_policy.clone(),
                                 })
                             });
                             let trace_span_for_upstream = trace_span.clone();
@@ -4205,6 +4214,7 @@ impl QUICListener {
         let h2_pool = Arc::clone(&shared_state.h2_pool);
         let backend_endpoints = Arc::clone(&shared_state.backend_endpoints);
         let upstream_host_policies = Arc::clone(&shared_state.upstream_host_policies);
+        let forwarded_header_policies = Arc::clone(&shared_state.forwarded_header_policies);
         let metrics = Arc::clone(&shared_state.metrics);
         let resilience = Arc::clone(&shared_state.resilience);
         let upstream_pools = shared_state.upstream_pools.clone();
@@ -4278,6 +4288,7 @@ impl QUICListener {
                 let h2_pool = Arc::clone(&h2_pool);
                 let backend_endpoints = Arc::clone(&backend_endpoints);
                 let upstream_host_policies = Arc::clone(&upstream_host_policies);
+                let forwarded_header_policies = Arc::clone(&forwarded_header_policies);
                 let metrics = Arc::clone(&metrics);
                 let resilience = Arc::clone(&resilience);
                 let upstream_pools = upstream_pools.clone();
@@ -4308,6 +4319,7 @@ impl QUICListener {
                             let h2_pool = Arc::clone(&h2_pool);
                             let backend_endpoints = Arc::clone(&backend_endpoints);
                             let upstream_host_policies = Arc::clone(&upstream_host_policies);
+                            let forwarded_header_policies = Arc::clone(&forwarded_header_policies);
                             let metrics = Arc::clone(&metrics);
                             let resilience = Arc::clone(&resilience);
                             let upstream_pools = upstream_pools.clone();
@@ -4473,8 +4485,40 @@ impl QUICListener {
 
                                 let bootstrap_connection_tokens =
                                     connection_header_tokens(req.headers());
+                                let mut forwarded_from_headers: Vec<Vec<u8>> = Vec::new();
+                                let mut x_forwarded_for_from_headers: Vec<Vec<u8>> = Vec::new();
+                                let mut x_forwarded_proto_from_headers: Vec<Vec<u8>> = Vec::new();
+                                let mut x_forwarded_host_from_headers: Vec<Vec<u8>> = Vec::new();
                                 for (name, value) in req.headers() {
                                     if name == http::header::HOST {
+                                        continue;
+                                    }
+                                    if name.as_str().eq_ignore_ascii_case("forwarded") {
+                                        forwarded_from_headers.push(value.as_bytes().to_vec());
+                                        continue;
+                                    }
+                                    if name
+                                        .as_str()
+                                        .eq_ignore_ascii_case("x-forwarded-for")
+                                    {
+                                        x_forwarded_for_from_headers
+                                            .push(value.as_bytes().to_vec());
+                                        continue;
+                                    }
+                                    if name
+                                        .as_str()
+                                        .eq_ignore_ascii_case("x-forwarded-proto")
+                                    {
+                                        x_forwarded_proto_from_headers
+                                            .push(value.as_bytes().to_vec());
+                                        continue;
+                                    }
+                                    if name
+                                        .as_str()
+                                        .eq_ignore_ascii_case("x-forwarded-host")
+                                    {
+                                        x_forwarded_host_from_headers
+                                            .push(value.as_bytes().to_vec());
                                         continue;
                                     }
                                     if !is_websocket_upgrade
@@ -4506,15 +4550,51 @@ impl QUICListener {
                                     }
                                     upstream_req = upstream_req.header(name, value);
                                 }
-                                upstream_req =
-                                    upstream_req.header(http::header::HOST, upstream_host);
-                                upstream_req = upstream_req.header(
-                                    "forwarded",
-                                    format!(
-                                        "for={};proto=https",
-                                        bootstrap_forwarded_for_value(peer.ip())
-                                    ),
-                                );
+                                upstream_req = upstream_req.header(http::header::HOST, upstream_host);
+
+                                let forwarded_policy = forwarded_header_policies
+                                    .get(&upstream_name)
+                                    .cloned()
+                                    .unwrap_or_default();
+                                let forwarded_values = match build_forwarded_header_values(
+                                    &forwarded_policy,
+                                    ForwardedHeaderChains {
+                                        forwarded: &forwarded_from_headers,
+                                        x_forwarded_for: &x_forwarded_for_from_headers,
+                                        x_forwarded_proto: &x_forwarded_proto_from_headers,
+                                        x_forwarded_host: &x_forwarded_host_from_headers,
+                                    },
+                                    peer.ip(),
+                                    upstream_host,
+                                ) {
+                                    Ok(values) => values,
+                                    Err(err) => {
+                                        warn!("Bootstrap forwarded header policy failed: {}", err);
+                                        return Ok(Response::builder()
+                                            .status(StatusCode::BAD_REQUEST)
+                                            .header("alt-svc", &alt)
+                                            .body(boxed_full(Bytes::from_static(
+                                                b"invalid forwarded headers\n",
+                                            )))
+                                            .unwrap_or_else(|_| {
+                                                Response::new(boxed_full(Bytes::from_static(
+                                                    b"error\n",
+                                                )))
+                                            }));
+                                    }
+                                };
+                                if let Some(value) = forwarded_values.forwarded {
+                                    upstream_req = upstream_req.header("forwarded", value);
+                                }
+                                if let Some(value) = forwarded_values.x_forwarded_for {
+                                    upstream_req = upstream_req.header("x-forwarded-for", value);
+                                }
+                                if let Some(value) = forwarded_values.x_forwarded_proto {
+                                    upstream_req = upstream_req.header("x-forwarded-proto", value);
+                                }
+                                if let Some(value) = forwarded_values.x_forwarded_host {
+                                    upstream_req = upstream_req.header("x-forwarded-host", value);
+                                }
 
                                 if !is_websocket_upgrade
                                     && content_length
@@ -5081,6 +5161,7 @@ mod tests {
                 key: lb_key.map(str::to_string),
             },
             host_policy: Default::default(),
+            forwarded_headers: Default::default(),
             route: RouteMatch {
                 host: None,
                 path_prefix: Some("/api".to_string()),

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -55,7 +55,7 @@ use tracing::{Instrument, info_span};
 
 use spooky_config::{
     backend_endpoint::{BackendEndpoint, BackendScheme},
-    config::{Config as SpookyConfig, ForwardedHeaderPolicy, UpstreamHostPolicy},
+    config::{Config as SpookyConfig, ForwardedHeaderPolicy, UpstreamHostPolicy, UpstreamTls},
 };
 
 use crate::{
@@ -418,13 +418,23 @@ impl QUICListener {
         Self::new_with_socket_and_shared_state(config, socket, shared_state)
     }
 
-    fn upstream_tls_client_config(config: &SpookyConfig) -> TlsClientConfig {
+    fn upstream_tls_client_config(tls: &UpstreamTls) -> TlsClientConfig {
         TlsClientConfig {
-            verify_certificates: config.upstream_tls.verify_certificates,
-            strict_sni: config.upstream_tls.strict_sni,
-            ca_file: config.upstream_tls.ca_file.clone(),
-            ca_dir: config.upstream_tls.ca_dir.clone(),
+            verify_certificates: tls.verify_certificates,
+            strict_sni: tls.strict_sni,
+            ca_file: tls.ca_file.clone(),
+            ca_dir: tls.ca_dir.clone(),
         }
+    }
+
+    fn effective_upstream_tls(
+        config: &SpookyConfig,
+        upstream: &spooky_config::config::Upstream,
+    ) -> UpstreamTls {
+        upstream
+            .tls
+            .clone()
+            .unwrap_or_else(|| config.upstream_tls.clone())
     }
 
     pub fn build_shared_state(config: &SpookyConfig) -> Result<SharedRuntimeState, ProxyError> {
@@ -471,7 +481,13 @@ impl QUICListener {
 
         let mut backend_addresses = Vec::new();
         let mut seen_backend_origins: HashMap<String, (String, String)> = HashMap::new();
+        let mut backend_tls_configs: HashMap<String, TlsClientConfig> = HashMap::new();
+        let mut upstream_tls_configs: HashMap<String, TlsClientConfig> = HashMap::new();
         for (upstream_name, upstream) in &config.upstream {
+            let upstream_tls = Self::effective_upstream_tls(config, upstream);
+            let upstream_tls_client = Self::upstream_tls_client_config(&upstream_tls);
+            upstream_tls_configs.insert(upstream_name.clone(), upstream_tls_client.clone());
+
             for backend in &upstream.backends {
                 let endpoint = match BackendEndpoint::parse(&backend.address) {
                     Ok(endpoint) => endpoint,
@@ -493,6 +509,7 @@ impl QUICListener {
                     )));
                 }
                 backend_addresses.push(backend.address.clone());
+                backend_tls_configs.insert(backend.address.clone(), upstream_tls_client.clone());
             }
         }
 
@@ -500,17 +517,18 @@ impl QUICListener {
         let h2_pool = Arc::new(
             H2Pool::new(
                 backend_addresses,
+                backend_tls_configs,
                 max_inflight_per_backend,
                 config.performance.h2_pool_max_idle_per_backend,
                 Duration::from_millis(config.performance.h2_pool_idle_timeout_ms),
                 Duration::from_millis(config.performance.backend_connect_timeout_ms),
-                Self::upstream_tls_client_config(config),
                 backend_dns_resolver.clone(),
             )
             .map_err(ProxyError::Tls)?,
         );
         let mut upstream_pools = HashMap::new();
         let mut upstream_inflight = HashMap::new();
+        let mut upstream_health_clients = HashMap::new();
 
         for (name, upstream) in &config.upstream {
             let upstream_pool = UpstreamPool::from_upstream(upstream).map_err(|err| {
@@ -521,6 +539,16 @@ impl QUICListener {
             })?;
             upstream_pools.insert(name.clone(), Arc::new(RwLock::new(upstream_pool)));
             upstream_inflight.insert(name.clone(), Arc::new(Semaphore::new(per_upstream_limit)));
+            let tls = upstream_tls_configs.get(name).cloned().unwrap_or_default();
+            let client = H2Client::new(
+                config.performance.h2_pool_max_idle_per_backend.max(1),
+                Duration::from_millis(config.performance.h2_pool_idle_timeout_ms.max(1)),
+                Duration::from_millis(config.performance.backend_connect_timeout_ms.max(1)),
+                tls,
+                backend_dns_resolver.clone(),
+            )
+            .map_err(ProxyError::Tls)?;
+            upstream_health_clients.insert(name.clone(), Arc::new(client));
         }
 
         config
@@ -578,6 +606,7 @@ impl QUICListener {
                     .collect(),
             ),
             backend_dns_resolver,
+            upstream_health_clients: Arc::new(upstream_health_clients),
             forwarded_header_policies: Arc::new(
                 config
                     .upstream
@@ -609,28 +638,13 @@ impl QUICListener {
         shared_state
             .watchdog
             .set_expected_workers(worker_count.max(1));
-        let health_client = match H2Client::new(
-            config.performance.h2_pool_max_idle_per_backend.max(1),
-            Duration::from_millis(config.performance.h2_pool_idle_timeout_ms.max(1)),
-            Duration::from_millis(config.performance.backend_connect_timeout_ms.max(1)),
-            Self::upstream_tls_client_config(config),
-            shared_state.backend_dns_resolver.clone(),
-        ) {
-            Ok(client) => Arc::new(client),
-            Err(err) => {
-                return Err(ProxyError::Transport(format!(
-                    "failed to initialize control-plane H2 client: {err}"
-                )));
-            }
-        };
         Self::spawn_health_checks(
             shared_state.upstream_pools.clone(),
-            health_client,
+            Arc::clone(&shared_state.upstream_health_clients),
             Arc::clone(&shared_state.metrics),
         );
         Self::spawn_metrics_endpoint(config, Arc::clone(&shared_state.metrics))?;
         Self::spawn_control_api_endpoint(config, shared_state, worker_count)?;
-        Self::spawn_bootstrap_tls_listener(config, shared_state)?;
         Self::spawn_watchdog(
             config,
             Arc::clone(&shared_state.metrics),
@@ -4197,7 +4211,7 @@ impl QUICListener {
         Self::build_server_tls_acceptor(config, true, vec![b"h2".to_vec(), b"http/1.1".to_vec()])
     }
 
-    fn spawn_bootstrap_tls_listener(
+    pub fn spawn_bootstrap_tls_listener(
         config: &SpookyConfig,
         shared_state: &SharedRuntimeState,
     ) -> Result<(), ProxyError> {
@@ -5160,6 +5174,7 @@ mod tests {
             },
             host_policy: Default::default(),
             forwarded_headers: Default::default(),
+            tls: None,
             route: RouteMatch {
                 host: None,
                 path_prefix: Some("/api".to_string()),
@@ -5221,6 +5236,7 @@ mod tests {
                     client_auth: ClientAuth::default(),
                 },
             },
+            listeners: vec![],
             upstream: upstreams,
             load_balancing: Some(LoadBalancing {
                 lb_type: "round-robin".to_string(),

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -29,6 +29,11 @@ use quiche::Config;
 use quiche::h3::NameValue;
 use rand::RngCore;
 use rustls::{RootCertStore, ServerConfig as RustlsServerConfig, server::WebPkiClientVerifier};
+use rustls::{
+    pki_types::{CertificateDer, PrivateKeyDer},
+    server::{ClientHello, ResolvesServerCert, ResolvesServerCertUsingSni},
+    sign::CertifiedKey,
+};
 use serde_json::json;
 use socket2::{Domain, Protocol, Socket, Type};
 use spooky_bridge::h3_to_h2::{ForwardedContext, build_h2_request_for_endpoint};
@@ -86,6 +91,20 @@ use validation::{
     RequestBufferError, extract_header_value, generated_span_id, generated_trace_id,
     parse_traceparent, validate_http_request, validate_request_headers,
 };
+
+#[derive(Debug)]
+struct FallbackServerCertResolver {
+    sni_resolver: ResolvesServerCertUsingSni,
+    fallback: Arc<CertifiedKey>,
+}
+
+impl ResolvesServerCert for FallbackServerCertResolver {
+    fn resolve(&self, client_hello: ClientHello<'_>) -> Option<Arc<CertifiedKey>> {
+        self.sni_resolver
+            .resolve(client_hello)
+            .or_else(|| Some(Arc::clone(&self.fallback)))
+    }
+}
 
 fn is_hop_header(name: &str) -> bool {
     matches!(
@@ -772,26 +791,63 @@ impl QUICListener {
         Ok(socket.into())
     }
 
+    fn legacy_tls_cert_pair(config: &SpookyConfig) -> Result<Option<(&str, &str)>, ProxyError> {
+        let cert = config.listen.tls.cert.trim();
+        let key = config.listen.tls.key.trim();
+        let has_pair = !cert.is_empty() || !key.is_empty();
+        if !has_pair {
+            return Ok(None);
+        }
+        if cert.is_empty() || key.is_empty() {
+            return Err(ProxyError::Tls(
+                "listen.tls.cert and listen.tls.key must both be set when either is provided"
+                    .to_string(),
+            ));
+        }
+        Ok(Some((cert, key)))
+    }
+
+    fn default_tls_cert_pair(config: &SpookyConfig) -> Result<(&str, &str), ProxyError> {
+        if let Some(pair) = Self::legacy_tls_cert_pair(config)? {
+            return Ok(pair);
+        }
+        let Some(entry) = config.listen.tls.certificates.first() else {
+            return Err(ProxyError::Tls(
+                "listen.tls requires either cert/key or certificates entries".to_string(),
+            ));
+        };
+        let cert = entry.cert.trim();
+        let key = entry.key.trim();
+        if cert.is_empty() || key.is_empty() {
+            return Err(ProxyError::Tls(
+                "listen.tls.certificates entries must include non-empty cert and key".to_string(),
+            ));
+        }
+        Ok((cert, key))
+    }
+
     fn build_quic_config(config: &SpookyConfig) -> Result<Config, ProxyError> {
         let mut quic_config = Config::new(quiche::PROTOCOL_VERSION)
             .map_err(|err| ProxyError::Transport(format!("failed to create QUIC config: {err}")))?;
 
-        match quic_config.load_cert_chain_from_pem_file(&config.listen.tls.cert) {
+        let (default_cert, default_key) = Self::default_tls_cert_pair(config)?;
+
+        match quic_config.load_cert_chain_from_pem_file(default_cert) {
             Ok(_) => debug!("Certificate loaded successfully"),
             Err(e) => {
                 return Err(ProxyError::Tls(format!(
                     "Failed to load certificate '{}': {}",
-                    config.listen.tls.cert, e
+                    default_cert, e
                 )));
             }
         }
 
-        match quic_config.load_priv_key_from_pem_file(&config.listen.tls.key) {
+        match quic_config.load_priv_key_from_pem_file(default_key) {
             Ok(_) => debug!("Private key loaded successfully"),
             Err(e) => {
                 return Err(ProxyError::Tls(format!(
                     "Failed to load key '{}': {}",
-                    config.listen.tls.key, e
+                    default_key, e
                 )));
             }
         }
@@ -3807,57 +3863,86 @@ impl QUICListener {
         Ok(())
     }
 
+    fn load_tls_cert_chain_from_pem_file(
+        path: &str,
+        field_name: &str,
+    ) -> Result<Vec<CertificateDer<'static>>, ProxyError> {
+        use rustls_pemfile::certs;
+        use std::io::BufReader;
+
+        let cert_bytes = std::fs::read(path).map_err(|err| {
+            ProxyError::Tls(format!("failed to read {field_name} '{}': {}", path, err))
+        })?;
+
+        certs(&mut BufReader::new(cert_bytes.as_slice()))
+            .collect::<Result<_, _>>()
+            .map_err(|err| ProxyError::Tls(format!("failed to parse {field_name} PEM: {err}")))
+    }
+
+    fn load_tls_private_key_from_pem_file(
+        path: &str,
+        field_name: &str,
+    ) -> Result<PrivateKeyDer<'static>, ProxyError> {
+        use rustls_pemfile::{pkcs8_private_keys, rsa_private_keys};
+        use std::io::BufReader;
+
+        let key_bytes = std::fs::read(path).map_err(|err| {
+            ProxyError::Tls(format!("failed to read {field_name} '{}': {}", path, err))
+        })?;
+
+        let mut reader = BufReader::new(key_bytes.as_slice());
+        let pkcs8: Vec<PrivateKeyDer<'static>> = pkcs8_private_keys(&mut reader)
+            .map(|r| r.map(PrivateKeyDer::Pkcs8))
+            .collect::<Result<_, _>>()
+            .map_err(|err| ProxyError::Tls(format!("failed to parse {field_name} PEM: {err}")))?;
+        if let Some(key) = pkcs8.into_iter().next() {
+            return Ok(key);
+        }
+
+        let mut reader2 = BufReader::new(key_bytes.as_slice());
+        let rsa: Vec<PrivateKeyDer<'static>> = rsa_private_keys(&mut reader2)
+            .map(|r| r.map(PrivateKeyDer::Pkcs1))
+            .collect::<Result<_, _>>()
+            .map_err(|err| ProxyError::Tls(format!("failed to parse {field_name} PEM: {err}")))?;
+        rsa.into_iter().next().ok_or_else(|| {
+            ProxyError::Tls(format!(
+                "no supported private key found in {field_name} '{}'",
+                path
+            ))
+        })
+    }
+
+    fn load_certified_key(
+        cert_path: &str,
+        key_path: &str,
+        cert_field: &str,
+        key_field: &str,
+    ) -> Result<CertifiedKey, ProxyError> {
+        let certs = Self::load_tls_cert_chain_from_pem_file(cert_path, cert_field)?;
+        let key = Self::load_tls_private_key_from_pem_file(key_path, key_field)?;
+        let signing_key = rustls::crypto::ring::sign::any_supported_type(&key).map_err(|err| {
+            ProxyError::Tls(format!(
+                "failed to parse private key from {} '{}': {}",
+                key_field, key_path, err
+            ))
+        })?;
+        let certified = CertifiedKey::new(certs, signing_key);
+        certified.keys_match().map_err(|err| {
+            ProxyError::Tls(format!(
+                "certificate/key mismatch for {} '{}' and {} '{}': {}",
+                cert_field, cert_path, key_field, key_path, err
+            ))
+        })?;
+        Ok(certified)
+    }
+
     fn build_server_tls_acceptor(
         config: &SpookyConfig,
         enforce_client_auth: bool,
         alpn_protocols: Vec<Vec<u8>>,
     ) -> Result<TlsAcceptor, ProxyError> {
-        use rustls_pemfile::{certs, pkcs8_private_keys, rsa_private_keys};
+        use rustls_pemfile::certs;
         use std::io::BufReader;
-
-        let cert_bytes = std::fs::read(&config.listen.tls.cert).map_err(|err| {
-            ProxyError::Tls(format!(
-                "failed to read TLS cert '{}': {}",
-                config.listen.tls.cert, err
-            ))
-        })?;
-        let key_bytes = std::fs::read(&config.listen.tls.key).map_err(|err| {
-            ProxyError::Tls(format!(
-                "failed to read TLS key '{}': {}",
-                config.listen.tls.key, err
-            ))
-        })?;
-
-        let server_certs: Vec<rustls::pki_types::CertificateDer<'static>> =
-            certs(&mut BufReader::new(cert_bytes.as_slice()))
-                .collect::<Result<_, _>>()
-                .map_err(|err| ProxyError::Tls(format!("failed to parse TLS cert PEM: {}", err)))?;
-
-        let key = {
-            let mut reader = BufReader::new(key_bytes.as_slice());
-            let pkcs8: Vec<rustls::pki_types::PrivateKeyDer<'static>> =
-                pkcs8_private_keys(&mut reader)
-                    .map(|r| r.map(rustls::pki_types::PrivateKeyDer::Pkcs8))
-                    .collect::<Result<_, _>>()
-                    .map_err(|err| {
-                        ProxyError::Tls(format!("failed to parse PKCS8 key PEM: {}", err))
-                    })?;
-            if let Some(key) = pkcs8.into_iter().next() {
-                key
-            } else {
-                let mut reader2 = BufReader::new(key_bytes.as_slice());
-                let rsa: Vec<rustls::pki_types::PrivateKeyDer<'static>> =
-                    rsa_private_keys(&mut reader2)
-                        .map(|r| r.map(rustls::pki_types::PrivateKeyDer::Pkcs1))
-                        .collect::<Result<_, _>>()
-                        .map_err(|err| {
-                            ProxyError::Tls(format!("failed to parse RSA key PEM: {}", err))
-                        })?;
-                rsa.into_iter().next().ok_or_else(|| {
-                    ProxyError::Tls("no supported private key found in TLS key file".to_string())
-                })?
-            }
-        };
 
         let builder = if enforce_client_auth && config.listen.tls.client_auth.enabled {
             let ca_file = config
@@ -3915,9 +4000,60 @@ impl QUICListener {
             RustlsServerConfig::builder().with_no_client_auth()
         };
 
-        let mut tls_config = builder.with_single_cert(server_certs, key).map_err(|err| {
-            ProxyError::Tls(format!("failed to build rustls ServerConfig: {}", err))
-        })?;
+        let legacy_pair = Self::legacy_tls_cert_pair(config)?;
+        let mut fallback_certified_key = if let Some((cert, key)) = legacy_pair {
+            Some(Self::load_certified_key(
+                cert,
+                key,
+                "listen.tls.cert",
+                "listen.tls.key",
+            )?)
+        } else {
+            None
+        };
+
+        let mut sni_resolver = ResolvesServerCertUsingSni::new();
+        for (idx, entry) in config.listen.tls.certificates.iter().enumerate() {
+            let cert_field = format!("listen.tls.certificates[{idx}].cert");
+            let key_field = format!("listen.tls.certificates[{idx}].key");
+            let certified = Self::load_certified_key(&entry.cert, &entry.key, &cert_field, &key_field)?;
+
+            sni_resolver
+                .add(entry.server_name.as_str(), certified.clone())
+                .map_err(|err| {
+                    ProxyError::Tls(format!(
+                        "failed to add SNI certificate mapping for '{}' in listen.tls.certificates[{idx}]: {}",
+                        entry.server_name, err
+                    ))
+                })?;
+
+            if fallback_certified_key.is_none() {
+                fallback_certified_key = Some(certified);
+            }
+        }
+
+        let Some(fallback) = fallback_certified_key else {
+            return Err(ProxyError::Tls(
+                "listen.tls requires either cert/key or certificates entries".to_string(),
+            ));
+        };
+
+        let mut tls_config = if config.listen.tls.certificates.is_empty() {
+            let certs = fallback.cert.clone();
+            let key = Self::load_tls_private_key_from_pem_file(
+                config.listen.tls.key.as_str(),
+                "listen.tls.key",
+            )?;
+            builder.with_single_cert(certs, key).map_err(|err| {
+                ProxyError::Tls(format!("failed to build rustls ServerConfig: {}", err))
+            })?
+        } else {
+            let resolver = Arc::new(FallbackServerCertResolver {
+                sni_resolver,
+                fallback: Arc::new(fallback),
+            });
+            builder.with_cert_resolver(resolver)
+        };
 
         tls_config.alpn_protocols = alpn_protocols;
 

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -42,7 +42,7 @@ use spooky_bridge::h3_to_h2::{
 };
 use spooky_errors::{PoolError, ProxyError, is_retryable};
 use spooky_lb::{HealthFailureReason, HealthTransition, UpstreamPool};
-use spooky_transport::h2_client::{H2Client, TlsClientConfig};
+use spooky_transport::h2_client::{H2Client, SharedDnsResolver, TlsClientConfig};
 use spooky_transport::h2_pool::H2Pool;
 use tokio::runtime::Handle;
 use tokio::sync::{
@@ -496,6 +496,7 @@ impl QUICListener {
             }
         }
 
+        let backend_dns_resolver = SharedDnsResolver::new();
         let h2_pool = Arc::new(
             H2Pool::new(
                 backend_addresses,
@@ -504,6 +505,7 @@ impl QUICListener {
                 Duration::from_millis(config.performance.h2_pool_idle_timeout_ms),
                 Duration::from_millis(config.performance.backend_connect_timeout_ms),
                 Self::upstream_tls_client_config(config),
+                backend_dns_resolver.clone(),
             )
             .map_err(ProxyError::Tls)?,
         );
@@ -575,6 +577,7 @@ impl QUICListener {
                     })
                     .collect(),
             ),
+            backend_dns_resolver,
             forwarded_header_policies: Arc::new(
                 config
                     .upstream
@@ -611,6 +614,7 @@ impl QUICListener {
             Duration::from_millis(config.performance.h2_pool_idle_timeout_ms.max(1)),
             Duration::from_millis(config.performance.backend_connect_timeout_ms.max(1)),
             Self::upstream_tls_client_config(config),
+            shared_state.backend_dns_resolver.clone(),
         ) {
             Ok(client) => Arc::new(client),
             Err(err) => {
@@ -711,6 +715,7 @@ impl QUICListener {
             h3_config,
             h2_pool: Arc::clone(&shared_state.h2_pool),
             backend_endpoints: Arc::clone(&shared_state.backend_endpoints),
+            backend_dns_resolver: shared_state.backend_dns_resolver.clone(),
             upstream_host_policies: Arc::clone(&shared_state.upstream_host_policies),
             forwarded_header_policies: Arc::clone(&shared_state.forwarded_header_policies),
             upstream_pools: shared_state.upstream_pools.clone(),

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -5073,7 +5073,8 @@ mod tests {
             false,
             vec![b"h2".to_vec()],
         )
-        .expect_err("mismatched SNI cert mapping should fail");
+        .err()
+        .expect("mismatched SNI cert mapping should fail");
         assert!(
             err.to_string()
                 .contains("failed to add SNI certificate mapping"),

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -328,13 +328,13 @@ impl Body for BootstrapStreamingBody {
 
         match Pin::new(&mut self.inner).poll_frame(cx) {
             Poll::Ready(Some(Ok(frame))) => {
-                if let Some(limit) = self.max_bytes {
-                    if let Some(data) = frame.data_ref() {
-                        self.bytes_seen = self.bytes_seen.saturating_add(data.len());
-                        if self.bytes_seen > limit {
-                            self.capped = true;
-                            return Poll::Ready(None);
-                        }
+                if let Some(limit) = self.max_bytes
+                    && let Some(data) = frame.data_ref()
+                {
+                    self.bytes_seen = self.bytes_seen.saturating_add(data.len());
+                    if self.bytes_seen > limit {
+                        self.capped = true;
+                        return Poll::Ready(None);
                     }
                 }
                 Poll::Ready(Some(Ok(frame)))

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -3098,8 +3098,7 @@ impl QUICListener {
                                                 .await;
                                             return;
                                         }
-                                        Ok(Some(Ok(f))) => {
-                                            match f.into_data() {
+                                        Ok(Some(Ok(f))) => match f.into_data() {
                                             Ok(data) => {
                                                 if !data.is_empty() {
                                                     saw_body_progress = true;
@@ -3163,7 +3162,8 @@ impl QUICListener {
                                             }
                                             Err(frame) => {
                                                 if let Ok(trailers) = frame.into_trailers() {
-                                                    let trailer_headers = collect_h3_trailers(&trailers);
+                                                    let trailer_headers =
+                                                        collect_h3_trailers(&trailers);
                                                     if !trailer_headers.is_empty()
                                                         && chunk_tx
                                                             .send(ResponseChunk::Trailers {
@@ -3176,8 +3176,7 @@ impl QUICListener {
                                                     }
                                                 }
                                             }
-                                            }
-                                        }
+                                        },
                                         Ok(Some(Err(_))) => {
                                             let _ = chunk_tx
                                                 .send(ResponseChunk::Error(ProxyError::Transport(
@@ -5429,18 +5428,25 @@ mod tests {
         );
         let collected = collect_h3_trailers(&trailers);
         assert_eq!(collected.len(), 2);
-        assert!(collected
-            .iter()
-            .any(|(k, v)| k.as_slice() == b"grpc-status" && v.as_slice() == b"0"));
-        assert!(collected
-            .iter()
-            .any(|(k, v)| k.as_slice() == b"grpc-message" && v.as_slice() == b"ok"));
+        assert!(
+            collected
+                .iter()
+                .any(|(k, v)| k.as_slice() == b"grpc-status" && v.as_slice() == b"0")
+        );
+        assert!(
+            collected
+                .iter()
+                .any(|(k, v)| k.as_slice() == b"grpc-message" && v.as_slice() == b"ok")
+        );
     }
 
     #[test]
     fn h3_trailer_collection_strips_hop_by_hop_and_content_length() {
         let mut trailers = HeaderMap::new();
-        trailers.insert(http::header::CONTENT_LENGTH, HeaderValue::from_static("123"));
+        trailers.insert(
+            http::header::CONTENT_LENGTH,
+            HeaderValue::from_static("123"),
+        );
         trailers.insert(http::header::TE, HeaderValue::from_static("trailers"));
         trailers.insert(http::header::TRAILER, HeaderValue::from_static("x-next"));
         trailers.insert(

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -209,6 +209,27 @@ fn response_size_exceeded_after_chunk(
     *response_bytes_received > max_response_body_bytes
 }
 
+fn is_connect_method(method: &str) -> bool {
+    method.eq_ignore_ascii_case("CONNECT")
+}
+
+fn is_connect_tunnel_response(method: &str, status: StatusCode) -> bool {
+    is_connect_method(method) && status.is_success()
+}
+
+fn can_poll_upstream_result(req: &RequestEnvelope) -> bool {
+    if is_connect_method(&req.method)
+        && (req.phase == StreamPhase::ReceivingRequest || req.phase == StreamPhase::AwaitingUpstream)
+    {
+        return true;
+    }
+
+    req.phase == StreamPhase::AwaitingUpstream
+        && req.request_fin_received
+        && req.body_tx.is_none()
+        && req.body_buf.is_empty()
+}
+
 fn header_has_token(value: &http::HeaderValue, token: &str) -> bool {
     value
         .to_str()
@@ -2521,7 +2542,8 @@ impl QUICListener {
                                     // Enforce cap on total bytes received for the stream,
                                     // including chunks already forwarded to the H2 body channel.
                                     let next_total = req.body_bytes_received.saturating_add(read);
-                                    if next_total > max_request_body_bytes {
+                                    let request_is_connect = is_connect_method(&req.method);
+                                    if !request_is_connect && next_total > max_request_body_bytes {
                                         payload_too_large = Some((
                                             req.upstream_name
                                                 .clone()
@@ -2814,13 +2836,10 @@ impl QUICListener {
             // Only transition to response handling once request-body ingestion is
             // complete. This preserves request-size enforcement semantics:
             // oversized requests must still be able to terminate with 413 even if
-            // upstream produced an early response.
-            let can_poll_upstream = streams.get(&stream_id).is_some_and(|req| {
-                req.phase == StreamPhase::AwaitingUpstream
-                    && req.request_fin_received
-                    && req.body_tx.is_none()
-                    && req.body_buf.is_empty()
-            });
+            // upstream produced an early response. CONNECT is the exception:
+            // successful CONNECT establishes a tunnel and must not wait for request FIN.
+            let can_poll_upstream =
+                streams.get(&stream_id).is_some_and(can_poll_upstream_result);
 
             // upstream_ready: Option<UpstreamResult>
             //   None          → oneshot not yet resolved (or not eligible), skip
@@ -2885,13 +2904,18 @@ impl QUICListener {
                 }
                 match forward_result.forward {
                     Ok((status, resp_headers, body)) => {
+                        let connect_tunnel = streams
+                            .get(&stream_id)
+                            .is_some_and(|req| is_connect_tunnel_response(&req.method, status));
                         // If upstream advertised a response length beyond our hard cap,
                         // fail fast with 503 before sending any downstream headers/body.
                         let upstream_content_length = resp_headers
                             .get(http::header::CONTENT_LENGTH)
                             .and_then(|v| v.to_str().ok())
                             .and_then(|v| v.parse::<usize>().ok());
-                        if upstream_content_length.is_some_and(|len| len > max_response_body_bytes)
+                        if !connect_tunnel
+                            && upstream_content_length
+                                .is_some_and(|len| len > max_response_body_bytes)
                         {
                             if let Some(req) = streams.get(&stream_id) {
                                 metrics.inc_failure();
@@ -2946,10 +2970,12 @@ impl QUICListener {
                             format!("h3=\":{}\"; ma=86400", listen_port).into_bytes(),
                         ));
 
-                        let defer_headers_until_body_validated = upstream_content_length.is_none();
-                        let immediate_end = upstream_content_length == Some(0)
-                            || status == http::StatusCode::NO_CONTENT
-                            || status == http::StatusCode::NOT_MODIFIED;
+                        let defer_headers_until_body_validated =
+                            upstream_content_length.is_none() && !connect_tunnel;
+                        let immediate_end = !connect_tunnel
+                            && (upstream_content_length == Some(0)
+                                || status == http::StatusCode::NO_CONTENT
+                                || status == http::StatusCode::NOT_MODIFIED);
                         let mut immediate_terminal = false;
 
                         if !defer_headers_until_body_validated {
@@ -3066,6 +3092,7 @@ impl QUICListener {
                                 tokio::time::Instant::now() + backend_body_total_timeout;
                             let deferred_status = status;
                             let deferred_headers = owned_h3_headers.clone();
+                            let tunnel_mode = connect_tunnel;
                             let fut = async move {
                                 use http_body_util::BodyExt;
                                 let mut body: hyper::body::Incoming = body;
@@ -3103,11 +3130,13 @@ impl QUICListener {
                                                 if !data.is_empty() {
                                                     saw_body_progress = true;
                                                 }
-                                                if response_size_exceeded_after_chunk(
-                                                    &mut response_bytes_received,
-                                                    data.len(),
-                                                    max_response_body_bytes,
-                                                ) {
+                                                if !tunnel_mode
+                                                    && response_size_exceeded_after_chunk(
+                                                        &mut response_bytes_received,
+                                                        data.len(),
+                                                        max_response_body_bytes,
+                                                    )
+                                                {
                                                     let _ = chunk_tx
                                                         .send(ResponseChunk::Error(ProxyError::Pool(
                                                             PoolError::BackendOverloaded(
@@ -4974,7 +5003,8 @@ mod tests {
 
     use super::{
         ConnectionRoutes, TokenBucket, abort_stream, classify_active_health_check_response,
-        collect_h3_trailers, connection_header_tokens, purge_connection_routes,
+        can_poll_upstream_result, collect_h3_trailers, connection_header_tokens,
+        is_connect_tunnel_response, purge_connection_routes,
         resolve_primary_from_radix_prefix, response_size_exceeded_after_chunk,
         should_strip_bootstrap_request_header, should_strip_bootstrap_response_header,
         should_strip_h3_response_header, sweep_closed_connections,
@@ -5546,6 +5576,37 @@ mod tests {
         assert_eq!(received, 10);
         assert!(response_size_exceeded_after_chunk(&mut received, 1, 10));
         assert_eq!(received, 11);
+    }
+
+    #[test]
+    fn connect_tunnel_response_detected_only_for_success_status() {
+        assert!(is_connect_tunnel_response("CONNECT", StatusCode::OK));
+        assert!(is_connect_tunnel_response("connect", StatusCode::NO_CONTENT));
+        assert!(!is_connect_tunnel_response("CONNECT", StatusCode::BAD_GATEWAY));
+        assert!(!is_connect_tunnel_response("GET", StatusCode::OK));
+    }
+
+    #[test]
+    fn connect_can_poll_upstream_before_request_fin() {
+        let (_tx, rx) = oneshot::channel::<crate::UpstreamResult>();
+        let mut req = make_envelope(StreamPhase::ReceivingRequest);
+        req.method = "CONNECT".to_string();
+        req.request_fin_received = false;
+        req.upstream_result_rx = Some(rx);
+        assert!(can_poll_upstream_result(&req));
+    }
+
+    #[test]
+    fn non_connect_requires_request_completion_before_upstream_poll() {
+        let (_tx, rx) = oneshot::channel::<crate::UpstreamResult>();
+        let mut req = make_envelope(StreamPhase::AwaitingUpstream);
+        req.method = "GET".to_string();
+        req.request_fin_received = false;
+        req.upstream_result_rx = Some(rx);
+        assert!(!can_poll_upstream_result(&req));
+
+        req.request_fin_received = true;
+        assert!(can_poll_upstream_result(&req));
     }
 
     #[test]

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -3409,7 +3409,13 @@ impl QUICListener {
                             for (name, value) in &headers {
                                 h3_headers.push(quiche::h3::Header::new(name, value));
                             }
-                            match h3.send_additional_headers(quic, stream_id, &h3_headers, false) {
+                            match h3.send_additional_headers(
+                                quic,
+                                stream_id,
+                                &h3_headers,
+                                true,
+                                false,
+                            ) {
                                 Ok(_) => {}
                                 Err(quiche::h3::Error::StreamBlocked) => {
                                     req.pending_chunk = Some(ResponseChunk::Trailers { headers });

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -289,11 +289,28 @@ type LbHeaderLookup<'a> = dyn Fn(&str) -> Option<String> + 'a;
 
 struct BootstrapStreamingBody {
     inner: Incoming,
+    max_bytes: Option<usize>,
+    bytes_seen: usize,
+    capped: bool,
 }
 
 impl BootstrapStreamingBody {
     fn new(inner: Incoming) -> Self {
-        Self { inner }
+        Self {
+            inner,
+            max_bytes: None,
+            bytes_seen: 0,
+            capped: false,
+        }
+    }
+
+    fn with_max_bytes(inner: Incoming, max_bytes: usize) -> Self {
+        Self {
+            inner,
+            max_bytes: Some(max_bytes),
+            bytes_seen: 0,
+            capped: false,
+        }
     }
 }
 
@@ -305,8 +322,23 @@ impl Body for BootstrapStreamingBody {
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        if self.capped {
+            return Poll::Ready(None);
+        }
+
         match Pin::new(&mut self.inner).poll_frame(cx) {
-            Poll::Ready(Some(Ok(frame))) => Poll::Ready(Some(Ok(frame))),
+            Poll::Ready(Some(Ok(frame))) => {
+                if let Some(limit) = self.max_bytes {
+                    if let Some(data) = frame.data_ref() {
+                        self.bytes_seen = self.bytes_seen.saturating_add(data.len());
+                        if self.bytes_seen > limit {
+                            self.capped = true;
+                            return Poll::Ready(None);
+                        }
+                    }
+                }
+                Poll::Ready(Some(Ok(frame)))
+            }
             Poll::Ready(Some(Err(_))) => Poll::Ready(None),
             Poll::Ready(None) => Poll::Ready(None),
             Poll::Pending => Poll::Pending,
@@ -4490,10 +4522,12 @@ impl QUICListener {
                                             Response::new(boxed_full(Bytes::new()))
                                         }));
                                 }
-                                let resp_body =
-                                    BootstrapStreamingBody::new(upstream_resp.into_body())
-                                        .map_err(|never| match never {})
-                                        .boxed();
+                                let resp_body = BootstrapStreamingBody::with_max_bytes(
+                                    upstream_resp.into_body(),
+                                    max_response_body_bytes,
+                                )
+                                .map_err(|never| match never {})
+                                .boxed();
 
                                 Ok(resp_builder
                                     .body(resp_body)

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -4016,7 +4016,8 @@ impl QUICListener {
         for (idx, entry) in config.listen.tls.certificates.iter().enumerate() {
             let cert_field = format!("listen.tls.certificates[{idx}].cert");
             let key_field = format!("listen.tls.certificates[{idx}].key");
-            let certified = Self::load_certified_key(&entry.cert, &entry.key, &cert_field, &key_field)?;
+            let certified =
+                Self::load_certified_key(&entry.cert, &entry.key, &cert_field, &key_field)?;
 
             sni_resolver
                 .add(entry.server_name.as_str(), certified.clone())
@@ -4952,11 +4953,7 @@ mod tests {
         }
     }
 
-    fn write_test_cert_for_name(
-        dir: &Path,
-        cert_name: &str,
-        dns_name: &str,
-    ) -> (String, String) {
+    fn write_test_cert_for_name(dir: &Path, cert_name: &str, dns_name: &str) -> (String, String) {
         let mut params = CertificateParams::new(vec![dns_name.to_string()]);
         params
             .subject_alt_names
@@ -4975,7 +4972,11 @@ mod tests {
         )
     }
 
-    fn tls_test_config(cert: String, key: String, certificates: Vec<TlsCertificate>) -> SpookyConfigConfig {
+    fn tls_test_config(
+        cert: String,
+        key: String,
+        certificates: Vec<TlsCertificate>,
+    ) -> SpookyConfigConfig {
         let mut upstreams = HashMap::new();
         upstreams.insert("api".to_string(), test_upstream("round-robin"));
         SpookyConfigConfig {
@@ -5046,11 +5047,8 @@ mod tests {
             }],
         );
 
-        let acceptor = super::QUICListener::build_server_tls_acceptor(
-            &config,
-            false,
-            vec![b"h2".to_vec()],
-        );
+        let acceptor =
+            super::QUICListener::build_server_tls_acceptor(&config, false, vec![b"h2".to_vec()]);
         assert!(acceptor.is_ok());
     }
 
@@ -5068,13 +5066,10 @@ mod tests {
             }],
         );
 
-        let err = super::QUICListener::build_server_tls_acceptor(
-            &config,
-            false,
-            vec![b"h2".to_vec()],
-        )
-        .err()
-        .expect("mismatched SNI cert mapping should fail");
+        let err =
+            super::QUICListener::build_server_tls_acceptor(&config, false, vec![b"h2".to_vec()])
+                .err()
+                .expect("mismatched SNI cert mapping should fail");
         assert!(
             err.to_string()
                 .contains("failed to add SNI certificate mapping"),

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -37,7 +37,8 @@ use rustls::{
 use serde_json::json;
 use socket2::{Domain, Protocol, Socket, Type};
 use spooky_bridge::h3_to_h2::{
-    ForwardedContext, ForwardedHeaderChains, build_forwarded_header_values, build_h2_request_for_endpoint_with_host_policy, resolve_upstream_host_value,
+    ForwardedContext, ForwardedHeaderChains, build_forwarded_header_values,
+    build_h2_request_for_endpoint_with_host_policy, resolve_upstream_host_value,
 };
 use spooky_errors::{PoolError, ProxyError, is_retryable};
 use spooky_lb::{HealthFailureReason, HealthTransition, UpstreamPool};
@@ -4497,26 +4498,17 @@ impl QUICListener {
                                         forwarded_from_headers.push(value.as_bytes().to_vec());
                                         continue;
                                     }
-                                    if name
-                                        .as_str()
-                                        .eq_ignore_ascii_case("x-forwarded-for")
-                                    {
+                                    if name.as_str().eq_ignore_ascii_case("x-forwarded-for") {
                                         x_forwarded_for_from_headers
                                             .push(value.as_bytes().to_vec());
                                         continue;
                                     }
-                                    if name
-                                        .as_str()
-                                        .eq_ignore_ascii_case("x-forwarded-proto")
-                                    {
+                                    if name.as_str().eq_ignore_ascii_case("x-forwarded-proto") {
                                         x_forwarded_proto_from_headers
                                             .push(value.as_bytes().to_vec());
                                         continue;
                                     }
-                                    if name
-                                        .as_str()
-                                        .eq_ignore_ascii_case("x-forwarded-host")
-                                    {
+                                    if name.as_str().eq_ignore_ascii_case("x-forwarded-host") {
                                         x_forwarded_host_from_headers
                                             .push(value.as_bytes().to_vec());
                                         continue;
@@ -4550,7 +4542,8 @@ impl QUICListener {
                                     }
                                     upstream_req = upstream_req.header(name, value);
                                 }
-                                upstream_req = upstream_req.header(http::header::HOST, upstream_host);
+                                upstream_req =
+                                    upstream_req.header(http::header::HOST, upstream_host);
 
                                 let forwarded_policy = forwarded_header_policies
                                     .get(&upstream_name)

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -179,6 +179,18 @@ fn should_strip_h3_response_header(
         || name == http::header::CONTENT_LENGTH
 }
 
+fn collect_h3_trailers(trailers: &http::HeaderMap) -> Vec<(Vec<u8>, Vec<u8>)> {
+    let connection_tokens = connection_header_tokens(trailers);
+    let mut out = Vec::with_capacity(trailers.len());
+    for (name, value) in trailers.iter() {
+        if should_strip_h3_response_header(name, &connection_tokens) {
+            continue;
+        }
+        out.push((name.as_str().as_bytes().to_vec(), value.as_bytes().to_vec()));
+    }
+    out
+}
+
 fn should_strip_bootstrap_response_header(
     name: &http::header::HeaderName,
     connection_tokens: &HashSet<String>,
@@ -2709,6 +2721,7 @@ impl QUICListener {
     ///      store `response_chunk_rx`, transition to SendingResponse.
     /// 4. Flush `response_chunk_rx` chunks into H3 (`try_recv` loop).
     ///    - `Data`  → `h3.send_body(..., false)`
+    ///    - `Trailers` → `h3.send_additional_headers(..., false)`
     ///    - `End`   → `h3.send_body(..., true)`, mark Completed
     ///    - `Error` → send 502, mark Failed
     /// 5. Remove streams in terminal phase (Completed / Failed).
@@ -3086,7 +3099,8 @@ impl QUICListener {
                                             return;
                                         }
                                         Ok(Some(Ok(f))) => {
-                                            if let Ok(data) = f.into_data() {
+                                            match f.into_data() {
+                                            Ok(data) => {
                                                 if !data.is_empty() {
                                                     saw_body_progress = true;
                                                 }
@@ -3147,7 +3161,22 @@ impl QUICListener {
                                                     }
                                                 }
                                             }
-                                            // skip trailers / other frame types
+                                            Err(frame) => {
+                                                if let Ok(trailers) = frame.into_trailers() {
+                                                    let trailer_headers = collect_h3_trailers(&trailers);
+                                                    if !trailer_headers.is_empty()
+                                                        && chunk_tx
+                                                            .send(ResponseChunk::Trailers {
+                                                                headers: trailer_headers,
+                                                            })
+                                                            .await
+                                                            .is_err()
+                                                    {
+                                                        return;
+                                                    }
+                                                }
+                                            }
+                                            }
                                         }
                                         Ok(Some(Err(_))) => {
                                             let _ = chunk_tx
@@ -3355,6 +3384,40 @@ impl QUICListener {
                                 Err(err) => {
                                     error!(
                                         "HTTP/3 send_body data protocol error on stream {}: {:?}",
+                                        stream_id, err
+                                    );
+                                    req.phase = StreamPhase::Failed;
+                                    metrics.inc_failure();
+                                    metrics.inc_backend_error();
+                                    let route_label =
+                                        req.upstream_name.as_deref().unwrap_or("unrouted");
+                                    metrics.record_route(
+                                        route_label,
+                                        req.start.elapsed(),
+                                        RouteOutcome::BackendError,
+                                    );
+                                    resilience
+                                        .adaptive_admission
+                                        .observe(req.start.elapsed(), true);
+                                    terminal = true;
+                                    break;
+                                }
+                            }
+                        }
+                        ResponseChunk::Trailers { headers } => {
+                            let mut h3_headers = Vec::with_capacity(headers.len());
+                            for (name, value) in &headers {
+                                h3_headers.push(quiche::h3::Header::new(name, value));
+                            }
+                            match h3.send_additional_headers(quic, stream_id, &h3_headers, false) {
+                                Ok(_) => {}
+                                Err(quiche::h3::Error::StreamBlocked) => {
+                                    req.pending_chunk = Some(ResponseChunk::Trailers { headers });
+                                    break;
+                                }
+                                Err(err) => {
+                                    error!(
+                                        "HTTP/3 send_additional_headers protocol error on stream {}: {:?}",
                                         stream_id, err
                                     );
                                     req.phase = StreamPhase::Failed;
@@ -4906,10 +4969,10 @@ mod tests {
 
     use super::{
         ConnectionRoutes, TokenBucket, abort_stream, classify_active_health_check_response,
-        connection_header_tokens, purge_connection_routes, resolve_primary_from_radix_prefix,
-        response_size_exceeded_after_chunk, should_strip_bootstrap_request_header,
-        should_strip_bootstrap_response_header, should_strip_h3_response_header,
-        sweep_closed_connections,
+        collect_h3_trailers, connection_header_tokens, purge_connection_routes,
+        resolve_primary_from_radix_prefix, response_size_exceeded_after_chunk,
+        should_strip_bootstrap_request_header, should_strip_bootstrap_response_header,
+        should_strip_h3_response_header, sweep_closed_connections,
     };
     type RoutingMaps = (
         HashMap<Arc<[u8]>, Arc<[u8]>>,
@@ -5345,6 +5408,51 @@ mod tests {
             &http::header::TRAILER,
             &tokens
         ));
+    }
+
+    #[test]
+    fn h3_trailer_collection_preserves_end_to_end_trailers() {
+        let mut trailers = HeaderMap::new();
+        trailers.insert(
+            http::HeaderName::from_static("grpc-status"),
+            HeaderValue::from_static("0"),
+        );
+        trailers.insert(
+            http::HeaderName::from_static("grpc-message"),
+            HeaderValue::from_static("ok"),
+        );
+        let collected = collect_h3_trailers(&trailers);
+        assert_eq!(collected.len(), 2);
+        assert!(collected
+            .iter()
+            .any(|(k, v)| k.as_slice() == b"grpc-status" && v.as_slice() == b"0"));
+        assert!(collected
+            .iter()
+            .any(|(k, v)| k.as_slice() == b"grpc-message" && v.as_slice() == b"ok"));
+    }
+
+    #[test]
+    fn h3_trailer_collection_strips_hop_by_hop_and_content_length() {
+        let mut trailers = HeaderMap::new();
+        trailers.insert(http::header::CONTENT_LENGTH, HeaderValue::from_static("123"));
+        trailers.insert(http::header::TE, HeaderValue::from_static("trailers"));
+        trailers.insert(http::header::TRAILER, HeaderValue::from_static("x-next"));
+        trailers.insert(
+            http::header::CONNECTION,
+            HeaderValue::from_static("x-hop-token"),
+        );
+        trailers.insert(
+            http::HeaderName::from_static("x-hop-token"),
+            HeaderValue::from_static("secret"),
+        );
+        trailers.insert(
+            http::HeaderName::from_static("grpc-status"),
+            HeaderValue::from_static("0"),
+        );
+        let collected = collect_h3_trailers(&trailers);
+        assert_eq!(collected.len(), 1);
+        assert_eq!(collected[0].0.as_slice(), b"grpc-status");
+        assert_eq!(collected[0].1.as_slice(), b"0");
     }
 
     #[test]

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -92,6 +92,8 @@ fn is_hop_header(name: &str) -> bool {
         name,
         "connection"
             | "keep-alive"
+            | "proxy-authenticate"
+            | "proxy-authorization"
             | "proxy-connection"
             | "transfer-encoding"
             | "upgrade"
@@ -156,6 +158,15 @@ fn should_strip_h3_response_header(
     connection_tokens.contains(name.as_str())
         || is_hop_header(name.as_str())
         || name == http::header::CONTENT_LENGTH
+}
+
+fn should_strip_bootstrap_response_header(
+    name: &http::header::HeaderName,
+    connection_tokens: &HashSet<String>,
+) -> bool {
+    connection_tokens.contains(name.as_str())
+        || is_hop_header(name.as_str())
+        || name.as_str().eq_ignore_ascii_case("alt-svc")
 }
 
 fn response_size_exceeded_after_chunk(
@@ -4419,12 +4430,13 @@ impl QUICListener {
 
                                 let status = upstream_resp.status();
                                 let mut resp_builder = Response::builder().status(status);
+                                let response_connection_tokens =
+                                    connection_header_tokens(upstream_resp.headers());
                                 for (name, value) in upstream_resp.headers() {
-                                    if name == http::header::CONNECTION
-                                        || name.as_str() == "keep-alive"
-                                        || name.as_str() == "transfer-encoding"
-                                        || name.as_str() == "alt-svc"
-                                    {
+                                    if should_strip_bootstrap_response_header(
+                                        name,
+                                        &response_connection_tokens,
+                                    ) {
                                         continue;
                                     }
                                     resp_builder = resp_builder.header(name, value);
@@ -4718,6 +4730,7 @@ mod tests {
         ConnectionRoutes, TokenBucket, abort_stream, classify_active_health_check_response,
         connection_header_tokens, purge_connection_routes, resolve_primary_from_radix_prefix,
         response_size_exceeded_after_chunk, should_strip_bootstrap_request_header,
+        should_strip_bootstrap_response_header,
         should_strip_h3_response_header, sweep_closed_connections,
     };
     type RoutingMaps = (
@@ -5042,6 +5055,67 @@ mod tests {
         let tokens = connection_header_tokens(&headers);
         let nominated = http::HeaderName::from_static("x-internal-hop");
         assert!(should_strip_h3_response_header(&nominated, &tokens));
+    }
+
+    #[test]
+    fn bootstrap_response_filter_strips_standard_hop_by_hop_headers() {
+        let tokens = HashSet::new();
+        assert!(should_strip_bootstrap_response_header(
+            &http::header::CONNECTION,
+            &tokens
+        ));
+        assert!(should_strip_bootstrap_response_header(
+            &http::header::TE,
+            &tokens
+        ));
+        assert!(should_strip_bootstrap_response_header(
+            &http::header::TRAILER,
+            &tokens
+        ));
+        assert!(should_strip_bootstrap_response_header(
+            &http::header::TRANSFER_ENCODING,
+            &tokens
+        ));
+        assert!(should_strip_bootstrap_response_header(
+            &http::header::UPGRADE,
+            &tokens
+        ));
+        assert!(should_strip_bootstrap_response_header(
+            &http::header::PROXY_AUTHENTICATE,
+            &tokens
+        ));
+        assert!(should_strip_bootstrap_response_header(
+            &http::header::PROXY_AUTHORIZATION,
+            &tokens
+        ));
+        let alt_svc = http::HeaderName::from_static("alt-svc");
+        assert!(should_strip_bootstrap_response_header(&alt_svc, &tokens));
+        let keep_alive = http::HeaderName::from_static("keep-alive");
+        assert!(should_strip_bootstrap_response_header(
+            &keep_alive,
+            &tokens
+        ));
+    }
+
+    #[test]
+    fn bootstrap_response_filter_strips_connection_nominated_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            http::header::CONNECTION,
+            HeaderValue::from_static("x-hop-token, x-alt"),
+        );
+        let tokens = connection_header_tokens(&headers);
+        let nominated = http::HeaderName::from_static("x-hop-token");
+        assert!(should_strip_bootstrap_response_header(&nominated, &tokens));
+    }
+
+    #[test]
+    fn bootstrap_response_filter_keeps_end_to_end_headers() {
+        let tokens = HashSet::new();
+        assert!(!should_strip_bootstrap_response_header(
+            &http::header::CACHE_CONTROL,
+            &tokens
+        ));
     }
 
     #[test]

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -219,7 +219,8 @@ fn is_connect_tunnel_response(method: &str, status: StatusCode) -> bool {
 
 fn can_poll_upstream_result(req: &RequestEnvelope) -> bool {
     if is_connect_method(&req.method)
-        && (req.phase == StreamPhase::ReceivingRequest || req.phase == StreamPhase::AwaitingUpstream)
+        && (req.phase == StreamPhase::ReceivingRequest
+            || req.phase == StreamPhase::AwaitingUpstream)
     {
         return true;
     }
@@ -2838,8 +2839,9 @@ impl QUICListener {
             // oversized requests must still be able to terminate with 413 even if
             // upstream produced an early response. CONNECT is the exception:
             // successful CONNECT establishes a tunnel and must not wait for request FIN.
-            let can_poll_upstream =
-                streams.get(&stream_id).is_some_and(can_poll_upstream_result);
+            let can_poll_upstream = streams
+                .get(&stream_id)
+                .is_some_and(can_poll_upstream_result);
 
             // upstream_ready: Option<UpstreamResult>
             //   None          → oneshot not yet resolved (or not eligible), skip
@@ -5002,12 +5004,12 @@ mod tests {
     use std::sync::atomic::Ordering;
 
     use super::{
-        ConnectionRoutes, TokenBucket, abort_stream, classify_active_health_check_response,
-        can_poll_upstream_result, collect_h3_trailers, connection_header_tokens,
-        is_connect_tunnel_response, purge_connection_routes,
-        resolve_primary_from_radix_prefix, response_size_exceeded_after_chunk,
-        should_strip_bootstrap_request_header, should_strip_bootstrap_response_header,
-        should_strip_h3_response_header, sweep_closed_connections,
+        ConnectionRoutes, TokenBucket, abort_stream, can_poll_upstream_result,
+        classify_active_health_check_response, collect_h3_trailers, connection_header_tokens,
+        is_connect_tunnel_response, purge_connection_routes, resolve_primary_from_radix_prefix,
+        response_size_exceeded_after_chunk, should_strip_bootstrap_request_header,
+        should_strip_bootstrap_response_header, should_strip_h3_response_header,
+        sweep_closed_connections,
     };
     type RoutingMaps = (
         HashMap<Arc<[u8]>, Arc<[u8]>>,
@@ -5581,8 +5583,14 @@ mod tests {
     #[test]
     fn connect_tunnel_response_detected_only_for_success_status() {
         assert!(is_connect_tunnel_response("CONNECT", StatusCode::OK));
-        assert!(is_connect_tunnel_response("connect", StatusCode::NO_CONTENT));
-        assert!(!is_connect_tunnel_response("CONNECT", StatusCode::BAD_GATEWAY));
+        assert!(is_connect_tunnel_response(
+            "connect",
+            StatusCode::NO_CONTENT
+        ));
+        assert!(!is_connect_tunnel_response(
+            "CONNECT",
+            StatusCode::BAD_GATEWAY
+        ));
         assert!(!is_connect_tunnel_response("GET", StatusCode::OK));
     }
 

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -4883,10 +4883,17 @@ static FALLBACK_RT_THREADS: AtomicUsize = AtomicUsize::new(2);
 mod tests {
     use std::{
         collections::HashMap,
+        path::Path,
         sync::{Arc, RwLock},
     };
 
-    use spooky_config::config::{Backend, LoadBalancing, RouteMatch, Upstream};
+    use rcgen::{Certificate, CertificateParams, SanType};
+    use spooky_config::config::{
+        Backend, ClientAuth, Config as SpookyConfigConfig, Listen, LoadBalancing, Log,
+        Observability, Performance, Resilience, RouteMatch, Security, Tls, TlsCertificate,
+        Upstream, UpstreamTls,
+    };
+    use tempfile::tempdir;
 
     use crate::REQUEST_ID_COUNTER;
     use crate::cid_radix::CidRadix;
@@ -4943,6 +4950,135 @@ mod tests {
                 },
             ],
         }
+    }
+
+    fn write_test_cert_for_name(
+        dir: &Path,
+        cert_name: &str,
+        dns_name: &str,
+    ) -> (String, String) {
+        let mut params = CertificateParams::new(vec![dns_name.to_string()]);
+        params
+            .subject_alt_names
+            .push(SanType::DnsName(dns_name.to_string()));
+        let cert = Certificate::from_params(params).expect("failed to build cert");
+
+        let cert_path = dir.join(format!("{cert_name}.pem"));
+        let key_path = dir.join(format!("{cert_name}.key.pem"));
+
+        std::fs::write(&cert_path, cert.serialize_pem().expect("serialize cert"))
+            .expect("write cert");
+        std::fs::write(&key_path, cert.serialize_private_key_pem()).expect("write key");
+        (
+            cert_path.to_string_lossy().to_string(),
+            key_path.to_string_lossy().to_string(),
+        )
+    }
+
+    fn tls_test_config(cert: String, key: String, certificates: Vec<TlsCertificate>) -> SpookyConfigConfig {
+        let mut upstreams = HashMap::new();
+        upstreams.insert("api".to_string(), test_upstream("round-robin"));
+        SpookyConfigConfig {
+            version: 1,
+            listen: Listen {
+                protocol: "http3".to_string(),
+                port: 9889,
+                address: "127.0.0.1".to_string(),
+                tls: Tls {
+                    cert,
+                    key,
+                    certificates,
+                    client_auth: ClientAuth::default(),
+                },
+            },
+            upstream: upstreams,
+            load_balancing: Some(LoadBalancing {
+                lb_type: "round-robin".to_string(),
+                key: None,
+            }),
+            upstream_tls: UpstreamTls::default(),
+            log: Log::default(),
+            performance: Performance::default(),
+            observability: Observability::default(),
+            resilience: Resilience::default(),
+            security: Security::default(),
+        }
+    }
+
+    #[test]
+    fn default_tls_pair_uses_first_sni_entry_when_legacy_pair_is_missing() {
+        let dir = tempdir().expect("tempdir");
+        let (api_cert, api_key) = write_test_cert_for_name(dir.path(), "api", "api.example.com");
+        let (www_cert, www_key) = write_test_cert_for_name(dir.path(), "www", "www.example.com");
+        let config = tls_test_config(
+            String::new(),
+            String::new(),
+            vec![
+                TlsCertificate {
+                    server_name: "api.example.com".to_string(),
+                    cert: api_cert.clone(),
+                    key: api_key.clone(),
+                },
+                TlsCertificate {
+                    server_name: "www.example.com".to_string(),
+                    cert: www_cert,
+                    key: www_key,
+                },
+            ],
+        );
+
+        let pair = super::QUICListener::default_tls_cert_pair(&config).expect("default pair");
+        assert_eq!(pair.0, api_cert);
+        assert_eq!(pair.1, api_key);
+    }
+
+    #[test]
+    fn build_server_tls_acceptor_accepts_sni_certs_without_legacy_pair() {
+        let dir = tempdir().expect("tempdir");
+        let (api_cert, api_key) = write_test_cert_for_name(dir.path(), "api", "api.example.com");
+        let config = tls_test_config(
+            String::new(),
+            String::new(),
+            vec![TlsCertificate {
+                server_name: "api.example.com".to_string(),
+                cert: api_cert,
+                key: api_key,
+            }],
+        );
+
+        let acceptor = super::QUICListener::build_server_tls_acceptor(
+            &config,
+            false,
+            vec![b"h2".to_vec()],
+        );
+        assert!(acceptor.is_ok());
+    }
+
+    #[test]
+    fn build_server_tls_acceptor_rejects_mismatched_sni_certificate_mapping() {
+        let dir = tempdir().expect("tempdir");
+        let (api_cert, api_key) = write_test_cert_for_name(dir.path(), "api", "api.example.com");
+        let config = tls_test_config(
+            String::new(),
+            String::new(),
+            vec![TlsCertificate {
+                server_name: "other.example.com".to_string(),
+                cert: api_cert,
+                key: api_key,
+            }],
+        );
+
+        let err = super::QUICListener::build_server_tls_acceptor(
+            &config,
+            false,
+            vec![b"h2".to_vec()],
+        )
+        .expect_err("mismatched SNI cert mapping should fail");
+        assert!(
+            err.to_string()
+                .contains("failed to add SNI certificate mapping"),
+            "unexpected error: {err}"
+        );
     }
 
     type TestRoutingContext = (

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -36,7 +36,9 @@ use rustls::{
 };
 use serde_json::json;
 use socket2::{Domain, Protocol, Socket, Type};
-use spooky_bridge::h3_to_h2::{ForwardedContext, build_h2_request_for_endpoint};
+use spooky_bridge::h3_to_h2::{
+    ForwardedContext, build_h2_request_for_endpoint_with_host_policy, resolve_upstream_host_value,
+};
 use spooky_errors::{PoolError, ProxyError, is_retryable};
 use spooky_lb::{HealthFailureReason, HealthTransition, UpstreamPool};
 use spooky_transport::h2_client::{H2Client, TlsClientConfig};
@@ -52,7 +54,7 @@ use tracing::{Instrument, info_span};
 
 use spooky_config::{
     backend_endpoint::{BackendEndpoint, BackendScheme},
-    config::Config as SpookyConfig,
+    config::{Config as SpookyConfig, UpstreamHostPolicy},
 };
 
 use crate::{
@@ -579,6 +581,13 @@ impl QUICListener {
                     })
                     .collect(),
             ),
+            upstream_host_policies: Arc::new(
+                config
+                    .upstream
+                    .iter()
+                    .map(|(name, upstream)| (name.clone(), upstream.host_policy.clone()))
+                    .collect(),
+            ),
             upstream_pools,
             upstream_inflight,
             global_inflight: Arc::new(Semaphore::new(global_inflight_limit)),
@@ -701,6 +710,7 @@ impl QUICListener {
             h3_config,
             h2_pool: Arc::clone(&shared_state.h2_pool),
             backend_endpoints: Arc::clone(&shared_state.backend_endpoints),
+            upstream_host_policies: Arc::clone(&shared_state.upstream_host_policies),
             upstream_pools: shared_state.upstream_pools.clone(),
             upstream_inflight: shared_state.upstream_inflight.clone(),
             global_inflight: Arc::clone(&shared_state.global_inflight),
@@ -1514,6 +1524,7 @@ impl QUICListener {
                 &mut connection,
                 Arc::clone(&h2_pool),
                 Arc::clone(&self.backend_endpoints),
+                Arc::clone(&self.upstream_host_policies),
                 &self.upstream_pools,
                 &self.upstream_inflight,
                 Arc::clone(&self.global_inflight),
@@ -1759,6 +1770,7 @@ impl QUICListener {
         connection: &mut QuicConnection,
         h2_pool: Arc<H2Pool>,
         backend_endpoints: Arc<HashMap<String, BackendEndpoint>>,
+        upstream_host_policies: Arc<HashMap<String, UpstreamHostPolicy>>,
         upstream_pools: &HashMap<String, Arc<RwLock<UpstreamPool>>>,
         upstream_inflight: &HashMap<String, Arc<Semaphore>>,
         global_inflight: Arc<Semaphore>,
@@ -2146,8 +2158,13 @@ impl QUICListener {
                                     continue;
                                 }
                             };
-                            let request = match build_h2_request_for_endpoint(
+                            let host_policy = upstream_host_policies
+                                .get(&upstream_name)
+                                .cloned()
+                                .unwrap_or_default();
+                            let request = match build_h2_request_for_endpoint_with_host_policy(
                                 &backend_endpoint,
+                                &host_policy,
                                 &method,
                                 &path,
                                 &list,
@@ -2205,6 +2222,7 @@ impl QUICListener {
                                     client_addr: connection.peer_address,
                                     request_id,
                                     traceparent: traceparent.as_deref().map(Arc::<str>::from),
+                                    host_policy: host_policy.clone(),
                                 })
                             });
                             let trace_span_for_upstream = trace_span.clone();
@@ -4186,6 +4204,7 @@ impl QUICListener {
 
         let h2_pool = Arc::clone(&shared_state.h2_pool);
         let backend_endpoints = Arc::clone(&shared_state.backend_endpoints);
+        let upstream_host_policies = Arc::clone(&shared_state.upstream_host_policies);
         let metrics = Arc::clone(&shared_state.metrics);
         let resilience = Arc::clone(&shared_state.resilience);
         let upstream_pools = shared_state.upstream_pools.clone();
@@ -4258,6 +4277,7 @@ impl QUICListener {
                 let alt_svc = alt_svc_value.clone();
                 let h2_pool = Arc::clone(&h2_pool);
                 let backend_endpoints = Arc::clone(&backend_endpoints);
+                let upstream_host_policies = Arc::clone(&upstream_host_policies);
                 let metrics = Arc::clone(&metrics);
                 let resilience = Arc::clone(&resilience);
                 let upstream_pools = upstream_pools.clone();
@@ -4287,6 +4307,7 @@ impl QUICListener {
                             let alt = alt_svc_conn.clone();
                             let h2_pool = Arc::clone(&h2_pool);
                             let backend_endpoints = Arc::clone(&backend_endpoints);
+                            let upstream_host_policies = Arc::clone(&upstream_host_policies);
                             let metrics = Arc::clone(&metrics);
                             let resilience = Arc::clone(&resilience);
                             let upstream_pools = upstream_pools.clone();
@@ -4359,8 +4380,8 @@ impl QUICListener {
                                     &routing_index,
                                     Some(&lb_header_lookup),
                                 );
-                                let backend_addr = match resolved {
-                                    Ok(value) => value.backend_addr,
+                                let (backend_addr, upstream_name) = match resolved {
+                                    Ok(value) => (value.backend_addr, value.upstream_name),
                                     Err(ProxyError::Transport(reason)) => {
                                         let (status, body) =
                                             bootstrap_resolution_error_response(&reason);
@@ -4417,6 +4438,36 @@ impl QUICListener {
                                     }
                                 };
 
+                                let host_policy = upstream_host_policies
+                                    .get(&upstream_name)
+                                    .cloned()
+                                    .unwrap_or_default();
+                                let request_host = req
+                                    .headers()
+                                    .get(http::header::HOST)
+                                    .and_then(|value| value.to_str().ok());
+                                let upstream_host = match resolve_upstream_host_value(
+                                    &endpoint,
+                                    &host_policy,
+                                    authority.as_deref(),
+                                    request_host,
+                                ) {
+                                    Ok(host) => host,
+                                    Err(_) => {
+                                        return Ok(Response::builder()
+                                            .status(StatusCode::BAD_REQUEST)
+                                            .header("alt-svc", &alt)
+                                            .body(boxed_full(Bytes::from_static(
+                                                b"invalid host policy\n",
+                                            )))
+                                            .unwrap_or_else(|_| {
+                                                Response::new(boxed_full(Bytes::from_static(
+                                                    b"error\n",
+                                                )))
+                                            }));
+                                    }
+                                };
+
                                 let mut upstream_req =
                                     Request::builder().method(method.as_str()).uri(upstream_uri);
 
@@ -4455,10 +4506,8 @@ impl QUICListener {
                                     }
                                     upstream_req = upstream_req.header(name, value);
                                 }
-                                upstream_req = upstream_req.header(
-                                    http::header::HOST,
-                                    authority.as_deref().unwrap_or(endpoint.authority()),
-                                );
+                                upstream_req =
+                                    upstream_req.header(http::header::HOST, upstream_host);
                                 upstream_req = upstream_req.header(
                                     "forwarded",
                                     format!(
@@ -5031,6 +5080,7 @@ mod tests {
                 lb_type: lb_type.to_string(),
                 key: lb_key.map(str::to_string),
             },
+            host_policy: Default::default(),
             route: RouteMatch {
                 host: None,
                 path_prefix: Some("/api".to_string()),

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -4730,8 +4730,8 @@ mod tests {
         ConnectionRoutes, TokenBucket, abort_stream, classify_active_health_check_response,
         connection_header_tokens, purge_connection_routes, resolve_primary_from_radix_prefix,
         response_size_exceeded_after_chunk, should_strip_bootstrap_request_header,
-        should_strip_bootstrap_response_header,
-        should_strip_h3_response_header, sweep_closed_connections,
+        should_strip_bootstrap_response_header, should_strip_h3_response_header,
+        sweep_closed_connections,
     };
     type RoutingMaps = (
         HashMap<Arc<[u8]>, Arc<[u8]>>,
@@ -5091,10 +5091,7 @@ mod tests {
         let alt_svc = http::HeaderName::from_static("alt-svc");
         assert!(should_strip_bootstrap_response_header(&alt_svc, &tokens));
         let keep_alive = http::HeaderName::from_static("keep-alive");
-        assert!(should_strip_bootstrap_response_header(
-            &keep_alive,
-            &tokens
-        ));
+        assert!(should_strip_bootstrap_response_header(&keep_alive, &tokens));
     }
 
     #[test]

--- a/crates/edge/src/quic_listener/validation.rs
+++ b/crates/edge/src/quic_listener/validation.rs
@@ -261,9 +261,9 @@ fn validate_request_parts(
         && let (Some(authority_value), Some(host_value)) = (authority.as_deref(), host.as_deref())
     {
         let normalized_authority = normalize_host_for_routing(authority_value)
-            .unwrap_or_else(|| authority_value.to_ascii_lowercase());
+            .unwrap_or_else(|| authority_value.to_ascii_lowercase().into());
         let normalized_host = normalize_host_for_routing(host_value)
-            .unwrap_or_else(|| host_value.to_ascii_lowercase());
+            .unwrap_or_else(|| host_value.to_ascii_lowercase().into());
         if normalized_authority != normalized_host {
             return Err((
                 http::StatusCode::BAD_REQUEST,

--- a/crates/edge/src/quic_listener/validation.rs
+++ b/crates/edge/src/quic_listener/validation.rs
@@ -129,9 +129,25 @@ pub(super) fn validate_request_headers(
             ));
         }
     };
-    let path = match path {
-        Some(path) => path,
-        None => {
+    let is_connect = method.eq_ignore_ascii_case("CONNECT");
+    let path = match (is_connect, path) {
+        (true, Some(path)) if path.is_empty() => {
+            return Err((
+                http::StatusCode::BAD_REQUEST,
+                b"invalid CONNECT :path header\n",
+                false,
+            ));
+        }
+        (true, Some(_)) => {
+            return Err((
+                http::StatusCode::BAD_REQUEST,
+                b"invalid CONNECT :path header\n",
+                false,
+            ));
+        }
+        (true, None) => "/".to_string(),
+        (false, Some(path)) => path,
+        (false, None) => {
             return Err((
                 http::StatusCode::BAD_REQUEST,
                 b"missing :path header\n",
@@ -151,6 +167,8 @@ pub(super) fn validate_request_headers(
             invalid_method: b"invalid :method header\n",
             invalid_path: b"invalid :path header\n",
             authority_mismatch: b":authority and host headers must match\n",
+            connect_path_not_allowed: b"invalid CONNECT :path header\n",
+            connect_authority_required: b"CONNECT requires authority host:port\n",
         },
     )
 }
@@ -221,6 +239,8 @@ pub(super) fn validate_http_request(
             invalid_method: b"invalid method header\n",
             invalid_path: b"invalid path header\n",
             authority_mismatch: b"authority and host headers must match\n",
+            connect_path_not_allowed: b"invalid CONNECT path\n",
+            connect_authority_required: b"CONNECT requires authority host:port\n",
         },
     )
 }
@@ -238,6 +258,8 @@ struct RequestPartErrors {
     invalid_method: &'static [u8],
     invalid_path: &'static [u8],
     authority_mismatch: &'static [u8],
+    connect_path_not_allowed: &'static [u8],
+    connect_authority_required: &'static [u8],
 }
 
 fn validate_request_parts(
@@ -249,11 +271,20 @@ fn validate_request_parts(
     resilience: &RuntimeResilience,
     errors: RequestPartErrors,
 ) -> Result<RequestValidationResult, (http::StatusCode, &'static [u8], bool)> {
+    let is_connect = method.eq_ignore_ascii_case("CONNECT");
     if method.trim().is_empty() || method.as_bytes().iter().any(|b| b.is_ascii_whitespace()) {
         return Err((http::StatusCode::BAD_REQUEST, errors.invalid_method, false));
     }
 
-    if path.is_empty() || !path.starts_with('/') {
+    if is_connect {
+        if !path.is_empty() && path != "/" {
+            return Err((
+                http::StatusCode::BAD_REQUEST,
+                errors.connect_path_not_allowed,
+                false,
+            ));
+        }
+    } else if path.is_empty() || !path.starts_with('/') {
         return Err((http::StatusCode::BAD_REQUEST, errors.invalid_path, false));
     }
 
@@ -281,7 +312,20 @@ fn validate_request_parts(
         ));
     }
 
-    if resilience.path_denied(&path) {
+    if is_connect {
+        let connect_authority = authority.as_deref().or(host.as_deref()).ok_or((
+            http::StatusCode::BAD_REQUEST,
+            errors.connect_authority_required,
+            false,
+        ))?;
+        if !resilience.connect_allowed(connect_authority) {
+            return Err((
+                http::StatusCode::FORBIDDEN,
+                b"CONNECT target denied by policy\n",
+                true,
+            ));
+        }
+    } else if resilience.path_denied(&path) {
         return Err((
             http::StatusCode::FORBIDDEN,
             b"request path blocked by policy\n",
@@ -561,5 +605,61 @@ mod tests {
         assert_eq!(err.0, http::StatusCode::BAD_REQUEST);
         assert_eq!(err.1, b"conflicting content-length header\n");
         assert!(!err.2);
+    }
+
+    #[test]
+    fn connect_without_path_is_accepted_when_policy_allows_target() {
+        let mut cfg = Resilience::default();
+        cfg.protocol.allow_connect = true;
+        cfg.protocol.connect_allowed_authorities = vec!["proxy.example.com:443".to_string()];
+        let resilience = RuntimeResilience::from_config(&cfg, 1024);
+        let headers = vec![
+            h3_header(b":method", b"CONNECT"),
+            h3_header(b":authority", b"proxy.example.com:443"),
+        ];
+
+        let request =
+            validate_request_headers(&headers, &resilience).expect("CONNECT request should pass");
+        assert_eq!(request.method, "CONNECT");
+        assert_eq!(request.path, "/");
+        assert_eq!(request.authority.as_deref(), Some("proxy.example.com:443"));
+    }
+
+    #[test]
+    fn connect_missing_authority_is_rejected() {
+        let mut cfg = Resilience::default();
+        cfg.protocol.allow_connect = true;
+        let resilience = RuntimeResilience::from_config(&cfg, 1024);
+        let headers = vec![h3_header(b":method", b"CONNECT")];
+
+        let err = validate_request_headers(&headers, &resilience)
+            .expect_err("CONNECT without authority must be rejected");
+        assert_eq!(err.0, http::StatusCode::BAD_REQUEST);
+        assert_eq!(err.1, b"CONNECT requires authority host:port\n");
+        assert!(!err.2);
+    }
+
+    #[test]
+    fn connect_is_denied_when_policy_disables_or_blocks_target() {
+        let resilience = runtime_resilience();
+        let headers = vec![
+            h3_header(b":method", b"CONNECT"),
+            h3_header(b":authority", b"proxy.example.com:443"),
+        ];
+        let err = validate_request_headers(&headers, &resilience)
+            .expect_err("CONNECT should be denied by default policy");
+        assert_eq!(err.0, http::StatusCode::FORBIDDEN);
+        assert_eq!(err.1, b"CONNECT target denied by policy\n");
+        assert!(err.2);
+
+        let mut cfg = Resilience::default();
+        cfg.protocol.allow_connect = true;
+        cfg.protocol.connect_allowed_ports = vec![8443];
+        let resilience = RuntimeResilience::from_config(&cfg, 1024);
+        let err = validate_request_headers(&headers, &resilience)
+            .expect_err("CONNECT should be denied when port is not allowlisted");
+        assert_eq!(err.0, http::StatusCode::FORBIDDEN);
+        assert_eq!(err.1, b"CONNECT target denied by policy\n");
+        assert!(err.2);
     }
 }

--- a/crates/edge/src/resilience.rs
+++ b/crates/edge/src/resilience.rs
@@ -441,12 +441,15 @@ pub struct RuntimeResilience {
     pub max_headers_count: usize,
     pub max_headers_bytes: usize,
     pub enforce_authority_host_match: bool,
+    pub allow_connect: bool,
     pub hedging_enabled: bool,
     pub hedging_delay: Duration,
     hedge_safe_methods: HashSet<String>,
     early_data_safe_methods: HashSet<String>,
     allowed_methods: HashSet<String>,
     denied_path_prefixes: Vec<String>,
+    connect_allowed_ports: HashSet<u16>,
+    connect_allowed_authorities: HashSet<String>,
     route_allowlist: HashSet<String>,
 }
 
@@ -510,6 +513,18 @@ impl RuntimeResilience {
             .iter()
             .cloned()
             .collect::<HashSet<_>>();
+        let connect_allowed_ports = config
+            .protocol
+            .connect_allowed_ports
+            .iter()
+            .copied()
+            .collect::<HashSet<_>>();
+        let connect_allowed_authorities = config
+            .protocol
+            .connect_allowed_authorities
+            .iter()
+            .filter_map(|authority| normalize_connect_authority(authority))
+            .collect::<HashSet<_>>();
 
         Self {
             adaptive_admission: admission,
@@ -522,12 +537,15 @@ impl RuntimeResilience {
             max_headers_count: config.protocol.max_headers_count.max(1),
             max_headers_bytes: config.protocol.max_headers_bytes.max(1),
             enforce_authority_host_match: config.protocol.enforce_authority_host_match,
+            allow_connect: config.protocol.allow_connect,
             hedging_enabled: config.hedging.enabled,
             hedging_delay: Duration::from_millis(config.hedging.delay_ms),
             hedge_safe_methods,
             early_data_safe_methods,
             allowed_methods,
             denied_path_prefixes: config.protocol.denied_path_prefixes.clone(),
+            connect_allowed_ports,
+            connect_allowed_authorities,
             route_allowlist,
         }
     }
@@ -562,6 +580,73 @@ impl RuntimeResilience {
             .iter()
             .any(|prefix| path.starts_with(prefix))
     }
+
+    pub fn connect_allowed(&self, authority: &str) -> bool {
+        if !self.allow_connect {
+            return false;
+        }
+        let Some(normalized_authority) = normalize_connect_authority(authority) else {
+            return false;
+        };
+        let Some(port) = connect_authority_port(&normalized_authority) else {
+            return false;
+        };
+        if !self.connect_allowed_ports.is_empty() && !self.connect_allowed_ports.contains(&port) {
+            return false;
+        }
+        if self.connect_allowed_authorities.is_empty() {
+            return true;
+        }
+        self.connect_allowed_authorities
+            .contains(&normalized_authority)
+    }
+}
+
+fn normalize_connect_authority(authority: &str) -> Option<String> {
+    let trimmed = authority.trim();
+    if trimmed.is_empty() || trimmed.chars().any(char::is_whitespace) {
+        return None;
+    }
+
+    if let Some(rest) = trimmed.strip_prefix('[') {
+        let end = rest.find(']')?;
+        let host = &rest[..end];
+        if host.is_empty() {
+            return None;
+        }
+        let suffix = &rest[end + 1..];
+        if !suffix.starts_with(':') || suffix.len() <= 1 {
+            return None;
+        }
+        let port = suffix[1..].parse::<u16>().ok().filter(|value| *value > 0)?;
+        return Some(format!(
+            "[{}]:{}",
+            host.trim_end_matches('.').to_ascii_lowercase(),
+            port
+        ));
+    }
+
+    let (host, port) = trimmed.rsplit_once(':')?;
+    if host.is_empty() || host.contains(':') {
+        return None;
+    }
+    let port = port.parse::<u16>().ok().filter(|value| *value > 0)?;
+    Some(format!(
+        "{}:{}",
+        host.trim_end_matches('.').to_ascii_lowercase(),
+        port
+    ))
+}
+
+fn connect_authority_port(normalized_authority: &str) -> Option<u16> {
+    if normalized_authority.starts_with('[') {
+        let end = normalized_authority.find(']')?;
+        let suffix = normalized_authority.get(end + 1..)?;
+        return suffix.strip_prefix(':')?.parse::<u16>().ok();
+    }
+    normalized_authority
+        .rsplit_once(':')
+        .and_then(|(_, port)| port.parse::<u16>().ok())
 }
 
 #[cfg(test)]
@@ -641,6 +726,9 @@ mod tests {
         cfg.protocol.denied_path_prefixes = vec!["/admin".to_string()];
         cfg.protocol.allow_0rtt = true;
         cfg.protocol.early_data_safe_methods = vec!["GET".to_string()];
+        cfg.protocol.allow_connect = true;
+        cfg.protocol.connect_allowed_ports = vec![443];
+        cfg.protocol.connect_allowed_authorities = vec!["proxy.example.com:443".to_string()];
 
         let runtime = RuntimeResilience::from_config(&cfg, 64);
         assert!(runtime.method_allowed("GET"));
@@ -649,5 +737,8 @@ mod tests {
         assert!(!runtime.path_denied("/api"));
         assert!(runtime.early_data_allowed_for("GET"));
         assert!(!runtime.early_data_allowed_for("POST"));
+        assert!(runtime.connect_allowed("proxy.example.com:443"));
+        assert!(!runtime.connect_allowed("proxy.example.com:8443"));
+        assert!(!runtime.connect_allowed("other.example.com:443"));
     }
 }

--- a/crates/edge/src/route_index.rs
+++ b/crates/edge/src/route_index.rs
@@ -40,6 +40,39 @@ pub(crate) fn normalize_host_for_routing(raw: &str) -> Option<String> {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum ConfiguredHostPattern {
+    Exact(String),
+    WildcardSuffix(String),
+}
+
+fn parse_configured_host_pattern(raw: &str) -> Option<ConfiguredHostPattern> {
+    let normalized = normalize_host_for_routing(raw)?;
+    let Some(wildcard_suffix) = normalized.strip_prefix("*.") else {
+        return Some(ConfiguredHostPattern::Exact(normalized));
+    };
+    if wildcard_suffix.is_empty() || wildcard_suffix.contains('*') {
+        return Some(ConfiguredHostPattern::Exact(format!("*.{wildcard_suffix}")));
+    }
+    Some(ConfiguredHostPattern::WildcardSuffix(
+        wildcard_suffix.to_string(),
+    ))
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+enum HostMatchKind {
+    Default,
+    Wildcard,
+    Exact,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct RouteCandidate {
+    route: IndexedRoute,
+    host_match_kind: HostMatchKind,
+    wildcard_suffix_len: usize,
+}
+
 /// Route precedence (deterministic):
 /// 1) Longest matching path_prefix wins.
 /// 2) On equal path length, host-specific routes win over host-agnostic routes.
@@ -62,6 +95,8 @@ enum RoutePreference {
     KeepCurrent,
     TakeCandidatePathLen,
     TakeCandidateHostSpecific,
+    TakeCandidateExactHost,
+    TakeCandidateWildcardSpecificity,
     TakeCandidateMethodSpecific,
     TakeCandidateLexicalOrder,
 }
@@ -228,6 +263,7 @@ fn prefix_boundary_matches(path: &str, prefix_len: usize) -> bool {
 
 pub(crate) struct RouteIndex {
     host_tries: HashMap<String, RouteTrie>,
+    wildcard_host_tries: HashMap<String, RouteTrie>,
     default_trie: RouteTrie,
     default_max_path_len: usize,
     upstream_names: Vec<String>,
@@ -237,6 +273,7 @@ pub(crate) struct RouteIndex {
 impl RouteIndex {
     pub(crate) fn from_upstreams(upstreams: &HashMap<String, Upstream>) -> Self {
         let mut host_tries = HashMap::new();
+        let mut wildcard_host_tries = HashMap::new();
         let mut default_trie = RouteTrie::default();
         let mut default_max_path_len = 0usize;
         let mut upstream_names = Vec::with_capacity(upstreams.len());
@@ -274,21 +311,17 @@ impl RouteIndex {
             };
 
             match upstream.route.host.as_deref() {
-                Some(host) => {
-                    let normalized_host = parsed_host_for_routing(host)
-                        .map(|value| {
-                            if host_has_uppercase_ascii(value) {
-                                value.to_ascii_lowercase()
-                            } else {
-                                value.to_string()
-                            }
-                        })
-                        .unwrap_or_else(|| host.to_ascii_lowercase());
-                    host_tries
+                Some(host) => match parse_configured_host_pattern(host) {
+                    Some(ConfiguredHostPattern::WildcardSuffix(suffix)) => wildcard_host_tries
+                        .entry(suffix)
+                        .or_insert_with(RouteTrie::default)
+                        .insert(upstream.route.path_prefix.as_deref(), route),
+                    Some(ConfiguredHostPattern::Exact(normalized_host)) => host_tries
                         .entry(normalized_host)
                         .or_insert_with(RouteTrie::default)
-                        .insert(upstream.route.path_prefix.as_deref(), route)
-                }
+                        .insert(upstream.route.path_prefix.as_deref(), route),
+                    None => {}
+                },
                 None => {
                     default_max_path_len = default_max_path_len.max(path_len);
                     default_trie.insert(upstream.route.path_prefix.as_deref(), route);
@@ -298,6 +331,7 @@ impl RouteIndex {
 
         Self {
             host_tries,
+            wildcard_host_tries,
             default_trie,
             default_max_path_len,
             upstream_names,
@@ -315,29 +349,27 @@ impl RouteIndex {
         host: Option<&str>,
         method: Option<&str>,
     ) -> Option<&'a str> {
-        let host_best = host.and_then(|raw_host| {
-            let parsed_host = parsed_host_for_routing(raw_host)?;
-            let host_trie = if host_has_uppercase_ascii(parsed_host) {
-                let normalized = parsed_host.to_ascii_lowercase();
-                self.host_tries.get(normalized.as_str())
-            } else {
-                self.host_tries.get(parsed_host)
-            }?;
-            host_trie.longest_prefix(path, method, &self.upstream_methods)
-        });
+        let host_best = host
+            .and_then(normalize_host_for_routing)
+            .and_then(|normalized_host| self.lookup_host_candidate(path, normalized_host, method));
 
         if let Some(best) = host_best
-            && best.path_len >= self.default_max_path_len
+            && best.route.path_len >= self.default_max_path_len
         {
-            return Some(self.upstream_names[best.upstream_idx].as_str());
+            return Some(self.upstream_names[best.route.upstream_idx].as_str());
         }
 
-        let best = prefer_route(
+        let best = prefer_route_candidate(
             self.default_trie
-                .longest_prefix(path, method, &self.upstream_methods),
+                .longest_prefix(path, method, &self.upstream_methods)
+                .map(|route| RouteCandidate {
+                    route,
+                    host_match_kind: HostMatchKind::Default,
+                    wildcard_suffix_len: 0,
+                }),
             host_best,
         );
-        best.map(|route| self.upstream_names[route.upstream_idx].as_str())
+        best.map(|candidate| self.upstream_names[candidate.route.upstream_idx].as_str())
     }
 
     #[allow(dead_code)]
@@ -438,6 +470,46 @@ impl RouteIndex {
             (None, None) => None,
         }
     }
+
+    fn lookup_host_candidate(
+        &self,
+        path: &str,
+        normalized_host: String,
+        method: Option<&str>,
+    ) -> Option<RouteCandidate> {
+        let exact_best = self
+            .host_tries
+            .get(normalized_host.as_str())
+            .and_then(|host_trie| host_trie.longest_prefix(path, method, &self.upstream_methods))
+            .map(|route| RouteCandidate {
+                route,
+                host_match_kind: HostMatchKind::Exact,
+                wildcard_suffix_len: 0,
+            });
+
+        let mut wildcard_best: Option<RouteCandidate> = None;
+        let mut remaining = normalized_host.as_str();
+        while let Some(dot_idx) = remaining.find('.') {
+            let suffix = &remaining[dot_idx + 1..];
+            if suffix.is_empty() {
+                break;
+            }
+
+            if let Some(trie) = self.wildcard_host_tries.get(suffix) {
+                let candidate = trie
+                    .longest_prefix(path, method, &self.upstream_methods)
+                    .map(|route| RouteCandidate {
+                        route,
+                        host_match_kind: HostMatchKind::Wildcard,
+                        wildcard_suffix_len: suffix.len(),
+                    });
+                wildcard_best = prefer_route_candidate(wildcard_best, candidate);
+            }
+            remaining = suffix;
+        }
+
+        prefer_route_candidate(wildcard_best, exact_best)
+    }
 }
 
 #[inline(always)]
@@ -455,6 +527,62 @@ fn prefer_route(
             | RoutePreference::TakeCandidateMethodSpecific
             | RoutePreference::TakeCandidateLexicalOrder => Some(candidate),
         },
+    }
+}
+
+#[inline(always)]
+fn prefer_route_candidate(
+    current: Option<RouteCandidate>,
+    candidate: Option<RouteCandidate>,
+) -> Option<RouteCandidate> {
+    match (current, candidate) {
+        (None, None) => None,
+        (Some(route), None) | (None, Some(route)) => Some(route),
+        (Some(current), Some(candidate)) => match compare_route_candidate(current, candidate) {
+            RoutePreference::KeepCurrent => Some(current),
+            RoutePreference::TakeCandidatePathLen
+            | RoutePreference::TakeCandidateHostSpecific
+            | RoutePreference::TakeCandidateExactHost
+            | RoutePreference::TakeCandidateWildcardSpecificity
+            | RoutePreference::TakeCandidateMethodSpecific
+            | RoutePreference::TakeCandidateLexicalOrder => Some(candidate),
+        },
+    }
+}
+
+#[inline(always)]
+fn compare_route_candidate(current: RouteCandidate, candidate: RouteCandidate) -> RoutePreference {
+    if candidate.route.path_len > current.route.path_len {
+        RoutePreference::TakeCandidatePathLen
+    } else if candidate.route.path_len == current.route.path_len
+        && candidate.route.host_specific
+        && !current.route.host_specific
+    {
+        RoutePreference::TakeCandidateHostSpecific
+    } else if candidate.route.path_len == current.route.path_len
+        && candidate.host_match_kind > current.host_match_kind
+    {
+        RoutePreference::TakeCandidateExactHost
+    } else if candidate.route.path_len == current.route.path_len
+        && candidate.host_match_kind == HostMatchKind::Wildcard
+        && current.host_match_kind == HostMatchKind::Wildcard
+        && candidate.wildcard_suffix_len > current.wildcard_suffix_len
+    {
+        RoutePreference::TakeCandidateWildcardSpecificity
+    } else if candidate.route.path_len == current.route.path_len
+        && candidate.host_match_kind == current.host_match_kind
+        && candidate.route.method_specific
+        && !current.route.method_specific
+    {
+        RoutePreference::TakeCandidateMethodSpecific
+    } else if candidate.route.path_len == current.route.path_len
+        && candidate.host_match_kind == current.host_match_kind
+        && candidate.route.method_specific == current.route.method_specific
+        && candidate.route.order < current.route.order
+    {
+        RoutePreference::TakeCandidateLexicalOrder
+    } else {
+        RoutePreference::KeepCurrent
     }
 }
 

--- a/crates/edge/src/route_index.rs
+++ b/crates/edge/src/route_index.rs
@@ -1138,7 +1138,7 @@ mod tests {
             index
                 .lookup_with_decision("/api/users", Some("x.a.example.com"))
                 .map(|decision| decision.reason),
-            Some(RouteDecisionReason::WildcardSpecificityTieBreak)
+            Some(RouteDecisionReason::HostPathLongerOrEqual)
         );
     }
 

--- a/crates/edge/src/route_index.rs
+++ b/crates/edge/src/route_index.rs
@@ -1123,6 +1123,7 @@ mod tests {
             "narrow".to_string(),
             test_upstream(Some("*.a.example.com"), Some("/api")),
         );
+        upstreams.insert("default".to_string(), test_upstream(None, Some("/")));
         let index = RouteIndex::from_upstreams(&upstreams);
 
         assert_eq!(

--- a/crates/edge/src/route_index.rs
+++ b/crates/edge/src/route_index.rs
@@ -107,6 +107,8 @@ pub(crate) enum RouteDecisionReason {
     HostPathLongerOrEqual,
     DefaultPathLonger,
     HostSpecificTieBreak,
+    ExactHostTieBreak,
+    WildcardSpecificityTieBreak,
     MethodSpecificTieBreak,
     LexicalTieBreak,
 }
@@ -387,28 +389,32 @@ impl RouteIndex {
         host: Option<&str>,
         method: Option<&str>,
     ) -> Option<RouteDecision<'a>> {
-        let host_best = host.and_then(|raw_host| {
-            let parsed_host = parsed_host_for_routing(raw_host)?;
-            let host_trie = if host_has_uppercase_ascii(parsed_host) {
-                let normalized = parsed_host.to_ascii_lowercase();
-                self.host_tries.get(normalized.as_str())
-            } else {
-                self.host_tries.get(parsed_host)
-            }?;
-            host_trie.longest_prefix(path, method, &self.upstream_methods)
-        });
+        let host_best = host
+            .and_then(normalize_host_for_routing)
+            .and_then(|normalized_host| self.lookup_host_candidate(path, normalized_host, method));
 
         let default_best = self
             .default_trie
-            .longest_prefix(path, method, &self.upstream_methods);
+            .longest_prefix(path, method, &self.upstream_methods)
+            .map(|route| RouteCandidate {
+                route,
+                host_match_kind: HostMatchKind::Default,
+                wildcard_suffix_len: 0,
+            });
         if let Some(best) = host_best
-            && best.path_len >= self.default_max_path_len
+            && best.route.path_len >= self.default_max_path_len
         {
             let reason = match default_best {
                 None => RouteDecisionReason::HostTrieNoDefault,
-                Some(default_route) => match compare_route(default_route, best) {
+                Some(default_route) => match compare_route_candidate(default_route, best) {
                     RoutePreference::TakeCandidateHostSpecific => {
                         RouteDecisionReason::HostSpecificTieBreak
+                    }
+                    RoutePreference::TakeCandidateExactHost => {
+                        RouteDecisionReason::ExactHostTieBreak
+                    }
+                    RoutePreference::TakeCandidateWildcardSpecificity => {
+                        RouteDecisionReason::WildcardSpecificityTieBreak
                     }
                     RoutePreference::TakeCandidateMethodSpecific => {
                         RouteDecisionReason::MethodSpecificTieBreak
@@ -420,33 +426,39 @@ impl RouteIndex {
                 },
             };
             return Some(RouteDecision {
-                upstream: self.upstream_names[best.upstream_idx].as_str(),
-                matched_path_len: best.path_len,
-                host_specific: best.host_specific,
+                upstream: self.upstream_names[best.route.upstream_idx].as_str(),
+                matched_path_len: best.route.path_len,
+                host_specific: best.route.host_specific,
                 reason,
             });
         }
 
         match (default_best, host_best) {
             (Some(default_route), None) => Some(RouteDecision {
-                upstream: self.upstream_names[default_route.upstream_idx].as_str(),
-                matched_path_len: default_route.path_len,
-                host_specific: default_route.host_specific,
+                upstream: self.upstream_names[default_route.route.upstream_idx].as_str(),
+                matched_path_len: default_route.route.path_len,
+                host_specific: default_route.route.host_specific,
                 reason: RouteDecisionReason::DefaultPathLonger,
             }),
             (None, Some(host_route)) => Some(RouteDecision {
-                upstream: self.upstream_names[host_route.upstream_idx].as_str(),
-                matched_path_len: host_route.path_len,
-                host_specific: host_route.host_specific,
+                upstream: self.upstream_names[host_route.route.upstream_idx].as_str(),
+                matched_path_len: host_route.route.path_len,
+                host_specific: host_route.route.host_specific,
                 reason: RouteDecisionReason::HostTrieNoDefault,
             }),
             (Some(current), Some(candidate)) => {
-                let reason = match compare_route(current, candidate) {
+                let reason = match compare_route_candidate(current, candidate) {
                     RoutePreference::TakeCandidatePathLen => {
                         RouteDecisionReason::HostPathLongerOrEqual
                     }
                     RoutePreference::TakeCandidateHostSpecific => {
                         RouteDecisionReason::HostSpecificTieBreak
+                    }
+                    RoutePreference::TakeCandidateExactHost => {
+                        RouteDecisionReason::ExactHostTieBreak
+                    }
+                    RoutePreference::TakeCandidateWildcardSpecificity => {
+                        RouteDecisionReason::WildcardSpecificityTieBreak
                     }
                     RoutePreference::TakeCandidateMethodSpecific => {
                         RouteDecisionReason::MethodSpecificTieBreak
@@ -456,14 +468,14 @@ impl RouteIndex {
                     }
                     RoutePreference::KeepCurrent => RouteDecisionReason::DefaultPathLonger,
                 };
-                let selected = match compare_route(current, candidate) {
+                let selected = match compare_route_candidate(current, candidate) {
                     RoutePreference::KeepCurrent => current,
                     _ => candidate,
                 };
                 Some(RouteDecision {
-                    upstream: self.upstream_names[selected.upstream_idx].as_str(),
-                    matched_path_len: selected.path_len,
-                    host_specific: selected.host_specific,
+                    upstream: self.upstream_names[selected.route.upstream_idx].as_str(),
+                    matched_path_len: selected.route.path_len,
+                    host_specific: selected.route.host_specific,
                     reason,
                 })
             }
@@ -627,8 +639,8 @@ pub(crate) fn scan_lookup_for_method<'a>(
     method: Option<&str>,
 ) -> Option<&'a str> {
     let path_bytes = path.as_bytes();
-    let normalized_request_host = host.and_then(parsed_host_for_routing);
-    let mut best_match: Option<(&str, usize, bool, bool)> = None;
+    let normalized_request_host = host.and_then(normalize_host_for_routing);
+    let mut best_match: Option<(&str, usize, bool, HostMatchKind, usize, bool)> = None;
 
     for (upstream_name, upstream) in upstreams {
         let has_method_match = match (
@@ -645,18 +657,29 @@ pub(crate) fn scan_lookup_for_method<'a>(
             continue;
         }
 
-        let has_host_match = match (&upstream.route.host, normalized_request_host) {
-            (Some(route_host), Some(request_host)) => {
-                if route_host == request_host {
-                    true
-                } else {
-                    parsed_host_for_routing(route_host)
-                        .is_some_and(|route_host| route_host.eq_ignore_ascii_case(request_host))
+        let (has_host_match, host_match_kind, wildcard_suffix_len) =
+            match (&upstream.route.host, normalized_request_host.as_deref()) {
+                (None, _) => (true, HostMatchKind::Default, 0usize),
+                (Some(_), None) => (false, HostMatchKind::Default, 0usize),
+                (Some(route_host), Some(request_host)) => {
+                    match parse_configured_host_pattern(route_host) {
+                        Some(ConfiguredHostPattern::Exact(route_host_exact)) => (
+                            route_host_exact.eq_ignore_ascii_case(request_host),
+                            HostMatchKind::Exact,
+                            0,
+                        ),
+                        Some(ConfiguredHostPattern::WildcardSuffix(suffix)) => (
+                            request_host.len() > suffix.len() + 1
+                                && request_host.ends_with(&suffix)
+                                && request_host.as_bytes()[request_host.len() - suffix.len() - 1]
+                                    == b'.',
+                            HostMatchKind::Wildcard,
+                            suffix.len(),
+                        ),
+                        None => (false, HostMatchKind::Default, 0usize),
+                    }
                 }
-            }
-            (None, _) => true,
-            (Some(_), None) => false,
-        };
+            };
 
         let path_match_len = match &upstream.route.path_prefix {
             Some(path_prefix) => {
@@ -692,15 +715,32 @@ pub(crate) fn scan_lookup_for_method<'a>(
             .is_some_and(|value| !value.trim().is_empty());
 
         match best_match {
-            Some((best_name, best_len, best_host_specific, best_method_specific)) => {
+            Some((
+                best_name,
+                best_len,
+                best_host_specific,
+                best_host_match_kind,
+                best_wildcard_suffix_len,
+                best_method_specific,
+            )) => {
                 if path_match_len > best_len
                     || (path_match_len == best_len && host_specific && !best_host_specific)
                     || (path_match_len == best_len
                         && host_specific == best_host_specific
+                        && host_match_kind > best_host_match_kind)
+                    || (path_match_len == best_len
+                        && host_specific == best_host_specific
+                        && host_match_kind == HostMatchKind::Wildcard
+                        && best_host_match_kind == HostMatchKind::Wildcard
+                        && wildcard_suffix_len > best_wildcard_suffix_len)
+                    || (path_match_len == best_len
+                        && host_specific == best_host_specific
+                        && host_match_kind == best_host_match_kind
                         && method_specific
                         && !best_method_specific)
                     || (path_match_len == best_len
                         && host_specific == best_host_specific
+                        && host_match_kind == best_host_match_kind
                         && method_specific == best_method_specific
                         && upstream_name.as_str() < best_name)
                 {
@@ -708,6 +748,8 @@ pub(crate) fn scan_lookup_for_method<'a>(
                         upstream_name.as_str(),
                         path_match_len,
                         host_specific,
+                        host_match_kind,
+                        wildcard_suffix_len,
                         method_specific,
                     ));
                 }
@@ -717,13 +759,15 @@ pub(crate) fn scan_lookup_for_method<'a>(
                     upstream_name.as_str(),
                     path_match_len,
                     host_specific,
+                    host_match_kind,
+                    wildcard_suffix_len,
                     method_specific,
                 ));
             }
         }
     }
 
-    best_match.map(|(name, _, _, _)| name)
+    best_match.map(|(name, _, _, _, _, _)| name)
 }
 
 #[cfg(test)]

--- a/crates/edge/src/route_index.rs
+++ b/crates/edge/src/route_index.rs
@@ -819,6 +819,7 @@ mod tests {
                 key: None,
             },
             host_policy: Default::default(),
+        forwarded_headers: Default::default(),
             route: RouteMatch {
                 host: host.map(str::to_string),
                 path_prefix: path_prefix.map(str::to_string),

--- a/crates/edge/src/route_index.rs
+++ b/crates/edge/src/route_index.rs
@@ -820,6 +820,7 @@ mod tests {
             },
             host_policy: Default::default(),
             forwarded_headers: Default::default(),
+            tls: None,
             route: RouteMatch {
                 host: host.map(str::to_string),
                 path_prefix: path_prefix.map(str::to_string),

--- a/crates/edge/src/route_index.rs
+++ b/crates/edge/src/route_index.rs
@@ -536,6 +536,8 @@ fn prefer_route(
             RoutePreference::KeepCurrent => Some(current),
             RoutePreference::TakeCandidatePathLen
             | RoutePreference::TakeCandidateHostSpecific
+            | RoutePreference::TakeCandidateExactHost
+            | RoutePreference::TakeCandidateWildcardSpecificity
             | RoutePreference::TakeCandidateMethodSpecific
             | RoutePreference::TakeCandidateLexicalOrder => Some(candidate),
         },

--- a/crates/edge/src/route_index.rs
+++ b/crates/edge/src/route_index.rs
@@ -1063,6 +1063,128 @@ mod tests {
         }
     }
 
+    #[test]
+    fn wildcard_host_route_matches_subdomains() {
+        let mut upstreams = HashMap::new();
+        upstreams.insert(
+            "wildcard".to_string(),
+            test_upstream(Some("*.example.com"), Some("/api")),
+        );
+        upstreams.insert("default".to_string(), test_upstream(None, Some("/")));
+        let index = RouteIndex::from_upstreams(&upstreams);
+
+        assert_eq!(
+            index.lookup("/api/users", Some("tenant.example.com")),
+            Some("wildcard")
+        );
+        assert_eq!(
+            scan_lookup(&upstreams, "/api/users", Some("tenant.example.com")),
+            Some("wildcard")
+        );
+        assert_eq!(
+            index.lookup("/api/users", Some("example.com")),
+            Some("default")
+        );
+    }
+
+    #[test]
+    fn exact_host_route_beats_wildcard_on_tie() {
+        let mut upstreams = HashMap::new();
+        upstreams.insert(
+            "wildcard".to_string(),
+            test_upstream(Some("*.example.com"), Some("/api")),
+        );
+        upstreams.insert(
+            "exact".to_string(),
+            test_upstream(Some("api.example.com"), Some("/api")),
+        );
+        let index = RouteIndex::from_upstreams(&upstreams);
+
+        assert_eq!(
+            index.lookup("/api/users", Some("api.example.com")),
+            Some("exact")
+        );
+        assert_eq!(
+            scan_lookup(&upstreams, "/api/users", Some("api.example.com")),
+            Some("exact")
+        );
+    }
+
+    #[test]
+    fn more_specific_wildcard_beats_less_specific_wildcard() {
+        let mut upstreams = HashMap::new();
+        upstreams.insert(
+            "wide".to_string(),
+            test_upstream(Some("*.example.com"), Some("/api")),
+        );
+        upstreams.insert(
+            "narrow".to_string(),
+            test_upstream(Some("*.a.example.com"), Some("/api")),
+        );
+        let index = RouteIndex::from_upstreams(&upstreams);
+
+        assert_eq!(
+            index.lookup("/api/users", Some("x.a.example.com")),
+            Some("narrow")
+        );
+        assert_eq!(
+            scan_lookup(&upstreams, "/api/users", Some("x.a.example.com")),
+            Some("narrow")
+        );
+        assert_eq!(
+            index
+                .lookup_with_decision("/api/users", Some("x.a.example.com"))
+                .map(|decision| decision.reason),
+            Some(RouteDecisionReason::WildcardSpecificityTieBreak)
+        );
+    }
+
+    #[test]
+    fn wildcard_keeps_method_and_path_precedence() {
+        let mut upstreams = HashMap::new();
+        upstreams.insert(
+            "wildcard-post".to_string(),
+            test_upstream_with_method(Some("*.example.com"), Some("/api"), Some("POST")),
+        );
+        upstreams.insert(
+            "wildcard-all".to_string(),
+            test_upstream_with_method(Some("*.example.com"), Some("/api"), None),
+        );
+        upstreams.insert(
+            "wildcard-deep".to_string(),
+            test_upstream(Some("*.example.com"), Some("/api/v2")),
+        );
+        let index = RouteIndex::from_upstreams(&upstreams);
+
+        assert_eq!(
+            index.lookup_for_method("/api/items", Some("tenant.example.com"), Some("POST")),
+            Some("wildcard-post")
+        );
+        assert_eq!(
+            scan_lookup_for_method(
+                &upstreams,
+                "/api/items",
+                Some("tenant.example.com"),
+                Some("POST")
+            ),
+            Some("wildcard-post")
+        );
+
+        assert_eq!(
+            index.lookup_for_method("/api/v2/items", Some("tenant.example.com"), Some("GET")),
+            Some("wildcard-deep")
+        );
+        assert_eq!(
+            scan_lookup_for_method(
+                &upstreams,
+                "/api/v2/items",
+                Some("tenant.example.com"),
+                Some("GET")
+            ),
+            Some("wildcard-deep")
+        );
+    }
+
     fn build_route_table(route_count: usize) -> HashMap<String, Upstream> {
         let mut upstreams = HashMap::with_capacity(route_count);
         for i in 0..route_count {

--- a/crates/edge/src/route_index.rs
+++ b/crates/edge/src/route_index.rs
@@ -818,6 +818,7 @@ mod tests {
                 lb_type: "random".to_string(),
                 key: None,
             },
+            host_policy: Default::default(),
             route: RouteMatch {
                 host: host.map(str::to_string),
                 path_prefix: path_prefix.map(str::to_string),

--- a/crates/edge/src/route_index.rs
+++ b/crates/edge/src/route_index.rs
@@ -819,7 +819,7 @@ mod tests {
                 key: None,
             },
             host_policy: Default::default(),
-        forwarded_headers: Default::default(),
+            forwarded_headers: Default::default(),
             route: RouteMatch {
                 host: host.map(str::to_string),
                 path_prefix: path_prefix.map(str::to_string),

--- a/crates/edge/src/route_index.rs
+++ b/crates/edge/src/route_index.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 use spooky_config::config::Upstream;
@@ -31,12 +32,12 @@ fn host_has_uppercase_ascii(host: &str) -> bool {
     host.bytes().any(|byte| byte.is_ascii_uppercase())
 }
 
-pub(crate) fn normalize_host_for_routing(raw: &str) -> Option<String> {
+pub(crate) fn normalize_host_for_routing(raw: &str) -> Option<Cow<'_, str>> {
     let host = parsed_host_for_routing(raw)?;
     if host_has_uppercase_ascii(host) {
-        Some(host.to_ascii_lowercase())
+        Some(Cow::Owned(host.to_ascii_lowercase()))
     } else {
-        Some(host.to_string())
+        Some(Cow::Borrowed(host))
     }
 }
 
@@ -46,17 +47,34 @@ enum ConfiguredHostPattern {
     WildcardSuffix(String),
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ConfiguredHostPatternRef<'a> {
+    Exact(&'a str),
+    WildcardSuffix(&'a str),
+}
+
 fn parse_configured_host_pattern(raw: &str) -> Option<ConfiguredHostPattern> {
     let normalized = normalize_host_for_routing(raw)?;
     let Some(wildcard_suffix) = normalized.strip_prefix("*.") else {
-        return Some(ConfiguredHostPattern::Exact(normalized));
+        return Some(ConfiguredHostPattern::Exact(normalized.into_owned()));
     };
     if wildcard_suffix.is_empty() || wildcard_suffix.contains('*') {
-        return Some(ConfiguredHostPattern::Exact(format!("*.{wildcard_suffix}")));
+        return Some(ConfiguredHostPattern::Exact(normalized.into_owned()));
     }
     Some(ConfiguredHostPattern::WildcardSuffix(
         wildcard_suffix.to_string(),
     ))
+}
+
+fn parse_configured_host_pattern_ref(raw: &str) -> Option<ConfiguredHostPatternRef<'_>> {
+    let host = parsed_host_for_routing(raw)?;
+    let Some(wildcard_suffix) = host.strip_prefix("*.") else {
+        return Some(ConfiguredHostPatternRef::Exact(host));
+    };
+    if wildcard_suffix.is_empty() || wildcard_suffix.contains('*') {
+        return Some(ConfiguredHostPatternRef::Exact(host));
+    }
+    Some(ConfiguredHostPatternRef::WildcardSuffix(wildcard_suffix))
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
@@ -353,7 +371,9 @@ impl RouteIndex {
     ) -> Option<&'a str> {
         let host_best = host
             .and_then(normalize_host_for_routing)
-            .and_then(|normalized_host| self.lookup_host_candidate(path, normalized_host, method));
+            .and_then(|normalized_host| {
+                self.lookup_host_candidate(path, normalized_host.as_ref(), method)
+            });
 
         if let Some(best) = host_best
             && best.route.path_len >= self.default_max_path_len
@@ -391,7 +411,9 @@ impl RouteIndex {
     ) -> Option<RouteDecision<'a>> {
         let host_best = host
             .and_then(normalize_host_for_routing)
-            .and_then(|normalized_host| self.lookup_host_candidate(path, normalized_host, method));
+            .and_then(|normalized_host| {
+                self.lookup_host_candidate(path, normalized_host.as_ref(), method)
+            });
 
         let default_best = self
             .default_trie
@@ -486,12 +508,12 @@ impl RouteIndex {
     fn lookup_host_candidate(
         &self,
         path: &str,
-        normalized_host: String,
+        normalized_host: &str,
         method: Option<&str>,
     ) -> Option<RouteCandidate> {
         let exact_best = self
             .host_tries
-            .get(normalized_host.as_str())
+            .get(normalized_host)
             .and_then(|host_trie| host_trie.longest_prefix(path, method, &self.upstream_methods))
             .map(|route| RouteCandidate {
                 route,
@@ -500,7 +522,7 @@ impl RouteIndex {
             });
 
         let mut wildcard_best: Option<RouteCandidate> = None;
-        let mut remaining = normalized_host.as_str();
+        let mut remaining = normalized_host;
         while let Some(dot_idx) = remaining.find('.') {
             let suffix = &remaining[dot_idx + 1..];
             if suffix.is_empty() {
@@ -664,20 +686,24 @@ pub(crate) fn scan_lookup_for_method<'a>(
                 (None, _) => (true, HostMatchKind::Default, 0usize),
                 (Some(_), None) => (false, HostMatchKind::Default, 0usize),
                 (Some(route_host), Some(request_host)) => {
-                    match parse_configured_host_pattern(route_host) {
-                        Some(ConfiguredHostPattern::Exact(route_host_exact)) => (
+                    match parse_configured_host_pattern_ref(route_host) {
+                        Some(ConfiguredHostPatternRef::Exact(route_host_exact)) => (
                             route_host_exact.eq_ignore_ascii_case(request_host),
                             HostMatchKind::Exact,
                             0,
                         ),
-                        Some(ConfiguredHostPattern::WildcardSuffix(suffix)) => (
-                            request_host.len() > suffix.len() + 1
-                                && request_host.ends_with(&suffix)
-                                && request_host.as_bytes()[request_host.len() - suffix.len() - 1]
-                                    == b'.',
-                            HostMatchKind::Wildcard,
-                            suffix.len(),
-                        ),
+                        Some(ConfiguredHostPatternRef::WildcardSuffix(suffix)) => {
+                            let suffix_start = request_host.len().saturating_sub(suffix.len());
+                            (
+                                request_host.len() > suffix.len() + 1
+                                    && request_host
+                                        .get(suffix_start..)
+                                        .is_some_and(|tail| tail.eq_ignore_ascii_case(suffix))
+                                    && request_host.as_bytes()[suffix_start - 1] == b'.',
+                                HostMatchKind::Wildcard,
+                                suffix.len(),
+                            )
+                        }
                         None => (false, HostMatchKind::Default, 0usize),
                     }
                 }

--- a/crates/edge/src/types.rs
+++ b/crates/edge/src/types.rs
@@ -6,7 +6,7 @@ use spooky_config::{
 };
 use spooky_errors::ProxyError;
 use spooky_lb::UpstreamPool;
-use spooky_transport::h2_pool::H2Pool;
+use spooky_transport::{h2_client::SharedDnsResolver, h2_pool::H2Pool};
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     net::UdpSocket,
@@ -27,6 +27,7 @@ use crate::watchdog::WatchdogCoordinator;
 pub struct SharedRuntimeState {
     pub(crate) h2_pool: Arc<H2Pool>,
     pub(crate) backend_endpoints: Arc<HashMap<String, BackendEndpoint>>,
+    pub(crate) backend_dns_resolver: SharedDnsResolver,
     pub(crate) upstream_host_policies: Arc<HashMap<String, UpstreamHostPolicy>>,
     pub(crate) forwarded_header_policies: Arc<HashMap<String, ForwardedHeaderPolicy>>,
     pub(crate) upstream_pools: HashMap<String, Arc<RwLock<UpstreamPool>>>,
@@ -80,6 +81,7 @@ pub struct QUICListener {
     pub h3_config: Arc<quiche::h3::Config>,
     pub h2_pool: Arc<H2Pool>,
     pub backend_endpoints: Arc<HashMap<String, BackendEndpoint>>,
+    pub backend_dns_resolver: SharedDnsResolver,
     pub upstream_host_policies: Arc<HashMap<String, UpstreamHostPolicy>>,
     pub forwarded_header_policies: Arc<HashMap<String, ForwardedHeaderPolicy>>,
     pub upstream_pools: HashMap<String, Arc<RwLock<UpstreamPool>>>,

--- a/crates/edge/src/types.rs
+++ b/crates/edge/src/types.rs
@@ -6,7 +6,10 @@ use spooky_config::{
 };
 use spooky_errors::ProxyError;
 use spooky_lb::UpstreamPool;
-use spooky_transport::{h2_client::SharedDnsResolver, h2_pool::H2Pool};
+use spooky_transport::{
+    h2_client::{H2Client, SharedDnsResolver},
+    h2_pool::H2Pool,
+};
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     net::UdpSocket,
@@ -30,6 +33,7 @@ pub struct SharedRuntimeState {
     pub(crate) backend_dns_resolver: SharedDnsResolver,
     pub(crate) upstream_host_policies: Arc<HashMap<String, UpstreamHostPolicy>>,
     pub(crate) forwarded_header_policies: Arc<HashMap<String, ForwardedHeaderPolicy>>,
+    pub(crate) upstream_health_clients: Arc<HashMap<String, Arc<H2Client>>>,
     pub(crate) upstream_pools: HashMap<String, Arc<RwLock<UpstreamPool>>>,
     pub(crate) upstream_inflight: HashMap<String, Arc<Semaphore>>,
     pub(crate) global_inflight: Arc<Semaphore>,

--- a/crates/edge/src/types.rs
+++ b/crates/edge/src/types.rs
@@ -2,7 +2,7 @@ use bytes::Bytes;
 use core::net::SocketAddr;
 use spooky_config::{
     backend_endpoint::BackendEndpoint,
-    config::{Config, UpstreamHostPolicy},
+    config::{Config, ForwardedHeaderPolicy, UpstreamHostPolicy},
 };
 use spooky_errors::ProxyError;
 use spooky_lb::UpstreamPool;
@@ -28,6 +28,7 @@ pub struct SharedRuntimeState {
     pub(crate) h2_pool: Arc<H2Pool>,
     pub(crate) backend_endpoints: Arc<HashMap<String, BackendEndpoint>>,
     pub(crate) upstream_host_policies: Arc<HashMap<String, UpstreamHostPolicy>>,
+    pub(crate) forwarded_header_policies: Arc<HashMap<String, ForwardedHeaderPolicy>>,
     pub(crate) upstream_pools: HashMap<String, Arc<RwLock<UpstreamPool>>>,
     pub(crate) upstream_inflight: HashMap<String, Arc<Semaphore>>,
     pub(crate) global_inflight: Arc<Semaphore>,
@@ -80,6 +81,7 @@ pub struct QUICListener {
     pub h2_pool: Arc<H2Pool>,
     pub backend_endpoints: Arc<HashMap<String, BackendEndpoint>>,
     pub upstream_host_policies: Arc<HashMap<String, UpstreamHostPolicy>>,
+    pub forwarded_header_policies: Arc<HashMap<String, ForwardedHeaderPolicy>>,
     pub upstream_pools: HashMap<String, Arc<RwLock<UpstreamPool>>>,
     pub upstream_inflight: HashMap<String, Arc<Semaphore>>,
     pub global_inflight: Arc<Semaphore>,

--- a/crates/edge/src/types.rs
+++ b/crates/edge/src/types.rs
@@ -179,7 +179,9 @@ pub enum ResponseChunk {
         headers: Vec<(Vec<u8>, Vec<u8>)>,
     },
     Data(Bytes),
-    Trailers { headers: Vec<(Vec<u8>, Vec<u8>)> },
+    Trailers {
+        headers: Vec<(Vec<u8>, Vec<u8>)>,
+    },
     End,
     Error(ProxyError),
 }

--- a/crates/edge/src/types.rs
+++ b/crates/edge/src/types.rs
@@ -1,6 +1,9 @@
 use bytes::Bytes;
 use core::net::SocketAddr;
-use spooky_config::{backend_endpoint::BackendEndpoint, config::Config};
+use spooky_config::{
+    backend_endpoint::BackendEndpoint,
+    config::{Config, UpstreamHostPolicy},
+};
 use spooky_errors::ProxyError;
 use spooky_lb::UpstreamPool;
 use spooky_transport::h2_pool::H2Pool;
@@ -24,6 +27,7 @@ use crate::watchdog::WatchdogCoordinator;
 pub struct SharedRuntimeState {
     pub(crate) h2_pool: Arc<H2Pool>,
     pub(crate) backend_endpoints: Arc<HashMap<String, BackendEndpoint>>,
+    pub(crate) upstream_host_policies: Arc<HashMap<String, UpstreamHostPolicy>>,
     pub(crate) upstream_pools: HashMap<String, Arc<RwLock<UpstreamPool>>>,
     pub(crate) upstream_inflight: HashMap<String, Arc<Semaphore>>,
     pub(crate) global_inflight: Arc<Semaphore>,
@@ -75,6 +79,7 @@ pub struct QUICListener {
     pub h3_config: Arc<quiche::h3::Config>,
     pub h2_pool: Arc<H2Pool>,
     pub backend_endpoints: Arc<HashMap<String, BackendEndpoint>>,
+    pub upstream_host_policies: Arc<HashMap<String, UpstreamHostPolicy>>,
     pub upstream_pools: HashMap<String, Arc<RwLock<UpstreamPool>>>,
     pub upstream_inflight: HashMap<String, Arc<Semaphore>>,
     pub global_inflight: Arc<Semaphore>,

--- a/crates/edge/src/types.rs
+++ b/crates/edge/src/types.rs
@@ -179,6 +179,7 @@ pub enum ResponseChunk {
         headers: Vec<(Vec<u8>, Vec<u8>)>,
     },
     Data(Bytes),
+    Trailers { headers: Vec<(Vec<u8>, Vec<u8>)> },
     End,
     Error(ProxyError),
 }

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -74,6 +74,7 @@ fn make_config(port: u32, backend_addr: String, cert: String, key: String) -> Co
                 key: None,
             },
             host_policy: Default::default(),
+        forwarded_headers: Default::default(),
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -75,6 +75,7 @@ fn make_config(port: u32, backend_addr: String, cert: String, key: String) -> Co
             },
             host_policy: Default::default(),
             forwarded_headers: Default::default(),
+            tls: None,
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()
@@ -108,6 +109,7 @@ fn make_config(port: u32, backend_addr: String, cert: String, key: String) -> Co
                 client_auth: ClientAuth::default(),
             },
         },
+        listeners: vec![],
         upstream,
         load_balancing: Some(LoadBalancing {
             lb_type: "random".to_string(),

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -102,6 +102,7 @@ fn make_config(port: u32, backend_addr: String, cert: String, key: String) -> Co
             tls: Tls {
                 cert,
                 key,
+                certificates: vec![],
                 client_auth: ClientAuth::default(),
             },
         },

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -73,6 +73,7 @@ fn make_config(port: u32, backend_addr: String, cert: String, key: String) -> Co
                 lb_type: "random".to_string(),
                 key: None,
             },
+            host_policy: Default::default(),
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -74,7 +74,7 @@ fn make_config(port: u32, backend_addr: String, cert: String, key: String) -> Co
                 key: None,
             },
             host_policy: Default::default(),
-        forwarded_headers: Default::default(),
+            forwarded_headers: Default::default(),
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()

--- a/crates/edge/tests/h3_edge.rs
+++ b/crates/edge/tests/h3_edge.rs
@@ -88,6 +88,7 @@ fn make_config(port: u32, cert: String, key: String, backend_address: String) ->
             tls: Tls {
                 cert,
                 key,
+                certificates: vec![],
                 client_auth: ClientAuth::default(),
             },
         },
@@ -826,6 +827,7 @@ fn make_config_with_rate_limit(
             tls: Tls {
                 cert,
                 key,
+                certificates: vec![],
                 client_auth: ClientAuth::default(),
             },
         },

--- a/crates/edge/tests/h3_edge.rs
+++ b/crates/edge/tests/h3_edge.rs
@@ -61,6 +61,7 @@ fn make_config(port: u32, cert: String, key: String, backend_address: String) ->
             },
             host_policy: Default::default(),
             forwarded_headers: Default::default(),
+            tls: None,
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()
@@ -94,6 +95,7 @@ fn make_config(port: u32, cert: String, key: String, backend_address: String) ->
                 client_auth: ClientAuth::default(),
             },
         },
+        listeners: vec![],
         upstream,
         load_balancing: Some(LoadBalancing {
             lb_type: "random".to_string(),
@@ -802,6 +804,7 @@ fn make_config_with_rate_limit(
             },
             host_policy: Default::default(),
             forwarded_headers: Default::default(),
+            tls: None,
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()
@@ -835,6 +838,7 @@ fn make_config_with_rate_limit(
                 client_auth: ClientAuth::default(),
             },
         },
+        listeners: vec![],
         upstream,
         load_balancing: Some(LoadBalancing {
             lb_type: "random".to_string(),

--- a/crates/edge/tests/h3_edge.rs
+++ b/crates/edge/tests/h3_edge.rs
@@ -60,6 +60,7 @@ fn make_config(port: u32, cert: String, key: String, backend_address: String) ->
                 key: None,
             },
             host_policy: Default::default(),
+        forwarded_headers: Default::default(),
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()
@@ -800,6 +801,7 @@ fn make_config_with_rate_limit(
                 key: None,
             },
             host_policy: Default::default(),
+        forwarded_headers: Default::default(),
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()

--- a/crates/edge/tests/h3_edge.rs
+++ b/crates/edge/tests/h3_edge.rs
@@ -59,6 +59,7 @@ fn make_config(port: u32, cert: String, key: String, backend_address: String) ->
                 lb_type: "random".to_string(),
                 key: None,
             },
+            host_policy: Default::default(),
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()
@@ -798,6 +799,7 @@ fn make_config_with_rate_limit(
                 lb_type: "random".to_string(),
                 key: None,
             },
+            host_policy: Default::default(),
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()

--- a/crates/edge/tests/h3_edge.rs
+++ b/crates/edge/tests/h3_edge.rs
@@ -60,7 +60,7 @@ fn make_config(port: u32, cert: String, key: String, backend_address: String) ->
                 key: None,
             },
             host_policy: Default::default(),
-        forwarded_headers: Default::default(),
+            forwarded_headers: Default::default(),
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()
@@ -801,7 +801,7 @@ fn make_config_with_rate_limit(
                 key: None,
             },
             host_policy: Default::default(),
-        forwarded_headers: Default::default(),
+            forwarded_headers: Default::default(),
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()

--- a/crates/edge/tests/lb_integration.rs
+++ b/crates/edge/tests/lb_integration.rs
@@ -90,6 +90,7 @@ fn make_config(
                 key: None,
             },
             host_policy: Default::default(),
+        forwarded_headers: Default::default(),
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()

--- a/crates/edge/tests/lb_integration.rs
+++ b/crates/edge/tests/lb_integration.rs
@@ -91,6 +91,7 @@ fn make_config(
             },
             host_policy: Default::default(),
             forwarded_headers: Default::default(),
+            tls: None,
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()
@@ -118,6 +119,7 @@ fn make_config(
                 client_auth: ClientAuth::default(),
             },
         },
+        listeners: vec![],
         upstream,
         load_balancing: Some(LoadBalancing {
             lb_type: lb_type.to_string(),

--- a/crates/edge/tests/lb_integration.rs
+++ b/crates/edge/tests/lb_integration.rs
@@ -112,6 +112,7 @@ fn make_config(
             tls: Tls {
                 cert,
                 key,
+                certificates: vec![],
                 client_auth: ClientAuth::default(),
             },
         },

--- a/crates/edge/tests/lb_integration.rs
+++ b/crates/edge/tests/lb_integration.rs
@@ -90,7 +90,7 @@ fn make_config(
                 key: None,
             },
             host_policy: Default::default(),
-        forwarded_headers: Default::default(),
+            forwarded_headers: Default::default(),
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()

--- a/crates/edge/tests/lb_integration.rs
+++ b/crates/edge/tests/lb_integration.rs
@@ -89,6 +89,7 @@ fn make_config(
                 lb_type: lb_type.to_string(),
                 key: None,
             },
+            host_policy: Default::default(),
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()

--- a/crates/lb/src/lib.rs
+++ b/crates/lb/src/lib.rs
@@ -1026,6 +1026,7 @@ mod tests {
             },
             host_policy: Default::default(),
             forwarded_headers: Default::default(),
+            tls: None,
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()

--- a/crates/lb/src/lib.rs
+++ b/crates/lb/src/lib.rs
@@ -1025,6 +1025,7 @@ mod tests {
                 key: None,
             },
             host_policy: Default::default(),
+        forwarded_headers: Default::default(),
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()

--- a/crates/lb/src/lib.rs
+++ b/crates/lb/src/lib.rs
@@ -1024,6 +1024,7 @@ mod tests {
                 lb_type: "round-robin".to_string(),
                 key: None,
             },
+            host_policy: Default::default(),
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()

--- a/crates/lb/src/lib.rs
+++ b/crates/lb/src/lib.rs
@@ -1025,7 +1025,7 @@ mod tests {
                 key: None,
             },
             host_policy: Default::default(),
-        forwarded_headers: Default::default(),
+            forwarded_headers: Default::default(),
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -13,5 +13,6 @@ hyper-rustls.workspace = true
 rustls.workspace = true
 rustls-pemfile.workspace = true
 tokio.workspace = true
+tower-service = "0.3"
 webpki-roots.workspace = true
 spooky-errors = { path = "../errors" }

--- a/crates/transport/src/h2_client.rs
+++ b/crates/transport/src/h2_client.rs
@@ -2,15 +2,18 @@ use std::convert::Infallible;
 use std::ffi::OsStr;
 use std::fs::File;
 use std::future::Future;
-use std::io::BufReader;
 use std::io;
+use std::io::BufReader;
 use std::net::SocketAddr;
 use std::path::Path;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::RwLock;
 use std::time::Duration;
-use std::{collections::HashMap, task::{Context, Poll}};
+use std::{
+    collections::HashMap,
+    task::{Context, Poll},
+};
 
 use http_body_util::combinators::BoxBody;
 use hyper::body::Bytes;
@@ -92,6 +95,12 @@ impl SharedDnsResolver {
             .read()
             .ok()
             .and_then(|guard| guard.get(&normalize_dns_cache_host(host)).cloned())
+    }
+}
+
+impl Default for SharedDnsResolver {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/transport/src/h2_client.rs
+++ b/crates/transport/src/h2_client.rs
@@ -3,19 +3,31 @@ use std::ffi::OsStr;
 use std::fs::File;
 use std::future::Future;
 use std::io::BufReader;
+use std::io;
+use std::net::SocketAddr;
 use std::path::Path;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::RwLock;
 use std::time::Duration;
+use std::{collections::HashMap, task::{Context, Poll}};
 
 use http_body_util::combinators::BoxBody;
 use hyper::body::Bytes;
 use hyper::{Request, rt::Executor};
 use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
-use hyper_util::client::legacy::{Client, connect::HttpConnector};
+use hyper_util::client::legacy::{
+    Client,
+    connect::{
+        HttpConnector,
+        dns::{GaiResolver, Name},
+    },
+};
 
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
 use rustls::{ClientConfig, DigitallySignedStruct, RootCertStore, SignatureScheme};
+use tower_service::Service;
 
 #[derive(Debug, Clone)]
 pub struct TlsClientConfig {
@@ -36,8 +48,77 @@ impl Default for TlsClientConfig {
     }
 }
 
+type ResolverResponse = std::vec::IntoIter<SocketAddr>;
+type ResolverFuture =
+    Pin<Box<dyn Future<Output = Result<ResolverResponse, io::Error>> + Send + 'static>>;
+
+#[derive(Clone)]
+pub struct SharedDnsResolver {
+    cache: Arc<RwLock<HashMap<String, Vec<SocketAddr>>>>,
+    fallback: GaiResolver,
+}
+
+impl SharedDnsResolver {
+    pub fn new() -> Self {
+        Self {
+            cache: Arc::new(RwLock::new(HashMap::new())),
+            fallback: GaiResolver::new(),
+        }
+    }
+
+    pub fn set_host_addrs<I>(&self, host: &str, addrs: I)
+    where
+        I: IntoIterator<Item = SocketAddr>,
+    {
+        let normalized = normalize_dns_cache_host(host);
+        let addrs: Vec<SocketAddr> = addrs.into_iter().collect();
+        if addrs.is_empty() {
+            self.remove_host(host);
+            return;
+        }
+        if let Ok(mut guard) = self.cache.write() {
+            guard.insert(normalized, addrs);
+        }
+    }
+
+    pub fn remove_host(&self, host: &str) {
+        if let Ok(mut guard) = self.cache.write() {
+            guard.remove(&normalize_dns_cache_host(host));
+        }
+    }
+
+    pub fn cached_addrs(&self, host: &str) -> Option<Vec<SocketAddr>> {
+        self.cache
+            .read()
+            .ok()
+            .and_then(|guard| guard.get(&normalize_dns_cache_host(host)).cloned())
+    }
+}
+
+impl Service<Name> for SharedDnsResolver {
+    type Response = ResolverResponse;
+    type Error = io::Error;
+    type Future = ResolverFuture;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.fallback.poll_ready(cx)
+    }
+
+    fn call(&mut self, name: Name) -> Self::Future {
+        if let Some(addrs) = self.cached_addrs(name.as_str()) {
+            return Box::pin(async move { Ok(addrs.into_iter()) });
+        }
+
+        let mut fallback = self.fallback.clone();
+        Box::pin(async move {
+            let resolved = fallback.call(name).await?;
+            Ok(resolved.collect::<Vec<_>>().into_iter())
+        })
+    }
+}
+
 pub struct H2Client {
-    client: Client<HttpsConnector<HttpConnector>, BoxBody<Bytes, Infallible>>,
+    client: Client<HttpsConnector<HttpConnector<SharedDnsResolver>>, BoxBody<Bytes, Infallible>>,
 }
 
 #[derive(Clone, Copy)]
@@ -59,8 +140,9 @@ impl H2Client {
         pool_idle_timeout: Duration,
         connect_timeout: Duration,
         tls: TlsClientConfig,
+        dns_resolver: SharedDnsResolver,
     ) -> Result<Self, String> {
-        let mut http = HttpConnector::new();
+        let mut http = HttpConnector::new_with_resolver(dns_resolver);
         http.enforce_http(false);
         http.set_connect_timeout(Some(connect_timeout));
 
@@ -93,8 +175,13 @@ impl H2Client {
             Duration::from_secs(30),
             Duration::from_secs(2),
             TlsClientConfig::default(),
+            SharedDnsResolver::new(),
         )
     }
+}
+
+fn normalize_dns_cache_host(host: &str) -> String {
+    host.trim().trim_end_matches('.').to_ascii_lowercase()
 }
 
 fn build_tls_config(tls: &TlsClientConfig) -> Result<ClientConfig, String> {
@@ -266,8 +353,10 @@ impl ServerCertVerifier for InsecureServerCertVerifier {
 
 #[cfg(test)]
 mod tests {
-    use super::{H2Client, TlsClientConfig};
-    use std::time::Duration;
+    use super::{H2Client, SharedDnsResolver, TlsClientConfig};
+    use hyper_util::client::legacy::connect::dns::Name;
+    use std::{net::SocketAddr, str::FromStr, time::Duration};
+    use tower_service::Service;
 
     #[test]
     fn default_tls_client_config_builds_h2_client() {
@@ -297,6 +386,7 @@ mod tests {
                 ca_file: Some(path.to_string_lossy().to_string()),
                 ca_dir: None,
             },
+            SharedDnsResolver::new(),
         );
         assert!(client.is_err());
 
@@ -315,7 +405,35 @@ mod tests {
                 ca_file: None,
                 ca_dir: None,
             },
+            SharedDnsResolver::new(),
         );
         assert!(client.is_ok());
+    }
+
+    #[tokio::test]
+    async fn shared_dns_resolver_returns_cached_addresses_case_insensitively() {
+        let resolver = SharedDnsResolver::new();
+        resolver.set_host_addrs(
+            "api.example.com",
+            [
+                SocketAddr::from(([127, 0, 0, 10], 0)),
+                SocketAddr::from(([127, 0, 0, 11], 0)),
+            ],
+        );
+
+        let mut service = resolver.clone();
+        let addrs: Vec<_> = service
+            .call(Name::from_str("API.EXAMPLE.COM").expect("name"))
+            .await
+            .expect("resolve")
+            .collect();
+
+        assert_eq!(
+            addrs,
+            vec![
+                SocketAddr::from(([127, 0, 0, 10], 0)),
+                SocketAddr::from(([127, 0, 0, 11], 0))
+            ]
+        );
     }
 }

--- a/crates/transport/src/h2_pool.rs
+++ b/crates/transport/src/h2_pool.rs
@@ -20,11 +20,11 @@ pub struct H2Pool {
 impl H2Pool {
     pub fn new<I>(
         backends: I,
+        backend_tls: HashMap<String, TlsClientConfig>,
         max_inflight: usize,
         max_idle_per_backend: usize,
         pool_idle_timeout: Duration,
         connect_timeout: Duration,
-        tls: TlsClientConfig,
         dns_resolver: SharedDnsResolver,
     ) -> Result<Self, String>
     where
@@ -38,7 +38,7 @@ impl H2Pool {
                 max_idle_per_backend,
                 pool_idle_timeout,
                 connect_timeout,
-                tls.clone(),
+                backend_tls.get(&backend).cloned().unwrap_or_default(),
                 dns_resolver.clone(),
             )?;
             map.insert(

--- a/crates/transport/src/h2_pool.rs
+++ b/crates/transport/src/h2_pool.rs
@@ -5,7 +5,7 @@ use hyper::Request;
 use hyper::body::{Bytes, Incoming};
 use tokio::sync::{Semaphore, TryAcquireError};
 
-use crate::h2_client::{H2Client, TlsClientConfig};
+use crate::h2_client::{H2Client, SharedDnsResolver, TlsClientConfig};
 pub use spooky_errors::PoolError;
 
 struct BackendHandle {
@@ -25,6 +25,7 @@ impl H2Pool {
         pool_idle_timeout: Duration,
         connect_timeout: Duration,
         tls: TlsClientConfig,
+        dns_resolver: SharedDnsResolver,
     ) -> Result<Self, String>
     where
         I: IntoIterator<Item = String>,
@@ -38,6 +39,7 @@ impl H2Pool {
                 pool_idle_timeout,
                 connect_timeout,
                 tls.clone(),
+                dns_resolver.clone(),
             )?;
             map.insert(
                 backend,

--- a/crates/transport/tests/h2_pool.rs
+++ b/crates/transport/tests/h2_pool.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
@@ -90,11 +91,11 @@ async fn pool_limits_inflight_per_backend() {
     let pool = Arc::new(
         H2Pool::new(
             vec![backend.clone()],
+            HashMap::from([(backend.clone(), TlsClientConfig::default())]),
             1,
             64,
             Duration::from_secs(30),
             Duration::from_secs(2),
-            TlsClientConfig::default(),
             SharedDnsResolver::new(),
         )
         .expect("pool"),
@@ -139,11 +140,11 @@ async fn pool_limits_inflight_per_backend() {
 async fn pool_rejects_unknown_backend() {
     let pool = H2Pool::new(
         vec!["127.0.0.1:12345".to_string()],
+        HashMap::from([("127.0.0.1:12345".to_string(), TlsClientConfig::default())]),
         1,
         64,
         Duration::from_secs(30),
         Duration::from_secs(2),
-        TlsClientConfig::default(),
         SharedDnsResolver::new(),
     )
     .expect("pool");
@@ -168,11 +169,11 @@ async fn pool_reports_overload_when_inflight_is_exhausted() {
     let pool = Arc::new(
         H2Pool::new(
             vec![backend.clone()],
+            HashMap::from([(backend.clone(), TlsClientConfig::default())]),
             1,
             64,
             Duration::from_secs(30),
             Duration::from_secs(2),
-            TlsClientConfig::default(),
             SharedDnsResolver::new(),
         )
         .expect("pool"),

--- a/crates/transport/tests/h2_pool.rs
+++ b/crates/transport/tests/h2_pool.rs
@@ -13,7 +13,7 @@ use hyper_util::rt::{TokioExecutor, TokioIo};
 use tokio::net::TcpListener;
 
 use spooky_transport::{
-    h2_client::TlsClientConfig,
+    h2_client::{SharedDnsResolver, TlsClientConfig},
     h2_pool::{H2Pool, PoolError},
 };
 
@@ -95,6 +95,7 @@ async fn pool_limits_inflight_per_backend() {
             Duration::from_secs(30),
             Duration::from_secs(2),
             TlsClientConfig::default(),
+            SharedDnsResolver::new(),
         )
         .expect("pool"),
     );
@@ -143,6 +144,7 @@ async fn pool_rejects_unknown_backend() {
         Duration::from_secs(30),
         Duration::from_secs(2),
         TlsClientConfig::default(),
+        SharedDnsResolver::new(),
     )
     .expect("pool");
     let req = Request::builder()
@@ -171,6 +173,7 @@ async fn pool_reports_overload_when_inflight_is_exhausted() {
             Duration::from_secs(30),
             Duration::from_secs(2),
             TlsClientConfig::default(),
+            SharedDnsResolver::new(),
         )
         .expect("pool"),
     );

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -131,6 +131,8 @@ The following table lists all default configuration values used when properties 
 | `performance.new_connections_per_sec` | `2000` | Token-bucket refill rate for new QUIC connections (conns/sec) |
 | `performance.new_connections_burst` | `500` | Burst capacity for new QUIC connections |
 | `performance.max_active_connections` | `20000` | Hard cap on concurrently tracked active QUIC connections per worker |
+| `performance.backend_dns_refresh_enabled` | `false` | Enable periodic control-plane DNS refresh for hostname-based upstream backends |
+| `performance.backend_dns_refresh_interval_ms` | `30000` | Refresh interval for hostname-based backend DNS records |
 | `performance.quic_max_idle_timeout_ms` | `5000` | QUIC idle timeout — connection closed after this many ms of inactivity |
 | `performance.quic_initial_max_data` | `10000000` | Connection-level flow control window (bytes) |
 | `performance.quic_initial_max_stream_data` | `1000000` | Per-stream flow control window (bytes) |
@@ -692,6 +694,8 @@ Controls resource limits, tuning knobs, and connection-flood protection. All fie
 | `udp_send_buffer_bytes` | integer | No | `8388608` | UDP socket send buffer size (bytes) |
 | `h2_pool_max_idle_per_backend` | integer | No | `256` | Maximum idle HTTP/2 connections kept open per backend |
 | `h2_pool_idle_timeout_ms` | integer | No | `90000` | How long an idle H2 connection is kept before being closed (ms) |
+| `backend_dns_refresh_enabled` | bool | No | `false` | Enable periodic DNS refresh for hostname-based upstream backends |
+| `backend_dns_refresh_interval_ms` | integer | No | `30000` | Control-plane DNS refresh interval for hostname-based upstream backends (ms) |
 | `new_connections_per_sec` | integer | No | `2000` | Steady-state rate at which new QUIC connections are accepted (token-bucket refill, connections/sec) |
 | `new_connections_burst` | integer | No | `500` | Burst capacity above the steady-state rate; the bucket starts full so the first burst of legitimate connections always succeeds |
 | `max_active_connections` | integer | No | `20000` | Hard cap on active QUIC connections per worker; unknown `Initial` packets are dropped once this cap is reached |

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -112,8 +112,9 @@ The following table lists all default configuration values used when properties 
 | `listen.protocol` | `"http3"` | Native ingress protocol (HTTP/3 over QUIC); TLS bootstrap ingress for HTTP/1.1/2 compatibility is also active |
 | `listen.port` | `9889` | Listening port |
 | `listen.address` | `"0.0.0.0"` | Listening address |
-| `listen.tls.cert` | Required | TLS certificate file path |
-| `listen.tls.key` | Required | TLS private key file path |
+| `listen.tls.cert` | optional | Legacy/default TLS certificate file path |
+| `listen.tls.key` | optional | Legacy/default TLS private key file path |
+| `listen.tls.certificates` | `[]` | Optional SNI certificate mappings (`server_name` + `cert` + `key`) |
 | `upstream[].route.path_prefix` | none | Path prefix for routing (set explicitly; use `/` for catch-all) |
 | `upstream[].backends[].weight` | `100` | Backend weight for load balancing |
 | `upstream[].backends[].health_check.path` | `"/health"` | Health check endpoint |
@@ -160,8 +161,18 @@ Spooky also exposes a TLS bootstrap ingress for HTTP/1.1 and HTTP/2 clients. Thi
 
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
-| `cert` | string | Yes | Path to TLS certificate file (PEM format) |
-| `key` | string | Yes | Path to TLS private key file (PEM format, PKCS#8 recommended) |
+| `cert` | string | Conditionally | Legacy/default TLS certificate path. Required with `key` when no `certificates` entries are configured |
+| `key` | string | Conditionally | Legacy/default TLS private key path. Required with `cert` when no `certificates` entries are configured |
+| `certificates` | array | No | SNI certificate entries |
+| `certificates[].server_name` | string | Yes | Exact SNI hostname (DNS name) to match |
+| `certificates[].cert` | string | Yes | Certificate path for that SNI hostname |
+| `certificates[].key` | string | Yes | Private key path for that SNI hostname |
+
+Certificate selection order:
+
+1. Exact SNI match in `listen.tls.certificates`.
+2. Fallback to `listen.tls.cert`/`listen.tls.key` when configured.
+3. If legacy pair is not configured, fallback to the first entry in `listen.tls.certificates`.
 
 ### Examples
 
@@ -183,6 +194,22 @@ listen:
   tls:
     cert: "certs/localhost.crt"
     key: "certs/localhost.key"
+
+# Multi-domain SNI certificates with legacy fallback
+listen:
+  protocol: http3
+  address: "0.0.0.0"
+  port: 9889
+  tls:
+    cert: "/etc/spooky/certs/default.crt"
+    key: "/etc/spooky/certs/default.key"
+    certificates:
+      - server_name: "api.example.com"
+        cert: "/etc/spooky/certs/api.crt"
+        key: "/etc/spooky/certs/api.key"
+      - server_name: "www.example.com"
+        cert: "/etc/spooky/certs/www.crt"
+        key: "/etc/spooky/certs/www.key"
 ```
 
 ## Upstream Configuration
@@ -865,7 +892,7 @@ Spooky validates configuration at startup and reports errors before attempting t
 ### Common Validation Errors
 
 1. **Missing required fields**
-   - TLS certificate or key paths not specified
+   - Neither `listen.tls.cert/key` nor `listen.tls.certificates` specified
    - Backend address or ID missing
    - Route configuration empty
 

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -215,17 +215,24 @@ Route matching determines which upstream pool handles a request. Routes are eval
 
 | Property | Type | Required | Default | Description |
 |----------|------|----------|---------|-------------|
-| `host` | string | No | - | Host header to match (e.g., `api.example.com`) |
+| `host` | string | No | - | Host matcher. Supports exact hosts (`api.example.com`) and leading-wildcard suffix patterns (`*.example.com`) |
 | `path_prefix` | string | No | - | Path prefix to match (e.g., `/api`) |
 | `method` | string | No | - | HTTP method to match (case-insensitive, e.g. `GET`, `POST`) |
 
 Route matching rules:
 
-1. If `host` is specified, the request Host header must match exactly
+1. If `host` is specified:
+   - Exact form: request Host must match exactly (case-insensitive after normalization)
+   - Wildcard form: `*.example.com` matches subdomains like `api.example.com`, but not the bare apex `example.com`
 2. If `path_prefix` is specified, the request path must start with the prefix
 3. If both are specified, both conditions must match
 4. Routes are evaluated by longest-prefix matching - the route with the most specific (longest) path prefix is selected
-5. For equal-length prefixes, ties are deterministic: host-specific routes win over host-agnostic routes, then lexicographically smaller upstream name wins
+5. For equal-length prefixes, ties are deterministic:
+   - host-specific routes win over host-agnostic routes
+   - exact-host matches win over wildcard-host matches
+   - among wildcard matches, longer suffixes win (`*.a.example.com` beats `*.example.com`)
+   - method-specific routes win over method-agnostic routes
+   - then lexicographically smaller upstream name wins
 
 #### Route Examples
 
@@ -240,6 +247,14 @@ upstream:
   web_pool:
     route:
       host: "www.example.com"
+    backends: [...]
+
+# Wildcard host routing
+upstream:
+  tenant_pool:
+    route:
+      host: "*.example.com"
+      path_prefix: "/api"
     backends: [...]
 
 # Path-based routing

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -233,6 +233,8 @@ upstream:
 | `load_balancing` | object | No | round-robin | Per-upstream load balancing algorithm configuration |
 | `route` | object | Yes | - | Route matching criteria |
 | `backends` | array | Yes | - | List of backend servers |
+| `host_policy` | object | No | `pass-through` | Controls how the `Host`/`:authority` header is set on upstream requests |
+| `forwarded_headers` | object | No | `overwrite` | Controls `X-Forwarded-For` forwarding behavior |
 
 ### Route Matching
 
@@ -405,6 +407,88 @@ backends:
     health_check:
       path: "/healthz"
       interval: 5000
+```
+
+### Host Policy
+
+Controls how the `Host` / `:authority` header is set on requests forwarded to the upstream.
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `mode` | string | No | `pass-through` | Header rewrite mode: `pass-through`, `rewrite`, or `upstream` |
+| `host` | string | No | - | Static host to use when `mode: rewrite` |
+
+#### Modes
+
+| Mode | Behavior |
+|------|----------|
+| `pass-through` | Forwards the original client `Host`/`:authority` unchanged to the upstream |
+| `rewrite` | Replaces the host with the value of `host` (required when using this mode) |
+| `upstream` | Uses the backend's own authority (hostname from the `address` field) |
+
+#### Examples
+
+```yaml
+upstream:
+  # Pass client host through as-is (default)
+  api_pool:
+    host_policy:
+      mode: pass-through
+    backends: [...]
+
+  # Rewrite to a static host
+  legacy_pool:
+    host_policy:
+      mode: rewrite
+      host: "legacy-origin.internal.example"
+    backends: [...]
+
+  # Use the backend's own hostname
+  direct_pool:
+    host_policy:
+      mode: upstream
+    backends: [...]
+```
+
+### Forwarded Headers Policy
+
+Controls how `X-Forwarded-For` and related forwarding headers are set on upstream requests.
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `mode` | string | No | `overwrite` | Forwarding mode: `append`, `preserve`, or `overwrite` |
+
+#### Modes
+
+| Mode | Behavior |
+|------|----------|
+| `overwrite` | Replaces any inbound `X-Forwarded-For` with the client IP only (default) |
+| `append` | Appends the client IP to the existing `X-Forwarded-For` chain |
+| `preserve` | Passes the inbound `X-Forwarded-For` chain through unchanged without adding the client IP |
+
+Use `append` in multi-hop deployments where the full client IP chain must be preserved. Use `overwrite` (default) when spooky is the first edge and inbound forwarded headers should not be trusted.
+
+#### Examples
+
+```yaml
+upstream:
+  # First edge — overwrite inbound XFF with real client IP (default)
+  public_pool:
+    forwarded_headers:
+      mode: overwrite
+    backends: [...]
+
+  # Behind another trusted proxy — append to the existing chain
+  internal_pool:
+    forwarded_headers:
+      mode: append
+    backends: [...]
+
+  # Pass the inbound chain through unchanged
+  passthrough_pool:
+    forwarded_headers:
+      mode: preserve
+    backends: [...]
 ```
 
 ## Load Balancing Configuration

--- a/spooky/src/main.rs
+++ b/spooky/src/main.rs
@@ -6,7 +6,7 @@ use std::sync::mpsc::{self, RecvTimeoutError, SyncSender, TrySendError};
 mod privilege_drop;
 mod runtime_guard;
 
-use spooky_config::config::Config;
+use spooky_config::config::{Config, effective_listens};
 use std::sync::{
     Arc,
     atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -114,14 +114,14 @@ fn main() {
     );
     runtime_guard::install_panic_hook();
 
-    // Require root only when binding a privileged port (< 1024).
+    // Require root only when binding privileged ports (< 1024).
     let uid = unsafe { libc::getuid() };
-    if uid != 0 && config_yaml.listen.port < 1024 {
+    let binds_privileged_port = std::iter::once(&config_yaml.listen)
+        .chain(config_yaml.listeners.iter())
+        .any(|listen| listen.port < 1024);
+    if uid != 0 && binds_privileged_port {
         fatal_startup_error(
-            &format!(
-                "binding privileged port {} requires root or CAP_NET_BIND_SERVICE. Use a port >= 1024 for unprivileged startup.",
-                config_yaml.listen.port
-            ),
+            "binding a privileged port requires root or CAP_NET_BIND_SERVICE. Use ports >= 1024 for unprivileged startup.",
             true,
             1,
         );
@@ -176,68 +176,18 @@ async fn run(config_yaml: Config, uid: libc::uid_t) {
         std::process::exit(1);
     }
 
-    let sockets = if worker_count > 1 {
-        match QUICListener::bind_reuseport_sockets(&config_yaml, worker_count) {
-            Ok(sockets) => sockets,
-            Err(e) => {
-                error!("Failed to bind SO_REUSEPORT sockets: {}", e);
-                std::process::exit(1);
-            }
-        }
-    } else {
-        match QUICListener::bind_socket(&config_yaml, false) {
-            Ok(socket) => vec![socket],
-            Err(e) => {
-                error!("Failed to bind UDP socket: {}", e);
-                std::process::exit(1);
-            }
-        }
-    };
-
-    let privileged_bind = config_yaml.listen.port < 1024;
-    if privileged_bind && uid == 0 {
-        if config_yaml.security.privileges.enabled {
-            match privilege_drop::drop_privileges(
-                &config_yaml.security.privileges.user,
-                &config_yaml.security.privileges.group,
-            ) {
-                Ok(()) => {
-                    info!(
-                        "Dropped root privileges to user='{}' group='{}'",
-                        config_yaml.security.privileges.user, config_yaml.security.privileges.group
-                    );
-                }
-                Err(err) => {
-                    error!("Failed to drop privileges after privileged bind: {}", err);
-                    std::process::exit(1);
-                }
-            }
-        } else {
-            warn!(
-                "Running as root on privileged port without privilege drop (security.privileges.enabled=false)"
-            );
-        }
+    let listens = effective_listens(&config_yaml);
+    let binds_privileged_port = listens.iter().any(|listen| listen.port < 1024);
+    if uid != 0 && binds_privileged_port {
+        fatal_startup_error(
+            "binding a privileged port requires root or CAP_NET_BIND_SERVICE. Use ports >= 1024 for unprivileged startup.",
+            true,
+            1,
+        );
     }
-
-    info!("Spooky is starting");
-    info!(
-        "Ingress: HTTP/3 (QUIC) on UDP {}:{}, HTTP/1.1+HTTP/2 bootstrap (TLS) on TCP {}:{} with Alt-Svc upgrade",
-        config_yaml.listen.address,
-        config_yaml.listen.port,
-        config_yaml.listen.address,
-        config_yaml.listen.port,
-    );
-    info!(
-        "Data-plane workers={} packet_shards_per_worker={} reuseport={} pin_workers={}",
-        sockets.len(),
-        shard_count,
-        config_yaml.performance.reuseport,
-        config_yaml.performance.pin_workers
-    );
 
     let shutdown = Arc::new(AtomicBool::new(false));
     let shutdown_flag = shutdown.clone();
-
     tokio::spawn(async move {
         wait_for_shutdown_signal().await;
         shutdown_flag.store(true, Ordering::Relaxed);
@@ -246,48 +196,65 @@ async fn run(config_yaml: Config, uid: libc::uid_t) {
     let pin_workers = config_yaml.performance.pin_workers;
     let shard_queue_capacity = config_yaml.performance.packet_shard_queue_capacity.max(1);
     let shard_queue_max_bytes = config_yaml.performance.packet_shard_queue_max_bytes.max(1);
-    let mut worker_handles = Vec::with_capacity(sockets.len());
-    for (worker_idx, socket) in sockets.into_iter().enumerate() {
-        let worker_config = config_yaml.clone();
-        let worker_shutdown = Arc::clone(&shutdown);
-        let worker_shared = Arc::clone(&shared_state);
-        let thread_name = format!("spooky-data-plane-{}", worker_idx);
-        let handle = thread::Builder::new().name(thread_name.clone()).spawn(
-            move || -> Result<(), String> {
-                if shard_count <= 1 {
-                    return run_single_listener_worker(
-                        worker_idx,
-                        pin_workers,
-                        worker_config,
-                        socket,
-                        worker_shared,
-                        worker_shutdown,
-                    );
-                }
+    let mut worker_handles: Vec<thread::JoinHandle<Result<(), String>>> = Vec::new();
+    let mut worker_index_base = 0usize;
 
-                run_sharded_listener_worker(
-                    worker_idx,
-                    shard_count,
-                    shard_queue_capacity,
-                    shard_queue_max_bytes,
-                    pin_workers,
-                    worker_config,
-                    socket,
-                    worker_shared,
-                    worker_shutdown,
-                )
-            },
-        );
+    for (listener_idx, listen) in listens.iter().enumerate() {
+        let mut listener_config = config_yaml.clone();
+        listener_config.listen = listen.clone();
 
-        match handle {
-            Ok(handle) => worker_handles.push(handle),
+        if let Err(err) =
+            QUICListener::spawn_bootstrap_tls_listener(&listener_config, &shared_state)
+        {
+            error!(
+                "Failed to initialize bootstrap TLS listener {} ({}:{}): {}",
+                listener_idx, listen.address, listen.port, err
+            );
+            std::process::exit(1);
+        }
+
+        match spawn_listener_worker_group(
+            listener_config,
+            worker_count,
+            shard_count,
+            shard_queue_capacity,
+            shard_queue_max_bytes,
+            pin_workers,
+            Arc::clone(&shared_state),
+            Arc::clone(&shutdown),
+            worker_index_base,
+        ) {
+            Ok(handles) => worker_handles.extend(handles),
             Err(err) => {
-                error!("Failed to spawn worker thread {}: {}", worker_idx, err);
-                shutdown.store(true, Ordering::Relaxed);
-                break;
+                error!("{}", err);
+                std::process::exit(1);
             }
         }
+
+        worker_index_base = worker_index_base.saturating_add(worker_count.max(1));
     }
+
+    info!("Spooky is starting");
+    info!(
+        "Ingress listeners={} packet_shards_per_worker={} reuseport={} pin_workers={}",
+        listens.len(),
+        shard_count,
+        config_yaml.performance.reuseport,
+        config_yaml.performance.pin_workers
+    );
+    for (idx, listen) in listens.iter().enumerate() {
+        info!(
+            "Listener {}: HTTP/3 (QUIC) on UDP {}:{}, HTTP/1.1+HTTP/2 bootstrap (TLS) on TCP {}:{} with Alt-Svc upgrade",
+            idx, listen.address, listen.port, listen.address, listen.port,
+        );
+    }
+    info!(
+        "Data-plane workers={} packet_shards_per_worker={} reuseport={} pin_workers={}",
+        worker_handles.len(),
+        shard_count,
+        config_yaml.performance.reuseport,
+        config_yaml.performance.pin_workers
+    );
 
     let mut worker_failed = false;
     let mut active_worker_handles = worker_handles;
@@ -330,6 +297,79 @@ async fn run(config_yaml: Config, uid: libc::uid_t) {
     }
     spooky_utils::telemetry::shutdown_tracing();
     info!("Spooky shutdown complete");
+}
+
+#[allow(clippy::too_many_arguments)]
+fn spawn_listener_worker_group(
+    listener_config: Config,
+    worker_count: usize,
+    shard_count: usize,
+    shard_queue_capacity: usize,
+    shard_queue_max_bytes: usize,
+    pin_workers: bool,
+    worker_shared: Arc<SharedRuntimeState>,
+    worker_shutdown: Arc<AtomicBool>,
+    worker_index_base: usize,
+) -> Result<Vec<thread::JoinHandle<Result<(), String>>>, String> {
+    let sockets = if worker_count > 1 {
+        match QUICListener::bind_reuseport_sockets(&listener_config, worker_count) {
+            Ok(sockets) => sockets,
+            Err(e) => return Err(format!("Failed to bind SO_REUSEPORT sockets: {}", e)),
+        }
+    } else {
+        match QUICListener::bind_socket(&listener_config, false) {
+            Ok(socket) => vec![socket],
+            Err(e) => return Err(format!("Failed to bind UDP socket: {}", e)),
+        }
+    };
+
+    let mut worker_handles = Vec::with_capacity(sockets.len());
+    for (socket_idx, socket) in sockets.into_iter().enumerate() {
+        let worker_idx = worker_index_base.saturating_add(socket_idx);
+        let worker_config = listener_config.clone();
+        let worker_shutdown = Arc::clone(&worker_shutdown);
+        let worker_shared = Arc::clone(&worker_shared);
+        let thread_name = format!("spooky-data-plane-{}", worker_idx);
+        let handle =
+            thread::Builder::new()
+                .name(thread_name)
+                .spawn(move || -> Result<(), String> {
+                    if shard_count <= 1 {
+                        return run_single_listener_worker(
+                            worker_idx,
+                            pin_workers,
+                            worker_config,
+                            socket,
+                            worker_shared,
+                            worker_shutdown,
+                        );
+                    }
+
+                    run_sharded_listener_worker(
+                        worker_idx,
+                        shard_count,
+                        shard_queue_capacity,
+                        shard_queue_max_bytes,
+                        pin_workers,
+                        worker_config,
+                        socket,
+                        worker_shared,
+                        worker_shutdown,
+                    )
+                });
+
+        match handle {
+            Ok(handle) => worker_handles.push(handle),
+            Err(err) => {
+                return Err(format!(
+                    "Failed to spawn worker thread {}: {}",
+                    worker_idx, err
+                ));
+            }
+        }
+    }
+
+    Ok(worker_handles)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/spooky/src/privilege_drop.rs
+++ b/spooky/src/privilege_drop.rs
@@ -1,4 +1,5 @@
 #[cfg(unix)]
+#[allow(dead_code)]
 pub fn drop_privileges(user: &str, group: &str) -> Result<(), String> {
     use std::{ffi::CString, io};
 
@@ -135,6 +136,7 @@ pub fn drop_privileges(user: &str, group: &str) -> Result<(), String> {
 }
 
 #[cfg(not(unix))]
+#[allow(dead_code)]
 pub fn drop_privileges(_user: &str, _group: &str) -> Result<(), String> {
     Ok(())
 }


### PR DESCRIPTION
## Summary

- **#199** — Adds `listeners` array to config for multiple independent listener
  blocks, each with its own address, port, and TLS identity. `effective_listens()`
  falls back to the single `listen` block for backwards compatibility. The runtime
  iterates over all listeners and spawns an independent QUIC worker group and
  bootstrap TLS listener per entry.

- **#198** — Adds optional `tls` override per upstream. When set, it overrides
  the global `upstream_tls` for that upstream's backends and health check client.
  `H2Pool` now accepts a per-backend TLS map instead of a single shared config.

## Files changed

- `crates/config/src/config.rs` — `listeners: Vec<Listen>`, `effective_listens()`,
  `Upstream.tls: Option<UpstreamTls>`
- `crates/config/src/validator.rs` — validation for `listeners` entries and
  per-upstream TLS override fields
- `crates/edge/src/quic_listener/mod.rs` — `effective_upstream_tls()`,
  per-upstream TLS map wired into `H2Pool` and health clients
- `crates/edge/src/quic_listener/health_check.rs` — per-upstream health client
  selection via `upstream_health_clients` map
- `crates/transport/src/h2_pool.rs` — accepts `HashMap<String, TlsClientConfig>`
  instead of a single `TlsClientConfig`
- `spooky/src/main.rs` — iterates `effective_listens()`, spawns worker group
  per listener
- `config/config.sample.yaml`, `config/config.production.yaml` — documented
