### PR TITLE
Implement Display for BackendScheme

### DIFF
--- a/crates/config/src/backend_endpoint.rs
+++ b/crates/config/src/backend_endpoint.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BackendScheme {
     Http,
@@ -10,6 +12,12 @@ impl BackendScheme {
             Self::Http => "http",
             Self::Https => "https",
         }
+    }
+}
+
+impl fmt::Display for BackendScheme {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 
@@ -153,6 +161,12 @@ fn validate_authority(authority: &str) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::{BackendEndpoint, BackendScheme};
+
+    #[test]
+    fn display_formats_backend_scheme() {
+        assert_eq!(BackendScheme::Http.to_string(), "http");
+        assert_eq!(format!("{}", BackendScheme::Https), "https");
+    }
 
     #[test]
     fn parse_host_port_defaults_to_https() {


### PR DESCRIPTION
﻿## Summary
- implement `Display` for `BackendScheme` by reusing `as_str()`
- add a unit test covering `to_string()` and `format!`

Closes #225

## Validation
- `cargo fmt --check`
- `cargo test -p spooky-config backend_endpoint::tests`
- `cargo check -p spooky-config`

Note: `cargo test -p spooky-config` has an existing Windows-local YAML path parsing failure in `validator::tests::yaml_parse_applies_performance_and_observability_defaults`; the touched backend endpoint tests pass.
