### PR TITLE
fix(errors): disambiguate proxy error display text

### DIFF
--- a/crates/errors/src/lib.rs
+++ b/crates/errors/src/lib.rs
@@ -41,7 +41,7 @@ pub enum ProxyError {
     #[error("bridge error: {0}")]
     Bridge(#[from] BridgeError),
 
-    #[error("transport error: {0}")]
+    #[error("pool error: {0}")]
     Pool(#[from] PoolError),
 
     #[error("transport error: {0}")]
@@ -64,5 +64,26 @@ pub fn is_retryable(err: &ProxyError) -> bool {
         ProxyError::Pool(PoolError::Send(_)) => false,
         ProxyError::Pool(_) => true,
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PoolError, ProxyError};
+
+    #[test]
+    fn pool_and_transport_errors_have_distinct_display_text() {
+        let pool = ProxyError::Pool(PoolError::UnknownBackend("api-a".to_string()));
+        let transport = ProxyError::Transport("api-a".to_string());
+
+        assert_eq!(pool.to_string(), "pool error: unknown backend: api-a");
+        assert_eq!(transport.to_string(), "transport error: api-a");
+    }
+
+    #[test]
+    fn overloaded_pool_error_keeps_pool_specific_prefix() {
+        let err = ProxyError::Pool(PoolError::BackendOverloaded("api-b".to_string()));
+
+        assert_eq!(err.to_string(), "pool error: backend overloaded: api-b");
     }
 }


### PR DESCRIPTION
Fixes: #219 

## Summary

Makes top-level `ProxyError` display text unambiguous for pool-related versus transport-related failures.

## Changes

- change `ProxyError::Pool` display text from `transport error: ...` to `pool error: ...`
- keep `ProxyError::Transport` display text unchanged
- add unit tests covering:
  - distinct display output for pool vs transport variants
  - pool overload errors preserving the pool-specific prefix

## Why

Previously, `ProxyError::Pool` and `ProxyError::Transport` could render the same top-level message, which made logs and metrics harder to interpret during troubleshooting. This change keeps those failure classes distinct at the display layer.