### PR TITLE
feat(transport): add HTTP/1 upstream backend support with scheme-aware dispatch

### DIFF
--- a/crates/bridge/src/h3_to_h2.rs
+++ b/crates/bridge/src/h3_to_h2.rs
@@ -9,7 +9,7 @@ use http::{HeaderName, HeaderValue, Method, Request, Uri};
 use http_body_util::combinators::BoxBody;
 use quiche::h3::NameValue;
 use spooky_config::{
-    backend_endpoint::BackendEndpoint,
+    backend_endpoint::{BackendEndpoint, BackendScheme},
     config::{
         ForwardedHeaderPolicy, ForwardedHeaderPolicyMode, UpstreamHostPolicy,
         UpstreamHostPolicyMode,
@@ -211,6 +211,10 @@ pub fn build_h2_request_for_endpoint_with_host_policy(
     }
     if let Some(value) = forwarded_values.x_forwarded_host {
         builder = builder.header(HeaderName::from_static("x-forwarded-host"), value);
+    }
+
+    if endpoint.scheme() == BackendScheme::Http && !is_connect {
+        builder = builder.header(http::header::TE, "trailers");
     }
 
     builder.body(body).map_err(BridgeError::Build)

--- a/crates/config/src/runtime.rs
+++ b/crates/config/src/runtime.rs
@@ -481,7 +481,7 @@ fn normalize_upstreams(
 
         let runtime_upstream =
             RuntimeUpstream::from_config(config, upstream_name.as_str(), upstream);
-        validate_runtime_upstream_tls(upstream_name, &runtime_upstream.effective_tls)?;
+        let mut upstream_uses_https_backends = false;
 
         for backend in &runtime_upstream.backends {
             if backend.backend.id.trim().is_empty() {
@@ -504,6 +504,9 @@ fn normalize_upstreams(
                     reason: err,
                 }
             })?;
+            if endpoint.scheme() == crate::backend_endpoint::BackendScheme::Https {
+                upstream_uses_https_backends = true;
+            }
 
             let origin = endpoint.origin();
             if let Some((existing_upstream, existing_backend)) = seen_backend_origins.insert(
@@ -520,6 +523,10 @@ fn normalize_upstreams(
                     ),
                 });
             }
+        }
+
+        if upstream_uses_https_backends {
+            validate_runtime_upstream_tls(upstream_name, &runtime_upstream.effective_tls)?;
         }
 
         normalized.insert(upstream_name.clone(), runtime_upstream);
@@ -915,6 +922,57 @@ mod tests {
         assert_eq!(
             upstream.policy.forwarded_headers.0.mode,
             ForwardedHeaderPolicyMode::Append
+        );
+    }
+
+    #[test]
+    fn runtime_http_only_upstream_skips_unused_global_tls_validation() {
+        let mut config = sample_config();
+        config.upstream.get_mut("api").expect("upstream").backends[0].address =
+            "http://127.0.0.1:8080".to_string();
+        config.upstream_tls.ca_file = Some("   ".to_string());
+        config.upstream_tls.ca_dir = Some("   ".to_string());
+
+        let runtime = RuntimeConfig::from_config(&config).expect("runtime config");
+        let upstream = runtime.upstreams.get("api").expect("runtime upstream");
+
+        assert_eq!(
+            upstream.backends[0].backend.address,
+            "http://127.0.0.1:8080"
+        );
+    }
+
+    #[test]
+    fn runtime_http_only_upstream_skips_unused_per_upstream_tls_validation() {
+        let mut config = sample_config();
+        config.upstream.get_mut("api").expect("upstream").backends[0].address =
+            "http://127.0.0.1:8080".to_string();
+        config.upstream.get_mut("api").expect("upstream").tls = Some(UpstreamTls {
+            verify_certificates: true,
+            strict_sni: true,
+            ca_file: Some("   ".to_string()),
+            ca_dir: Some("   ".to_string()),
+        });
+
+        let runtime = RuntimeConfig::from_config(&config).expect("runtime config");
+        let upstream = runtime.upstreams.get("api").expect("runtime upstream");
+
+        assert_eq!(
+            upstream.backends[0].backend.address,
+            "http://127.0.0.1:8080"
+        );
+    }
+
+    #[test]
+    fn runtime_https_upstream_still_requires_non_empty_effective_tls_fields() {
+        let mut config = sample_config();
+        config.upstream_tls.ca_file = Some("   ".to_string());
+
+        let err = RuntimeConfig::from_config(&config).expect_err("https upstream must validate");
+        assert_eq!(err.category(), "tls_material_invalid");
+        assert!(
+            err.to_string()
+                .contains("upstream 'api' has an empty effective upstream_tls.ca_file")
         );
     }
 

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -1225,19 +1225,8 @@ fn validate_inner(config: &Config) -> bool {
         }
     }
 
-    // --- Validate upstream TLS trust-store configuration ---
-    if !validate_upstream_tls("upstream_tls", &config.upstream_tls) {
-        return false;
-    }
-
     // --- Validate upstream routes ---
     for (upstream_name, upstream) in &config.upstream {
-        if let Some(tls) = upstream.tls.as_ref()
-            && !validate_upstream_tls(&format!("upstream['{}'].tls", upstream_name), tls)
-        {
-            return false;
-        }
-
         // Validate route matcher has at least one condition
         let has_host = upstream.route.host.is_some();
         let has_path = upstream.route.path_prefix.is_some();
@@ -1323,6 +1312,7 @@ fn validate_inner(config: &Config) -> bool {
     }
 
     let mut seen_backend_origins: HashMap<String, (String, String)> = HashMap::new();
+    let mut validate_global_upstream_tls = false;
 
     for (upstream_name, upstream) in &config.upstream {
         if upstream_name.is_empty() {
@@ -1349,6 +1339,7 @@ fn validate_inner(config: &Config) -> bool {
             return false;
         }
 
+        let mut upstream_uses_https_backends = false;
         for backend in &upstream.backends {
             // Validate backend ID
             if backend.id.is_empty() {
@@ -1383,6 +1374,8 @@ fn validate_inner(config: &Config) -> bool {
                     "Backend '{}' in upstream '{}' uses explicit insecure cleartext transport ({})",
                     backend.id, upstream_name, backend.address
                 );
+            } else {
+                upstream_uses_https_backends = true;
             }
 
             let origin = endpoint.origin();
@@ -1459,6 +1452,21 @@ fn validate_inner(config: &Config) -> bool {
                 }
             }
         }
+
+        if upstream_uses_https_backends {
+            if let Some(tls) = upstream.tls.as_ref() {
+                if !validate_upstream_tls(&format!("upstream['{}'].tls", upstream_name), tls) {
+                    return false;
+                }
+            } else {
+                validate_global_upstream_tls = true;
+            }
+        }
+    }
+
+    if validate_global_upstream_tls && !validate_upstream_tls("upstream_tls", &config.upstream_tls)
+    {
+        return false;
     }
 
     info!("Configuration validation passed successfully\n");
@@ -2096,6 +2104,44 @@ upstream:
             tracing: Tracing::default(),
             routing: crate::config::RoutingTransparency::default(),
         };
+
+        assert!(validate(&cfg).is_ok());
+    }
+
+    #[test]
+    fn skips_unused_global_upstream_tls_validation_for_http_only_backends() {
+        let dir = tempdir().expect("tempdir");
+        let (cert, key) = write_test_certs(dir.path());
+
+        let mut cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.upstream_tls.ca_file = Some("/path/does/not/exist.pem".to_string());
+        cfg.upstream_tls.ca_dir = Some("/path/does/not/exist".to_string());
+        cfg.upstream
+            .get_mut("test_upstream")
+            .expect("upstream")
+            .backends[0]
+            .address = "http://127.0.0.1:8080".to_string();
+
+        assert!(validate(&cfg).is_ok());
+    }
+
+    #[test]
+    fn skips_unused_per_upstream_tls_validation_for_http_only_backends() {
+        let dir = tempdir().expect("tempdir");
+        let (cert, key) = write_test_certs(dir.path());
+
+        let mut cfg = base_config(&cert.to_string_lossy(), &key.to_string_lossy());
+        cfg.upstream.get_mut("test_upstream").expect("upstream").tls = Some(UpstreamTls {
+            verify_certificates: true,
+            strict_sni: true,
+            ca_file: Some("/path/does/not/exist.pem".to_string()),
+            ca_dir: Some("/path/does/not/exist".to_string()),
+        });
+        cfg.upstream
+            .get_mut("test_upstream")
+            .expect("upstream")
+            .backends[0]
+            .address = "http://127.0.0.1:8080".to_string();
 
         assert!(validate(&cfg).is_ok());
     }

--- a/crates/edge/src/quic_listener/backend_resolution.rs
+++ b/crates/edge/src/quic_listener/backend_resolution.rs
@@ -39,7 +39,7 @@ enum BackendDnsRefreshOutcome {
 impl QUICListener {
     pub(super) fn spawn_backend_dns_refresh(
         config: &RuntimeConfig,
-        h2_pool: Arc<H2Pool>,
+        transport_pool: Arc<UpstreamTransportPool>,
         backend_resolution_store: Arc<RuntimeBackendResolutionStore>,
         backend_dns_resolver: SharedDnsResolver,
         metrics: Arc<Metrics>,
@@ -72,7 +72,7 @@ impl QUICListener {
                 for backend in backend_resolution_store.hostname_entries() {
                     match refresh_backend_hostname(
                         &backend,
-                        &h2_pool,
+                        &transport_pool,
                         &backend_resolution_store,
                         &backend_dns_resolver,
                     )
@@ -162,7 +162,7 @@ impl QUICListener {
 
 async fn refresh_backend_hostname(
     backend: &RuntimeBackendResolution,
-    h2_pool: &H2Pool,
+    transport_pool: &UpstreamTransportPool,
     backend_resolution_store: &RuntimeBackendResolutionStore,
     backend_dns_resolver: &SharedDnsResolver,
 ) -> BackendDnsRefreshOutcome {
@@ -211,8 +211,8 @@ async fn refresh_backend_hostname(
 
     let client_rotated = if update.changed() {
         matches!(
-            h2_pool.rotate_backend_client(&update.backend_addr),
-            Ok(Some(_))
+            transport_pool.rotate_backend_client(&update.backend_addr),
+            Ok(true)
         )
     } else {
         false

--- a/crates/edge/src/quic_listener/health_check.rs
+++ b/crates/edge/src/quic_listener/health_check.rs
@@ -3,7 +3,7 @@ use super::*;
 impl QUICListener {
     pub(super) fn spawn_health_checks(
         upstream_pools: HashMap<String, Arc<RwLock<UpstreamPool>>>,
-        h2_pool: Arc<H2Pool>,
+        transport_pool: Arc<UpstreamTransportPool>,
         backend_endpoints: Arc<HashMap<String, BackendEndpoint>>,
         backend_resolution_store: Arc<RuntimeBackendResolutionStore>,
         metrics: Arc<Metrics>,
@@ -82,7 +82,7 @@ impl QUICListener {
         };
 
         for (base_interval_ms, mut jobs) in grouped_jobs {
-            let h2_pool = Arc::clone(&h2_pool);
+            let transport_pool = Arc::clone(&transport_pool);
             let backend_resolution_store = Arc::clone(&backend_resolution_store);
             let task_metrics = Arc::clone(&metrics);
             let handle = handle.clone();
@@ -121,7 +121,7 @@ impl QUICListener {
                             );
                             let result = tokio::time::timeout(
                                 job.timeout,
-                                h2_pool.send(&job.backend_identity, request),
+                                transport_pool.send(&job.backend_identity, request),
                             )
                             .await;
 

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -49,7 +49,7 @@ use spooky_bridge::h3_to_h2::{
 use spooky_errors::{PoolError, ProxyError, is_retryable};
 use spooky_lb::{HealthFailureReason, HealthTransition, UpstreamPool};
 use spooky_transport::h2_client::{SharedDnsResolver, TlsClientConfig};
-use spooky_transport::h2_pool::H2Pool;
+use spooky_transport::transport_pool::{BackendTransportKind, UpstreamTransportPool};
 use tokio::runtime::Handle;
 use tokio::sync::{
     Semaphore, mpsc,
@@ -554,7 +554,7 @@ impl QUICListener {
             .collect::<HashMap<_, _>>();
         let listener_tls_store = Arc::new(Self::build_listener_tls_reload_store(config)?);
 
-        let mut backend_addresses = Vec::new();
+        let mut backend_transports = Vec::new();
         let mut backend_resolutions = Vec::new();
         let mut seen_backend_origins: HashMap<String, (String, String)> = HashMap::new();
         let mut backend_tls_configs: HashMap<String, TlsClientConfig> = HashMap::new();
@@ -578,7 +578,7 @@ impl QUICListener {
                     (upstream_name.clone(), backend.backend.id.clone()),
                 ) {
                     return Err(ProxyError::Transport(format!(
-                        "duplicate backend address '{}' detected while building H2 pool: upstream '{}' backend '{}' conflicts with upstream '{}' backend '{}'",
+                        "duplicate backend address '{}' detected while building upstream transport pool: upstream '{}' backend '{}' conflicts with upstream '{}' backend '{}'",
                         origin,
                         upstream_name,
                         backend.backend.id,
@@ -586,7 +586,13 @@ impl QUICListener {
                         existing_backend
                     )));
                 }
-                backend_addresses.push(backend.backend.address.clone());
+                backend_transports.push((
+                    backend.backend.address.clone(),
+                    match endpoint.scheme() {
+                        BackendScheme::Http => BackendTransportKind::Http1,
+                        BackendScheme::Https => BackendTransportKind::H2,
+                    },
+                ));
                 let authority_host = endpoint.authority_host().to_string();
                 let authority_port = endpoint.authority_port();
                 let resolution = if endpoint.authority_is_ip_literal() {
@@ -625,17 +631,19 @@ impl QUICListener {
                     upstream_tls_client.ca_dir,
                     authority_kind
                 );
-                backend_tls_configs
-                    .insert(backend.backend.address.clone(), upstream_tls_client.clone());
+                if endpoint.scheme() == BackendScheme::Https {
+                    backend_tls_configs
+                        .insert(backend.backend.address.clone(), upstream_tls_client.clone());
+                }
             }
         }
 
         let backend_dns_resolver = SharedDnsResolver::new();
         let backend_resolution_store =
             Arc::new(RuntimeBackendResolutionStore::new(backend_resolutions));
-        let h2_pool = Arc::new(
-            H2Pool::new(
-                backend_addresses,
+        let transport_pool = Arc::new(
+            UpstreamTransportPool::new(
+                backend_transports,
                 backend_tls_configs,
                 max_inflight_per_backend,
                 config.performance.h2_pool_max_idle_per_backend,
@@ -707,7 +715,7 @@ impl QUICListener {
         Ok(SharedRuntimeState {
             listener_runtime_configs: Arc::new(listener_runtime_configs),
             listener_tls_store,
-            h2_pool,
+            transport_pool,
             backend_endpoints: Arc::new(
                 config
                     .upstreams
@@ -749,14 +757,14 @@ impl QUICListener {
             .set_expected_workers(worker_count.max(1));
         Self::spawn_backend_dns_refresh(
             config,
-            Arc::clone(&shared_state.h2_pool),
+            Arc::clone(&shared_state.transport_pool),
             Arc::clone(&shared_state.backend_resolution_store),
             shared_state.backend_dns_resolver.clone(),
             Arc::clone(&shared_state.metrics),
         );
         Self::spawn_health_checks(
             shared_state.upstream_pools.clone(),
-            Arc::clone(&shared_state.h2_pool),
+            Arc::clone(&shared_state.transport_pool),
             Arc::clone(&shared_state.backend_endpoints),
             Arc::clone(&shared_state.backend_resolution_store),
             Arc::clone(&shared_state.metrics),
@@ -869,7 +877,7 @@ impl QUICListener {
             tls_reload_generation,
             quic_config,
             h3_config,
-            h2_pool: Arc::clone(&shared_state.h2_pool),
+            transport_pool: Arc::clone(&shared_state.transport_pool),
             backend_endpoints: Arc::clone(&shared_state.backend_endpoints),
             backend_resolution_store: Arc::clone(&shared_state.backend_resolution_store),
             backend_dns_resolver: shared_state.backend_dns_resolver.clone(),
@@ -1674,7 +1682,7 @@ impl QUICListener {
             return;
         }
 
-        let h2_pool = self.h2_pool.clone();
+        let transport_pool = self.transport_pool.clone();
 
         // First, try to find existing connection by DCID
         debug!("Looking up connection with DCID: {:?}", hex::encode(dcid));
@@ -1848,7 +1856,7 @@ impl QUICListener {
             && (connection.quic.is_established() || connection.quic.is_in_early_data())
             && let Err(e) = Self::handle_h3(
                 &mut connection,
-                Arc::clone(&h2_pool),
+                Arc::clone(&transport_pool),
                 Arc::clone(&self.backend_endpoints),
                 Arc::clone(&self.backend_resolution_store),
                 Arc::clone(&self.upstream_policies),
@@ -2119,7 +2127,7 @@ impl QUICListener {
     #[allow(clippy::too_many_arguments)]
     fn handle_h3(
         connection: &mut QuicConnection,
-        h2_pool: Arc<H2Pool>,
+        transport_pool: Arc<UpstreamTransportPool>,
         backend_endpoints: Arc<HashMap<String, BackendEndpoint>>,
         backend_resolution_store: Arc<RuntimeBackendResolutionStore>,
         upstream_policies: Arc<HashMap<String, RuntimeUpstreamPolicy>>,
@@ -2572,7 +2580,7 @@ impl QUICListener {
                                 }
                             };
 
-                            let h2 = h2_pool.clone();
+                            let transport = transport_pool.clone();
                             let fwd_addr = addr.clone();
                             let cb = Arc::clone(&resilience.circuit_breakers);
                             let retry_budget = Arc::clone(&resilience.retry_budget);
@@ -2617,7 +2625,7 @@ impl QUICListener {
                                             BoxBody<Bytes, std::convert::Infallible>,
                                         >,
                                          cb: Arc<crate::resilience::CircuitBreakers>,
-                                         h2: Arc<H2Pool>,
+                                         transport: Arc<UpstreamTransportPool>,
                                          metrics: Arc<Metrics>,
                                          backend_resolutions: Arc<RuntimeBackendResolutionStore>| async move {
                                             if !cb.allow_request(&backend) {
@@ -2632,7 +2640,7 @@ impl QUICListener {
                                             );
                                             let send_result = tokio::time::timeout(
                                                 backend_timeout,
-                                                h2.send(&backend, req),
+                                                transport.send(&backend, req),
                                             )
                                             .await
                                             .map_err(|_| ProxyError::Timeout);
@@ -2663,7 +2671,7 @@ impl QUICListener {
                                                 primary_backend,
                                                 request,
                                                 Arc::clone(&cb),
-                                                Arc::clone(&h2),
+                                                Arc::clone(&transport),
                                                 Arc::clone(&send_metrics),
                                                 Arc::clone(&backend_resolutions),
                                             );
@@ -2682,7 +2690,7 @@ impl QUICListener {
                                                     hedge_backend,
                                                     hedge_request,
                                                     Arc::clone(&cb),
-                                                    Arc::clone(&h2),
+                                                    Arc::clone(&transport),
                                                     Arc::clone(&send_metrics),
                                                     Arc::clone(&backend_resolutions),
                                                 );
@@ -2709,7 +2717,7 @@ impl QUICListener {
                                                 fwd_addr.clone(),
                                                 request,
                                                 Arc::clone(&cb),
-                                                Arc::clone(&h2),
+                                                Arc::clone(&transport),
                                                 Arc::clone(&send_metrics),
                                                 Arc::clone(&backend_resolutions),
                                             )
@@ -2720,7 +2728,7 @@ impl QUICListener {
                                             fwd_addr.clone(),
                                             request,
                                             Arc::clone(&cb),
-                                            Arc::clone(&h2),
+                                            Arc::clone(&transport),
                                             Arc::clone(&send_metrics),
                                             Arc::clone(&backend_resolutions),
                                         )
@@ -2762,7 +2770,7 @@ impl QUICListener {
                                                         retry_backend,
                                                         retry_request,
                                                         Arc::clone(&cb),
-                                                        Arc::clone(&h2),
+                                                        Arc::clone(&transport),
                                                         Arc::clone(&send_metrics),
                                                         Arc::clone(&backend_resolutions),
                                                     )
@@ -4960,7 +4968,7 @@ impl QUICListener {
                 ))
             })?;
 
-        let h2_pool = Arc::clone(&shared_state.h2_pool);
+        let transport_pool = Arc::clone(&shared_state.transport_pool);
         let backend_endpoints = Arc::clone(&shared_state.backend_endpoints);
         let backend_resolution_store = Arc::clone(&shared_state.backend_resolution_store);
         let upstream_policies = Arc::clone(&shared_state.upstream_policies);
@@ -5032,7 +5040,7 @@ impl QUICListener {
                 };
 
                 let alt_svc = alt_svc_value.clone();
-                let h2_pool = Arc::clone(&h2_pool);
+                let transport_pool = Arc::clone(&transport_pool);
                 let backend_endpoints = Arc::clone(&backend_endpoints);
                 let backend_resolution_store = Arc::clone(&backend_resolution_store);
                 let upstream_policies = Arc::clone(&upstream_policies);
@@ -5116,7 +5124,7 @@ impl QUICListener {
                     let svc = service_fn(
                         move |mut req: Request<Incoming>| -> BootstrapServiceFuture {
                             let alt = alt_svc_conn.clone();
-                            let h2_pool = Arc::clone(&h2_pool);
+                            let transport_pool = Arc::clone(&transport_pool);
                             let backend_endpoints = Arc::clone(&backend_endpoints);
                             let backend_resolution_store = Arc::clone(&backend_resolution_store);
                             let upstream_policies = Arc::clone(&upstream_policies);
@@ -5607,7 +5615,7 @@ impl QUICListener {
                                     );
                                     match tokio::time::timeout(
                                         backend_timeout,
-                                        h2_pool.send(&backend_addr, upstream_req),
+                                        transport_pool.send(&backend_addr, upstream_req),
                                     )
                                     .await
                                     {

--- a/crates/edge/src/types.rs
+++ b/crates/edge/src/types.rs
@@ -9,7 +9,7 @@ use spooky_config::{
 };
 use spooky_errors::ProxyError;
 use spooky_lb::UpstreamPool;
-use spooky_transport::{h2_client::SharedDnsResolver, h2_pool::H2Pool};
+use spooky_transport::{h2_client::SharedDnsResolver, transport_pool::UpstreamTransportPool};
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     net::UdpSocket,
@@ -30,7 +30,7 @@ use crate::watchdog::WatchdogCoordinator;
 pub struct SharedRuntimeState {
     pub(crate) listener_runtime_configs: Arc<HashMap<String, ListenerRuntimeConfig>>,
     pub(crate) listener_tls_store: Arc<ListenerTlsReloadStore>,
-    pub(crate) h2_pool: Arc<H2Pool>,
+    pub(crate) transport_pool: Arc<UpstreamTransportPool>,
     pub(crate) backend_endpoints: Arc<HashMap<String, BackendEndpoint>>,
     pub(crate) backend_resolution_store: Arc<RuntimeBackendResolutionStore>,
     pub(crate) backend_dns_resolver: SharedDnsResolver,
@@ -88,7 +88,7 @@ pub struct QUICListener {
     pub tls_reload_generation: u64,
     pub quic_config: quiche::Config,
     pub h3_config: Arc<quiche::h3::Config>,
-    pub h2_pool: Arc<H2Pool>,
+    pub transport_pool: Arc<UpstreamTransportPool>,
     pub backend_endpoints: Arc<HashMap<String, BackendEndpoint>>,
     pub backend_resolution_store: Arc<RuntimeBackendResolutionStore>,
     pub backend_dns_resolver: SharedDnsResolver,

--- a/crates/edge/tests/h1_upstream.rs
+++ b/crates/edge/tests/h1_upstream.rs
@@ -1,0 +1,648 @@
+use std::{
+    collections::HashMap,
+    net::{SocketAddr, UdpSocket},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+use bytes::Bytes;
+use http_body_util::Full;
+use hyper::{Request, Response, body::Incoming, service::service_fn};
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use quiche::h3::NameValue;
+use rand::RngCore;
+use rcgen::{Certificate, CertificateParams, SanType};
+use rustls_pki_types::{CertificateDer, PrivateKeyDer, pem::PemObject};
+use tempfile::{TempDir, tempdir};
+use tokio::net::TcpListener;
+use tokio_rustls::{TlsAcceptor, rustls::ServerConfig};
+
+use spooky_config::{
+    config::{
+        Backend, ClientAuth, Config, Listen, LoadBalancing, Log, LogFormat, RouteMatch, Security,
+        Tls, Upstream, UpstreamTls,
+    },
+    validator::validate,
+};
+use spooky_edge::QUICListener;
+use spooky_edge::constants::{
+    MAX_DATAGRAM_SIZE_BYTES, MAX_UDP_PAYLOAD_BYTES, QUIC_IDLE_TIMEOUT_MS, QUIC_INITIAL_MAX_DATA,
+    QUIC_INITIAL_MAX_STREAMS_BIDI, QUIC_INITIAL_MAX_STREAMS_UNI, QUIC_INITIAL_STREAM_DATA,
+    REQUEST_TIMEOUT_SECS, UDP_READ_TIMEOUT_MS,
+};
+
+fn write_test_certs(dir: &TempDir) -> (String, String) {
+    let mut params = CertificateParams::new(vec!["localhost".into()]);
+    params
+        .subject_alt_names
+        .push(SanType::DnsName("localhost".to_string()));
+    params.subject_alt_names.push(SanType::IpAddress(
+        "127.0.0.1".parse().expect("loopback ip"),
+    ));
+    let cert = Certificate::from_params(params).expect("failed to build cert");
+
+    let cert_path = dir.path().join("cert.pem");
+    let key_path = dir.path().join("key.pem");
+
+    std::fs::write(&cert_path, cert.serialize_pem().expect("serialize cert")).expect("write cert");
+    std::fs::write(&key_path, cert.serialize_private_key_pem()).expect("write key");
+
+    (
+        cert_path.to_string_lossy().to_string(),
+        key_path.to_string_lossy().to_string(),
+    )
+}
+
+fn read_test_chain(cert_path: &str) -> Vec<CertificateDer<'static>> {
+    CertificateDer::pem_file_iter(cert_path)
+        .expect("open cert file")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("parse certs")
+}
+
+fn read_test_key(key_path: &str) -> PrivateKeyDer<'static> {
+    PrivateKeyDer::from_pem_file(key_path).expect("parse private key")
+}
+
+fn make_config(
+    cert: String,
+    key: String,
+    upstreams: HashMap<String, Upstream>,
+    upstream_tls: UpstreamTls,
+) -> Config {
+    let listen_port = reserve_unused_udp_port();
+    Config {
+        version: 1,
+        listen: Listen {
+            protocol: "http3".to_string(),
+            port: listen_port,
+            address: "127.0.0.1".to_string(),
+            tls: Tls {
+                cert,
+                key,
+                certificates: Vec::new(),
+                client_auth: ClientAuth::default(),
+            },
+        },
+        listeners: Vec::new(),
+        upstream: upstreams,
+        load_balancing: Some(LoadBalancing {
+            lb_type: "round-robin".to_string(),
+            key: None,
+        }),
+        upstream_tls,
+        log: Log {
+            level: "info".to_string(),
+            file: Default::default(),
+            format: LogFormat::Plain,
+        },
+        performance: spooky_config::config::Performance::default(),
+        observability: spooky_config::config::Observability::default(),
+        resilience: spooky_config::config::Resilience::default(),
+        security: Security::default(),
+    }
+}
+
+fn make_upstream(
+    path_prefix: &str,
+    backends: Vec<Backend>,
+    tls: Option<UpstreamTls>,
+    lb_type: &str,
+) -> Upstream {
+    Upstream {
+        load_balancing: LoadBalancing {
+            lb_type: lb_type.to_string(),
+            key: None,
+        },
+        host_policy: Default::default(),
+        forwarded_headers: Default::default(),
+        tls,
+        route: RouteMatch {
+            host: None,
+            path_prefix: Some(path_prefix.to_string()),
+            method: None,
+        },
+        backends,
+    }
+}
+
+fn make_backend(id: &str, address: String) -> Backend {
+    Backend {
+        id: id.to_string(),
+        address,
+        weight: 1,
+        health_check: None,
+    }
+}
+
+async fn start_h1_backend<F>(handler: F) -> SocketAddr
+where
+    F: Fn(Request<Incoming>) -> Response<Full<Bytes>> + Clone + Send + 'static,
+{
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind h1 backend");
+    let addr = listener.local_addr().expect("h1 local addr");
+
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = match listener.accept().await {
+                Ok(value) => value,
+                Err(_) => break,
+            };
+            let handler = handler.clone();
+            tokio::spawn(async move {
+                let service = service_fn(move |req: Request<Incoming>| {
+                    let handler = handler.clone();
+                    async move { Ok::<_, hyper::Error>(handler(req)) }
+                });
+
+                let _ = hyper::server::conn::http1::Builder::new()
+                    .serve_connection(TokioIo::new(stream), service)
+                    .await;
+            });
+        }
+    });
+
+    addr
+}
+
+async fn start_h1_delayed_backend(body: &'static str, delay: Duration) -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind delayed h1 backend");
+    let addr = listener.local_addr().expect("delayed h1 local addr");
+
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = match listener.accept().await {
+                Ok(value) => value,
+                Err(_) => break,
+            };
+            tokio::spawn(async move {
+                let service = service_fn(move |_req: Request<Incoming>| async move {
+                    tokio::time::sleep(delay).await;
+                    Ok::<_, hyper::Error>(Response::new(Full::new(Bytes::from_static(
+                        body.as_bytes(),
+                    ))))
+                });
+
+                let _ = hyper::server::conn::http1::Builder::new()
+                    .serve_connection(TokioIo::new(stream), service)
+                    .await;
+            });
+        }
+    });
+
+    addr
+}
+
+async fn start_h2_tls_backend<F>(cert_path: &str, key_path: &str, handler: F) -> SocketAddr
+where
+    F: Fn(Request<Incoming>) -> Response<Full<Bytes>> + Clone + Send + 'static,
+{
+    let mut tls_config = ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(read_test_chain(cert_path), read_test_key(key_path))
+        .expect("server tls config");
+    tls_config.alpn_protocols = vec![b"h2".to_vec()];
+    let acceptor = TlsAcceptor::from(Arc::new(tls_config));
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind h2 backend");
+    let addr = listener.local_addr().expect("h2 local addr");
+
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = match listener.accept().await {
+                Ok(value) => value,
+                Err(_) => break,
+            };
+            let acceptor = acceptor.clone();
+            let handler = handler.clone();
+            tokio::spawn(async move {
+                let tls_stream = match acceptor.accept(stream).await {
+                    Ok(stream) => stream,
+                    Err(_) => return,
+                };
+                let service = service_fn(move |req: Request<Incoming>| {
+                    let handler = handler.clone();
+                    async move { Ok::<_, hyper::Error>(handler(req)) }
+                });
+                let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
+                    .serve_connection(TokioIo::new(tls_stream), service)
+                    .await;
+            });
+        }
+    });
+
+    addr
+}
+
+struct ListenerTaskGuard {
+    stop: Arc<AtomicBool>,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl ListenerTaskGuard {
+    fn spawn(rt: &tokio::runtime::Runtime, mut listener: QUICListener) -> Self {
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_flag = Arc::clone(&stop);
+        let handle = rt.spawn_blocking(move || {
+            while !stop_flag.load(Ordering::Relaxed) {
+                listener.poll();
+            }
+        });
+        Self { stop, handle }
+    }
+}
+
+impl Drop for ListenerTaskGuard {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        self.handle.abort();
+    }
+}
+
+struct H3Response {
+    status: String,
+    body: Vec<u8>,
+}
+
+fn quic_read_timeout(conn: &quiche::Connection) -> Duration {
+    conn.timeout()
+        .filter(|timeout| !timeout.is_zero())
+        .unwrap_or(Duration::from_millis(UDP_READ_TIMEOUT_MS))
+}
+
+fn run_h3_get(
+    addr: SocketAddr,
+    authority: &str,
+    path: &str,
+    headers: &[(&str, &str)],
+) -> Result<H3Response, String> {
+    let socket = UdpSocket::bind("0.0.0.0:0").map_err(|err| err.to_string())?;
+    let local_addr = socket.local_addr().map_err(|err| err.to_string())?;
+
+    let mut config =
+        quiche::Config::new(quiche::PROTOCOL_VERSION).map_err(|err| format!("config: {err:?}"))?;
+    config.verify_peer(false);
+    config
+        .set_application_protos(quiche::h3::APPLICATION_PROTOCOL)
+        .map_err(|err| format!("alpn: {err:?}"))?;
+    config.set_max_idle_timeout(QUIC_IDLE_TIMEOUT_MS);
+    config.set_max_recv_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    config.set_max_send_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    config.set_initial_max_data(QUIC_INITIAL_MAX_DATA);
+    config.set_initial_max_stream_data_bidi_local(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_stream_data_bidi_remote(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_stream_data_uni(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_streams_bidi(QUIC_INITIAL_MAX_STREAMS_BIDI);
+    config.set_initial_max_streams_uni(QUIC_INITIAL_MAX_STREAMS_UNI);
+    config.set_disable_active_migration(true);
+
+    let mut scid_bytes = [0u8; quiche::MAX_CONN_ID_LEN];
+    rand::thread_rng().fill_bytes(&mut scid_bytes);
+    let scid = quiche::ConnectionId::from_ref(&scid_bytes);
+
+    let mut conn = quiche::connect(Some("localhost"), &scid, local_addr, addr, &mut config)
+        .map_err(|err| format!("connect: {err:?}"))?;
+    let h3_config = quiche::h3::Config::new().map_err(|err| format!("h3: {err:?}"))?;
+    let mut h3: Option<quiche::h3::Connection> = None;
+
+    let mut out = [0u8; MAX_UDP_PAYLOAD_BYTES];
+    let mut buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
+    let mut status = String::new();
+    let mut body = Vec::new();
+    let mut request_sent = false;
+    let start = Instant::now();
+
+    let (write, send_info) = conn
+        .send(&mut out)
+        .map_err(|err| format!("send: {err:?}"))?;
+    socket
+        .send_to(&out[..write], send_info.to)
+        .map_err(|err| format!("send_to: {err:?}"))?;
+
+    loop {
+        loop {
+            match conn.send(&mut out) {
+                Ok((write, send_info)) => {
+                    let _ = socket.send_to(&out[..write], send_info.to);
+                }
+                Err(quiche::Error::Done) => break,
+                Err(err) => return Err(format!("send loop: {err:?}")),
+            }
+        }
+
+        socket
+            .set_read_timeout(Some(quic_read_timeout(&conn)))
+            .map_err(|err| format!("timeout: {err:?}"))?;
+
+        match socket.recv_from(&mut buf) {
+            Ok((len, from)) => {
+                conn.recv(
+                    &mut buf[..len],
+                    quiche::RecvInfo {
+                        from,
+                        to: local_addr,
+                    },
+                )
+                .map_err(|err| format!("recv: {err:?}"))?;
+            }
+            Err(ref err)
+                if err.kind() == std::io::ErrorKind::WouldBlock
+                    || err.kind() == std::io::ErrorKind::TimedOut =>
+            {
+                conn.on_timeout();
+            }
+            Err(err) => return Err(format!("recv: {err:?}")),
+        }
+
+        if conn.is_established() && h3.is_none() {
+            h3 = Some(
+                quiche::h3::Connection::with_transport(&mut conn, &h3_config)
+                    .map_err(|err| format!("h3 conn: {err:?}"))?,
+            );
+        }
+
+        if let Some(h3_conn) = h3.as_mut() {
+            if conn.is_established() && !request_sent {
+                let mut request_headers = vec![
+                    quiche::h3::Header::new(b":method", b"GET"),
+                    quiche::h3::Header::new(b":scheme", b"https"),
+                    quiche::h3::Header::new(b":authority", authority.as_bytes()),
+                    quiche::h3::Header::new(b":path", path.as_bytes()),
+                    quiche::h3::Header::new(b"user-agent", b"spooky-h1-regression"),
+                ];
+                request_headers.extend(headers.iter().map(|(name, value)| {
+                    quiche::h3::Header::new(name.as_bytes(), value.as_bytes())
+                }));
+                h3_conn
+                    .send_request(&mut conn, &request_headers, true)
+                    .map_err(|err| format!("send_request: {err:?}"))?;
+                request_sent = true;
+            }
+
+            loop {
+                match h3_conn.poll(&mut conn) {
+                    Ok((_stream_id, quiche::h3::Event::Headers { list, .. })) => {
+                        for header in &list {
+                            if header.name() == b":status" {
+                                status = String::from_utf8_lossy(header.value()).to_string();
+                            }
+                        }
+                    }
+                    Ok((stream_id, quiche::h3::Event::Data)) => loop {
+                        match h3_conn.recv_body(&mut conn, stream_id, &mut buf) {
+                            Ok(read) => body.extend_from_slice(&buf[..read]),
+                            Err(quiche::h3::Error::Done) => break,
+                            Err(err) => return Err(format!("recv_body: {err:?}")),
+                        }
+                    },
+                    Ok((_stream_id, quiche::h3::Event::Finished)) => {
+                        return Ok(H3Response { status, body });
+                    }
+                    Ok((_stream_id, quiche::h3::Event::Reset(_))) => {
+                        return Err("stream reset".to_string());
+                    }
+                    Ok((_stream_id, quiche::h3::Event::PriorityUpdate)) => {}
+                    Ok((_stream_id, quiche::h3::Event::GoAway)) => {}
+                    Err(quiche::h3::Error::Done) => break,
+                    Err(err) => return Err(format!("poll: {err:?}")),
+                }
+            }
+        }
+
+        if start.elapsed() > Duration::from_secs(REQUEST_TIMEOUT_SECS) {
+            return Err(format!(
+                "timeout waiting for response (status='{}', body_len={})",
+                status,
+                body.len()
+            ));
+        }
+    }
+}
+
+fn reserve_unused_udp_port() -> u16 {
+    let socket = UdpSocket::bind("127.0.0.1:0").expect("reserve udp port");
+    let port = socket.local_addr().expect("udp local addr").port();
+    drop(socket);
+    port
+}
+
+#[test]
+fn http_only_upstream_starts_and_forwards_requests_end_to_end() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_certs(&dir);
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let backend_addr = rt.block_on(start_h1_backend(|_req| {
+        Response::new(Full::new(Bytes::from_static(b"http-only ok\n")))
+    }));
+
+    let mut upstreams = HashMap::new();
+    upstreams.insert(
+        "plain".to_string(),
+        make_upstream(
+            "/",
+            vec![make_backend("plain-1", format!("http://{backend_addr}"))],
+            Some(UpstreamTls {
+                verify_certificates: true,
+                strict_sni: true,
+                ca_file: Some("/path/does/not/exist.pem".to_string()),
+                ca_dir: Some("/path/does/not/exist".to_string()),
+            }),
+            "round-robin",
+        ),
+    );
+    let config = make_config(
+        cert,
+        key,
+        upstreams,
+        UpstreamTls {
+            verify_certificates: true,
+            strict_sni: true,
+            ca_file: Some("/path/does/not/exist-global.pem".to_string()),
+            ca_dir: Some("/path/does/not/exist-global".to_string()),
+        },
+    );
+
+    validate(&config).expect("http-only config should validate");
+    let listener = QUICListener::new(config).expect("listener");
+    let listen_addr = listener.socket.local_addr().expect("listen addr");
+    let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
+
+    let response = run_h3_get(listen_addr, "public.example.com", "/", &[]).expect("h3 request");
+    assert_eq!(response.status, "200");
+    assert_eq!(String::from_utf8_lossy(&response.body), "http-only ok\n");
+}
+
+#[test]
+fn http_only_upstream_normalizes_forwarding_headers() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_certs(&dir);
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let backend_addr = rt.block_on(start_h1_backend(|req| {
+        let header = |name: &str| {
+            req.headers()
+                .get(name)
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or("<missing>")
+                .to_string()
+        };
+        let body = format!(
+            "host={}\nforwarded={}\nxff={}\nxfp={}\nxfh={}\nhas_connection={}\nx-secret={}\n",
+            header("host"),
+            header("forwarded"),
+            header("x-forwarded-for"),
+            header("x-forwarded-proto"),
+            header("x-forwarded-host"),
+            req.headers().contains_key("connection"),
+            header("x-secret"),
+        );
+        Response::new(Full::new(Bytes::from(body)))
+    }));
+
+    let mut upstreams = HashMap::new();
+    upstreams.insert(
+        "headers".to_string(),
+        make_upstream(
+            "/headers",
+            vec![make_backend("headers-1", format!("http://{backend_addr}"))],
+            None,
+            "round-robin",
+        ),
+    );
+    let config = make_config(cert, key, upstreams, UpstreamTls::default());
+
+    validate(&config).expect("config should validate");
+    let listener = QUICListener::new(config).expect("listener");
+    let listen_addr = listener.socket.local_addr().expect("listen addr");
+    let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
+
+    let response = run_h3_get(
+        listen_addr,
+        "public.example.com",
+        "/headers",
+        &[
+            ("forwarded", "for=1.2.3.4;proto=http;host=\"evil.example\""),
+            ("x-forwarded-for", "1.2.3.4"),
+            ("x-forwarded-proto", "http"),
+            ("x-forwarded-host", "evil.example"),
+            ("connection", "keep-alive, x-secret"),
+            ("x-secret", "should-strip"),
+        ],
+    )
+    .expect("h3 request");
+    let body = String::from_utf8_lossy(&response.body);
+
+    assert_eq!(response.status, "200");
+    assert!(body.contains("host=public.example.com"));
+    assert!(body.contains("forwarded=for=127.0.0.1;proto=https;host=\"public.example.com\""));
+    assert!(body.contains("xff=127.0.0.1"));
+    assert!(body.contains("xfp=https"));
+    assert!(body.contains("xfh=public.example.com"));
+    assert!(body.contains("has_connection=false"));
+    assert!(body.contains("x-secret=<missing>"));
+}
+
+#[test]
+fn http_only_upstream_retries_bodyless_requests_on_alternate_backend() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_certs(&dir);
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let stalled_backend = rt.block_on(start_h1_delayed_backend(
+        "too slow\n",
+        Duration::from_secs(2),
+    ));
+    let healthy_backend = rt.block_on(start_h1_backend(|_req| {
+        Response::new(Full::new(Bytes::from_static(b"retry ok\n")))
+    }));
+
+    let mut upstreams = HashMap::new();
+    upstreams.insert(
+        "retry".to_string(),
+        make_upstream(
+            "/retry",
+            vec![
+                make_backend("stalled", format!("http://{stalled_backend}")),
+                make_backend("healthy", format!("http://{healthy_backend}")),
+            ],
+            None,
+            "round-robin",
+        ),
+    );
+    let mut config = make_config(cert, key, upstreams, UpstreamTls::default());
+    config.performance.backend_connect_timeout_ms = 50;
+    config.performance.backend_timeout_ms = 100;
+
+    validate(&config).expect("config should validate");
+    let listener = QUICListener::new(config).expect("listener");
+    let listen_addr = listener.socket.local_addr().expect("listen addr");
+    let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
+
+    let response =
+        run_h3_get(listen_addr, "retry.example.com", "/retry", &[]).expect("retry request");
+    assert_eq!(response.status, "200");
+    assert_eq!(String::from_utf8_lossy(&response.body), "retry ok\n");
+}
+
+#[test]
+fn mixed_http_and_https_upstreams_route_by_scheme() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_certs(&dir);
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let plain_backend = rt.block_on(start_h1_backend(|_req| {
+        Response::new(Full::new(Bytes::from_static(b"plain backend\n")))
+    }));
+    let secure_backend = rt.block_on(start_h2_tls_backend(&cert, &key, |_req| {
+        Response::new(Full::new(Bytes::from_static(b"secure backend\n")))
+    }));
+
+    let mut upstreams = HashMap::new();
+    upstreams.insert(
+        "plain".to_string(),
+        make_upstream(
+            "/plain",
+            vec![make_backend("plain-1", format!("http://{plain_backend}"))],
+            None,
+            "round-robin",
+        ),
+    );
+    upstreams.insert(
+        "secure".to_string(),
+        make_upstream(
+            "/secure",
+            vec![make_backend(
+                "secure-1",
+                format!("https://{secure_backend}"),
+            )],
+            Some(UpstreamTls {
+                verify_certificates: false,
+                strict_sni: true,
+                ca_file: None,
+                ca_dir: None,
+            }),
+            "round-robin",
+        ),
+    );
+    let config = make_config(cert, key, upstreams, UpstreamTls::default());
+
+    validate(&config).expect("mixed config should validate");
+    let listener = QUICListener::new(config).expect("listener");
+    let listen_addr = listener.socket.local_addr().expect("listen addr");
+    let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
+
+    let plain = run_h3_get(listen_addr, "mixed.example.com", "/plain", &[]).expect("plain request");
+    let secure =
+        run_h3_get(listen_addr, "mixed.example.com", "/secure", &[]).expect("secure request");
+
+    assert_eq!(plain.status, "200");
+    assert_eq!(String::from_utf8_lossy(&plain.body), "plain backend\n");
+    assert_eq!(secure.status, "200");
+    assert_eq!(String::from_utf8_lossy(&secure.body), "secure backend\n");
+}

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -285,7 +285,7 @@ async fn start_h2_backend() -> SocketAddr {
                     Ok::<_, hyper::Error>(Response::new(Full::new(Bytes::from("backend ok\n"))))
                 });
 
-                let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
+                let _ = hyper::server::conn::http1::Builder::new()
                     .serve_connection(io, service)
                     .await;
             });
@@ -316,7 +316,7 @@ async fn start_h2_backend_draining() -> SocketAddr {
                         Full::new(Bytes::from_static(b"ok\n")).boxed(),
                     ))
                 });
-                let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
+                let _ = hyper::server::conn::http1::Builder::new()
                     .serve_connection(io, service)
                     .await;
             });
@@ -1246,12 +1246,13 @@ async fn start_h2_backend_with_trailers() -> SocketAddr {
                     Ok::<_, hyper::Error>(
                         Response::builder()
                             .header("content-type", "application/grpc")
+                            .header(http::header::TRAILER, "grpc-status, grpc-message")
                             .body(body)
                             .expect("response"),
                     )
                 });
 
-                let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
+                let _ = hyper::server::conn::http1::Builder::new()
                     .serve_connection(io, service)
                     .await;
             });
@@ -1287,6 +1288,7 @@ async fn start_h2_backend_with_grpc_routes() -> SocketAddr {
                             );
                             Response::builder()
                                 .header("content-type", "application/grpc")
+                                .header(http::header::TRAILER, "grpc-status, grpc-message")
                                 .body(
                                     TrailerThenEndBody::new(
                                         Bytes::from_static(b"\x00\x00\x00\x00\x00"),
@@ -1308,6 +1310,7 @@ async fn start_h2_backend_with_grpc_routes() -> SocketAddr {
                             );
                             Response::builder()
                                 .header("content-type", "application/grpc")
+                                .header(http::header::TRAILER, "grpc-status, grpc-message")
                                 .body(TrailerThenEndBody::new(Bytes::new(), trailers).boxed())
                                 .expect("grpc error response")
                         }
@@ -1324,7 +1327,7 @@ async fn start_h2_backend_with_grpc_routes() -> SocketAddr {
                     Ok::<_, hyper::Error>(response)
                 });
 
-                let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
+                let _ = hyper::server::conn::http1::Builder::new()
                     .serve_connection(io, service)
                     .await;
             });
@@ -2156,7 +2159,7 @@ async fn start_h2_backend_with_regression_routes() -> SocketAddr {
             });
 
             tokio::spawn(async move {
-                let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
+                let _ = hyper::server::conn::http1::Builder::new()
                     .serve_connection(io, service)
                     .await;
             });
@@ -2196,7 +2199,7 @@ async fn start_h2_backend_with_drain_probe(inflight_seen: Arc<AtomicBool>) -> So
             });
 
             tokio::spawn(async move {
-                let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
+                let _ = hyper::server::conn::http1::Builder::new()
                     .serve_connection(io, service)
                     .await;
             });
@@ -2259,7 +2262,7 @@ async fn start_h2_backend_with_chaos_routes() -> SocketAddr {
             });
 
             tokio::spawn(async move {
-                let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
+                let _ = hyper::server::conn::http1::Builder::new()
                     .serve_connection(io, service)
                     .await;
             });
@@ -4343,7 +4346,7 @@ fn response_body_cap_returns_503_on_declared_length_breach() {
                         Ok::<_, hyper::Error>(response)
                     }
                 });
-                let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
+                let _ = hyper::server::conn::http1::Builder::new()
                     .serve_connection(io, service)
                     .await;
             });
@@ -4529,7 +4532,7 @@ fn response_body_cap_returns_503_on_unknown_length_breach() {
                     });
                     Ok::<_, hyper::Error>(Response::new(body.boxed()))
                 });
-                let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
+                let _ = hyper::server::conn::http1::Builder::new()
                     .serve_connection(io, service)
                     .await;
             });

--- a/crates/edge/tests/lb_integration.rs
+++ b/crates/edge/tests/lb_integration.rs
@@ -10,7 +10,7 @@ use std::{
 use bytes::Bytes;
 use http_body_util::Full;
 use hyper::{Request, Response, body::Incoming, service::service_fn};
-use hyper_util::rt::{TokioExecutor, TokioIo};
+use hyper_util::rt::TokioIo;
 use rand::RngCore;
 use rcgen::{Certificate, CertificateParams, SanType};
 use tempfile::{TempDir, tempdir};
@@ -62,7 +62,7 @@ async fn start_h2_backend(body: &'static str) -> SocketAddr {
             });
 
             tokio::spawn(async move {
-                let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
+                let _ = hyper::server::conn::http1::Builder::new()
                     .serve_connection(io, service)
                     .await;
             });

--- a/crates/transport/src/h1_client.rs
+++ b/crates/transport/src/h1_client.rs
@@ -1,0 +1,81 @@
+use http_body_util::combinators::BoxBody;
+use hyper::Request;
+use hyper::body::Bytes;
+use hyper_util::client::legacy::{Client, connect::HttpConnector};
+use std::convert::Infallible;
+
+use crate::h2_client::{
+    DEFAULT_CONNECT_TIMEOUT, DEFAULT_MAX_IDLE_PER_HOST, DEFAULT_POOL_IDLE_TIMEOUT,
+    SharedDnsResolver, TokioExecutor,
+};
+
+pub struct H1Client {
+    client: Client<HttpConnector<SharedDnsResolver>, BoxBody<Bytes, Infallible>>,
+}
+
+impl Default for H1Client {
+    fn default() -> Self {
+        let dns_resolver = SharedDnsResolver::new();
+        let mut http = HttpConnector::new_with_resolver(dns_resolver);
+        http.enforce_http(true);
+        http.set_connect_timeout(Some(DEFAULT_CONNECT_TIMEOUT));
+
+        let client = Client::builder(TokioExecutor)
+            .pool_max_idle_per_host(DEFAULT_MAX_IDLE_PER_HOST)
+            .pool_idle_timeout(DEFAULT_POOL_IDLE_TIMEOUT)
+            .build(http);
+
+        Self { client }
+    }
+}
+
+impl H1Client {
+    pub fn new(
+        max_idle_per_host: usize,
+        pool_idle_timeout: std::time::Duration,
+        connect_timeout: std::time::Duration,
+        dns_resolver: SharedDnsResolver,
+    ) -> Self {
+        let mut http = HttpConnector::new_with_resolver(dns_resolver);
+        http.enforce_http(true);
+        http.set_connect_timeout(Some(connect_timeout));
+
+        let client = Client::builder(TokioExecutor)
+            .pool_max_idle_per_host(max_idle_per_host)
+            .pool_idle_timeout(pool_idle_timeout)
+            .build(http);
+
+        Self { client }
+    }
+
+    pub async fn send(
+        &self,
+        req: Request<BoxBody<Bytes, Infallible>>,
+    ) -> Result<hyper::Response<hyper::body::Incoming>, hyper_util::client::legacy::Error> {
+        self.client.request(req).await
+    }
+
+    pub fn try_default() -> Self {
+        Self::new(
+            DEFAULT_MAX_IDLE_PER_HOST,
+            DEFAULT_POOL_IDLE_TIMEOUT,
+            DEFAULT_CONNECT_TIMEOUT,
+            SharedDnsResolver::new(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::H1Client;
+
+    #[test]
+    fn default_h1_client_does_not_panic() {
+        let _client = H1Client::default();
+    }
+
+    #[test]
+    fn default_h1_client_builds() {
+        let _client = H1Client::try_default();
+    }
+}

--- a/crates/transport/src/h1_pool.rs
+++ b/crates/transport/src/h1_pool.rs
@@ -1,0 +1,119 @@
+use std::{
+    collections::HashMap,
+    convert::Infallible,
+    sync::{Arc, RwLock},
+    time::Duration,
+};
+
+use http_body_util::combinators::BoxBody;
+use hyper::Request;
+use hyper::body::{Bytes, Incoming};
+use tokio::sync::{Semaphore, TryAcquireError};
+
+use crate::h1_client::H1Client;
+use crate::h2_client::SharedDnsResolver;
+pub use spooky_errors::PoolError;
+
+struct BackendClientState {
+    client: Arc<H1Client>,
+}
+
+struct BackendHandle {
+    state: RwLock<BackendClientState>,
+    inflight: Arc<Semaphore>,
+}
+
+pub struct H1Pool {
+    backends: HashMap<String, BackendHandle>,
+    max_idle_per_backend: usize,
+    pool_idle_timeout: Duration,
+    connect_timeout: Duration,
+    dns_resolver: SharedDnsResolver,
+}
+
+impl H1Pool {
+    pub fn new<I>(
+        backends: I,
+        max_inflight: usize,
+        max_idle_per_backend: usize,
+        pool_idle_timeout: Duration,
+        connect_timeout: Duration,
+        dns_resolver: SharedDnsResolver,
+    ) -> Self
+    where
+        I: IntoIterator<Item = String>,
+    {
+        let inflight = max_inflight.max(1);
+        let max_idle_per_backend = max_idle_per_backend.max(1);
+        let mut map = HashMap::new();
+        for backend in backends {
+            let client = Arc::new(H1Client::new(
+                max_idle_per_backend,
+                pool_idle_timeout,
+                connect_timeout,
+                dns_resolver.clone(),
+            ));
+            map.insert(
+                backend,
+                BackendHandle {
+                    state: RwLock::new(BackendClientState { client }),
+                    inflight: Arc::new(Semaphore::new(inflight)),
+                },
+            );
+        }
+
+        Self {
+            backends: map,
+            max_idle_per_backend,
+            pool_idle_timeout,
+            connect_timeout,
+            dns_resolver,
+        }
+    }
+
+    pub async fn send(
+        &self,
+        backend: &str,
+        req: Request<BoxBody<Bytes, Infallible>>,
+    ) -> Result<hyper::Response<Incoming>, PoolError> {
+        let handle = self
+            .backends
+            .get(backend)
+            .ok_or_else(|| PoolError::UnknownBackend(backend.to_string()))?;
+        let client = handle
+            .state
+            .read()
+            .map(|state| Arc::clone(&state.client))
+            .map_err(|_| PoolError::InflightLimiterClosed)?;
+
+        let _permit = match Arc::clone(&handle.inflight).try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(TryAcquireError::NoPermits) => {
+                return Err(PoolError::BackendOverloaded(backend.to_string()));
+            }
+            Err(TryAcquireError::Closed) => return Err(PoolError::InflightLimiterClosed),
+        };
+
+        client.send(req).await.map_err(PoolError::Send)
+    }
+
+    pub fn rotate_backend_client(&self, backend: &str) -> Result<bool, String> {
+        let Some(handle) = self.backends.get(backend) else {
+            return Ok(false);
+        };
+
+        let client = Arc::new(H1Client::new(
+            self.max_idle_per_backend,
+            self.pool_idle_timeout,
+            self.connect_timeout,
+            self.dns_resolver.clone(),
+        ));
+
+        let mut state = handle
+            .state
+            .write()
+            .map_err(|_| format!("backend client state poisoned for '{backend}'"))?;
+        state.client = client;
+        Ok(true)
+    }
+}

--- a/crates/transport/src/h2_client.rs
+++ b/crates/transport/src/h2_client.rs
@@ -55,9 +55,9 @@ type ResolverResponse = std::vec::IntoIter<SocketAddr>;
 type ResolverFuture =
     Pin<Box<dyn Future<Output = Result<ResolverResponse, io::Error>> + Send + 'static>>;
 
-const DEFAULT_MAX_IDLE_PER_HOST: usize = 64;
-const DEFAULT_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
-const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
+pub(crate) const DEFAULT_MAX_IDLE_PER_HOST: usize = 64;
+pub(crate) const DEFAULT_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+pub(crate) const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DnsCacheUpdate {
@@ -197,7 +197,7 @@ impl Default for H2Client {
 }
 
 #[derive(Clone, Copy)]
-struct TokioExecutor;
+pub(crate) struct TokioExecutor;
 
 impl<F> Executor<F> for TokioExecutor
 where

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -1,2 +1,5 @@
+pub mod h1_client;
+pub mod h1_pool;
 pub mod h2_client;
 pub mod h2_pool;
+pub mod transport_pool;

--- a/crates/transport/src/transport_pool.rs
+++ b/crates/transport/src/transport_pool.rs
@@ -1,0 +1,96 @@
+use std::{collections::HashMap, convert::Infallible, time::Duration};
+
+use http_body_util::combinators::BoxBody;
+use hyper::Request;
+use hyper::body::{Bytes, Incoming};
+
+use crate::h1_pool::H1Pool;
+use crate::h2_client::{SharedDnsResolver, TlsClientConfig};
+use crate::h2_pool::H2Pool;
+pub use spooky_errors::PoolError;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackendTransportKind {
+    Http1,
+    H2,
+}
+
+pub struct UpstreamTransportPool {
+    backend_kinds: HashMap<String, BackendTransportKind>,
+    h1_pool: H1Pool,
+    h2_pool: H2Pool,
+}
+
+impl UpstreamTransportPool {
+    pub fn new<I>(
+        backends: I,
+        backend_tls: HashMap<String, TlsClientConfig>,
+        max_inflight: usize,
+        max_idle_per_backend: usize,
+        pool_idle_timeout: Duration,
+        connect_timeout: Duration,
+        dns_resolver: SharedDnsResolver,
+    ) -> Result<Self, String>
+    where
+        I: IntoIterator<Item = (String, BackendTransportKind)>,
+    {
+        let mut backend_kinds = HashMap::new();
+        let mut h1_backends = Vec::new();
+        let mut h2_backends = Vec::new();
+
+        for (backend, kind) in backends {
+            backend_kinds.insert(backend.clone(), kind);
+            match kind {
+                BackendTransportKind::Http1 => h1_backends.push(backend),
+                BackendTransportKind::H2 => h2_backends.push(backend),
+            }
+        }
+
+        let h1_pool = H1Pool::new(
+            h1_backends,
+            max_inflight,
+            max_idle_per_backend,
+            pool_idle_timeout,
+            connect_timeout,
+            dns_resolver.clone(),
+        );
+        let h2_pool = H2Pool::new(
+            h2_backends,
+            backend_tls,
+            max_inflight,
+            max_idle_per_backend,
+            pool_idle_timeout,
+            connect_timeout,
+            dns_resolver,
+        )?;
+
+        Ok(Self {
+            backend_kinds,
+            h1_pool,
+            h2_pool,
+        })
+    }
+
+    pub async fn send(
+        &self,
+        backend: &str,
+        req: Request<BoxBody<Bytes, Infallible>>,
+    ) -> Result<hyper::Response<Incoming>, PoolError> {
+        match self.backend_kinds.get(backend).copied() {
+            Some(BackendTransportKind::Http1) => self.h1_pool.send(backend, req).await,
+            Some(BackendTransportKind::H2) => self.h2_pool.send(backend, req).await,
+            None => Err(PoolError::UnknownBackend(backend.to_string())),
+        }
+    }
+
+    pub fn rotate_backend_client(&self, backend: &str) -> Result<bool, String> {
+        match self.backend_kinds.get(backend).copied() {
+            Some(BackendTransportKind::Http1) => self.h1_pool.rotate_backend_client(backend),
+            Some(BackendTransportKind::H2) => self
+                .h2_pool
+                .rotate_backend_client(backend)
+                .map(|rotation| rotation.is_some()),
+            None => Ok(false),
+        }
+    }
+}

--- a/crates/transport/tests/h1_pool.rs
+++ b/crates/transport/tests/h1_pool.rs
@@ -1,0 +1,191 @@
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use bytes::Bytes;
+use http_body_util::{BodyExt, Full};
+use hyper::{Request, Response, body::Incoming, service::service_fn};
+use hyper_util::rt::TokioIo;
+use tokio::net::TcpListener;
+
+use spooky_transport::{
+    h1_pool::{H1Pool, PoolError},
+    h2_client::SharedDnsResolver,
+};
+
+struct ConcurrencyTracker {
+    current: AtomicUsize,
+    max: AtomicUsize,
+}
+
+impl ConcurrencyTracker {
+    fn new() -> Self {
+        Self {
+            current: AtomicUsize::new(0),
+            max: AtomicUsize::new(0),
+        }
+    }
+
+    fn enter(&self) {
+        let now = self.current.fetch_add(1, Ordering::SeqCst) + 1;
+        let mut prev = self.max.load(Ordering::SeqCst);
+        while now > prev {
+            match self
+                .max
+                .compare_exchange(prev, now, Ordering::SeqCst, Ordering::SeqCst)
+            {
+                Ok(_) => break,
+                Err(next) => prev = next,
+            }
+        }
+    }
+
+    fn exit(&self) {
+        self.current.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+async fn start_h1_server(tracker: Arc<ConcurrencyTracker>) -> std::io::Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let port = listener.local_addr()?.port();
+
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = match listener.accept().await {
+                Ok(v) => v,
+                Err(_) => break,
+            };
+            let tracker = tracker.clone();
+            let service = service_fn(move |_req: Request<Incoming>| {
+                let tracker = tracker.clone();
+                async move {
+                    tracker.enter();
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    tracker.exit();
+                    Ok::<_, std::convert::Infallible>(Response::new(Full::new(Bytes::from("ok"))))
+                }
+            });
+
+            tokio::spawn(async move {
+                let _ = hyper::server::conn::http1::Builder::new()
+                    .serve_connection(TokioIo::new(stream), service)
+                    .await;
+            });
+        }
+    });
+
+    Ok(port)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pool_limits_inflight_per_backend() {
+    let tracker = Arc::new(ConcurrencyTracker::new());
+    let port = start_h1_server(tracker.clone()).await.unwrap();
+    let backend = format!("127.0.0.1:{port}");
+
+    let pool = Arc::new(H1Pool::new(
+        vec![backend.clone()],
+        1,
+        64,
+        Duration::from_secs(30),
+        Duration::from_secs(2),
+        SharedDnsResolver::new(),
+    ));
+    let req1 = Request::builder()
+        .method("GET")
+        .uri(format!("http://{backend}/"))
+        .body(Full::new(Bytes::new()).boxed())
+        .unwrap();
+    let req2 = Request::builder()
+        .method("GET")
+        .uri(format!("http://{backend}/"))
+        .body(Full::new(Bytes::new()).boxed())
+        .unwrap();
+
+    let pool1 = pool.clone();
+    let backend1 = backend.clone();
+    let r1 = tokio::spawn(async move { pool1.send(&backend1, req1).await });
+
+    let pool2 = pool.clone();
+    let backend2 = backend.clone();
+    let r2 = tokio::spawn(async move { pool2.send(&backend2, req2).await });
+
+    let (r1, r2) = tokio::join!(r1, r2);
+    let r1 = r1.unwrap();
+    let r2 = r2.unwrap();
+    assert!(
+        r1.is_ok() || r2.is_ok(),
+        "at least one request should be admitted"
+    );
+    assert!(
+        matches!(r1, Err(PoolError::BackendOverloaded(_)))
+            || matches!(r2, Err(PoolError::BackendOverloaded(_))),
+        "one request should be rejected by backend inflight admission"
+    );
+
+    let max = tracker.max.load(Ordering::SeqCst);
+    assert_eq!(max, 1);
+}
+
+#[tokio::test]
+async fn pool_rejects_unknown_backend() {
+    let pool = H1Pool::new(
+        vec!["127.0.0.1:12345".to_string()],
+        1,
+        64,
+        Duration::from_secs(30),
+        Duration::from_secs(2),
+        SharedDnsResolver::new(),
+    );
+    let req = Request::builder()
+        .method("GET")
+        .uri("http://127.0.0.1:12345/")
+        .body(Full::new(Bytes::new()).boxed())
+        .unwrap();
+
+    let err = pool.send("127.0.0.1:9999", req).await.unwrap_err();
+    match err {
+        PoolError::UnknownBackend(name) => assert_eq!(name, "127.0.0.1:9999"),
+        _ => panic!("unexpected error"),
+    }
+}
+
+#[tokio::test]
+async fn pool_reports_overload_when_inflight_is_exhausted() {
+    let tracker = Arc::new(ConcurrencyTracker::new());
+    let port = start_h1_server(tracker).await.unwrap();
+    let backend = format!("127.0.0.1:{port}");
+    let pool = Arc::new(H1Pool::new(
+        vec![backend.clone()],
+        1,
+        64,
+        Duration::from_secs(30),
+        Duration::from_secs(2),
+        SharedDnsResolver::new(),
+    ));
+
+    let req1 = Request::builder()
+        .method("GET")
+        .uri(format!("http://{backend}/"))
+        .body(Full::new(Bytes::new()).boxed())
+        .unwrap();
+    let req2 = Request::builder()
+        .method("GET")
+        .uri(format!("http://{backend}/"))
+        .body(Full::new(Bytes::new()).boxed())
+        .unwrap();
+
+    let pool_task = Arc::clone(&pool);
+    let backend_task = backend.clone();
+    let handle = tokio::spawn(async move { pool_task.send(&backend_task, req1).await });
+
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    let overload = pool.send(&backend, req2).await;
+    assert!(matches!(overload, Err(PoolError::BackendOverloaded(_))));
+
+    let _ = handle.await.expect("request task join");
+}

--- a/crates/transport/tests/h1_pool.rs
+++ b/crates/transport/tests/h1_pool.rs
@@ -189,3 +189,25 @@ async fn pool_reports_overload_when_inflight_is_exhausted() {
 
     let _ = handle.await.expect("request task join");
 }
+
+#[test]
+fn pool_rotates_known_backend_client_and_ignores_unknown_backend() {
+    let pool = H1Pool::new(
+        vec!["127.0.0.1:12345".to_string()],
+        1,
+        64,
+        Duration::from_secs(30),
+        Duration::from_secs(2),
+        SharedDnsResolver::new(),
+    );
+
+    assert!(
+        pool.rotate_backend_client("127.0.0.1:12345")
+            .expect("known backend")
+    );
+    assert!(
+        !pool
+            .rotate_backend_client("127.0.0.1:9999")
+            .expect("unknown backend should be ignored")
+    );
+}


### PR DESCRIPTION
Adds first-class HTTP/1.1 upstream transport alongside the existing H2 path.

- H1Client and H1Pool for plain http:// backends with connect timeout, pooling, and inflight limiting
- Scheme-aware dispatch in the data plane — http:// routes to H1Pool, https:// stays on H2Pool
- Config validator skips TLS trust-store checks for HTTP-only upstreams
- DNS refresh rotation wired through UpstreamTransportPool for H1 backends
- Health checks routed through scheme-aware transport pool (H1 for http://, H2 for https://)
- TE: trailers header added to H1 upstream requests to preserve trailer forwarding semantics
- End-to-end regression tests covering plain forwarding, header normalization, retry, and mixed http/https deployments

Closes #244, #245, #246, #247, #248, #249
