### PR TITLE
fix(edge): guard control API and hot reload against stale TLS state and unsafe listener topology changes

### DIFF
--- a/crates/edge/src/quic_listener/control_api.rs
+++ b/crates/edge/src/quic_listener/control_api.rs
@@ -765,6 +765,7 @@ impl QUICListener {
             let next_runtime = RuntimeBundle {
                 generation: runtime.generation.saturating_add(1),
                 config_path,
+                log_config: config.log.clone(),
                 runtime_config,
                 shared_state: Arc::clone(&next_shared_state),
             };
@@ -799,6 +800,17 @@ impl QUICListener {
                     json!({
                         "reloaded": false,
                         "error": err,
+                    }),
+                );
+            }
+            let startup_owned_issues =
+                Self::validate_startup_owned_reload_compatibility(&runtime, &next_runtime);
+            if !startup_owned_issues.is_empty() {
+                return Self::json_response(
+                    StatusCode::CONFLICT,
+                    json!({
+                        "reloaded": false,
+                        "error": startup_owned_issues.join("; "),
                     }),
                 );
             }
@@ -1014,6 +1026,135 @@ impl QUICListener {
             ));
         }
         None
+    }
+
+    fn note_restart_required_change<T>(issues: &mut Vec<String>, field: &str, current: &T, next: &T)
+    where
+        T: PartialEq + std::fmt::Debug,
+    {
+        if current != next {
+            issues.push(format!(
+                "runtime reload rejected: {field} changed from {current:?} to {next:?}; restart required"
+            ));
+        }
+    }
+
+    fn validate_startup_owned_reload_compatibility(
+        current: &RuntimeBundle,
+        next: &RuntimeBundle,
+    ) -> Vec<String> {
+        let mut issues = Vec::new();
+
+        Self::note_restart_required_change(
+            &mut issues,
+            "log.level",
+            &current.log_config.level,
+            &next.log_config.level,
+        );
+        Self::note_restart_required_change(
+            &mut issues,
+            "log.file.enabled",
+            &current.log_config.file.enabled,
+            &next.log_config.file.enabled,
+        );
+        Self::note_restart_required_change(
+            &mut issues,
+            "log.file.path",
+            &current.log_config.file.path,
+            &next.log_config.file.path,
+        );
+        Self::note_restart_required_change(
+            &mut issues,
+            "log.format",
+            &current.log_config.format,
+            &next.log_config.format,
+        );
+
+        let current_tracing = &current.runtime_config.observability.tracing;
+        let next_tracing = &next.runtime_config.observability.tracing;
+        Self::note_restart_required_change(
+            &mut issues,
+            "observability.tracing.enabled",
+            &current_tracing.enabled,
+            &next_tracing.enabled,
+        );
+        Self::note_restart_required_change(
+            &mut issues,
+            "observability.tracing.service_name",
+            &current_tracing.service_name,
+            &next_tracing.service_name,
+        );
+        Self::note_restart_required_change(
+            &mut issues,
+            "observability.tracing.otlp_endpoint",
+            &current_tracing.otlp_endpoint,
+            &next_tracing.otlp_endpoint,
+        );
+        Self::note_restart_required_change(
+            &mut issues,
+            "observability.tracing.sample_ratio",
+            &current_tracing.sample_ratio,
+            &next_tracing.sample_ratio,
+        );
+
+        let current_perf = &current.runtime_config.performance;
+        let next_perf = &next.runtime_config.performance;
+        Self::note_restart_required_change(
+            &mut issues,
+            "performance.control_plane_threads",
+            &current_perf.control_plane_threads,
+            &next_perf.control_plane_threads,
+        );
+        Self::note_restart_required_change(
+            &mut issues,
+            "performance.worker_threads",
+            &current_perf.worker_threads,
+            &next_perf.worker_threads,
+        );
+        Self::note_restart_required_change(
+            &mut issues,
+            "performance.packet_shards_per_worker",
+            &current_perf.packet_shards_per_worker,
+            &next_perf.packet_shards_per_worker,
+        );
+        Self::note_restart_required_change(
+            &mut issues,
+            "performance.packet_shard_queue_capacity",
+            &current_perf.packet_shard_queue_capacity,
+            &next_perf.packet_shard_queue_capacity,
+        );
+        Self::note_restart_required_change(
+            &mut issues,
+            "performance.packet_shard_queue_max_bytes",
+            &current_perf.packet_shard_queue_max_bytes,
+            &next_perf.packet_shard_queue_max_bytes,
+        );
+        Self::note_restart_required_change(
+            &mut issues,
+            "performance.reuseport",
+            &current_perf.reuseport,
+            &next_perf.reuseport,
+        );
+        Self::note_restart_required_change(
+            &mut issues,
+            "performance.pin_workers",
+            &current_perf.pin_workers,
+            &next_perf.pin_workers,
+        );
+        Self::note_restart_required_change(
+            &mut issues,
+            "performance.udp_recv_buffer_bytes",
+            &current_perf.udp_recv_buffer_bytes,
+            &next_perf.udp_recv_buffer_bytes,
+        );
+        Self::note_restart_required_change(
+            &mut issues,
+            "performance.udp_send_buffer_bytes",
+            &current_perf.udp_send_buffer_bytes,
+            &next_perf.udp_send_buffer_bytes,
+        );
+
+        issues
     }
 
     pub(super) fn control_api_is_authorized(
@@ -1322,8 +1463,12 @@ mod tests {
 
     fn runtime_bundle_from_config(config_path: &str, config: &SpookyConfigConfig) -> RuntimeBundle {
         let runtime_config = RuntimeConfig::from_config(config).expect("runtime config");
-        QUICListener::build_runtime_bundle(config_path.to_string(), &runtime_config)
-            .expect("runtime bundle")
+        QUICListener::build_runtime_bundle(
+            config_path.to_string(),
+            config.log.clone(),
+            &runtime_config,
+        )
+        .expect("runtime bundle")
     }
 
     fn control_api_state_with_runtime_bundle(
@@ -1486,5 +1631,57 @@ mod tests {
                 .expect("bind change should be rejected");
 
         assert!(err.contains("observability.metrics bind changed"));
+    }
+
+    #[test]
+    fn validate_startup_owned_reload_compatibility_rejects_log_change() {
+        let dir = tempdir().expect("tempdir");
+        let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+        let current = test_config(cert.clone(), key.clone());
+
+        let mut next = current.clone();
+        next.log.level = "debug".to_string();
+
+        let current_bundle = runtime_bundle_from_config("current.yaml", &current);
+        let next_bundle = runtime_bundle_from_config("next.yaml", &next);
+        let issues = QUICListener::validate_startup_owned_reload_compatibility(
+            &current_bundle,
+            &next_bundle,
+        );
+
+        assert!(
+            issues
+                .iter()
+                .any(|issue| issue.contains("log.level") && issue.contains("restart required"))
+        );
+    }
+
+    #[test]
+    fn validate_startup_owned_reload_compatibility_rejects_worker_topology_change() {
+        let dir = tempdir().expect("tempdir");
+        let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+        let current = test_config(cert.clone(), key.clone());
+
+        let mut next = current.clone();
+        next.performance.worker_threads = 4;
+        next.performance.packet_shards_per_worker = 2;
+
+        let current_bundle = runtime_bundle_from_config("current.yaml", &current);
+        let next_bundle = runtime_bundle_from_config("next.yaml", &next);
+        let issues = QUICListener::validate_startup_owned_reload_compatibility(
+            &current_bundle,
+            &next_bundle,
+        );
+
+        assert!(
+            issues
+                .iter()
+                .any(|issue| issue.contains("performance.worker_threads"))
+        );
+        assert!(
+            issues
+                .iter()
+                .any(|issue| issue.contains("performance.packet_shards_per_worker"))
+        );
     }
 }

--- a/crates/edge/src/quic_listener/control_api.rs
+++ b/crates/edge/src/quic_listener/control_api.rs
@@ -799,16 +799,13 @@ impl QUICListener {
                 runtime_config,
                 shared_state: Arc::clone(&next_shared_state),
             };
-            if let Some((missing, existing)) =
-                Self::validate_runtime_reload_compatibility(&runtime, &next_runtime)
+            if let Some(err) = Self::validate_runtime_reload_compatibility(&runtime, &next_runtime)
             {
                 return Self::json_response(
                     StatusCode::CONFLICT,
                     json!({
                         "reloaded": false,
-                        "error": format!(
-                            "runtime reload rejected: listener set changed (missing={missing:?}, extra={existing:?})"
-                        ),
+                        "error": err,
                     }),
                 );
             }
@@ -927,69 +924,40 @@ impl QUICListener {
     fn validate_runtime_reload_compatibility(
         current: &RuntimeBundle,
         next: &RuntimeBundle,
-    ) -> Option<(Vec<String>, Vec<String>)> {
-        let current_labels = current
-            .shared_state
-            .listener_runtime_configs
-            .keys()
-            .cloned()
-            .collect::<Vec<_>>();
-        let next_labels = next
-            .shared_state
-            .listener_runtime_configs
-            .keys()
-            .cloned()
-            .collect::<Vec<_>>();
-        if current_labels.len() != next_labels.len() {
-            let missing = current_labels
-                .iter()
-                .filter(|label| {
-                    !next
-                        .shared_state
-                        .listener_runtime_configs
-                        .contains_key(*label)
-                })
-                .cloned()
-                .collect::<Vec<_>>();
-            let extra = next_labels
-                .iter()
-                .filter(|label| {
-                    !current
-                        .shared_state
-                        .listener_runtime_configs
-                        .contains_key(*label)
-                })
-                .cloned()
-                .collect::<Vec<_>>();
-            return Some((missing, extra));
-        }
-        if current_labels.iter().any(|label| {
-            !next
+    ) -> Option<String> {
+        let worker_count = next.runtime_config.performance.worker_threads.max(1);
+        for (label, listener_config) in next.shared_state.listener_runtime_configs.iter() {
+            if current
                 .shared_state
                 .listener_runtime_configs
                 .contains_key(label)
-        }) {
-            let missing = current_labels
-                .iter()
-                .filter(|label| {
-                    !next
-                        .shared_state
-                        .listener_runtime_configs
-                        .contains_key(*label)
-                })
-                .cloned()
-                .collect::<Vec<_>>();
-            let extra = next_labels
-                .iter()
-                .filter(|label| {
-                    !current
-                        .shared_state
-                        .listener_runtime_configs
-                        .contains_key(*label)
-                })
-                .cloned()
-                .collect::<Vec<_>>();
-            return Some((missing, extra));
+            {
+                continue;
+            }
+            if worker_count > 1 {
+                if let Err(err) = Self::bind_reuseport_sockets(listener_config, worker_count) {
+                    return Some(format!(
+                        "runtime reload rejected: failed to preflight QUIC listener {}: {}",
+                        label, err
+                    ));
+                }
+            } else if let Err(err) = Self::bind_socket(listener_config, false) {
+                return Some(format!(
+                    "runtime reload rejected: failed to preflight QUIC listener {}: {}",
+                    label, err
+                ));
+            }
+
+            let bind = format!(
+                "{}:{}",
+                listener_config.listen.listen.address, listener_config.listen.listen.port
+            );
+            if let Err(err) = Self::probe_tcp_bind(&bind, "bootstrap TLS listener") {
+                return Some(format!(
+                    "runtime reload rejected: failed to preflight bootstrap listener {}: {}",
+                    label, err
+                ));
+            }
         }
         None
     }
@@ -1133,54 +1101,6 @@ impl QUICListener {
             "performance.control_plane_threads",
             &current_perf.control_plane_threads,
             &next_perf.control_plane_threads,
-        );
-        Self::note_restart_required_change(
-            &mut issues,
-            "performance.worker_threads",
-            &current_perf.worker_threads,
-            &next_perf.worker_threads,
-        );
-        Self::note_restart_required_change(
-            &mut issues,
-            "performance.packet_shards_per_worker",
-            &current_perf.packet_shards_per_worker,
-            &next_perf.packet_shards_per_worker,
-        );
-        Self::note_restart_required_change(
-            &mut issues,
-            "performance.packet_shard_queue_capacity",
-            &current_perf.packet_shard_queue_capacity,
-            &next_perf.packet_shard_queue_capacity,
-        );
-        Self::note_restart_required_change(
-            &mut issues,
-            "performance.packet_shard_queue_max_bytes",
-            &current_perf.packet_shard_queue_max_bytes,
-            &next_perf.packet_shard_queue_max_bytes,
-        );
-        Self::note_restart_required_change(
-            &mut issues,
-            "performance.reuseport",
-            &current_perf.reuseport,
-            &next_perf.reuseport,
-        );
-        Self::note_restart_required_change(
-            &mut issues,
-            "performance.pin_workers",
-            &current_perf.pin_workers,
-            &next_perf.pin_workers,
-        );
-        Self::note_restart_required_change(
-            &mut issues,
-            "performance.udp_recv_buffer_bytes",
-            &current_perf.udp_recv_buffer_bytes,
-            &next_perf.udp_recv_buffer_bytes,
-        );
-        Self::note_restart_required_change(
-            &mut issues,
-            "performance.udp_send_buffer_bytes",
-            &current_perf.udp_send_buffer_bytes,
-            &next_perf.udp_send_buffer_bytes,
         );
 
         issues
@@ -1684,7 +1604,7 @@ mod tests {
     }
 
     #[test]
-    fn validate_startup_owned_reload_compatibility_rejects_worker_topology_change() {
+    fn validate_startup_owned_reload_compatibility_allows_worker_topology_change() {
         let dir = tempdir().expect("tempdir");
         let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
         let current = test_config(cert.clone(), key.clone());
@@ -1700,15 +1620,49 @@ mod tests {
             &next_bundle,
         );
 
+        assert!(issues.is_empty());
+    }
+
+    #[test]
+    fn validate_runtime_reload_compatibility_allows_listener_addition_when_binds_are_free() {
+        let dir = tempdir().expect("tempdir");
+        let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+        let current = test_config(cert.clone(), key.clone());
+
+        let mut next = current.clone();
+        let mut extra_listener = next.listen.clone();
+        extra_listener.port = 9891;
+        next.listeners = vec![next.listen.clone(), extra_listener];
+
+        let current_bundle = runtime_bundle_from_config("current.yaml", &current);
+        let next_bundle = runtime_bundle_from_config("next.yaml", &next);
+
         assert!(
-            issues
-                .iter()
-                .any(|issue| issue.contains("performance.worker_threads"))
+            QUICListener::validate_runtime_reload_compatibility(&current_bundle, &next_bundle)
+                .is_none()
         );
+    }
+
+    #[test]
+    fn validate_startup_owned_reload_compatibility_rejects_control_plane_thread_change() {
+        let dir = tempdir().expect("tempdir");
+        let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+        let current = test_config(cert.clone(), key.clone());
+
+        let mut next = current.clone();
+        next.performance.control_plane_threads = 7;
+
+        let current_bundle = runtime_bundle_from_config("current.yaml", &current);
+        let next_bundle = runtime_bundle_from_config("next.yaml", &next);
+        let issues = QUICListener::validate_startup_owned_reload_compatibility(
+            &current_bundle,
+            &next_bundle,
+        );
+
         assert!(
             issues
                 .iter()
-                .any(|issue| issue.contains("performance.packet_shards_per_worker"))
+                .any(|issue| issue.contains("performance.control_plane_threads"))
         );
     }
 }

--- a/crates/edge/src/quic_listener/control_api.rs
+++ b/crates/edge/src/quic_listener/control_api.rs
@@ -43,6 +43,12 @@ pub(super) struct ControlApiState {
     pub(super) runtime_bundle: Option<Arc<RuntimeBundleHandle>>,
 }
 
+struct ControlApiListenerBinding {
+    bind: String,
+    listener: tokio::net::TcpListener,
+    active_connections: Arc<AtomicUsize>,
+}
+
 impl ControlApiState {
     fn current_runtime(&self) -> Option<Arc<RuntimeBundle>> {
         self.runtime_bundle.as_ref().map(|handle| handle.current())
@@ -138,22 +144,20 @@ impl QUICListener {
         worker_count: usize,
     ) -> Result<(), ProxyError> {
         let endpoint = &config.observability.control_api;
-        if !endpoint.enabled {
+        if runtime_bundle.is_none() && !endpoint.enabled {
             return Ok(());
         }
         let required = endpoint.required;
-
-        let bind = format!("{}:{}", endpoint.address, endpoint.port);
-        let max_connections = endpoint.max_connections.max(1);
-        let connection_timeout = Duration::from_millis(endpoint.connection_timeout_ms.max(1));
+        let startup_endpoint = endpoint.clone();
         let listener_config = config.primary_listener_runtime_config().ok_or_else(|| {
             ProxyError::Transport("no effective listeners configured".to_string())
         })?;
         let primary_listener_label = Self::listener_label(&listener_config);
-        if shared_state
-            .listener_tls_store
-            .bootstrap_server_config(&primary_listener_label)
-            .is_none()
+        if startup_endpoint.enabled
+            && shared_state
+                .listener_tls_store
+                .bootstrap_server_config(&primary_listener_label)
+                .is_none()
         {
             let msg = format!(
                 "failed to initialize control API TLS config: missing reload state for listener '{}'",
@@ -191,45 +195,24 @@ impl QUICListener {
             }
         };
 
-        let std_listener = match std::net::TcpListener::bind(&bind) {
-            Ok(listener) => listener,
-            Err(err) => {
-                let msg = format!("failed to bind control API endpoint {bind}: {err}");
-                if required {
-                    return Err(ProxyError::Transport(msg));
+        let initial_binding = if startup_endpoint.enabled {
+            let bind = format!("{}:{}", startup_endpoint.address, startup_endpoint.port);
+            match Self::bind_tcp_listener(&bind, Some(&handle), "control API endpoint") {
+                Ok(listener) => Some(ControlApiListenerBinding {
+                    bind,
+                    listener,
+                    active_connections: Arc::new(AtomicUsize::new(0)),
+                }),
+                Err(msg) => {
+                    if required {
+                        return Err(ProxyError::Transport(msg));
+                    }
+                    error!("{}", msg);
+                    None
                 }
-                error!("{}", msg);
-                return Ok(());
             }
-        };
-        if let Err(err) = std_listener.set_nonblocking(true) {
-            let msg = format!(
-                "failed to set control API endpoint listener nonblocking ({}): {}",
-                bind, err
-            );
-            if required {
-                return Err(ProxyError::Transport(msg));
-            }
-            error!("{}", msg);
-            return Ok(());
-        }
-        let from_std_result = {
-            let _guard = handle.enter();
-            tokio::net::TcpListener::from_std(std_listener)
-        };
-        let listener = match from_std_result {
-            Ok(listener) => listener,
-            Err(err) => {
-                let msg = format!(
-                    "failed to register control API endpoint listener {}: {}",
-                    bind, err
-                );
-                if required {
-                    return Err(ProxyError::Transport(msg));
-                }
-                error!("{}", msg);
-                return Ok(());
-            }
+        } else {
+            None
         };
 
         spawn_supervised_async_task(
@@ -237,21 +220,68 @@ impl QUICListener {
             "control-api-endpoint",
             Some(Arc::clone(&shared_state.metrics)),
             async move {
-                let paths = state.current_paths();
-                info!(
-                    "Control API endpoint listening on https://{}{} (ready={}, runtime={}, reload_certs={}, max_connections={}, connection_timeout_ms={})",
-                    bind,
-                    paths.health_path,
-                    paths.ready_path,
-                    paths.runtime_path,
-                    paths.reload_certs_path,
-                    max_connections,
-                    connection_timeout.as_millis()
-                );
-                let active_connections = Arc::new(AtomicUsize::new(0));
+                let mut listener_binding = initial_binding;
 
                 loop {
-                    let (stream, peer) = match listener.accept().await {
+                    let endpoint = state.current_control_api();
+                    let desired_bind = format!("{}:{}", endpoint.address, endpoint.port);
+
+                    if !endpoint.enabled {
+                        if let Some(binding) = listener_binding.take() {
+                            info!(
+                                "Control API endpoint disabled via runtime reload on {}",
+                                binding.bind
+                            );
+                        }
+                        tokio::time::sleep(Duration::from_millis(200)).await;
+                        continue;
+                    }
+
+                    let needs_rebind = match listener_binding.as_ref() {
+                        Some(binding) => binding.bind != desired_bind,
+                        None => true,
+                    };
+                    if needs_rebind {
+                        match Self::bind_tcp_listener(&desired_bind, None, "control API endpoint") {
+                            Ok(listener) => {
+                                let paths = ControlApiPaths::from_endpoint(&endpoint);
+                                info!(
+                                    "Control API endpoint listening on https://{}{} (ready={}, runtime={}, reload_certs={}, max_connections={}, connection_timeout_ms={})",
+                                    desired_bind,
+                                    paths.health_path,
+                                    paths.ready_path,
+                                    paths.runtime_path,
+                                    paths.reload_certs_path,
+                                    endpoint.max_connections.max(1),
+                                    endpoint.connection_timeout_ms.max(1)
+                                );
+                                listener_binding = Some(ControlApiListenerBinding {
+                                    bind: desired_bind.clone(),
+                                    listener,
+                                    active_connections: Arc::new(AtomicUsize::new(0)),
+                                });
+                            }
+                            Err(err) => {
+                                error!("{}", err);
+                                tokio::time::sleep(Duration::from_millis(200)).await;
+                                continue;
+                            }
+                        }
+                    }
+
+                    let Some(binding) = listener_binding.as_mut() else {
+                        tokio::time::sleep(Duration::from_millis(200)).await;
+                        continue;
+                    };
+
+                    let accept_result = tokio::select! {
+                        accept = binding.listener.accept() => Some(accept),
+                        _ = tokio::time::sleep(Duration::from_millis(200)) => None,
+                    };
+                    let Some(accept_result) = accept_result else {
+                        continue;
+                    };
+                    let (stream, peer) = match accept_result {
                         Ok(v) => v,
                         Err(err) => {
                             error!("Control API endpoint accept failed: {}", err);
@@ -259,7 +289,7 @@ impl QUICListener {
                         }
                     };
                     let state = state.clone();
-                    let active_connections = Arc::clone(&active_connections);
+                    let active_connections = Arc::clone(&binding.active_connections);
                     let endpoint = state.current_control_api();
                     let max_connections = endpoint.max_connections.max(1);
                     if !Self::try_claim_connection_slot(&active_connections, max_connections) {
@@ -968,30 +998,39 @@ impl QUICListener {
         current: &RuntimeBundle,
         next: &RuntimeBundle,
     ) -> Option<String> {
-        let current_control_api = &current.runtime_config.observability.control_api;
         let next_control_api = &next.runtime_config.observability.control_api;
-        if current_control_api.enabled != next_control_api.enabled {
-            return Some(format!(
-                "runtime reload rejected: observability.control_api.enabled changed from {} to {}; restart required",
-                current_control_api.enabled, next_control_api.enabled
-            ));
+        if !next_control_api.enabled {
+            return None;
         }
-        if current_control_api.required != next_control_api.required {
-            return Some(format!(
-                "runtime reload rejected: observability.control_api.required changed from {} to {}; restart required",
-                current_control_api.required, next_control_api.required
-            ));
-        }
-        if current_control_api.address != next_control_api.address
-            || current_control_api.port != next_control_api.port
+
+        let Some(listener_config) = next.runtime_config.primary_listener_runtime_config() else {
+            return Some(
+                "runtime reload rejected: no effective listeners configured for control API TLS"
+                    .to_string(),
+            );
+        };
+        let primary_listener_label = Self::listener_label(&listener_config);
+        if next
+            .shared_state
+            .listener_tls_store
+            .bootstrap_server_config(&primary_listener_label)
+            .is_none()
         {
             return Some(format!(
-                "runtime reload rejected: observability.control_api bind changed from {}:{} to {}:{}; restart required",
-                current_control_api.address,
-                current_control_api.port,
-                next_control_api.address,
-                next_control_api.port
+                "runtime reload rejected: control API TLS config missing for listener '{}'",
+                primary_listener_label
             ));
+        }
+
+        let current_control_api = &current.runtime_config.observability.control_api;
+        let bind_changed = !current_control_api.enabled
+            || current_control_api.address != next_control_api.address
+            || current_control_api.port != next_control_api.port;
+        if bind_changed {
+            let bind = format!("{}:{}", next_control_api.address, next_control_api.port);
+            if let Err(err) = Self::probe_tcp_bind(&bind, "control API endpoint") {
+                return Some(err);
+            }
         }
         None
     }
@@ -1000,30 +1039,20 @@ impl QUICListener {
         current: &RuntimeBundle,
         next: &RuntimeBundle,
     ) -> Option<String> {
-        let current_metrics = &current.runtime_config.observability.metrics;
         let next_metrics = &next.runtime_config.observability.metrics;
-        if current_metrics.enabled != next_metrics.enabled {
-            return Some(format!(
-                "runtime reload rejected: observability.metrics.enabled changed from {} to {}; restart required",
-                current_metrics.enabled, next_metrics.enabled
-            ));
+        if !next_metrics.enabled {
+            return None;
         }
-        if current_metrics.required != next_metrics.required {
-            return Some(format!(
-                "runtime reload rejected: observability.metrics.required changed from {} to {}; restart required",
-                current_metrics.required, next_metrics.required
-            ));
-        }
-        if current_metrics.address != next_metrics.address
-            || current_metrics.port != next_metrics.port
-        {
-            return Some(format!(
-                "runtime reload rejected: observability.metrics bind changed from {}:{} to {}:{}; restart required",
-                current_metrics.address,
-                current_metrics.port,
-                next_metrics.address,
-                next_metrics.port
-            ));
+
+        let current_metrics = &current.runtime_config.observability.metrics;
+        let bind_changed = !current_metrics.enabled
+            || current_metrics.address != next_metrics.address
+            || current_metrics.port != next_metrics.port;
+        if bind_changed {
+            let bind = format!("{}:{}", next_metrics.address, next_metrics.port);
+            if let Err(err) = Self::probe_tcp_bind(&bind, "metrics endpoint") {
+                return Some(err);
+            }
         }
         None
     }
@@ -1592,7 +1621,7 @@ mod tests {
     }
 
     #[test]
-    fn validate_control_api_reload_compatibility_rejects_bind_change() {
+    fn validate_control_api_reload_compatibility_allows_bind_change_when_socket_is_free() {
         let dir = tempdir().expect("tempdir");
         let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
         let mut current = test_config(cert.clone(), key.clone());
@@ -1605,15 +1634,14 @@ mod tests {
 
         let current_bundle = runtime_bundle_from_config("current.yaml", &current);
         let next_bundle = runtime_bundle_from_config("next.yaml", &next);
-        let err =
+        assert!(
             QUICListener::validate_control_api_reload_compatibility(&current_bundle, &next_bundle)
-                .expect("bind change should be rejected");
-
-        assert!(err.contains("observability.control_api bind changed"));
+                .is_none()
+        );
     }
 
     #[test]
-    fn validate_metrics_reload_compatibility_rejects_bind_change() {
+    fn validate_metrics_reload_compatibility_allows_bind_change_when_socket_is_free() {
         let dir = tempdir().expect("tempdir");
         let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
         let mut current = test_config(cert.clone(), key.clone());
@@ -1626,11 +1654,10 @@ mod tests {
 
         let current_bundle = runtime_bundle_from_config("current.yaml", &current);
         let next_bundle = runtime_bundle_from_config("next.yaml", &next);
-        let err =
+        assert!(
             QUICListener::validate_metrics_reload_compatibility(&current_bundle, &next_bundle)
-                .expect("bind change should be rejected");
-
-        assert!(err.contains("observability.metrics bind changed"));
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/edge/src/quic_listener/control_api.rs
+++ b/crates/edge/src/quic_listener/control_api.rs
@@ -934,6 +934,19 @@ impl QUICListener {
         current: &RuntimeBundle,
         next: &RuntimeBundle,
     ) -> Option<String> {
+        // Reject any listener that the running workers know about but that the
+        // next bundle has dropped (or renamed via a bind address/port change).
+        // The live QUIC socket looks itself up by label; if the label is gone it
+        // falls out of sync with the active runtime, so we must reject early.
+        for label in current.shared_state.listener_runtime_configs.keys() {
+            if !next.shared_state.listener_runtime_configs.contains_key(label) {
+                return Some(format!(
+                    "runtime reload rejected: listener '{}' was removed or its bind address changed; restart required",
+                    label
+                ));
+            }
+        }
+
         let worker_count = next.runtime_config.performance.worker_threads.max(1);
         for (label, listener_config) in next.shared_state.listener_runtime_configs.iter() {
             if current
@@ -1649,6 +1662,56 @@ mod tests {
         assert!(
             QUICListener::validate_runtime_reload_compatibility(&current_bundle, &next_bundle)
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn validate_runtime_reload_compatibility_rejects_listener_removal() {
+        let dir = tempdir().expect("tempdir");
+        let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+        let current = test_config(cert.clone(), key.clone());
+
+        // next removes the primary listener entirely by switching to an explicit
+        // listeners list that omits the original bind address
+        let mut next = current.clone();
+        next.listeners = vec![{
+            let mut l = next.listen.clone();
+            l.port = 9892;
+            l
+        }];
+
+        let current_bundle = runtime_bundle_from_config("current.yaml", &current);
+        let next_bundle = runtime_bundle_from_config("next.yaml", &next);
+
+        let err = QUICListener::validate_runtime_reload_compatibility(&current_bundle, &next_bundle);
+        assert!(
+            err.as_deref()
+                .is_some_and(|e| e.contains("restart required")),
+            "expected rejection, got: {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn validate_runtime_reload_compatibility_rejects_listener_bind_change() {
+        let dir = tempdir().expect("tempdir");
+        let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+        let current = test_config(cert.clone(), key.clone());
+
+        // next keeps one listener but moves it to a different port — the label
+        // changes, so the old label disappears from the next bundle
+        let mut next = current.clone();
+        next.listen.port = 9893;
+
+        let current_bundle = runtime_bundle_from_config("current.yaml", &current);
+        let next_bundle = runtime_bundle_from_config("next.yaml", &next);
+
+        let err = QUICListener::validate_runtime_reload_compatibility(&current_bundle, &next_bundle);
+        assert!(
+            err.as_deref()
+                .is_some_and(|e| e.contains("restart required")),
+            "expected rejection, got: {:?}",
+            err
         );
     }
 

--- a/crates/edge/src/quic_listener/control_api.rs
+++ b/crates/edge/src/quic_listener/control_api.rs
@@ -939,7 +939,11 @@ impl QUICListener {
         // The live QUIC socket looks itself up by label; if the label is gone it
         // falls out of sync with the active runtime, so we must reject early.
         for label in current.shared_state.listener_runtime_configs.keys() {
-            if !next.shared_state.listener_runtime_configs.contains_key(label) {
+            if !next
+                .shared_state
+                .listener_runtime_configs
+                .contains_key(label)
+            {
                 return Some(format!(
                     "runtime reload rejected: listener '{}' was removed or its bind address changed; restart required",
                     label
@@ -1683,7 +1687,8 @@ mod tests {
         let current_bundle = runtime_bundle_from_config("current.yaml", &current);
         let next_bundle = runtime_bundle_from_config("next.yaml", &next);
 
-        let err = QUICListener::validate_runtime_reload_compatibility(&current_bundle, &next_bundle);
+        let err =
+            QUICListener::validate_runtime_reload_compatibility(&current_bundle, &next_bundle);
         assert!(
             err.as_deref()
                 .is_some_and(|e| e.contains("restart required")),
@@ -1706,7 +1711,8 @@ mod tests {
         let current_bundle = runtime_bundle_from_config("current.yaml", &current);
         let next_bundle = runtime_bundle_from_config("next.yaml", &next);
 
-        let err = QUICListener::validate_runtime_reload_compatibility(&current_bundle, &next_bundle);
+        let err =
+            QUICListener::validate_runtime_reload_compatibility(&current_bundle, &next_bundle);
         assert!(
             err.as_deref()
                 .is_some_and(|e| e.contains("restart required")),

--- a/crates/edge/src/quic_listener/control_api.rs
+++ b/crates/edge/src/quic_listener/control_api.rs
@@ -70,6 +70,12 @@ impl ControlApiState {
             .unwrap_or_else(|| Arc::clone(&self.listener_tls_store))
     }
 
+    fn current_listener_runtime_configs(&self) -> Arc<HashMap<String, ListenerRuntimeConfig>> {
+        self.current_runtime()
+            .map(|runtime| runtime.shared_state.listener_runtime_configs.clone())
+            .unwrap_or_else(|| Arc::clone(&self.listener_runtime_configs))
+    }
+
     fn current_metrics(&self) -> Arc<Metrics> {
         self.current_runtime()
             .map(|runtime| runtime.shared_state.metrics.clone())
@@ -444,8 +450,8 @@ impl QUICListener {
                 );
             }
             let (healthy_backends, total_backends) = state.snapshot_backend_health();
-            let tls_listeners = state
-                .listener_tls_store
+            let live_tls_store = state.current_listener_tls_store();
+            let tls_listeners = live_tls_store
                 .snapshot()
                 .into_iter()
                 .map(|(listener, inventory)| {
@@ -458,7 +464,7 @@ impl QUICListener {
                             "sni_names": inventory.sni_identities.keys().cloned().collect::<Vec<_>>(),
                             "client_auth_enabled": inventory.listener_tls.client_auth.enabled,
                             "require_client_cert": inventory.listener_tls.client_auth.require_client_cert,
-                            "generation": state.listener_tls_store.generation(&listener).unwrap_or(0),
+                            "generation": live_tls_store.generation(&listener).unwrap_or(0),
                         }),
                     )
                 })
@@ -514,8 +520,11 @@ impl QUICListener {
                 );
             }
 
+            let live_tls_store = state.current_listener_tls_store();
+            let live_listener_configs = state.current_listener_runtime_configs();
+            let live_metrics = state.current_metrics();
             let mut reloaded = Vec::new();
-            for (listener_label, listener_config) in state.listener_runtime_configs.iter() {
+            for (listener_label, listener_config) in live_listener_configs.iter() {
                 let reloaded_state = match Self::build_listener_tls_reload_state(listener_config) {
                     Ok(state) => state,
                     Err(err) => {
@@ -529,7 +538,7 @@ impl QUICListener {
                         );
                     }
                 };
-                let generation = match state.listener_tls_store.replace_listener(
+                let generation = match live_tls_store.replace_listener(
                     listener_label,
                     reloaded_state.inventory.clone(),
                     reloaded_state.bootstrap_server_config,
@@ -547,7 +556,7 @@ impl QUICListener {
                     }
                 };
                 Self::update_listener_tls_expiry_metrics(
-                    &state.metrics,
+                    &live_metrics,
                     listener_label,
                     &reloaded_state.inventory,
                 );

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -805,12 +805,14 @@ impl QUICListener {
 
     pub fn build_runtime_bundle(
         config_path: String,
+        log_config: spooky_config::config::Log,
         runtime_config: &RuntimeConfig,
     ) -> Result<RuntimeBundle, ProxyError> {
         let shared_state = Arc::new(Self::build_shared_state(runtime_config)?);
         Ok(RuntimeBundle {
             generation: 0,
             config_path,
+            log_config,
             runtime_config: runtime_config.clone(),
             shared_state,
         })
@@ -1431,6 +1433,8 @@ impl QUICListener {
             Duration::from_millis(self.config.performance.backend_total_request_timeout_ms);
         self.inflight_acquire_wait =
             Duration::from_millis(self.config.performance.inflight_acquire_wait_ms);
+        self.drain_timeout =
+            Duration::from_millis(self.config.performance.shutdown_drain_timeout_ms);
         self.max_active_connections = self.config.performance.max_active_connections.max(1);
         self.max_streams_per_connection =
             usize::try_from(self.config.performance.quic_initial_max_streams_bidi)
@@ -1447,6 +1451,10 @@ impl QUICListener {
         self.require_client_cert = Self::runtime_listener_tls(&self.config)?
             .client_auth
             .require_client_cert;
+        self.conn_rate_limiter.reconfigure(
+            self.config.performance.new_connections_per_sec,
+            self.config.performance.new_connections_burst,
+        );
         self.quic_config = Self::build_quic_config(&self.config)?;
         self.runtime_generation = runtime.generation;
         self.tls_reload_generation = current_tls_generation;
@@ -6763,6 +6771,7 @@ mod tests {
         let reloaded_runtime = RuntimeConfig::from_config(&reloaded).expect("reloaded runtime");
         let reloaded_bundle = super::QUICListener::build_runtime_bundle(
             "reloaded.yaml".to_string(),
+            reloaded.log.clone(),
             &reloaded_runtime,
         )
         .expect("reloaded bundle");
@@ -6800,6 +6809,7 @@ mod tests {
         let reloaded_runtime = RuntimeConfig::from_config(&reloaded).expect("reloaded runtime");
         let reloaded_bundle = super::QUICListener::build_runtime_bundle(
             "reloaded.yaml".to_string(),
+            reloaded.log.clone(),
             &reloaded_runtime,
         )
         .expect("reloaded bundle");
@@ -6816,6 +6826,68 @@ mod tests {
         assert_eq!(state.metrics_path, "/metrics-live");
         assert_eq!(state.max_connections, 29);
         assert_eq!(state.connection_timeout, Duration::from_millis(3456));
+    }
+
+    #[test]
+    fn quic_listener_syncs_drain_timeout_and_connection_rate_limiter_after_reload() {
+        let dir = tempdir().expect("tempdir");
+        let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+        let mut startup = tls_test_config(cert.clone(), key.clone(), Vec::new());
+        startup.listen.port = 0;
+        startup.performance.shutdown_drain_timeout_ms = 5_000;
+        startup.performance.new_connections_per_sec = 100;
+        startup.performance.new_connections_burst = 5;
+
+        let startup_runtime = RuntimeConfig::from_config(&startup).expect("startup runtime");
+        let startup_bundle = super::QUICListener::build_runtime_bundle(
+            "startup.yaml".to_string(),
+            startup.log.clone(),
+            &startup_runtime,
+        )
+        .expect("startup bundle");
+        let runtime_handle = Arc::new(super::RuntimeBundleHandle::new(startup_bundle.clone()));
+        let listener_config = startup_bundle
+            .runtime_config
+            .primary_listener_runtime_config()
+            .expect("listener runtime config");
+        let socket =
+            super::QUICListener::bind_socket(&listener_config, false).expect("bind socket");
+        let mut listener = super::QUICListener::new_with_socket_and_shared_state(
+            listener_config,
+            socket,
+            Arc::clone(&startup_bundle.shared_state),
+        )
+        .expect("listener")
+        .with_runtime_bundle(Arc::clone(&runtime_handle));
+
+        let mut reloaded = startup.clone();
+        reloaded.performance.shutdown_drain_timeout_ms = 1_234;
+        reloaded.performance.new_connections_per_sec = 50;
+        reloaded.performance.new_connections_burst = 2;
+
+        let reloaded_runtime = RuntimeConfig::from_config(&reloaded).expect("reloaded runtime");
+        let mut reloaded_bundle = super::QUICListener::build_runtime_bundle(
+            "reloaded.yaml".to_string(),
+            reloaded.log.clone(),
+            &reloaded_runtime,
+        )
+        .expect("reloaded bundle");
+        reloaded_bundle.generation = 1;
+        runtime_handle
+            .replace(reloaded_bundle)
+            .expect("replace runtime bundle");
+
+        listener
+            .sync_runtime_bundle_if_needed()
+            .expect("sync runtime bundle");
+
+        assert_eq!(listener.drain_timeout, Duration::from_millis(1_234));
+        assert!(listener.conn_rate_limiter.try_consume());
+        assert!(listener.conn_rate_limiter.try_consume());
+        assert!(
+            !listener.conn_rate_limiter.try_consume(),
+            "reconfigured burst should clamp immediate capacity to the new limit"
+        );
     }
 
     #[test]

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -428,6 +428,12 @@ struct MetricsEndpointState {
     metrics: Arc<Metrics>,
 }
 
+struct MetricsEndpointBinding {
+    bind: String,
+    listener: tokio::net::TcpListener,
+    active_connections: Arc<AtomicUsize>,
+}
+
 struct RuntimeConnectionSlotGuard {
     active_connections: Arc<AtomicUsize>,
 }
@@ -4484,15 +4490,15 @@ impl QUICListener {
         runtime_bundle: Option<Arc<RuntimeBundleHandle>>,
     ) -> Result<(), ProxyError> {
         let endpoint = &config.observability.metrics;
-        if !endpoint.enabled {
+        if runtime_bundle.is_none() && !endpoint.enabled {
             return Ok(());
         }
         let required = endpoint.required;
-
-        let bind = format!("{}:{}", endpoint.address, endpoint.port);
-        let metrics_path = endpoint.path.clone();
-        let max_connections = endpoint.max_connections.max(1);
-        let connection_timeout = Duration::from_millis(endpoint.connection_timeout_ms.max(1));
+        let startup_endpoint = endpoint.clone();
+        let startup_metrics_path = startup_endpoint.path.clone();
+        let startup_max_connections = startup_endpoint.max_connections.max(1);
+        let startup_connection_timeout =
+            Duration::from_millis(startup_endpoint.connection_timeout_ms.max(1));
 
         let handle = match runtime_handle() {
             Some(handle) => handle,
@@ -4506,42 +4512,24 @@ impl QUICListener {
             }
         };
 
-        // Bind synchronously so endpoint readiness does not race with task scheduling.
-        let std_listener = match std::net::TcpListener::bind(&bind) {
-            Ok(listener) => listener,
-            Err(err) => {
-                let msg = format!("failed to bind metrics endpoint {bind}: {err}");
-                if required {
-                    return Err(ProxyError::Transport(msg));
+        let initial_binding = if startup_endpoint.enabled {
+            let bind = format!("{}:{}", startup_endpoint.address, startup_endpoint.port);
+            match Self::bind_tcp_listener(&bind, Some(&handle), "metrics endpoint") {
+                Ok(listener) => Some(MetricsEndpointBinding {
+                    bind,
+                    listener,
+                    active_connections: Arc::new(AtomicUsize::new(0)),
+                }),
+                Err(msg) => {
+                    if required {
+                        return Err(ProxyError::Transport(msg));
+                    }
+                    error!("{}", msg);
+                    None
                 }
-                error!("{}", msg);
-                return Ok(());
             }
-        };
-        if let Err(err) = std_listener.set_nonblocking(true) {
-            let msg = format!(
-                "failed to set metrics endpoint listener nonblocking ({}): {}",
-                bind, err
-            );
-            if required {
-                return Err(ProxyError::Transport(msg));
-            }
-            error!("{}", msg);
-            return Ok(());
-        }
-        let listener = match tokio::net::TcpListener::from_std(std_listener) {
-            Ok(listener) => listener,
-            Err(err) => {
-                let msg = format!(
-                    "failed to register metrics endpoint listener {}: {}",
-                    bind, err
-                );
-                if required {
-                    return Err(ProxyError::Transport(msg));
-                }
-                error!("{}", msg);
-                return Ok(());
-            }
+        } else {
+            None
         };
 
         spawn_supervised_async_task(
@@ -4549,17 +4537,67 @@ impl QUICListener {
             "metrics-endpoint",
             Some(Arc::clone(&metrics)),
             async move {
-                info!(
-                    "Metrics endpoint listening on http://{}{} (max_connections={}, connection_timeout_ms={})",
-                    bind,
-                    metrics_path,
-                    max_connections,
-                    connection_timeout.as_millis()
-                );
-                let active_connections = Arc::new(AtomicUsize::new(0));
+                let mut listener_binding = initial_binding;
 
                 loop {
-                    let (stream, _peer) = match listener.accept().await {
+                    let endpoint = Self::current_metrics_endpoint_config(
+                        runtime_bundle.as_ref(),
+                        &startup_endpoint,
+                    );
+                    let desired_bind = format!("{}:{}", endpoint.address, endpoint.port);
+
+                    if !endpoint.enabled {
+                        if let Some(binding) = listener_binding.take() {
+                            info!(
+                                "Metrics endpoint disabled via runtime reload on {}",
+                                binding.bind
+                            );
+                        }
+                        tokio::time::sleep(Duration::from_millis(200)).await;
+                        continue;
+                    }
+
+                    let needs_rebind = match listener_binding.as_ref() {
+                        Some(binding) => binding.bind != desired_bind,
+                        None => true,
+                    };
+                    if needs_rebind {
+                        match Self::bind_tcp_listener(&desired_bind, None, "metrics endpoint") {
+                            Ok(listener) => {
+                                info!(
+                                    "Metrics endpoint listening on http://{}{} (max_connections={}, connection_timeout_ms={})",
+                                    desired_bind,
+                                    endpoint.path,
+                                    endpoint.max_connections.max(1),
+                                    endpoint.connection_timeout_ms.max(1)
+                                );
+                                listener_binding = Some(MetricsEndpointBinding {
+                                    bind: desired_bind.clone(),
+                                    listener,
+                                    active_connections: Arc::new(AtomicUsize::new(0)),
+                                });
+                            }
+                            Err(err) => {
+                                error!("{}", err);
+                                tokio::time::sleep(Duration::from_millis(200)).await;
+                                continue;
+                            }
+                        }
+                    }
+
+                    let Some(binding) = listener_binding.as_mut() else {
+                        tokio::time::sleep(Duration::from_millis(200)).await;
+                        continue;
+                    };
+
+                    let accept_result = tokio::select! {
+                        accept = binding.listener.accept() => Some(accept),
+                        _ = tokio::time::sleep(Duration::from_millis(200)) => None,
+                    };
+                    let Some(accept_result) = accept_result else {
+                        continue;
+                    };
+                    let (stream, _peer) = match accept_result {
                         Ok(v) => v,
                         Err(err) => {
                             error!("Metrics endpoint accept failed: {}", err);
@@ -4568,12 +4606,12 @@ impl QUICListener {
                     };
                     let runtime_state = Self::metrics_endpoint_state(
                         runtime_bundle.as_ref(),
-                        metrics_path.clone(),
-                        max_connections,
-                        connection_timeout,
+                        startup_metrics_path.clone(),
+                        startup_max_connections,
+                        startup_connection_timeout,
                         Arc::clone(&metrics),
                     );
-                    let active_connections = Arc::clone(&active_connections);
+                    let active_connections = Arc::clone(&binding.active_connections);
                     if !Self::try_claim_runtime_connection_slot(
                         &active_connections,
                         runtime_state.max_connections,
@@ -4615,6 +4653,51 @@ impl QUICListener {
             },
         );
         Ok(())
+    }
+
+    fn bind_tcp_listener(
+        bind: &str,
+        handle: Option<&Handle>,
+        context: &str,
+    ) -> Result<tokio::net::TcpListener, String> {
+        let std_listener = std::net::TcpListener::bind(bind)
+            .map_err(|err| format!("failed to bind {context} {bind}: {err}"))?;
+        std_listener.set_nonblocking(true).map_err(|err| {
+            format!(
+                "failed to set {context} listener nonblocking ({}): {}",
+                bind, err
+            )
+        })?;
+        let from_std_result = if let Some(handle) = handle {
+            let _guard = handle.enter();
+            tokio::net::TcpListener::from_std(std_listener)
+        } else {
+            tokio::net::TcpListener::from_std(std_listener)
+        };
+        from_std_result
+            .map_err(|err| format!("failed to register {context} listener {}: {}", bind, err))
+    }
+
+    fn probe_tcp_bind(bind: &str, context: &str) -> Result<(), String> {
+        std::net::TcpListener::bind(bind)
+            .map(|_| ())
+            .map_err(|err| format!("failed to bind {context} {bind}: {err}"))
+    }
+
+    fn current_metrics_endpoint_config(
+        runtime_bundle: Option<&Arc<RuntimeBundleHandle>>,
+        startup_endpoint: &spooky_config::config::MetricsEndpoint,
+    ) -> spooky_config::config::MetricsEndpoint {
+        runtime_bundle
+            .map(|handle| {
+                handle
+                    .current()
+                    .runtime_config
+                    .observability
+                    .metrics
+                    .clone()
+            })
+            .unwrap_or_else(|| startup_endpoint.clone())
     }
 
     fn metrics_endpoint_state(

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -50,6 +50,7 @@ use spooky_errors::{PoolError, ProxyError, is_retryable};
 use spooky_lb::{HealthFailureReason, HealthTransition, UpstreamPool};
 use spooky_transport::h2_client::{SharedDnsResolver, TlsClientConfig};
 use spooky_transport::transport_pool::{BackendTransportKind, UpstreamTransportPool};
+use std::sync::atomic::AtomicBool;
 use tokio::runtime::Handle;
 use tokio::sync::{
     Semaphore, mpsc,
@@ -5272,6 +5273,7 @@ impl QUICListener {
         config: &ListenerRuntimeConfig,
         shared_state: &SharedRuntimeState,
         runtime_bundle: Option<Arc<RuntimeBundleHandle>>,
+        shutdown_signal: Option<Arc<AtomicBool>>,
     ) -> Result<(), ProxyError> {
         let bind = format!(
             "{}:{}",
@@ -5356,7 +5358,28 @@ impl QUICListener {
             );
             let active_connections = Arc::new(AtomicUsize::new(0));
             loop {
-                let (stream, peer) = match listener.accept().await {
+                let accept_result = if let Some(shutdown_signal) = shutdown_signal.as_ref() {
+                    tokio::select! {
+                        accept = listener.accept() => Some(accept),
+                        _ = tokio::time::sleep(Duration::from_millis(200)) => {
+                            if shutdown_signal.load(Ordering::Relaxed) {
+                                None
+                            } else {
+                                continue;
+                            }
+                        }
+                    }
+                } else {
+                    Some(listener.accept().await)
+                };
+                let Some(accept_result) = accept_result else {
+                    info!(
+                        "Bootstrap TLS listener on {} stopping due to runtime group shutdown",
+                        bind
+                    );
+                    break;
+                };
+                let (stream, peer) = match accept_result {
                     Ok(v) => v,
                     Err(err) => {
                         error!("Bootstrap TLS listener accept failed: {}", err);

--- a/crates/edge/src/quic_listener/token_bucket.rs
+++ b/crates/edge/src/quic_listener/token_bucket.rs
@@ -51,6 +51,15 @@ impl TokenBucket {
             false
         }
     }
+
+    pub(super) fn reconfigure(&mut self, rate_per_sec: u32, burst: u32) {
+        let burst = burst.max(1) as f64;
+        let rate_per_sec = rate_per_sec.max(1) as f64;
+        self.burst = burst;
+        self.rate_per_sec = rate_per_sec;
+        self.tokens = self.tokens.min(self.burst);
+        self.last_refill = Instant::now();
+    }
 }
 
 #[cfg(test)]
@@ -73,6 +82,18 @@ mod tests {
 
         assert!(tb.try_consume(), "long idle should refill bucket");
         assert!(tb.tokens.is_finite());
+        assert!(tb.tokens <= tb.burst);
+    }
+
+    #[test]
+    fn reconfigure_clamps_tokens_to_new_burst() {
+        let mut tb = TokenBucket::new(100, 5);
+        assert!(tb.try_consume());
+        assert!(tb.try_consume());
+        tb.reconfigure(200, 2);
+
+        assert_eq!(tb.burst, 2.0);
+        assert_eq!(tb.rate_per_sec, 200.0);
         assert!(tb.tokens <= tb.burst);
     }
 }

--- a/crates/edge/src/types.rs
+++ b/crates/edge/src/types.rs
@@ -4,6 +4,7 @@ use log::warn;
 use rustls::ServerConfig as RustlsServerConfig;
 use spooky_config::{
     backend_endpoint::BackendEndpoint,
+    config::Log,
     runtime::{
         ListenerRuntimeConfig, RuntimeConfig, RuntimeListenerTls, RuntimeTlsIdentity,
         RuntimeUpstreamPolicy,
@@ -235,6 +236,7 @@ pub struct QUICListener {
 pub struct RuntimeBundle {
     pub generation: u64,
     pub config_path: String,
+    pub log_config: Log,
     pub runtime_config: RuntimeConfig,
     pub shared_state: Arc<SharedRuntimeState>,
 }

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -262,7 +262,7 @@ fn make_listener_with_bootstrap(config: Config) -> QUICListener {
         Arc::new(QUICListener::build_shared_state(&runtime_config).expect("shared runtime state"));
     QUICListener::spawn_control_plane_tasks(&runtime_config, &shared_state, 1)
         .expect("control plane tasks");
-    QUICListener::spawn_bootstrap_tls_listener(&listener_config, &shared_state, None)
+    QUICListener::spawn_bootstrap_tls_listener(&listener_config, &shared_state, None, None)
         .expect("bootstrap tls listener");
     let socket = QUICListener::bind_socket(&listener_config, false).expect("bind socket");
     QUICListener::new_with_socket_and_shared_state(listener_config, socket, shared_state)

--- a/spooky/src/main.rs
+++ b/spooky/src/main.rs
@@ -168,17 +168,28 @@ fn main() {
         }
     };
 
-    runtime.block_on(run(runtime_config, uid, config_path));
+    runtime.block_on(run(
+        runtime_config,
+        config_yaml.log.clone(),
+        uid,
+        config_path,
+    ));
 }
 
-async fn run(runtime_config: RuntimeConfig, uid: libc::uid_t, config_path: String) {
-    let runtime_bundle = match QUICListener::build_runtime_bundle(config_path, &runtime_config) {
-        Ok(bundle) => bundle,
-        Err(e) => {
-            error!("Failed to initialize shared runtime state: {}", e);
-            std::process::exit(1);
-        }
-    };
+async fn run(
+    runtime_config: RuntimeConfig,
+    log_config: spooky_config::config::Log,
+    uid: libc::uid_t,
+    config_path: String,
+) {
+    let runtime_bundle =
+        match QUICListener::build_runtime_bundle(config_path, log_config, &runtime_config) {
+            Ok(bundle) => bundle,
+            Err(e) => {
+                error!("Failed to initialize shared runtime state: {}", e);
+                std::process::exit(1);
+            }
+        };
     let shared_state = Arc::clone(&runtime_bundle.shared_state);
     let runtime_bundle = Arc::new(RuntimeBundleHandle::new(runtime_bundle));
 

--- a/spooky/src/main.rs
+++ b/spooky/src/main.rs
@@ -1,5 +1,6 @@
 //! Spooky HTTP/3 Load Balancer - Main Entry Point
 
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::path::Path;
 use std::sync::mpsc::{self, RecvTimeoutError, SyncSender, TrySendError};
@@ -35,6 +36,206 @@ struct IngressPacket {
     peer: SocketAddr,
     local_addr: SocketAddr,
     bytes: Vec<u8>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ListenerGroupSignature {
+    label: String,
+    worker_count: usize,
+    shard_count: usize,
+    shard_queue_capacity: usize,
+    shard_queue_max_bytes: usize,
+    pin_workers: bool,
+    reuseport: bool,
+    udp_recv_buffer_bytes: usize,
+    udp_send_buffer_bytes: usize,
+}
+
+struct ListenerGroupRuntime {
+    signature: ListenerGroupSignature,
+    shutdown: Arc<AtomicBool>,
+    worker_handles: Vec<thread::JoinHandle<Result<(), String>>>,
+}
+
+impl ListenerGroupRuntime {
+    fn request_shutdown(&self) {
+        self.shutdown.store(true, Ordering::Relaxed);
+    }
+
+    fn collect_finished(&mut self, worker_failed: &mut bool) {
+        let mut idx = 0usize;
+        while idx < self.worker_handles.len() {
+            if !self.worker_handles[idx].is_finished() {
+                idx += 1;
+                continue;
+            }
+
+            let handle = self.worker_handles.swap_remove(idx);
+            join_worker_handle(handle, worker_failed);
+        }
+    }
+
+    fn retired(&self) -> bool {
+        self.shutdown.load(Ordering::Relaxed) && self.worker_handles.is_empty()
+    }
+
+    fn join_all(mut self, worker_failed: &mut bool) {
+        for handle in self.worker_handles.drain(..) {
+            join_worker_handle(handle, worker_failed);
+        }
+    }
+}
+
+fn listener_label(config: &ListenerRuntimeConfig) -> String {
+    format!(
+        "{}:{}",
+        config.listen.listen.address, config.listen.listen.port
+    )
+}
+
+fn listener_group_signature(config: &ListenerRuntimeConfig) -> ListenerGroupSignature {
+    ListenerGroupSignature {
+        label: listener_label(config),
+        worker_count: config.performance.worker_threads.max(1),
+        shard_count: config.performance.packet_shards_per_worker.max(1),
+        shard_queue_capacity: config.performance.packet_shard_queue_capacity.max(1),
+        shard_queue_max_bytes: config.performance.packet_shard_queue_max_bytes.max(1),
+        pin_workers: config.performance.pin_workers,
+        reuseport: config.performance.reuseport,
+        udp_recv_buffer_bytes: config.performance.udp_recv_buffer_bytes,
+        udp_send_buffer_bytes: config.performance.udp_send_buffer_bytes,
+    }
+}
+
+fn spawn_managed_listener_group(
+    listener_config: ListenerRuntimeConfig,
+    worker_shared: Arc<SharedRuntimeState>,
+    runtime_bundle: Arc<RuntimeBundleHandle>,
+    worker_index_base: usize,
+) -> Result<ListenerGroupRuntime, String> {
+    let signature = listener_group_signature(&listener_config);
+    let shutdown = Arc::new(AtomicBool::new(false));
+
+    QUICListener::spawn_bootstrap_tls_listener(
+        &listener_config,
+        worker_shared.as_ref(),
+        Some(Arc::clone(&runtime_bundle)),
+        Some(Arc::clone(&shutdown)),
+    )
+    .map_err(|err| {
+        format!(
+            "Failed to initialize bootstrap TLS listener {} ({}:{}): {}",
+            listener_config.listen.index,
+            listener_config.listen.listen.address,
+            listener_config.listen.listen.port,
+            err
+        )
+    })?;
+
+    let worker_handles = spawn_listener_worker_group(
+        listener_config,
+        signature.worker_count,
+        signature.shard_count,
+        signature.shard_queue_capacity,
+        signature.shard_queue_max_bytes,
+        signature.pin_workers,
+        worker_shared,
+        runtime_bundle,
+        Arc::clone(&shutdown),
+        worker_index_base,
+    )?;
+
+    Ok(ListenerGroupRuntime {
+        signature,
+        shutdown,
+        worker_handles,
+    })
+}
+
+fn reconcile_listener_groups(
+    runtime_bundle: &Arc<RuntimeBundleHandle>,
+    groups: &mut Vec<ListenerGroupRuntime>,
+    next_worker_index_base: &mut usize,
+) {
+    let runtime = runtime_bundle.current();
+    let desired_configs = runtime.runtime_config.listener_runtime_configs();
+    let desired_signatures = desired_configs
+        .iter()
+        .map(|config| (listener_label(config), listener_group_signature(config)))
+        .collect::<HashMap<_, _>>();
+
+    for group in groups.iter_mut() {
+        match desired_signatures.get(&group.signature.label) {
+            Some(signature) if signature == &group.signature => {}
+            Some(signature) => {
+                if !group.shutdown.load(Ordering::Relaxed) {
+                    info!(
+                        "Retiring listener group {} for topology reload",
+                        signature.label
+                    );
+                    group.request_shutdown();
+                }
+            }
+            None => {
+                if !group.shutdown.load(Ordering::Relaxed) {
+                    info!(
+                        "Retiring listener group {} because it is no longer configured",
+                        group.signature.label
+                    );
+                    group.request_shutdown();
+                }
+            }
+        }
+    }
+
+    for listener_config in desired_configs {
+        let signature = listener_group_signature(&listener_config);
+        let active_match = groups.iter().any(|group| {
+            group.signature.label == signature.label && !group.shutdown.load(Ordering::Relaxed)
+        });
+        let pending_retire = groups
+            .iter()
+            .any(|group| group.signature.label == signature.label);
+        if active_match {
+            continue;
+        }
+        if pending_retire {
+            continue;
+        }
+
+        match spawn_managed_listener_group(
+            listener_config,
+            Arc::clone(&runtime.shared_state),
+            Arc::clone(runtime_bundle),
+            *next_worker_index_base,
+        ) {
+            Ok(group) => {
+                info!("Spawned listener group {}", group.signature.label);
+                *next_worker_index_base =
+                    next_worker_index_base.saturating_add(group.signature.worker_count);
+                groups.push(group);
+            }
+            Err(err) => {
+                error!("{}", err);
+            }
+        }
+    }
+}
+
+fn collect_finished_listener_groups(
+    groups: &mut Vec<ListenerGroupRuntime>,
+    worker_failed: &mut bool,
+) {
+    let mut idx = 0usize;
+    while idx < groups.len() {
+        groups[idx].collect_finished(worker_failed);
+        if groups[idx].retired() {
+            info!("Retired listener group {}", groups[idx].signature.label);
+            groups.swap_remove(idx);
+            continue;
+        }
+        idx += 1;
+    }
 }
 
 #[cfg(unix)]
@@ -225,54 +426,25 @@ async fn run(
         shutdown_flag.store(true, Ordering::Relaxed);
     });
 
-    let pin_workers = runtime_config.performance.pin_workers;
-    let shard_queue_capacity = runtime_config
-        .performance
-        .packet_shard_queue_capacity
-        .max(1);
-    let shard_queue_max_bytes = runtime_config
-        .performance
-        .packet_shard_queue_max_bytes
-        .max(1);
-    let mut worker_handles: Vec<thread::JoinHandle<Result<(), String>>> = Vec::new();
-    let mut worker_index_base = 0usize;
-
+    let mut listener_groups = Vec::new();
+    let mut next_worker_index_base = 0usize;
     for listener_config in runtime_config.listener_runtime_configs() {
-        if let Err(err) = QUICListener::spawn_bootstrap_tls_listener(
-            &listener_config,
-            &shared_state,
-            Some(Arc::clone(&runtime_bundle)),
-        ) {
-            error!(
-                "Failed to initialize bootstrap TLS listener {} ({}:{}): {}",
-                listener_config.listen.index,
-                listener_config.listen.listen.address,
-                listener_config.listen.listen.port,
-                err
-            );
-            std::process::exit(1);
-        }
-
-        match spawn_listener_worker_group(
+        match spawn_managed_listener_group(
             listener_config,
-            worker_count,
-            shard_count,
-            shard_queue_capacity,
-            shard_queue_max_bytes,
-            pin_workers,
             Arc::clone(&shared_state),
             Arc::clone(&runtime_bundle),
-            Arc::clone(&shutdown),
-            worker_index_base,
+            next_worker_index_base,
         ) {
-            Ok(handles) => worker_handles.extend(handles),
+            Ok(group) => {
+                next_worker_index_base =
+                    next_worker_index_base.saturating_add(group.signature.worker_count);
+                listener_groups.push(group);
+            }
             Err(err) => {
                 error!("{}", err);
                 std::process::exit(1);
             }
         }
-
-        worker_index_base = worker_index_base.saturating_add(worker_count.max(1));
     }
 
     info!("Spooky is starting");
@@ -295,29 +467,23 @@ async fn run(
     }
     info!(
         "Data-plane workers={} packet_shards_per_worker={} reuseport={} pin_workers={}",
-        worker_handles.len(),
+        listener_groups
+            .iter()
+            .map(|group| group.worker_handles.len())
+            .sum::<usize>(),
         shard_count,
         runtime_config.performance.reuseport,
         runtime_config.performance.pin_workers
     );
 
     let mut worker_failed = false;
-    let mut active_worker_handles = worker_handles;
     while !shutdown.load(Ordering::Relaxed) {
-        let mut idx = 0usize;
-        while idx < active_worker_handles.len() {
-            if !active_worker_handles[idx].is_finished() {
-                idx += 1;
-                continue;
-            }
-
-            let handle = active_worker_handles.swap_remove(idx);
-            join_worker_handle(handle, &mut worker_failed);
-            if worker_failed {
-                shutdown.store(true, Ordering::Relaxed);
-                break;
-            }
-        }
+        collect_finished_listener_groups(&mut listener_groups, &mut worker_failed);
+        reconcile_listener_groups(
+            &runtime_bundle,
+            &mut listener_groups,
+            &mut next_worker_index_base,
+        );
 
         if worker_failed {
             break;
@@ -326,8 +492,19 @@ async fn run(
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
 
-    for handle in active_worker_handles {
-        join_worker_handle(handle, &mut worker_failed);
+    for group in &listener_groups {
+        group.request_shutdown();
+    }
+    loop {
+        collect_finished_listener_groups(&mut listener_groups, &mut worker_failed);
+        if listener_groups.is_empty() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    for group in listener_groups.drain(..) {
+        group.join_all(&mut worker_failed);
     }
 
     let panic_count = runtime_guard::panic_count();


### PR DESCRIPTION
## Description

### Summary

- `GET /admin/runtime` and `POST /admin/runtime/reload-certs` were reading from
  the startup-snapshot TLS store and listener configs after a hot reload swapped
  in a new bundle. Both handlers now resolve the live TLS store, listener
  configs, and metrics from the current runtime bundle via a new
  `current_listener_runtime_configs()` helper.

- `validate_runtime_reload_compatibility()` only preflighted *new* listeners,
  silently accepting reloads that removed or renamed an existing listener. Since
  `listener_label` is derived from the bind tuple, a port/address change
  produces a new label and drops the old one — causing the live QUIC worker to
  fall out of sync with the active bundle. The validator now rejects any reload
  where a label present in the current bundle is absent from the next.