### PR TITLE
fix(utils): make OTLP endpoint configurable by env

### DIFF
--- a/crates/utils/src/telemetry.rs
+++ b/crates/utils/src/telemetry.rs
@@ -96,7 +96,10 @@ fn resolve_otlp_endpoint<F>(
 where
     F: FnMut(&str) -> Option<String>,
 {
-    if let Some(endpoint) = otlp_endpoint.map(str::trim).filter(|value| !value.is_empty()) {
+    if let Some(endpoint) = otlp_endpoint
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
         return (endpoint.to_string(), OtlpEndpointSource::Config);
     }
 
@@ -128,9 +131,7 @@ mod tests {
     fn config_endpoint_overrides_environment() {
         let (endpoint, source) =
             resolve_otlp_endpoint(Some(" http://cfg-collector:4317 "), |key| match key {
-                "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT" => {
-                    Some("http://env-traces:4317".to_string())
-                }
+                "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT" => Some("http://env-traces:4317".to_string()),
                 "OTEL_EXPORTER_OTLP_ENDPOINT" => Some("http://env-generic:4317".to_string()),
                 _ => None,
             });

--- a/crates/utils/src/telemetry.rs
+++ b/crates/utils/src/telemetry.rs
@@ -9,7 +9,17 @@ use opentelemetry_sdk::trace::{Sampler, SdkTracerProvider};
 use tracing_subscriber::Registry;
 use tracing_subscriber::layer::SubscriberExt;
 
+const DEFAULT_OTLP_ENDPOINT: &str = "http://127.0.0.1:4317";
+
 static TRACER_PROVIDER: OnceLock<SdkTracerProvider> = OnceLock::new();
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum OtlpEndpointSource {
+    Config,
+    EnvTraces,
+    EnvGeneric,
+    Default,
+}
 
 pub fn init_tracing(
     enabled: bool,
@@ -22,14 +32,12 @@ pub fn init_tracing(
     }
 
     let ratio = sample_ratio.clamp(0.0, 1.0);
-    let endpoint = otlp_endpoint
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or("http://127.0.0.1:4317");
+    let (endpoint, endpoint_source) =
+        resolve_otlp_endpoint(otlp_endpoint, |key| std::env::var(key).ok());
 
     let exporter = match opentelemetry_otlp::SpanExporter::builder()
         .with_tonic()
-        .with_endpoint(endpoint)
+        .with_endpoint(endpoint.as_str())
         .build()
     {
         Ok(exporter) => exporter,
@@ -70,13 +78,95 @@ pub fn init_tracing(
     }
 
     info!(
-        "OpenTelemetry tracing enabled (service_name={}, endpoint={}, sample_ratio={})",
-        service_name, endpoint, ratio
+        "OpenTelemetry tracing enabled (service_name={}, endpoint={}, endpoint_source={:?}, sample_ratio={})",
+        service_name, endpoint, endpoint_source, ratio
     );
 }
 
 pub fn shutdown_tracing() {
     if let Some(provider) = TRACER_PROVIDER.get() {
         let _ = provider.shutdown();
+    }
+}
+
+fn resolve_otlp_endpoint<F>(
+    otlp_endpoint: Option<&str>,
+    mut lookup_env: F,
+) -> (String, OtlpEndpointSource)
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    if let Some(endpoint) = otlp_endpoint.map(str::trim).filter(|value| !value.is_empty()) {
+        return (endpoint.to_string(), OtlpEndpointSource::Config);
+    }
+
+    if let Some(endpoint) = lookup_env("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+    {
+        return (endpoint, OtlpEndpointSource::EnvTraces);
+    }
+
+    if let Some(endpoint) = lookup_env("OTEL_EXPORTER_OTLP_ENDPOINT")
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+    {
+        return (endpoint, OtlpEndpointSource::EnvGeneric);
+    }
+
+    (
+        DEFAULT_OTLP_ENDPOINT.to_string(),
+        OtlpEndpointSource::Default,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DEFAULT_OTLP_ENDPOINT, OtlpEndpointSource, resolve_otlp_endpoint};
+
+    #[test]
+    fn config_endpoint_overrides_environment() {
+        let (endpoint, source) =
+            resolve_otlp_endpoint(Some(" http://cfg-collector:4317 "), |key| match key {
+                "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT" => {
+                    Some("http://env-traces:4317".to_string())
+                }
+                "OTEL_EXPORTER_OTLP_ENDPOINT" => Some("http://env-generic:4317".to_string()),
+                _ => None,
+            });
+
+        assert_eq!(endpoint, "http://cfg-collector:4317");
+        assert_eq!(source, OtlpEndpointSource::Config);
+    }
+
+    #[test]
+    fn traces_environment_overrides_generic_environment() {
+        let (endpoint, source) = resolve_otlp_endpoint(None, |key| match key {
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT" => Some("http://env-traces:4317".to_string()),
+            "OTEL_EXPORTER_OTLP_ENDPOINT" => Some("http://env-generic:4317".to_string()),
+            _ => None,
+        });
+
+        assert_eq!(endpoint, "http://env-traces:4317");
+        assert_eq!(source, OtlpEndpointSource::EnvTraces);
+    }
+
+    #[test]
+    fn generic_environment_is_used_when_traces_endpoint_is_absent() {
+        let (endpoint, source) = resolve_otlp_endpoint(None, |key| match key {
+            "OTEL_EXPORTER_OTLP_ENDPOINT" => Some(" http://env-generic:4317 ".to_string()),
+            _ => None,
+        });
+
+        assert_eq!(endpoint, "http://env-generic:4317");
+        assert_eq!(source, OtlpEndpointSource::EnvGeneric);
+    }
+
+    #[test]
+    fn default_endpoint_is_used_when_config_and_environment_are_absent() {
+        let (endpoint, source) = resolve_otlp_endpoint(None, |_| None);
+
+        assert_eq!(endpoint, DEFAULT_OTLP_ENDPOINT);
+        assert_eq!(source, OtlpEndpointSource::Default);
     }
 }


### PR DESCRIPTION
Fixes: #222 

## Summary

Makes the OTLP tracing exporter endpoint configurable via standard environment variables instead of relying only on a hardcoded fallback.

## Changes

- add a dedicated OTLP endpoint resolver in `crates/utils/src/telemetry.rs`
- keep explicit config precedence via `observability.tracing.otlp_endpoint`
- add environment fallback support for:
  - `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`
  - `OTEL_EXPORTER_OTLP_ENDPOINT`
- keep `http://127.0.0.1:4317` as the final default only when neither config nor environment provides an endpoint
- include the endpoint source in the tracing startup log
- add unit tests covering endpoint resolution precedence

## Why

Tracing already accepted a config-provided OTLP endpoint, but the fallback path was still hardcoded. This change makes deployments configurable through standard OTLP environment variables without requiring code changes, while preserving explicit config override behavior.

## Endpoint precedence

1. `observability.tracing.otlp_endpoint`
2. `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`
3. `OTEL_EXPORTER_OTLP_ENDPOINT`
4. `http://127.0.0.1:4317`