### PR TITLE
feat(reverse-proxy): multi-listener support and per-upstream TLS policy

### DIFF
--- a/config/config.production.yaml
+++ b/config/config.production.yaml
@@ -8,6 +8,22 @@ listen:
     cert: "/etc/spooky/certs/fullchain.pem"
     key: "/etc/spooky/certs/privkey.pem"
 
+# listeners: optional multi-listener block; overrides the top-level listen block when set.
+# Use this to bind multiple independent listeners with separate TLS identities.
+# listeners:
+#   - protocol: http3
+#     address: "0.0.0.0"
+#     port: 9889
+#     tls:
+#       cert: "/etc/spooky/certs/public-fullchain.pem"
+#       key: "/etc/spooky/certs/public-privkey.pem"
+#   - protocol: http3
+#     address: "10.0.0.1"
+#     port: 9890
+#     tls:
+#       cert: "/etc/spooky/certs/internal-fullchain.pem"
+#       key: "/etc/spooky/certs/internal-privkey.pem"
+
 upstream_tls:
   verify_certificates: true
   strict_sni: true

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -19,6 +19,22 @@ listen:
             require_client_cert: false  # when true, close connections that complete handshake without a client cert
             ca_file: null               # PEM CA bundle used to verify client certificates when enabled=true
 
+# listeners: optional multi-listener block; when set, overrides the top-level listen block.
+# Each entry is an independent listener with its own address, port, and TLS identity.
+# listeners:
+#   - protocol: http3
+#     address: "0.0.0.0"
+#     port: 9889
+#     tls:
+#       cert: certs/public-fullchain.pem
+#       key: certs/public-key-pkcs8.pem
+#   - protocol: http3
+#     address: "10.0.0.1"
+#     port: 9890
+#     tls:
+#       cert: certs/internal-fullchain.pem
+#       key: certs/internal-key-pkcs8.pem
+
 upstream_tls:
     verify_certificates: true  # safe-by-default for HTTPS upstreams
     strict_sni: true           # send backend host as SNI for HTTPS upstream connections
@@ -39,6 +55,13 @@ upstream:
 
     forwarded_headers:
       mode: append         # append | preserve | overwrite
+
+    # tls: optional per-upstream TLS override; inherits from upstream_tls when omitted
+    # tls:
+    #   verify_certificates: true
+    #   strict_sni: true
+    #   ca_file: certs/private-ca.pem  # optional custom CA bundle for this upstream only
+    #   ca_dir: null
 
     backends:
       - id: "backend1"

--- a/crates/bench/src/main.rs
+++ b/crates/bench/src/main.rs
@@ -738,6 +738,7 @@ fn build_lb_upstream(scale: usize, lb_type: &str) -> Upstream {
         },
         host_policy: Default::default(),
         forwarded_headers: Default::default(),
+        tls: None,
         route: RouteMatch {
             host: None,
             path_prefix: Some("/".to_string()),

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -71,6 +71,9 @@ pub struct Config {
 
     pub listen: Listen,
 
+    #[serde(default)]
+    pub listeners: Vec<Listen>,
+
     pub upstream: HashMap<String, Upstream>,
 
     #[serde(default)]
@@ -120,6 +123,14 @@ impl Default for PrivilegeDrop {
             user: security_default_user(),
             group: security_default_group(),
         }
+    }
+}
+
+pub fn effective_listens(config: &Config) -> Vec<Listen> {
+    if config.listeners.is_empty() {
+        vec![config.listen.clone()]
+    } else {
+        config.listeners.clone()
     }
 }
 
@@ -204,6 +215,9 @@ pub struct Upstream {
 
     #[serde(default)]
     pub forwarded_headers: ForwardedHeaderPolicy,
+
+    #[serde(default)]
+    pub tls: Option<UpstreamTls>,
 
     pub route: RouteMatch, // Route matching criteria for this upstream
 

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -1,6 +1,7 @@
 use crate::backend_endpoint::{BackendEndpoint, BackendScheme};
 use crate::config::{
-    CURRENT_CONFIG_VERSION, Config, SUPPORTED_CONFIG_VERSIONS, UpstreamHostPolicyMode,
+    CURRENT_CONFIG_VERSION, Config, Listen, SUPPORTED_CONFIG_VERSIONS, UpstreamHostPolicyMode,
+    UpstreamTls,
 };
 use log::{error, info, warn};
 use std::collections::HashMap;
@@ -102,6 +103,166 @@ fn validate_pem_private_key(path: &str, field_name: &str) -> bool {
             false
         }
     }
+}
+
+fn validate_upstream_tls(field_prefix: &str, tls: &UpstreamTls) -> bool {
+    if !tls.verify_certificates {
+        warn!(
+            "{}.verify_certificates=false: upstream TLS certificate verification is disabled; only use in trusted/development environments",
+            field_prefix
+        );
+    }
+
+    if let Some(ca_file) = tls.ca_file.as_ref() {
+        if ca_file.trim().is_empty() {
+            error!("{}.ca_file cannot be empty when provided", field_prefix);
+            return false;
+        }
+        if !validate_pem_certificates(ca_file, &format!("{}.ca_file", field_prefix)) {
+            return false;
+        }
+    }
+
+    if let Some(ca_dir) = tls.ca_dir.as_ref() {
+        if ca_dir.trim().is_empty() {
+            error!("{}.ca_dir cannot be empty when provided", field_prefix);
+            return false;
+        }
+        let metadata = match std::fs::metadata(ca_dir) {
+            Ok(metadata) => metadata,
+            Err(err) => {
+                error!("Cannot stat {}.ca_dir '{}': {}", field_prefix, ca_dir, err);
+                return false;
+            }
+        };
+        if !metadata.is_dir() {
+            error!("{}.ca_dir must be a directory: {}", field_prefix, ca_dir);
+            return false;
+        }
+    }
+
+    true
+}
+
+fn validate_listen_config(listen: &Listen, field_prefix: &str) -> bool {
+    if listen.protocol != "http3" {
+        error!(
+            "{} protocol: expected 'http3', found '{}'",
+            field_prefix, listen.protocol
+        );
+        return false;
+    }
+
+    if listen.address.is_empty() {
+        error!("{} address is empty", field_prefix);
+        return false;
+    }
+
+    if listen.port == 0 {
+        error!(
+            "Invalid {} port: {} (must be between 1 and 65535)",
+            field_prefix, listen.port
+        );
+        return false;
+    }
+
+    let tls_prefix = format!("{}.tls", field_prefix);
+    let legacy_cert = listen.tls.cert.trim();
+    let legacy_key = listen.tls.key.trim();
+    let has_legacy_cert_pair = !legacy_cert.is_empty() || !legacy_key.is_empty();
+    let has_sni_certificates = !listen.tls.certificates.is_empty();
+
+    if !has_legacy_cert_pair && !has_sni_certificates {
+        error!(
+            "{} requires either cert/key or certificates entries",
+            tls_prefix
+        );
+        return false;
+    }
+
+    if has_legacy_cert_pair {
+        if legacy_cert.is_empty() || legacy_key.is_empty() {
+            error!(
+                "{}.cert and {}.key must both be set when either is provided",
+                tls_prefix, tls_prefix
+            );
+            return false;
+        }
+        if !validate_pem_certificates(legacy_cert, &format!("{}.cert", tls_prefix)) {
+            return false;
+        }
+        if !validate_pem_private_key(legacy_key, &format!("{}.key", tls_prefix)) {
+            return false;
+        }
+    }
+
+    let mut seen_sni_names: HashMap<String, usize> = HashMap::new();
+    for (idx, entry) in listen.tls.certificates.iter().enumerate() {
+        let field_prefix = format!("{}.certificates[{idx}]", tls_prefix);
+        let sni_name = match normalize_sni_server_name(&entry.server_name) {
+            Some(sni) => sni,
+            None => {
+                error!(
+                    "{}.server_name '{}' is not a valid DNS hostname",
+                    field_prefix, entry.server_name
+                );
+                return false;
+            }
+        };
+
+        if let Some(first_idx) = seen_sni_names.insert(sni_name.clone(), idx) {
+            error!(
+                "{}.server_name '{}' duplicates {}.certificates[{}].server_name",
+                field_prefix, entry.server_name, tls_prefix, first_idx
+            );
+            return false;
+        }
+
+        let cert = entry.cert.trim();
+        if cert.is_empty() {
+            error!("{}.cert cannot be empty", field_prefix);
+            return false;
+        }
+        if !validate_pem_certificates(cert, &format!("{}.cert", field_prefix)) {
+            return false;
+        }
+
+        let key = entry.key.trim();
+        if key.is_empty() {
+            error!("{}.key cannot be empty", field_prefix);
+            return false;
+        }
+        if !validate_pem_private_key(key, &format!("{}.key", field_prefix)) {
+            return false;
+        }
+    }
+
+    if listen.tls.client_auth.require_client_cert && !listen.tls.client_auth.enabled {
+        error!(
+            "{}.client_auth.require_client_cert requires client_auth.enabled=true",
+            tls_prefix
+        );
+        return false;
+    }
+
+    if listen.tls.client_auth.enabled {
+        let Some(ca_file) = listen.tls.client_auth.ca_file.as_ref() else {
+            error!(
+                "{}.client_auth.ca_file is required when client_auth.enabled=true",
+                tls_prefix
+            );
+            return false;
+        };
+        if ca_file.trim().is_empty() {
+            error!("{}.client_auth.ca_file cannot be empty", tls_prefix);
+            return false;
+        }
+        if !validate_pem_certificates(ca_file, &format!("{}.client_auth.ca_file", tls_prefix)) {
+            return false;
+        }
+    }
+
+    true
 }
 
 fn is_loopback_bind_address(raw: &str) -> bool {
@@ -255,13 +416,29 @@ pub fn validate(config: &Config) -> bool {
         );
     }
 
-    // --- Validate protocol ---
-    if config.listen.protocol != "http3" {
-        error!(
-            "Invalid protocol: expected 'http3', found '{}'",
-            config.listen.protocol
-        );
+    // --- Validate listen blocks ---
+    if !validate_listen_config(&config.listen, "listen") {
         return false;
+    }
+    for (idx, listen) in config.listeners.iter().enumerate() {
+        if !validate_listen_config(listen, &format!("listeners[{idx}]")) {
+            return false;
+        }
+    }
+
+    let mut seen_listener_bindings: HashMap<(String, u16), String> = HashMap::new();
+    let listen_key = (config.listen.address.clone(), config.listen.port);
+    seen_listener_bindings.insert(listen_key, "listen".to_string());
+    for (idx, listen) in config.listeners.iter().enumerate() {
+        let key = (listen.address.clone(), listen.port);
+        let current = format!("listeners[{idx}]");
+        if let Some(existing) = seen_listener_bindings.insert(key, current.clone()) {
+            error!(
+                "listener binding conflict: {} duplicates {} on {}:{}",
+                current, existing, listen.address, listen.port
+            );
+            return false;
+        }
     }
 
     // --- Validate log level ---
@@ -280,21 +457,6 @@ pub fn validate(config: &Config) -> bool {
             .any(|lb_type| lb_type.eq_ignore_ascii_case(&lb.lb_type))
     {
         error!("Invalid global load balancing type: {}", lb.lb_type);
-        return false;
-    }
-
-    // --- Validate listen address ---
-    if config.listen.address.is_empty() {
-        error!("Listen address is empty");
-        return false;
-    }
-
-    // --- Validate listen port ---
-    if config.listen.port == 0 {
-        error!(
-            "Invalid listen port: {} (must be between 1 and 65535)",
-            config.listen.port
-        );
         return false;
     }
 
@@ -930,128 +1092,19 @@ pub fn validate(config: &Config) -> bool {
         }
     }
 
-    // --- Validate TLS certs ---
-    let legacy_cert = config.listen.tls.cert.trim();
-    let legacy_key = config.listen.tls.key.trim();
-    let has_legacy_cert_pair = !legacy_cert.is_empty() || !legacy_key.is_empty();
-    let has_sni_certificates = !config.listen.tls.certificates.is_empty();
-
-    if !has_legacy_cert_pair && !has_sni_certificates {
-        error!("listen.tls requires either cert/key or certificates entries");
-        return false;
-    }
-
-    if has_legacy_cert_pair {
-        if legacy_cert.is_empty() || legacy_key.is_empty() {
-            error!("listen.tls.cert and listen.tls.key must both be set when either is provided");
-            return false;
-        }
-        if !validate_pem_certificates(legacy_cert, "listen.tls.cert") {
-            return false;
-        }
-        if !validate_pem_private_key(legacy_key, "listen.tls.key") {
-            return false;
-        }
-    }
-
-    let mut seen_sni_names: HashMap<String, usize> = HashMap::new();
-    for (idx, entry) in config.listen.tls.certificates.iter().enumerate() {
-        let field_prefix = format!("listen.tls.certificates[{idx}]");
-        let sni_name = match normalize_sni_server_name(&entry.server_name) {
-            Some(sni) => sni,
-            None => {
-                error!(
-                    "{field_prefix}.server_name '{}' is not a valid DNS hostname",
-                    entry.server_name
-                );
-                return false;
-            }
-        };
-
-        if let Some(first_idx) = seen_sni_names.insert(sni_name.clone(), idx) {
-            error!(
-                "{field_prefix}.server_name '{}' duplicates listen.tls.certificates[{}].server_name",
-                entry.server_name, first_idx
-            );
-            return false;
-        }
-
-        let cert = entry.cert.trim();
-        if cert.is_empty() {
-            error!("{field_prefix}.cert cannot be empty");
-            return false;
-        }
-        if !validate_pem_certificates(cert, &format!("{field_prefix}.cert")) {
-            return false;
-        }
-
-        let key = entry.key.trim();
-        if key.is_empty() {
-            error!("{field_prefix}.key cannot be empty");
-            return false;
-        }
-        if !validate_pem_private_key(key, &format!("{field_prefix}.key")) {
-            return false;
-        }
-    }
-
-    // --- Validate optional downstream client-auth (mTLS) ---
-    if config.listen.tls.client_auth.require_client_cert && !config.listen.tls.client_auth.enabled {
-        error!("listen.tls.client_auth.require_client_cert requires client_auth.enabled=true");
-        return false;
-    }
-
-    if config.listen.tls.client_auth.enabled {
-        let Some(ca_file) = config.listen.tls.client_auth.ca_file.as_ref() else {
-            error!("listen.tls.client_auth.ca_file is required when client_auth.enabled=true");
-            return false;
-        };
-        if ca_file.trim().is_empty() {
-            error!("listen.tls.client_auth.ca_file cannot be empty");
-            return false;
-        }
-        if !validate_pem_certificates(ca_file, "listen.tls.client_auth.ca_file") {
-            return false;
-        }
-    }
-
     // --- Validate upstream TLS trust-store configuration ---
-    if !config.upstream_tls.verify_certificates {
-        warn!(
-            "upstream_tls.verify_certificates=false: upstream TLS certificate verification is disabled; only use in trusted/development environments"
-        );
-    }
-
-    if let Some(ca_file) = config.upstream_tls.ca_file.as_ref() {
-        if ca_file.trim().is_empty() {
-            error!("upstream_tls.ca_file cannot be empty when provided");
-            return false;
-        }
-        if !validate_pem_certificates(ca_file, "upstream_tls.ca_file") {
-            return false;
-        }
-    }
-
-    if let Some(ca_dir) = config.upstream_tls.ca_dir.as_ref() {
-        if ca_dir.trim().is_empty() {
-            error!("upstream_tls.ca_dir cannot be empty when provided");
-            return false;
-        }
-        let metadata = match std::fs::metadata(ca_dir) {
-            Ok(metadata) => metadata,
-            Err(err) => {
-                error!("Cannot stat upstream_tls.ca_dir '{}': {}", ca_dir, err);
-                return false;
-            }
-        };
-        if !metadata.is_dir() {
-            error!("upstream_tls.ca_dir must be a directory: {}", ca_dir);
-            return false;
-        }
+    if !validate_upstream_tls("upstream_tls", &config.upstream_tls) {
+        return false;
     }
 
     // --- Validate upstream routes ---
     for (upstream_name, upstream) in &config.upstream {
+        if let Some(tls) = upstream.tls.as_ref()
+            && !validate_upstream_tls(&format!("upstream['{}'].tls", upstream_name), tls)
+        {
+            return false;
+        }
+
         // Validate route matcher has at least one condition
         let has_host = upstream.route.host.is_some();
         let has_path = upstream.route.path_prefix.is_some();
@@ -1298,6 +1351,7 @@ mod tests {
                 },
                 host_policy: Default::default(),
                 forwarded_headers: Default::default(),
+                tls: None,
                 route: RouteMatch {
                     host: None,
                     path_prefix: Some("/".to_string()),
@@ -1332,6 +1386,7 @@ mod tests {
                     client_auth: ClientAuth::default(),
                 },
             },
+            listeners: vec![],
             upstream,
             load_balancing: Some(LoadBalancing {
                 lb_type: "random".to_string(),
@@ -2035,6 +2090,7 @@ upstream:
             },
             host_policy: Default::default(),
             forwarded_headers: Default::default(),
+            tls: None,
             route: RouteMatch {
                 host: Some("api.example.com".to_string()),
                 path_prefix: Some("/api".to_string()),
@@ -2074,6 +2130,7 @@ upstream:
             },
             host_policy: Default::default(),
             forwarded_headers: Default::default(),
+            tls: None,
             route: RouteMatch {
                 host: Some("api.example.com".to_string()),
                 path_prefix: Some("/api".to_string()),

--- a/crates/edge/src/benchmark.rs
+++ b/crates/edge/src/benchmark.rs
@@ -31,6 +31,7 @@ fn build_benchmark_upstream(host: Option<String>, path_prefix: String) -> Upstre
         },
         host_policy: Default::default(),
         forwarded_headers: Default::default(),
+        tls: None,
         route: RouteMatch {
             host,
             path_prefix: Some(path_prefix),

--- a/crates/edge/src/quic_listener/health_check.rs
+++ b/crates/edge/src/quic_listener/health_check.rs
@@ -3,10 +3,11 @@ use super::*;
 impl QUICListener {
     pub(super) fn spawn_health_checks(
         upstream_pools: HashMap<String, Arc<RwLock<UpstreamPool>>>,
-        health_client: Arc<H2Client>,
+        health_clients: Arc<HashMap<String, Arc<H2Client>>>,
         metrics: Arc<Metrics>,
     ) {
         struct HealthCheckJob {
+            upstream_name: String,
             upstream_pool: Arc<RwLock<UpstreamPool>>,
             index: usize,
             address: String,
@@ -18,7 +19,7 @@ impl QUICListener {
         }
 
         let mut grouped_jobs: HashMap<u64, Vec<HealthCheckJob>> = HashMap::new();
-        for (_upstream_name, upstream_pool) in upstream_pools.iter() {
+        for (upstream_name, upstream_pool) in upstream_pools.iter() {
             let pool = match upstream_pool.read() {
                 Ok(pool) => pool,
                 Err(_) => continue,
@@ -52,6 +53,7 @@ impl QUICListener {
                 };
                 let next_due_at = Instant::now() + Duration::from_millis(initial_jitter_ms);
                 let job = HealthCheckJob {
+                    upstream_name: upstream_name.clone(),
                     upstream_pool: Arc::clone(upstream_pool),
                     index,
                     address,
@@ -78,7 +80,7 @@ impl QUICListener {
         };
 
         for (base_interval_ms, mut jobs) in grouped_jobs {
-            let health_client = Arc::clone(&health_client);
+            let health_clients = Arc::clone(&health_clients);
             let task_metrics = Arc::clone(&metrics);
             let handle = handle.clone();
             let supervise_metrics = Arc::clone(&task_metrics);
@@ -107,6 +109,10 @@ impl QUICListener {
                             {
                                 Ok(req) => req,
                                 Err(_) => continue,
+                            };
+
+                            let Some(health_client) = health_clients.get(&job.upstream_name) else {
+                                continue;
                             };
 
                             let result =

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -55,7 +55,7 @@ use tracing::{Instrument, info_span};
 
 use spooky_config::{
     backend_endpoint::{BackendEndpoint, BackendScheme},
-    config::{Config as SpookyConfig, ForwardedHeaderPolicy, UpstreamHostPolicy},
+    config::{Config as SpookyConfig, ForwardedHeaderPolicy, UpstreamHostPolicy, UpstreamTls},
 };
 
 use crate::{
@@ -418,13 +418,23 @@ impl QUICListener {
         Self::new_with_socket_and_shared_state(config, socket, shared_state)
     }
 
-    fn upstream_tls_client_config(config: &SpookyConfig) -> TlsClientConfig {
+    fn upstream_tls_client_config(tls: &UpstreamTls) -> TlsClientConfig {
         TlsClientConfig {
-            verify_certificates: config.upstream_tls.verify_certificates,
-            strict_sni: config.upstream_tls.strict_sni,
-            ca_file: config.upstream_tls.ca_file.clone(),
-            ca_dir: config.upstream_tls.ca_dir.clone(),
+            verify_certificates: tls.verify_certificates,
+            strict_sni: tls.strict_sni,
+            ca_file: tls.ca_file.clone(),
+            ca_dir: tls.ca_dir.clone(),
         }
+    }
+
+    fn effective_upstream_tls(
+        config: &SpookyConfig,
+        upstream: &spooky_config::config::Upstream,
+    ) -> UpstreamTls {
+        upstream
+            .tls
+            .clone()
+            .unwrap_or_else(|| config.upstream_tls.clone())
     }
 
     pub fn build_shared_state(config: &SpookyConfig) -> Result<SharedRuntimeState, ProxyError> {
@@ -471,7 +481,13 @@ impl QUICListener {
 
         let mut backend_addresses = Vec::new();
         let mut seen_backend_origins: HashMap<String, (String, String)> = HashMap::new();
+        let mut backend_tls_configs: HashMap<String, TlsClientConfig> = HashMap::new();
+        let mut upstream_tls_configs: HashMap<String, TlsClientConfig> = HashMap::new();
         for (upstream_name, upstream) in &config.upstream {
+            let upstream_tls = Self::effective_upstream_tls(config, upstream);
+            let upstream_tls_client = Self::upstream_tls_client_config(&upstream_tls);
+            upstream_tls_configs.insert(upstream_name.clone(), upstream_tls_client.clone());
+
             for backend in &upstream.backends {
                 let endpoint = match BackendEndpoint::parse(&backend.address) {
                     Ok(endpoint) => endpoint,
@@ -493,6 +509,7 @@ impl QUICListener {
                     )));
                 }
                 backend_addresses.push(backend.address.clone());
+                backend_tls_configs.insert(backend.address.clone(), upstream_tls_client.clone());
             }
         }
 
@@ -500,17 +517,18 @@ impl QUICListener {
         let h2_pool = Arc::new(
             H2Pool::new(
                 backend_addresses,
+                backend_tls_configs,
                 max_inflight_per_backend,
                 config.performance.h2_pool_max_idle_per_backend,
                 Duration::from_millis(config.performance.h2_pool_idle_timeout_ms),
                 Duration::from_millis(config.performance.backend_connect_timeout_ms),
-                Self::upstream_tls_client_config(config),
                 backend_dns_resolver.clone(),
             )
             .map_err(ProxyError::Tls)?,
         );
         let mut upstream_pools = HashMap::new();
         let mut upstream_inflight = HashMap::new();
+        let mut upstream_health_clients = HashMap::new();
 
         for (name, upstream) in &config.upstream {
             let upstream_pool = UpstreamPool::from_upstream(upstream).map_err(|err| {
@@ -521,6 +539,16 @@ impl QUICListener {
             })?;
             upstream_pools.insert(name.clone(), Arc::new(RwLock::new(upstream_pool)));
             upstream_inflight.insert(name.clone(), Arc::new(Semaphore::new(per_upstream_limit)));
+            let tls = upstream_tls_configs.get(name).cloned().unwrap_or_default();
+            let client = H2Client::new(
+                config.performance.h2_pool_max_idle_per_backend.max(1),
+                Duration::from_millis(config.performance.h2_pool_idle_timeout_ms.max(1)),
+                Duration::from_millis(config.performance.backend_connect_timeout_ms.max(1)),
+                tls,
+                backend_dns_resolver.clone(),
+            )
+            .map_err(ProxyError::Tls)?;
+            upstream_health_clients.insert(name.clone(), Arc::new(client));
         }
 
         config
@@ -578,6 +606,7 @@ impl QUICListener {
                     .collect(),
             ),
             backend_dns_resolver,
+            upstream_health_clients: Arc::new(upstream_health_clients),
             forwarded_header_policies: Arc::new(
                 config
                     .upstream
@@ -609,28 +638,13 @@ impl QUICListener {
         shared_state
             .watchdog
             .set_expected_workers(worker_count.max(1));
-        let health_client = match H2Client::new(
-            config.performance.h2_pool_max_idle_per_backend.max(1),
-            Duration::from_millis(config.performance.h2_pool_idle_timeout_ms.max(1)),
-            Duration::from_millis(config.performance.backend_connect_timeout_ms.max(1)),
-            Self::upstream_tls_client_config(config),
-            shared_state.backend_dns_resolver.clone(),
-        ) {
-            Ok(client) => Arc::new(client),
-            Err(err) => {
-                return Err(ProxyError::Transport(format!(
-                    "failed to initialize control-plane H2 client: {err}"
-                )));
-            }
-        };
         Self::spawn_health_checks(
             shared_state.upstream_pools.clone(),
-            health_client,
+            Arc::clone(&shared_state.upstream_health_clients),
             Arc::clone(&shared_state.metrics),
         );
         Self::spawn_metrics_endpoint(config, Arc::clone(&shared_state.metrics))?;
         Self::spawn_control_api_endpoint(config, shared_state, worker_count)?;
-        Self::spawn_bootstrap_tls_listener(config, shared_state)?;
         Self::spawn_watchdog(
             config,
             Arc::clone(&shared_state.metrics),
@@ -4197,7 +4211,7 @@ impl QUICListener {
         Self::build_server_tls_acceptor(config, true, vec![b"h2".to_vec(), b"http/1.1".to_vec()])
     }
 
-    fn spawn_bootstrap_tls_listener(
+    pub fn spawn_bootstrap_tls_listener(
         config: &SpookyConfig,
         shared_state: &SharedRuntimeState,
     ) -> Result<(), ProxyError> {
@@ -5160,6 +5174,7 @@ mod tests {
             },
             host_policy: Default::default(),
             forwarded_headers: Default::default(),
+            tls: None,
             route: RouteMatch {
                 host: None,
                 path_prefix: Some("/api".to_string()),
@@ -5221,6 +5236,7 @@ mod tests {
                     client_auth: ClientAuth::default(),
                 },
             },
+            listeners: vec![],
             upstream: upstreams,
             load_balancing: Some(LoadBalancing {
                 lb_type: "round-robin".to_string(),

--- a/crates/edge/src/route_index.rs
+++ b/crates/edge/src/route_index.rs
@@ -820,6 +820,7 @@ mod tests {
             },
             host_policy: Default::default(),
             forwarded_headers: Default::default(),
+            tls: None,
             route: RouteMatch {
                 host: host.map(str::to_string),
                 path_prefix: path_prefix.map(str::to_string),

--- a/crates/edge/src/types.rs
+++ b/crates/edge/src/types.rs
@@ -6,7 +6,10 @@ use spooky_config::{
 };
 use spooky_errors::ProxyError;
 use spooky_lb::UpstreamPool;
-use spooky_transport::{h2_client::SharedDnsResolver, h2_pool::H2Pool};
+use spooky_transport::{
+    h2_client::{H2Client, SharedDnsResolver},
+    h2_pool::H2Pool,
+};
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     net::UdpSocket,
@@ -30,6 +33,7 @@ pub struct SharedRuntimeState {
     pub(crate) backend_dns_resolver: SharedDnsResolver,
     pub(crate) upstream_host_policies: Arc<HashMap<String, UpstreamHostPolicy>>,
     pub(crate) forwarded_header_policies: Arc<HashMap<String, ForwardedHeaderPolicy>>,
+    pub(crate) upstream_health_clients: Arc<HashMap<String, Arc<H2Client>>>,
     pub(crate) upstream_pools: HashMap<String, Arc<RwLock<UpstreamPool>>>,
     pub(crate) upstream_inflight: HashMap<String, Arc<Semaphore>>,
     pub(crate) global_inflight: Arc<Semaphore>,

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -75,6 +75,7 @@ fn make_config(port: u32, backend_addr: String, cert: String, key: String) -> Co
             },
             host_policy: Default::default(),
             forwarded_headers: Default::default(),
+            tls: None,
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()
@@ -108,6 +109,7 @@ fn make_config(port: u32, backend_addr: String, cert: String, key: String) -> Co
                 client_auth: ClientAuth::default(),
             },
         },
+        listeners: vec![],
         upstream,
         load_balancing: Some(LoadBalancing {
             lb_type: "random".to_string(),

--- a/crates/edge/tests/h3_edge.rs
+++ b/crates/edge/tests/h3_edge.rs
@@ -61,6 +61,7 @@ fn make_config(port: u32, cert: String, key: String, backend_address: String) ->
             },
             host_policy: Default::default(),
             forwarded_headers: Default::default(),
+            tls: None,
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()
@@ -94,6 +95,7 @@ fn make_config(port: u32, cert: String, key: String, backend_address: String) ->
                 client_auth: ClientAuth::default(),
             },
         },
+        listeners: vec![],
         upstream,
         load_balancing: Some(LoadBalancing {
             lb_type: "random".to_string(),
@@ -802,6 +804,7 @@ fn make_config_with_rate_limit(
             },
             host_policy: Default::default(),
             forwarded_headers: Default::default(),
+            tls: None,
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()
@@ -835,6 +838,7 @@ fn make_config_with_rate_limit(
                 client_auth: ClientAuth::default(),
             },
         },
+        listeners: vec![],
         upstream,
         load_balancing: Some(LoadBalancing {
             lb_type: "random".to_string(),

--- a/crates/edge/tests/lb_integration.rs
+++ b/crates/edge/tests/lb_integration.rs
@@ -91,6 +91,7 @@ fn make_config(
             },
             host_policy: Default::default(),
             forwarded_headers: Default::default(),
+            tls: None,
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()
@@ -118,6 +119,7 @@ fn make_config(
                 client_auth: ClientAuth::default(),
             },
         },
+        listeners: vec![],
         upstream,
         load_balancing: Some(LoadBalancing {
             lb_type: lb_type.to_string(),

--- a/crates/lb/src/lib.rs
+++ b/crates/lb/src/lib.rs
@@ -1026,6 +1026,7 @@ mod tests {
             },
             host_policy: Default::default(),
             forwarded_headers: Default::default(),
+            tls: None,
             route: RouteMatch {
                 path_prefix: Some("/".to_string()),
                 ..Default::default()

--- a/crates/transport/src/h2_pool.rs
+++ b/crates/transport/src/h2_pool.rs
@@ -20,11 +20,11 @@ pub struct H2Pool {
 impl H2Pool {
     pub fn new<I>(
         backends: I,
+        backend_tls: HashMap<String, TlsClientConfig>,
         max_inflight: usize,
         max_idle_per_backend: usize,
         pool_idle_timeout: Duration,
         connect_timeout: Duration,
-        tls: TlsClientConfig,
         dns_resolver: SharedDnsResolver,
     ) -> Result<Self, String>
     where
@@ -38,7 +38,7 @@ impl H2Pool {
                 max_idle_per_backend,
                 pool_idle_timeout,
                 connect_timeout,
-                tls.clone(),
+                backend_tls.get(&backend).cloned().unwrap_or_default(),
                 dns_resolver.clone(),
             )?;
             map.insert(

--- a/crates/transport/tests/h2_pool.rs
+++ b/crates/transport/tests/h2_pool.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
@@ -90,11 +91,11 @@ async fn pool_limits_inflight_per_backend() {
     let pool = Arc::new(
         H2Pool::new(
             vec![backend.clone()],
+            HashMap::from([(backend.clone(), TlsClientConfig::default())]),
             1,
             64,
             Duration::from_secs(30),
             Duration::from_secs(2),
-            TlsClientConfig::default(),
             SharedDnsResolver::new(),
         )
         .expect("pool"),
@@ -139,11 +140,11 @@ async fn pool_limits_inflight_per_backend() {
 async fn pool_rejects_unknown_backend() {
     let pool = H2Pool::new(
         vec!["127.0.0.1:12345".to_string()],
+        HashMap::from([("127.0.0.1:12345".to_string(), TlsClientConfig::default())]),
         1,
         64,
         Duration::from_secs(30),
         Duration::from_secs(2),
-        TlsClientConfig::default(),
         SharedDnsResolver::new(),
     )
     .expect("pool");
@@ -168,11 +169,11 @@ async fn pool_reports_overload_when_inflight_is_exhausted() {
     let pool = Arc::new(
         H2Pool::new(
             vec![backend.clone()],
+            HashMap::from([(backend.clone(), TlsClientConfig::default())]),
             1,
             64,
             Duration::from_secs(30),
             Duration::from_secs(2),
-            TlsClientConfig::default(),
             SharedDnsResolver::new(),
         )
         .expect("pool"),

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -88,7 +88,11 @@ Configuration schema version.
 
 ### listen
 
-Server listening configuration. Defines the protocol, address, and port for incoming client connections.
+Server listening configuration. Defines the protocol, address, and port for incoming client connections. Used as the single listener when `listeners` is absent or empty.
+
+### listeners
+
+Optional multi-listener array. When set, overrides the top-level `listen` block. Each entry is an independent listener with its own address, port, and TLS identity. Spooky spawns a separate QUIC worker group and bootstrap TLS listener per entry.
 
 ### upstream
 
@@ -214,6 +218,40 @@ listen:
         key: "/etc/spooky/certs/www.key"
 ```
 
+### Multi-Listener Configuration
+
+Use `listeners` instead of `listen` when you need multiple independent listeners — for example, a public-facing port and a private/internal port with different TLS identities.
+
+`listeners` and `listen` share the same per-entry schema. When `listeners` is set, the top-level `listen` block is ignored.
+
+```yaml
+# Single listener — use the top-level listen block (default)
+listen:
+  protocol: http3
+  address: "0.0.0.0"
+  port: 9889
+  tls:
+    cert: "/etc/spooky/certs/fullchain.pem"
+    key: "/etc/spooky/certs/privkey.pem"
+
+# Multi-listener — independent public and internal listeners
+listeners:
+  - protocol: http3
+    address: "0.0.0.0"
+    port: 9889
+    tls:
+      cert: "/etc/spooky/certs/public-fullchain.pem"
+      key: "/etc/spooky/certs/public-privkey.pem"
+  - protocol: http3
+    address: "10.0.0.1"
+    port: 9890
+    tls:
+      cert: "/etc/spooky/certs/internal-fullchain.pem"
+      key: "/etc/spooky/certs/internal-privkey.pem"
+```
+
+Each listener entry shares the same upstream routing table — route matching, load balancing, and health checks are global across all listeners.
+
 ## Upstream Configuration
 
 Upstream pools define groups of backend servers with routing rules and load balancing strategies. Each upstream pool is identified by a unique name and contains routing criteria, load balancing configuration, and backend definitions.
@@ -236,6 +274,7 @@ upstream:
 | `route` | object | Yes | - | Route matching criteria |
 | `backends` | array | Yes | - | List of backend servers |
 | `host_policy` | object | No | `pass-through` | Controls how the `Host`/`:authority` header is set on upstream requests |
+| `tls` | object | No | inherits `upstream_tls` | Per-upstream TLS policy override (verify_certificates, strict_sni, ca_file, ca_dir) |
 | `forwarded_headers` | object | No | `overwrite` | Controls `X-Forwarded-For` forwarding behavior |
 
 ### Route Matching
@@ -490,6 +529,53 @@ upstream:
   passthrough_pool:
     forwarded_headers:
       mode: preserve
+    backends: [...]
+```
+
+### Per-Upstream TLS Policy
+
+Each upstream can optionally override the global `upstream_tls` settings with its own TLS profile. When `tls` is omitted, the global `upstream_tls` block applies.
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `verify_certificates` | bool | No | `true` | Verify upstream TLS certificates |
+| `strict_sni` | bool | No | `true` | Send backend hostname as SNI |
+| `ca_file` | string | No | - | Path to a PEM CA bundle for this upstream |
+| `ca_dir` | string | No | - | Path to a directory of PEM CA bundles for this upstream |
+
+This is useful when backends have heterogeneous trust requirements — for example, one upstream uses a private internal CA while another uses a public CA.
+
+#### Examples
+
+```yaml
+upstream_tls:
+  verify_certificates: true   # global default
+  strict_sni: true
+
+upstream:
+  # Uses global upstream_tls — no override needed
+  public_pool:
+    route:
+      path_prefix: "/api"
+    backends: [...]
+
+  # Override: trust a private CA for this upstream only
+  internal_pool:
+    tls:
+      verify_certificates: true
+      strict_sni: true
+      ca_file: "/etc/spooky/certs/internal-ca.pem"
+    route:
+      path_prefix: "/internal"
+    backends: [...]
+
+  # Override: disable verification for a trusted dev upstream
+  dev_pool:
+    tls:
+      verify_certificates: false
+      strict_sni: false
+    route:
+      path_prefix: "/dev"
     backends: [...]
 ```
 

--- a/spooky/src/main.rs
+++ b/spooky/src/main.rs
@@ -6,7 +6,7 @@ use std::sync::mpsc::{self, RecvTimeoutError, SyncSender, TrySendError};
 mod privilege_drop;
 mod runtime_guard;
 
-use spooky_config::config::Config;
+use spooky_config::config::{Config, effective_listens};
 use std::sync::{
     Arc,
     atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -114,14 +114,14 @@ fn main() {
     );
     runtime_guard::install_panic_hook();
 
-    // Require root only when binding a privileged port (< 1024).
+    // Require root only when binding privileged ports (< 1024).
     let uid = unsafe { libc::getuid() };
-    if uid != 0 && config_yaml.listen.port < 1024 {
+    let binds_privileged_port = std::iter::once(&config_yaml.listen)
+        .chain(config_yaml.listeners.iter())
+        .any(|listen| listen.port < 1024);
+    if uid != 0 && binds_privileged_port {
         fatal_startup_error(
-            &format!(
-                "binding privileged port {} requires root or CAP_NET_BIND_SERVICE. Use a port >= 1024 for unprivileged startup.",
-                config_yaml.listen.port
-            ),
+            "binding a privileged port requires root or CAP_NET_BIND_SERVICE. Use ports >= 1024 for unprivileged startup.",
             true,
             1,
         );
@@ -176,68 +176,18 @@ async fn run(config_yaml: Config, uid: libc::uid_t) {
         std::process::exit(1);
     }
 
-    let sockets = if worker_count > 1 {
-        match QUICListener::bind_reuseport_sockets(&config_yaml, worker_count) {
-            Ok(sockets) => sockets,
-            Err(e) => {
-                error!("Failed to bind SO_REUSEPORT sockets: {}", e);
-                std::process::exit(1);
-            }
-        }
-    } else {
-        match QUICListener::bind_socket(&config_yaml, false) {
-            Ok(socket) => vec![socket],
-            Err(e) => {
-                error!("Failed to bind UDP socket: {}", e);
-                std::process::exit(1);
-            }
-        }
-    };
-
-    let privileged_bind = config_yaml.listen.port < 1024;
-    if privileged_bind && uid == 0 {
-        if config_yaml.security.privileges.enabled {
-            match privilege_drop::drop_privileges(
-                &config_yaml.security.privileges.user,
-                &config_yaml.security.privileges.group,
-            ) {
-                Ok(()) => {
-                    info!(
-                        "Dropped root privileges to user='{}' group='{}'",
-                        config_yaml.security.privileges.user, config_yaml.security.privileges.group
-                    );
-                }
-                Err(err) => {
-                    error!("Failed to drop privileges after privileged bind: {}", err);
-                    std::process::exit(1);
-                }
-            }
-        } else {
-            warn!(
-                "Running as root on privileged port without privilege drop (security.privileges.enabled=false)"
-            );
-        }
+    let listens = effective_listens(&config_yaml);
+    let binds_privileged_port = listens.iter().any(|listen| listen.port < 1024);
+    if uid != 0 && binds_privileged_port {
+        fatal_startup_error(
+            "binding a privileged port requires root or CAP_NET_BIND_SERVICE. Use ports >= 1024 for unprivileged startup.",
+            true,
+            1,
+        );
     }
-
-    info!("Spooky is starting");
-    info!(
-        "Ingress: HTTP/3 (QUIC) on UDP {}:{}, HTTP/1.1+HTTP/2 bootstrap (TLS) on TCP {}:{} with Alt-Svc upgrade",
-        config_yaml.listen.address,
-        config_yaml.listen.port,
-        config_yaml.listen.address,
-        config_yaml.listen.port,
-    );
-    info!(
-        "Data-plane workers={} packet_shards_per_worker={} reuseport={} pin_workers={}",
-        sockets.len(),
-        shard_count,
-        config_yaml.performance.reuseport,
-        config_yaml.performance.pin_workers
-    );
 
     let shutdown = Arc::new(AtomicBool::new(false));
     let shutdown_flag = shutdown.clone();
-
     tokio::spawn(async move {
         wait_for_shutdown_signal().await;
         shutdown_flag.store(true, Ordering::Relaxed);
@@ -246,48 +196,65 @@ async fn run(config_yaml: Config, uid: libc::uid_t) {
     let pin_workers = config_yaml.performance.pin_workers;
     let shard_queue_capacity = config_yaml.performance.packet_shard_queue_capacity.max(1);
     let shard_queue_max_bytes = config_yaml.performance.packet_shard_queue_max_bytes.max(1);
-    let mut worker_handles = Vec::with_capacity(sockets.len());
-    for (worker_idx, socket) in sockets.into_iter().enumerate() {
-        let worker_config = config_yaml.clone();
-        let worker_shutdown = Arc::clone(&shutdown);
-        let worker_shared = Arc::clone(&shared_state);
-        let thread_name = format!("spooky-data-plane-{}", worker_idx);
-        let handle = thread::Builder::new().name(thread_name.clone()).spawn(
-            move || -> Result<(), String> {
-                if shard_count <= 1 {
-                    return run_single_listener_worker(
-                        worker_idx,
-                        pin_workers,
-                        worker_config,
-                        socket,
-                        worker_shared,
-                        worker_shutdown,
-                    );
-                }
+    let mut worker_handles: Vec<thread::JoinHandle<Result<(), String>>> = Vec::new();
+    let mut worker_index_base = 0usize;
 
-                run_sharded_listener_worker(
-                    worker_idx,
-                    shard_count,
-                    shard_queue_capacity,
-                    shard_queue_max_bytes,
-                    pin_workers,
-                    worker_config,
-                    socket,
-                    worker_shared,
-                    worker_shutdown,
-                )
-            },
-        );
+    for (listener_idx, listen) in listens.iter().enumerate() {
+        let mut listener_config = config_yaml.clone();
+        listener_config.listen = listen.clone();
 
-        match handle {
-            Ok(handle) => worker_handles.push(handle),
+        if let Err(err) =
+            QUICListener::spawn_bootstrap_tls_listener(&listener_config, &shared_state)
+        {
+            error!(
+                "Failed to initialize bootstrap TLS listener {} ({}:{}): {}",
+                listener_idx, listen.address, listen.port, err
+            );
+            std::process::exit(1);
+        }
+
+        match spawn_listener_worker_group(
+            listener_config,
+            worker_count,
+            shard_count,
+            shard_queue_capacity,
+            shard_queue_max_bytes,
+            pin_workers,
+            Arc::clone(&shared_state),
+            Arc::clone(&shutdown),
+            worker_index_base,
+        ) {
+            Ok(handles) => worker_handles.extend(handles),
             Err(err) => {
-                error!("Failed to spawn worker thread {}: {}", worker_idx, err);
-                shutdown.store(true, Ordering::Relaxed);
-                break;
+                error!("{}", err);
+                std::process::exit(1);
             }
         }
+
+        worker_index_base = worker_index_base.saturating_add(worker_count.max(1));
     }
+
+    info!("Spooky is starting");
+    info!(
+        "Ingress listeners={} packet_shards_per_worker={} reuseport={} pin_workers={}",
+        listens.len(),
+        shard_count,
+        config_yaml.performance.reuseport,
+        config_yaml.performance.pin_workers
+    );
+    for (idx, listen) in listens.iter().enumerate() {
+        info!(
+            "Listener {}: HTTP/3 (QUIC) on UDP {}:{}, HTTP/1.1+HTTP/2 bootstrap (TLS) on TCP {}:{} with Alt-Svc upgrade",
+            idx, listen.address, listen.port, listen.address, listen.port,
+        );
+    }
+    info!(
+        "Data-plane workers={} packet_shards_per_worker={} reuseport={} pin_workers={}",
+        worker_handles.len(),
+        shard_count,
+        config_yaml.performance.reuseport,
+        config_yaml.performance.pin_workers
+    );
 
     let mut worker_failed = false;
     let mut active_worker_handles = worker_handles;
@@ -330,6 +297,79 @@ async fn run(config_yaml: Config, uid: libc::uid_t) {
     }
     spooky_utils::telemetry::shutdown_tracing();
     info!("Spooky shutdown complete");
+}
+
+#[allow(clippy::too_many_arguments)]
+fn spawn_listener_worker_group(
+    listener_config: Config,
+    worker_count: usize,
+    shard_count: usize,
+    shard_queue_capacity: usize,
+    shard_queue_max_bytes: usize,
+    pin_workers: bool,
+    worker_shared: Arc<SharedRuntimeState>,
+    worker_shutdown: Arc<AtomicBool>,
+    worker_index_base: usize,
+) -> Result<Vec<thread::JoinHandle<Result<(), String>>>, String> {
+    let sockets = if worker_count > 1 {
+        match QUICListener::bind_reuseport_sockets(&listener_config, worker_count) {
+            Ok(sockets) => sockets,
+            Err(e) => return Err(format!("Failed to bind SO_REUSEPORT sockets: {}", e)),
+        }
+    } else {
+        match QUICListener::bind_socket(&listener_config, false) {
+            Ok(socket) => vec![socket],
+            Err(e) => return Err(format!("Failed to bind UDP socket: {}", e)),
+        }
+    };
+
+    let mut worker_handles = Vec::with_capacity(sockets.len());
+    for (socket_idx, socket) in sockets.into_iter().enumerate() {
+        let worker_idx = worker_index_base.saturating_add(socket_idx);
+        let worker_config = listener_config.clone();
+        let worker_shutdown = Arc::clone(&worker_shutdown);
+        let worker_shared = Arc::clone(&worker_shared);
+        let thread_name = format!("spooky-data-plane-{}", worker_idx);
+        let handle =
+            thread::Builder::new()
+                .name(thread_name)
+                .spawn(move || -> Result<(), String> {
+                    if shard_count <= 1 {
+                        return run_single_listener_worker(
+                            worker_idx,
+                            pin_workers,
+                            worker_config,
+                            socket,
+                            worker_shared,
+                            worker_shutdown,
+                        );
+                    }
+
+                    run_sharded_listener_worker(
+                        worker_idx,
+                        shard_count,
+                        shard_queue_capacity,
+                        shard_queue_max_bytes,
+                        pin_workers,
+                        worker_config,
+                        socket,
+                        worker_shared,
+                        worker_shutdown,
+                    )
+                });
+
+        match handle {
+            Ok(handle) => worker_handles.push(handle),
+            Err(err) => {
+                return Err(format!(
+                    "Failed to spawn worker thread {}: {}",
+                    worker_idx, err
+                ));
+            }
+        }
+    }
+
+    Ok(worker_handles)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/spooky/src/privilege_drop.rs
+++ b/spooky/src/privilege_drop.rs
@@ -1,4 +1,5 @@
 #[cfg(unix)]
+#[allow(dead_code)]
 pub fn drop_privileges(user: &str, group: &str) -> Result<(), String> {
     use std::{ffi::CString, io};
 
@@ -135,6 +136,7 @@ pub fn drop_privileges(user: &str, group: &str) -> Result<(), String> {
 }
 
 #[cfg(not(unix))]
+#[allow(dead_code)]
 pub fn drop_privileges(_user: &str, _group: &str) -> Result<(), String> {
     Ok(())
 }


### PR DESCRIPTION
Closes- #198 and #199 

## Summary

- **#199** — Adds `listeners` array to config for multiple independent listener
  blocks, each with its own address, port, and TLS identity. `effective_listens()`
  falls back to the single `listen` block for backwards compatibility. The runtime
  iterates over all listeners and spawns an independent QUIC worker group and
  bootstrap TLS listener per entry.

- **#198** — Adds optional `tls` override per upstream. When set, it overrides
  the global `upstream_tls` for that upstream's backends and health check client.
  `H2Pool` now accepts a per-backend TLS map instead of a single shared config.

## Files changed

- `crates/config/src/config.rs` — `listeners: Vec<Listen>`, `effective_listens()`,
  `Upstream.tls: Option<UpstreamTls>`
- `crates/config/src/validator.rs` — validation for `listeners` entries and
  per-upstream TLS override fields
- `crates/edge/src/quic_listener/mod.rs` — `effective_upstream_tls()`,
  per-upstream TLS map wired into `H2Pool` and health clients
- `crates/edge/src/quic_listener/health_check.rs` — per-upstream health client
  selection via `upstream_health_clients` map
- `crates/transport/src/h2_pool.rs` — accepts `HashMap<String, TlsClientConfig>`
  instead of a single `TlsClientConfig`
- `spooky/src/main.rs` — iterates `effective_listens()`, spawns worker group
  per listener
- `config/config.sample.yaml`, `config/config.production.yaml` — documented
