### PR TITLE
fix(h1-backend): preserve WebSocket upgrade headers and tunnel to H1 upstream

### DIFF
--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -9,5 +9,6 @@ http.workspace = true
 quiche.workspace = true
 bytes.workspace = true
 http-body-util.workspace = true
+hyper.workspace = true
 spooky-errors = { path = "../errors" }
 spooky-config = { path = "../config" }

--- a/crates/bridge/src/h3_to_h1.rs
+++ b/crates/bridge/src/h3_to_h1.rs
@@ -88,8 +88,8 @@ pub fn build_h1_request_for_endpoint_with_host_policy(
     )?;
 
     let request_path = if path.is_empty() { "/" } else { path };
-    let uri = Uri::try_from(endpoint.uri_for_path(request_path))
-        .map_err(|_| BridgeError::InvalidUri)?;
+    let uri =
+        Uri::try_from(endpoint.uri_for_path(request_path)).map_err(|_| BridgeError::InvalidUri)?;
     builder = builder.uri(uri).header(http::header::HOST, host_value);
 
     if let Some(len) = content_length

--- a/crates/bridge/src/h3_to_h1.rs
+++ b/crates/bridge/src/h3_to_h1.rs
@@ -1,0 +1,152 @@
+use std::convert::Infallible;
+
+use bytes::Bytes;
+use http::{HeaderName, HeaderValue, Method, Request, Uri};
+use http_body_util::combinators::BoxBody;
+use quiche::h3::NameValue;
+use spooky_config::{
+    backend_endpoint::BackendEndpoint,
+    config::{ForwardedHeaderPolicy, UpstreamHostPolicy},
+};
+
+use crate::{
+    BridgeError, ForwardedContext, ForwardedHeaderChains, H3WebsocketRequestKind,
+    build_forwarded_header_values, connection_header_tokens, h3_websocket_request_kind,
+    resolve_upstream_host_value, should_strip_request_header,
+};
+
+/// Build an HTTP/1.1 request forwarded to an `http://` upstream.
+///
+/// For plain requests: strips hop-by-hop headers and adds `TE: trailers`.
+/// For WebSocket legacy upgrades (`GET` + `Upgrade: websocket`): preserves
+/// `Connection` and `Upgrade` so the H1 upstream can complete the handshake.
+#[allow(clippy::too_many_arguments)]
+pub fn build_h1_request_for_endpoint_with_host_policy(
+    endpoint: &BackendEndpoint,
+    host_policy: &UpstreamHostPolicy,
+    forwarded_policy: &ForwardedHeaderPolicy,
+    method: &str,
+    path: &str,
+    headers: &[quiche::h3::Header],
+    body: BoxBody<Bytes, Infallible>,
+    content_length: Option<usize>,
+    forwarded_ctx: ForwardedContext<'_>,
+) -> Result<Request<BoxBody<Bytes, Infallible>>, BridgeError> {
+    let method = Method::from_bytes(method.as_bytes()).map_err(|_| BridgeError::InvalidMethod)?;
+    let websocket_kind = h3_websocket_request_kind(method.as_str(), headers);
+    let preserve_upgrade = websocket_kind == H3WebsocketRequestKind::LegacyUpgrade;
+
+    let mut builder = Request::builder().method(method.clone());
+    let connection_tokens = connection_header_tokens(headers);
+    let mut host_from_headers: Option<String> = None;
+    let mut forwarded_from_headers: Vec<Vec<u8>> = Vec::new();
+    let mut x_forwarded_for_from_headers: Vec<Vec<u8>> = Vec::new();
+    let mut x_forwarded_proto_from_headers: Vec<Vec<u8>> = Vec::new();
+    let mut x_forwarded_host_from_headers: Vec<Vec<u8>> = Vec::new();
+
+    for header in headers {
+        let name = header.name();
+        if name.starts_with(b":") {
+            continue;
+        }
+        if name.eq_ignore_ascii_case(b"forwarded") {
+            forwarded_from_headers.push(header.value().to_vec());
+            continue;
+        }
+        if name.eq_ignore_ascii_case(b"x-forwarded-for") {
+            x_forwarded_for_from_headers.push(header.value().to_vec());
+            continue;
+        }
+        if name.eq_ignore_ascii_case(b"x-forwarded-proto") {
+            x_forwarded_proto_from_headers.push(header.value().to_vec());
+            continue;
+        }
+        if name.eq_ignore_ascii_case(b"x-forwarded-host") {
+            x_forwarded_host_from_headers.push(header.value().to_vec());
+            continue;
+        }
+
+        let header_name = HeaderName::from_bytes(name).map_err(|_| BridgeError::InvalidHeader)?;
+        if should_strip_request_header(&header_name, &connection_tokens, preserve_upgrade) {
+            continue;
+        }
+
+        let header_value =
+            HeaderValue::from_bytes(header.value()).map_err(|_| BridgeError::InvalidHeader)?;
+        if header_name == http::header::HOST {
+            host_from_headers = header_value.to_str().ok().map(str::to_string);
+            continue;
+        }
+        builder = builder.header(header_name, header_value);
+    }
+
+    let host_value = resolve_upstream_host_value(
+        endpoint,
+        host_policy,
+        forwarded_ctx.request_authority,
+        host_from_headers.as_deref(),
+    )?;
+
+    let request_path = if path.is_empty() { "/" } else { path };
+    let uri = Uri::try_from(endpoint.uri_for_path(request_path))
+        .map_err(|_| BridgeError::InvalidUri)?;
+    builder = builder.uri(uri).header(http::header::HOST, host_value);
+
+    if let Some(len) = content_length
+        && len > 0
+    {
+        builder = builder.header(http::header::CONTENT_LENGTH, len);
+    }
+
+    let has_request_id = builder
+        .headers_ref()
+        .is_some_and(|h| h.contains_key("x-request-id"));
+    if !has_request_id {
+        builder = builder.header(
+            HeaderName::from_static("x-request-id"),
+            HeaderValue::from_str(&forwarded_ctx.request_id.to_string())
+                .map_err(|_| BridgeError::InvalidHeader)?,
+        );
+    }
+
+    let has_traceparent = builder
+        .headers_ref()
+        .is_some_and(|h| h.contains_key("traceparent"));
+    if !has_traceparent && let Some(traceparent) = forwarded_ctx.traceparent {
+        builder = builder.header(
+            HeaderName::from_static("traceparent"),
+            HeaderValue::from_str(traceparent).map_err(|_| BridgeError::InvalidHeader)?,
+        );
+    }
+
+    let forwarded_values = build_forwarded_header_values(
+        forwarded_policy,
+        ForwardedHeaderChains {
+            forwarded: &forwarded_from_headers,
+            x_forwarded_for: &x_forwarded_for_from_headers,
+            x_forwarded_proto: &x_forwarded_proto_from_headers,
+            x_forwarded_host: &x_forwarded_host_from_headers,
+        },
+        forwarded_ctx.client_addr.ip(),
+        host_value,
+    )?;
+    if let Some(value) = forwarded_values.forwarded {
+        builder = builder.header(HeaderName::from_static("forwarded"), value);
+    }
+    if let Some(value) = forwarded_values.x_forwarded_for {
+        builder = builder.header(HeaderName::from_static("x-forwarded-for"), value);
+    }
+    if let Some(value) = forwarded_values.x_forwarded_proto {
+        builder = builder.header(HeaderName::from_static("x-forwarded-proto"), value);
+    }
+    if let Some(value) = forwarded_values.x_forwarded_host {
+        builder = builder.header(HeaderName::from_static("x-forwarded-host"), value);
+    }
+
+    // Plain H1 requests advertise trailer support; upgrade tunnels must not add this.
+    if !preserve_upgrade {
+        builder = builder.header(http::header::TE, "trailers");
+    }
+
+    builder.body(body).map_err(BridgeError::Build)
+}

--- a/crates/bridge/src/h3_to_h2.rs
+++ b/crates/bridge/src/h3_to_h2.rs
@@ -1,8 +1,4 @@
-use std::{
-    collections::HashSet,
-    convert::Infallible,
-    net::{IpAddr, SocketAddr},
-};
+use std::convert::Infallible;
 
 use bytes::Bytes;
 use http::{HeaderName, HeaderValue, Method, Request, Uri, Version};
@@ -10,37 +6,17 @@ use http_body_util::combinators::BoxBody;
 use hyper::ext::Protocol;
 use quiche::h3::NameValue;
 use spooky_config::{
-    backend_endpoint::{BackendEndpoint, BackendScheme},
-    config::{
-        ForwardedHeaderPolicy, ForwardedHeaderPolicyMode, UpstreamHostPolicy,
-        UpstreamHostPolicyMode,
-    },
+    backend_endpoint::BackendEndpoint,
+    config::{ForwardedHeaderPolicy, UpstreamHostPolicy},
 };
 
-pub use spooky_errors::BridgeError;
-
-pub struct ForwardedContext<'a> {
-    pub client_addr: SocketAddr,
-    pub request_authority: Option<&'a str>,
-    pub request_id: u64,
-    pub traceparent: Option<&'a str>,
-}
-
-#[derive(Debug, Clone, Copy, Default)]
-pub struct ForwardedHeaderChains<'a> {
-    pub forwarded: &'a [Vec<u8>],
-    pub x_forwarded_for: &'a [Vec<u8>],
-    pub x_forwarded_proto: &'a [Vec<u8>],
-    pub x_forwarded_host: &'a [Vec<u8>],
-}
-
-#[derive(Debug, Default)]
-pub struct ForwardedHeaderValues {
-    pub forwarded: Option<HeaderValue>,
-    pub x_forwarded_for: Option<HeaderValue>,
-    pub x_forwarded_proto: Option<HeaderValue>,
-    pub x_forwarded_host: Option<HeaderValue>,
-}
+// Re-export shared types so existing `spooky_bridge::h3_to_h2::*` imports keep working.
+pub use crate::{
+    BridgeError, ForwardedContext, ForwardedHeaderChains, ForwardedHeaderValues,
+    H3WebsocketRequestKind, build_forwarded_header_values, h3_websocket_request_kind,
+    h3_websocket_tunnel_requested, resolve_upstream_host_value,
+};
+use crate::{connection_header_tokens, should_strip_request_header};
 
 /// Build an HTTP/2 request with a pre-boxed streaming body.
 /// `content_length` is `Some(n)` only when the full length is known upfront
@@ -102,10 +78,9 @@ pub fn build_h2_request_for_endpoint_with_host_policy(
 ) -> Result<Request<BoxBody<Bytes, Infallible>>, BridgeError> {
     let method = Method::from_bytes(method.as_bytes()).map_err(|_| BridgeError::InvalidMethod)?;
     let websocket_kind = h3_websocket_request_kind(method.as_str(), headers);
-    let websocket_extended_connect =
-        websocket_kind != H3WebsocketRequestKind::None && endpoint.scheme() == BackendScheme::Https;
-    let preserve_legacy_upgrade_headers = websocket_kind == H3WebsocketRequestKind::LegacyUpgrade
-        && endpoint.scheme() == BackendScheme::Http;
+    // Extended CONNECT is the H2 websocket path (RFC 8441).
+    let websocket_extended_connect = websocket_kind == H3WebsocketRequestKind::ExtendedConnect
+        || websocket_kind == H3WebsocketRequestKind::LegacyUpgrade;
     let upstream_method = if websocket_extended_connect {
         Method::CONNECT
     } else {
@@ -143,11 +118,8 @@ pub fn build_h2_request_for_endpoint_with_host_policy(
         }
 
         let header_name = HeaderName::from_bytes(name).map_err(|_| BridgeError::InvalidHeader)?;
-        if should_strip_request_header(
-            &header_name,
-            &connection_tokens,
-            preserve_legacy_upgrade_headers,
-        ) {
+        // H2 never preserves upgrade headers — extended CONNECT uses :protocol instead.
+        if should_strip_request_header(&header_name, &connection_tokens, false) {
             continue;
         }
 
@@ -239,228 +211,7 @@ pub fn build_h2_request_for_endpoint_with_host_policy(
         builder = builder.header(HeaderName::from_static("x-forwarded-host"), value);
     }
 
-    if endpoint.scheme() == BackendScheme::Http && !is_connect && !preserve_legacy_upgrade_headers {
-        builder = builder.header(http::header::TE, "trailers");
-    }
-
     builder.body(body).map_err(BridgeError::Build)
-}
-
-pub fn resolve_upstream_host_value<'a>(
-    endpoint: &'a BackendEndpoint,
-    host_policy: &'a UpstreamHostPolicy,
-    request_authority: Option<&'a str>,
-    host_header: Option<&'a str>,
-) -> Result<&'a str, BridgeError> {
-    match host_policy.mode {
-        UpstreamHostPolicyMode::PassThrough => Ok(request_authority
-            .or(host_header)
-            .filter(|value| !value.trim().is_empty())
-            .unwrap_or(endpoint.authority())),
-        UpstreamHostPolicyMode::Rewrite => host_policy
-            .host
-            .as_deref()
-            .filter(|value| !value.trim().is_empty())
-            .ok_or(BridgeError::InvalidHeader),
-        UpstreamHostPolicyMode::Upstream => Ok(endpoint.authority()),
-    }
-}
-
-pub fn build_forwarded_header_values(
-    policy: &ForwardedHeaderPolicy,
-    inbound: ForwardedHeaderChains<'_>,
-    client_ip: IpAddr,
-    host_value: &str,
-) -> Result<ForwardedHeaderValues, BridgeError> {
-    let forwarded_current = format!(
-        "for={};proto=https;host=\"{}\"",
-        forwarded_for_value(client_ip),
-        escape_forwarded_host(host_value),
-    );
-    let x_forwarded_for_current = client_ip.to_string();
-    let x_forwarded_proto_current = "https";
-    let x_forwarded_host_current = host_value;
-
-    Ok(ForwardedHeaderValues {
-        forwarded: merge_forwarded_chain(
-            policy.mode,
-            inbound.forwarded,
-            Some(forwarded_current.as_bytes()),
-        )?,
-        x_forwarded_for: merge_forwarded_chain(
-            policy.mode,
-            inbound.x_forwarded_for,
-            Some(x_forwarded_for_current.as_bytes()),
-        )?,
-        x_forwarded_proto: merge_forwarded_chain(
-            policy.mode,
-            inbound.x_forwarded_proto,
-            Some(x_forwarded_proto_current.as_bytes()),
-        )?,
-        x_forwarded_host: merge_forwarded_chain(
-            policy.mode,
-            inbound.x_forwarded_host,
-            Some(x_forwarded_host_current.as_bytes()),
-        )?,
-    })
-}
-
-fn merge_forwarded_chain(
-    mode: ForwardedHeaderPolicyMode,
-    inbound: &[Vec<u8>],
-    current: Option<&[u8]>,
-) -> Result<Option<HeaderValue>, BridgeError> {
-    match mode {
-        ForwardedHeaderPolicyMode::Preserve => join_header_chain(inbound),
-        ForwardedHeaderPolicyMode::Append => {
-            let mut values = inbound.to_vec();
-            if let Some(current) = current {
-                values.push(current.to_vec());
-            }
-            join_header_chain(&values)
-        }
-        ForwardedHeaderPolicyMode::Overwrite => current
-            .map(HeaderValue::from_bytes)
-            .transpose()
-            .map_err(|_| BridgeError::InvalidHeader),
-    }
-}
-
-fn join_header_chain(values: &[Vec<u8>]) -> Result<Option<HeaderValue>, BridgeError> {
-    if values.is_empty() {
-        return Ok(None);
-    }
-
-    let mut joined = Vec::new();
-    for (index, value) in values.iter().enumerate() {
-        if index > 0 {
-            joined.extend_from_slice(b", ");
-        }
-        joined.extend_from_slice(value);
-    }
-
-    HeaderValue::from_bytes(&joined)
-        .map(Some)
-        .map_err(|_| BridgeError::InvalidHeader)
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum H3WebsocketRequestKind {
-    None,
-    LegacyUpgrade,
-    ExtendedConnect,
-}
-
-pub fn h3_websocket_request_kind(
-    method: &str,
-    headers: &[quiche::h3::Header],
-) -> H3WebsocketRequestKind {
-    let upgrade_is_websocket = headers.iter().any(|header| {
-        header.name().eq_ignore_ascii_case(b"upgrade")
-            && std::str::from_utf8(header.value())
-                .map(|value| value.eq_ignore_ascii_case("websocket"))
-                .unwrap_or(false)
-    });
-    let connection_mentions_upgrade = headers.iter().any(|header| {
-        header.name().eq_ignore_ascii_case(b"connection")
-            && std::str::from_utf8(header.value())
-                .map(|value| {
-                    value
-                        .split(',')
-                        .any(|part| part.trim().eq_ignore_ascii_case("upgrade"))
-                })
-                .unwrap_or(false)
-    });
-    let protocol_is_websocket = headers.iter().any(|header| {
-        header.name().eq_ignore_ascii_case(b":protocol")
-            && std::str::from_utf8(header.value())
-                .map(|value| value.eq_ignore_ascii_case("websocket"))
-                .unwrap_or(false)
-    });
-
-    if method.eq_ignore_ascii_case("CONNECT") && protocol_is_websocket {
-        H3WebsocketRequestKind::ExtendedConnect
-    } else if method.eq_ignore_ascii_case("GET")
-        && upgrade_is_websocket
-        && connection_mentions_upgrade
-    {
-        H3WebsocketRequestKind::LegacyUpgrade
-    } else {
-        H3WebsocketRequestKind::None
-    }
-}
-
-pub fn h3_websocket_tunnel_requested(method: &str, headers: &[quiche::h3::Header]) -> bool {
-    h3_websocket_request_kind(method, headers) != H3WebsocketRequestKind::None
-}
-
-fn connection_header_tokens(headers: &[quiche::h3::Header]) -> HashSet<String> {
-    let mut tokens = HashSet::new();
-    for header in headers {
-        if !header.name().eq_ignore_ascii_case(b"connection") {
-            continue;
-        }
-        let Ok(value) = std::str::from_utf8(header.value()) else {
-            continue;
-        };
-        for token in value.split(',') {
-            let normalized = token.trim().to_ascii_lowercase();
-            if !normalized.is_empty() {
-                tokens.insert(normalized);
-            }
-        }
-    }
-    tokens
-}
-
-fn should_strip_request_header(
-    name: &HeaderName,
-    connection_tokens: &HashSet<String>,
-    preserve_websocket_upgrade_headers: bool,
-) -> bool {
-    if preserve_websocket_upgrade_headers
-        && (name == http::header::CONNECTION || name == http::header::UPGRADE)
-    {
-        return false;
-    }
-
-    if connection_tokens.contains(name.as_str()) {
-        return true;
-    }
-
-    if name == http::header::CONTENT_LENGTH {
-        return true;
-    }
-
-    if name == http::header::CONNECTION
-        || name == http::header::PROXY_AUTHENTICATE
-        || name == http::header::PROXY_AUTHORIZATION
-        || name == http::header::TE
-        || name == http::header::TRAILER
-        || name == http::header::TRANSFER_ENCODING
-        || name == http::header::UPGRADE
-        || name.as_str().eq_ignore_ascii_case("keep-alive")
-        || name.as_str().eq_ignore_ascii_case("proxy-connection")
-        || name.as_str().eq_ignore_ascii_case("forwarded")
-        || name.as_str().eq_ignore_ascii_case("x-forwarded-for")
-        || name.as_str().eq_ignore_ascii_case("x-forwarded-proto")
-        || name.as_str().eq_ignore_ascii_case("x-forwarded-host")
-    {
-        return true;
-    }
-
-    false
-}
-
-fn forwarded_for_value(ip: IpAddr) -> String {
-    match ip {
-        IpAddr::V4(v4) => v4.to_string(),
-        IpAddr::V6(v6) => format!("\"[{}]\"", v6),
-    }
-}
-
-fn escape_forwarded_host(host: &str) -> String {
-    host.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
 #[cfg(test)]
@@ -478,7 +229,8 @@ mod tests {
     };
 
     use super::{
-        ForwardedContext, build_h2_request, build_h2_request_for_endpoint_with_host_policy,
+        BridgeError, ForwardedContext, build_h2_request,
+        build_h2_request_for_endpoint_with_host_policy,
     };
 
     #[test]
@@ -555,7 +307,7 @@ mod tests {
         )
         .expect_err("invalid backend endpoint should fail");
 
-        assert!(matches!(err, crate::h3_to_h2::BridgeError::InvalidUri));
+        assert!(matches!(err, BridgeError::InvalidUri));
     }
 
     #[test]

--- a/crates/bridge/src/h3_to_h2.rs
+++ b/crates/bridge/src/h3_to_h2.rs
@@ -5,8 +5,9 @@ use std::{
 };
 
 use bytes::Bytes;
-use http::{HeaderName, HeaderValue, Method, Request, Uri};
+use http::{HeaderName, HeaderValue, Method, Request, Uri, Version};
 use http_body_util::combinators::BoxBody;
+use hyper::ext::Protocol;
 use quiche::h3::NameValue;
 use spooky_config::{
     backend_endpoint::{BackendEndpoint, BackendScheme},
@@ -100,8 +101,18 @@ pub fn build_h2_request_for_endpoint_with_host_policy(
     forwarded_ctx: ForwardedContext<'_>,
 ) -> Result<Request<BoxBody<Bytes, Infallible>>, BridgeError> {
     let method = Method::from_bytes(method.as_bytes()).map_err(|_| BridgeError::InvalidMethod)?;
-    let is_connect = method == Method::CONNECT;
-    let mut builder = Request::builder().method(method.clone());
+    let websocket_kind = h3_websocket_request_kind(method.as_str(), headers);
+    let websocket_extended_connect =
+        websocket_kind != H3WebsocketRequestKind::None && endpoint.scheme() == BackendScheme::Https;
+    let preserve_legacy_upgrade_headers = websocket_kind == H3WebsocketRequestKind::LegacyUpgrade
+        && endpoint.scheme() == BackendScheme::Http;
+    let upstream_method = if websocket_extended_connect {
+        Method::CONNECT
+    } else {
+        method.clone()
+    };
+    let is_connect = upstream_method == Method::CONNECT;
+    let mut builder = Request::builder().method(upstream_method.clone());
     let connection_tokens = connection_header_tokens(headers);
     let mut host_from_headers: Option<String> = None;
     let mut forwarded_from_headers: Vec<Vec<u8>> = Vec::new();
@@ -132,7 +143,11 @@ pub fn build_h2_request_for_endpoint_with_host_policy(
         }
 
         let header_name = HeaderName::from_bytes(name).map_err(|_| BridgeError::InvalidHeader)?;
-        if should_strip_request_header(&header_name, &connection_tokens) {
+        if should_strip_request_header(
+            &header_name,
+            &connection_tokens,
+            preserve_legacy_upgrade_headers,
+        ) {
             continue;
         }
 
@@ -152,7 +167,11 @@ pub fn build_h2_request_for_endpoint_with_host_policy(
         host_from_headers.as_deref(),
     )?;
 
-    let uri = if is_connect {
+    let uri = if websocket_extended_connect {
+        let request_path = if path.is_empty() { "/" } else { path };
+        let uri = endpoint.uri_for_path(request_path);
+        Uri::try_from(uri).map_err(|_| BridgeError::InvalidUri)?
+    } else if is_connect {
         Uri::try_from(host_value).map_err(|_| BridgeError::InvalidUri)?
     } else {
         let request_path = if path.is_empty() { "/" } else { path };
@@ -160,10 +179,17 @@ pub fn build_h2_request_for_endpoint_with_host_policy(
         Uri::try_from(uri).map_err(|_| BridgeError::InvalidUri)?
     };
     builder = builder.uri(uri);
-    builder = builder.header(http::header::HOST, host_value);
+    if websocket_extended_connect {
+        builder = builder
+            .version(Version::HTTP_2)
+            .extension(Protocol::from_static("websocket"));
+    } else {
+        builder = builder.header(http::header::HOST, host_value);
+    }
 
     if let Some(len) = content_length
         && len > 0
+        && !websocket_extended_connect
     {
         builder = builder.header(http::header::CONTENT_LENGTH, len);
     }
@@ -213,7 +239,7 @@ pub fn build_h2_request_for_endpoint_with_host_policy(
         builder = builder.header(HeaderName::from_static("x-forwarded-host"), value);
     }
 
-    if endpoint.scheme() == BackendScheme::Http && !is_connect {
+    if endpoint.scheme() == BackendScheme::Http && !is_connect && !preserve_legacy_upgrade_headers {
         builder = builder.header(http::header::TE, "trailers");
     }
 
@@ -318,6 +344,56 @@ fn join_header_chain(values: &[Vec<u8>]) -> Result<Option<HeaderValue>, BridgeEr
         .map_err(|_| BridgeError::InvalidHeader)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum H3WebsocketRequestKind {
+    None,
+    LegacyUpgrade,
+    ExtendedConnect,
+}
+
+pub fn h3_websocket_request_kind(
+    method: &str,
+    headers: &[quiche::h3::Header],
+) -> H3WebsocketRequestKind {
+    let upgrade_is_websocket = headers.iter().any(|header| {
+        header.name().eq_ignore_ascii_case(b"upgrade")
+            && std::str::from_utf8(header.value())
+                .map(|value| value.eq_ignore_ascii_case("websocket"))
+                .unwrap_or(false)
+    });
+    let connection_mentions_upgrade = headers.iter().any(|header| {
+        header.name().eq_ignore_ascii_case(b"connection")
+            && std::str::from_utf8(header.value())
+                .map(|value| {
+                    value
+                        .split(',')
+                        .any(|part| part.trim().eq_ignore_ascii_case("upgrade"))
+                })
+                .unwrap_or(false)
+    });
+    let protocol_is_websocket = headers.iter().any(|header| {
+        header.name().eq_ignore_ascii_case(b":protocol")
+            && std::str::from_utf8(header.value())
+                .map(|value| value.eq_ignore_ascii_case("websocket"))
+                .unwrap_or(false)
+    });
+
+    if method.eq_ignore_ascii_case("CONNECT") && protocol_is_websocket {
+        H3WebsocketRequestKind::ExtendedConnect
+    } else if method.eq_ignore_ascii_case("GET")
+        && upgrade_is_websocket
+        && connection_mentions_upgrade
+    {
+        H3WebsocketRequestKind::LegacyUpgrade
+    } else {
+        H3WebsocketRequestKind::None
+    }
+}
+
+pub fn h3_websocket_tunnel_requested(method: &str, headers: &[quiche::h3::Header]) -> bool {
+    h3_websocket_request_kind(method, headers) != H3WebsocketRequestKind::None
+}
+
 fn connection_header_tokens(headers: &[quiche::h3::Header]) -> HashSet<String> {
     let mut tokens = HashSet::new();
     for header in headers {
@@ -337,7 +413,17 @@ fn connection_header_tokens(headers: &[quiche::h3::Header]) -> HashSet<String> {
     tokens
 }
 
-fn should_strip_request_header(name: &HeaderName, connection_tokens: &HashSet<String>) -> bool {
+fn should_strip_request_header(
+    name: &HeaderName,
+    connection_tokens: &HashSet<String>,
+    preserve_websocket_upgrade_headers: bool,
+) -> bool {
+    if preserve_websocket_upgrade_headers
+        && (name == http::header::CONNECTION || name == http::header::UPGRADE)
+    {
+        return false;
+    }
+
     if connection_tokens.contains(name.as_str()) {
         return true;
     }

--- a/crates/bridge/src/lib.rs
+++ b/crates/bridge/src/lib.rs
@@ -1,1 +1,272 @@
+pub mod h3_to_h1;
 pub mod h3_to_h2;
+
+use std::{
+    collections::HashSet,
+    net::IpAddr,
+};
+
+use http::{HeaderName, HeaderValue};
+use spooky_config::{
+    backend_endpoint::BackendEndpoint,
+    config::{ForwardedHeaderPolicy, ForwardedHeaderPolicyMode, UpstreamHostPolicy, UpstreamHostPolicyMode},
+};
+use std::net::SocketAddr;
+
+pub use spooky_errors::BridgeError;
+
+// --- Shared context and header value types ---
+
+pub struct ForwardedContext<'a> {
+    pub client_addr: SocketAddr,
+    pub request_authority: Option<&'a str>,
+    pub request_id: u64,
+    pub traceparent: Option<&'a str>,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ForwardedHeaderChains<'a> {
+    pub forwarded: &'a [Vec<u8>],
+    pub x_forwarded_for: &'a [Vec<u8>],
+    pub x_forwarded_proto: &'a [Vec<u8>],
+    pub x_forwarded_host: &'a [Vec<u8>],
+}
+
+#[derive(Debug, Default)]
+pub struct ForwardedHeaderValues {
+    pub forwarded: Option<HeaderValue>,
+    pub x_forwarded_for: Option<HeaderValue>,
+    pub x_forwarded_proto: Option<HeaderValue>,
+    pub x_forwarded_host: Option<HeaderValue>,
+}
+
+// --- Shared websocket detection ---
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum H3WebsocketRequestKind {
+    None,
+    LegacyUpgrade,
+    ExtendedConnect,
+}
+
+pub fn h3_websocket_request_kind(
+    method: &str,
+    headers: &[quiche::h3::Header],
+) -> H3WebsocketRequestKind {
+    use quiche::h3::NameValue;
+
+    let upgrade_is_websocket = headers.iter().any(|header| {
+        header.name().eq_ignore_ascii_case(b"upgrade")
+            && std::str::from_utf8(header.value())
+                .map(|value| value.eq_ignore_ascii_case("websocket"))
+                .unwrap_or(false)
+    });
+    let connection_mentions_upgrade = headers.iter().any(|header| {
+        header.name().eq_ignore_ascii_case(b"connection")
+            && std::str::from_utf8(header.value())
+                .map(|value| {
+                    value
+                        .split(',')
+                        .any(|part| part.trim().eq_ignore_ascii_case("upgrade"))
+                })
+                .unwrap_or(false)
+    });
+    let protocol_is_websocket = headers.iter().any(|header| {
+        header.name().eq_ignore_ascii_case(b":protocol")
+            && std::str::from_utf8(header.value())
+                .map(|value| value.eq_ignore_ascii_case("websocket"))
+                .unwrap_or(false)
+    });
+
+    if method.eq_ignore_ascii_case("CONNECT") && protocol_is_websocket {
+        H3WebsocketRequestKind::ExtendedConnect
+    } else if method.eq_ignore_ascii_case("GET")
+        && upgrade_is_websocket
+        && connection_mentions_upgrade
+    {
+        H3WebsocketRequestKind::LegacyUpgrade
+    } else {
+        H3WebsocketRequestKind::None
+    }
+}
+
+pub fn h3_websocket_tunnel_requested(method: &str, headers: &[quiche::h3::Header]) -> bool {
+    h3_websocket_request_kind(method, headers) != H3WebsocketRequestKind::None
+}
+
+// --- Shared header utilities ---
+
+pub(crate) fn connection_header_tokens(headers: &[quiche::h3::Header]) -> HashSet<String> {
+    use quiche::h3::NameValue;
+
+    let mut tokens = HashSet::new();
+    for header in headers {
+        if !header.name().eq_ignore_ascii_case(b"connection") {
+            continue;
+        }
+        let Ok(value) = std::str::from_utf8(header.value()) else {
+            continue;
+        };
+        for token in value.split(',') {
+            let normalized = token.trim().to_ascii_lowercase();
+            if !normalized.is_empty() {
+                tokens.insert(normalized);
+            }
+        }
+    }
+    tokens
+}
+
+/// Strip hop-by-hop and proxy-injected headers from an inbound H3 request.
+/// `preserve_upgrade` keeps `Connection` and `Upgrade` for H1 WebSocket tunnels.
+pub(crate) fn should_strip_request_header(
+    name: &HeaderName,
+    connection_tokens: &HashSet<String>,
+    preserve_upgrade: bool,
+) -> bool {
+    if preserve_upgrade
+        && (name == http::header::CONNECTION || name == http::header::UPGRADE)
+    {
+        return false;
+    }
+
+    if connection_tokens.contains(name.as_str()) {
+        return true;
+    }
+
+    if name == http::header::CONTENT_LENGTH {
+        return true;
+    }
+
+    if name == http::header::CONNECTION
+        || name == http::header::PROXY_AUTHENTICATE
+        || name == http::header::PROXY_AUTHORIZATION
+        || name == http::header::TE
+        || name == http::header::TRAILER
+        || name == http::header::TRANSFER_ENCODING
+        || name == http::header::UPGRADE
+        || name.as_str().eq_ignore_ascii_case("keep-alive")
+        || name.as_str().eq_ignore_ascii_case("proxy-connection")
+        || name.as_str().eq_ignore_ascii_case("forwarded")
+        || name.as_str().eq_ignore_ascii_case("x-forwarded-for")
+        || name.as_str().eq_ignore_ascii_case("x-forwarded-proto")
+        || name.as_str().eq_ignore_ascii_case("x-forwarded-host")
+    {
+        return true;
+    }
+
+    false
+}
+
+// --- Shared upstream host resolution ---
+
+pub fn resolve_upstream_host_value<'a>(
+    endpoint: &'a BackendEndpoint,
+    host_policy: &'a UpstreamHostPolicy,
+    request_authority: Option<&'a str>,
+    host_header: Option<&'a str>,
+) -> Result<&'a str, BridgeError> {
+    match host_policy.mode {
+        UpstreamHostPolicyMode::PassThrough => Ok(request_authority
+            .or(host_header)
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or(endpoint.authority())),
+        UpstreamHostPolicyMode::Rewrite => host_policy
+            .host
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+            .ok_or(BridgeError::InvalidHeader),
+        UpstreamHostPolicyMode::Upstream => Ok(endpoint.authority()),
+    }
+}
+
+// --- Shared forwarded header helpers ---
+
+pub fn build_forwarded_header_values(
+    policy: &ForwardedHeaderPolicy,
+    inbound: ForwardedHeaderChains<'_>,
+    client_ip: IpAddr,
+    host_value: &str,
+) -> Result<ForwardedHeaderValues, BridgeError> {
+    let forwarded_current = format!(
+        "for={};proto=https;host=\"{}\"",
+        forwarded_for_value(client_ip),
+        escape_forwarded_host(host_value),
+    );
+    let x_forwarded_for_current = client_ip.to_string();
+    let x_forwarded_proto_current = "https";
+    let x_forwarded_host_current = host_value;
+
+    Ok(ForwardedHeaderValues {
+        forwarded: merge_forwarded_chain(
+            policy.mode,
+            inbound.forwarded,
+            Some(forwarded_current.as_bytes()),
+        )?,
+        x_forwarded_for: merge_forwarded_chain(
+            policy.mode,
+            inbound.x_forwarded_for,
+            Some(x_forwarded_for_current.as_bytes()),
+        )?,
+        x_forwarded_proto: merge_forwarded_chain(
+            policy.mode,
+            inbound.x_forwarded_proto,
+            Some(x_forwarded_proto_current.as_bytes()),
+        )?,
+        x_forwarded_host: merge_forwarded_chain(
+            policy.mode,
+            inbound.x_forwarded_host,
+            Some(x_forwarded_host_current.as_bytes()),
+        )?,
+    })
+}
+
+fn merge_forwarded_chain(
+    mode: ForwardedHeaderPolicyMode,
+    inbound: &[Vec<u8>],
+    current: Option<&[u8]>,
+) -> Result<Option<HeaderValue>, BridgeError> {
+    match mode {
+        ForwardedHeaderPolicyMode::Preserve => join_header_chain(inbound),
+        ForwardedHeaderPolicyMode::Append => {
+            let mut values = inbound.to_vec();
+            if let Some(current) = current {
+                values.push(current.to_vec());
+            }
+            join_header_chain(&values)
+        }
+        ForwardedHeaderPolicyMode::Overwrite => current
+            .map(HeaderValue::from_bytes)
+            .transpose()
+            .map_err(|_| BridgeError::InvalidHeader),
+    }
+}
+
+fn join_header_chain(values: &[Vec<u8>]) -> Result<Option<HeaderValue>, BridgeError> {
+    if values.is_empty() {
+        return Ok(None);
+    }
+
+    let mut joined = Vec::new();
+    for (index, value) in values.iter().enumerate() {
+        if index > 0 {
+            joined.extend_from_slice(b", ");
+        }
+        joined.extend_from_slice(value);
+    }
+
+    HeaderValue::from_bytes(&joined)
+        .map(Some)
+        .map_err(|_| BridgeError::InvalidHeader)
+}
+
+pub(crate) fn forwarded_for_value(ip: IpAddr) -> String {
+    match ip {
+        IpAddr::V4(v4) => v4.to_string(),
+        IpAddr::V6(v6) => format!("\"[{}]\"", v6),
+    }
+}
+
+pub(crate) fn escape_forwarded_host(host: &str) -> String {
+    host.replace('\\', "\\\\").replace('"', "\\\"")
+}

--- a/crates/bridge/src/lib.rs
+++ b/crates/bridge/src/lib.rs
@@ -1,15 +1,15 @@
 pub mod h3_to_h1;
 pub mod h3_to_h2;
 
-use std::{
-    collections::HashSet,
-    net::IpAddr,
-};
+use std::{collections::HashSet, net::IpAddr};
 
 use http::{HeaderName, HeaderValue};
 use spooky_config::{
     backend_endpoint::BackendEndpoint,
-    config::{ForwardedHeaderPolicy, ForwardedHeaderPolicyMode, UpstreamHostPolicy, UpstreamHostPolicyMode},
+    config::{
+        ForwardedHeaderPolicy, ForwardedHeaderPolicyMode, UpstreamHostPolicy,
+        UpstreamHostPolicyMode,
+    },
 };
 use std::net::SocketAddr;
 
@@ -124,9 +124,7 @@ pub(crate) fn should_strip_request_header(
     connection_tokens: &HashSet<String>,
     preserve_upgrade: bool,
 ) -> bool {
-    if preserve_upgrade
-        && (name == http::header::CONNECTION || name == http::header::UPGRADE)
-    {
+    if preserve_upgrade && (name == http::header::CONNECTION || name == http::header::UPGRADE) {
         return false;
     }
 

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -72,7 +72,7 @@ impl fmt::Display for ValidationError {
 impl StdError for ValidationError {}
 
 thread_local! {
-    static LAST_VALIDATION_ERROR: RefCell<Option<ValidationError>> = RefCell::new(None);
+    static LAST_VALIDATION_ERROR: RefCell<Option<ValidationError>> = const { RefCell::new(None) };
 }
 
 fn clear_validation_error() {

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::error::Error as StdError;
 use std::fmt;
 use std::net::IpAddr;
-use std::sync::{Mutex, OnceLock};
+use std::cell::RefCell;
 
 #[path = "validator/helpers.rs"]
 mod helpers;
@@ -71,31 +71,25 @@ impl fmt::Display for ValidationError {
 
 impl StdError for ValidationError {}
 
-static LAST_VALIDATION_ERROR: OnceLock<Mutex<Option<ValidationError>>> = OnceLock::new();
-
-fn validation_error_slot() -> &'static Mutex<Option<ValidationError>> {
-    LAST_VALIDATION_ERROR.get_or_init(|| Mutex::new(None))
+thread_local! {
+    static LAST_VALIDATION_ERROR: RefCell<Option<ValidationError>> = RefCell::new(None);
 }
 
 fn clear_validation_error() {
-    if let Ok(mut guard) = validation_error_slot().lock() {
-        *guard = None;
-    }
+    LAST_VALIDATION_ERROR.with(|slot| *slot.borrow_mut() = None);
 }
 
 fn record_validation_error(message: String) {
-    if let Ok(mut guard) = validation_error_slot().lock()
-        && guard.is_none()
-    {
-        *guard = Some(ValidationError::new(message));
-    }
+    LAST_VALIDATION_ERROR.with(|slot| {
+        let mut guard = slot.borrow_mut();
+        if guard.is_none() {
+            *guard = Some(ValidationError::new(message));
+        }
+    });
 }
 
 fn take_validation_error() -> Option<ValidationError> {
-    validation_error_slot()
-        .lock()
-        .ok()
-        .and_then(|mut guard| guard.take())
+    LAST_VALIDATION_ERROR.with(|slot| slot.borrow_mut().take())
 }
 
 macro_rules! validation_error {

--- a/crates/config/src/validator.rs
+++ b/crates/config/src/validator.rs
@@ -5,11 +5,11 @@ use crate::config::{
 };
 use log::{info, warn};
 use rustls_pki_types::{CertificateDer, PrivateKeyDer, pem::PemObject};
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::error::Error as StdError;
 use std::fmt;
 use std::net::IpAddr;
-use std::cell::RefCell;
 
 #[path = "validator/helpers.rs"]
 mod helpers;

--- a/crates/edge/src/quic_listener/bootstrap_tls.rs
+++ b/crates/edge/src/quic_listener/bootstrap_tls.rs
@@ -849,11 +849,17 @@ impl QUICListener {
                                 let mut resp_builder = Response::builder().status(status);
                                 let response_connection_tokens =
                                     connection_header_tokens(upstream_resp.headers());
+                                let preserve_upgrade_response_headers = is_websocket_upgrade
+                                    && status == StatusCode::SWITCHING_PROTOCOLS;
                                 for (name, value) in upstream_resp.headers() {
+                                    let preserve_upgrade_header = preserve_upgrade_response_headers
+                                        && (*name == http::header::CONNECTION
+                                            || *name == http::header::UPGRADE);
                                     if should_strip_bootstrap_response_header(
                                         name,
                                         &response_connection_tokens,
-                                    ) {
+                                    ) && !preserve_upgrade_header
+                                    {
                                         continue;
                                     }
                                     resp_builder = resp_builder.header(name, value);

--- a/crates/edge/src/quic_listener/bootstrap_tls.rs
+++ b/crates/edge/src/quic_listener/bootstrap_tls.rs
@@ -15,6 +15,7 @@ use hyper::service::service_fn;
 use hyper::upgrade;
 use hyper_util::rt::TokioIo;
 use log::{debug, error, info, warn};
+use spooky_bridge::h3_to_h1::build_h1_request_for_endpoint_with_host_policy;
 use spooky_bridge::h3_to_h2::{
     ForwardedContext, ForwardedHeaderChains, build_forwarded_header_values,
     build_h2_request_for_endpoint_with_host_policy, resolve_upstream_host_value,
@@ -617,24 +618,41 @@ impl QUICListener {
                                             )
                                         })
                                         .collect();
-                                    match build_h2_request_for_endpoint_with_host_policy(
-                                        &endpoint,
-                                        &upstream_policy.host.0,
-                                        &upstream_policy.forwarded_headers.0,
-                                        &method,
-                                        &path,
-                                        &bridge_headers,
-                                        BootstrapStreamingBody::new(req.into_body())
-                                            .map_err(|never| match never {})
-                                            .boxed(),
-                                        None,
-                                        ForwardedContext {
-                                            client_addr: peer,
-                                            request_authority: authority.as_deref(),
-                                            request_id,
-                                            traceparent: traceparent.as_deref(),
-                                        },
-                                    ) {
+                                    let bridge_body = BootstrapStreamingBody::new(req.into_body())
+                                        .map_err(|never| match never {})
+                                        .boxed();
+                                    let bridge_ctx = ForwardedContext {
+                                        client_addr: peer,
+                                        request_authority: authority.as_deref(),
+                                        request_id,
+                                        traceparent: traceparent.as_deref(),
+                                    };
+                                    let build_result = if endpoint.scheme() == BackendScheme::Http {
+                                        build_h1_request_for_endpoint_with_host_policy(
+                                            &endpoint,
+                                            &upstream_policy.host.0,
+                                            &upstream_policy.forwarded_headers.0,
+                                            &method,
+                                            &path,
+                                            &bridge_headers,
+                                            bridge_body,
+                                            None,
+                                            bridge_ctx,
+                                        )
+                                    } else {
+                                        build_h2_request_for_endpoint_with_host_policy(
+                                            &endpoint,
+                                            &upstream_policy.host.0,
+                                            &upstream_policy.forwarded_headers.0,
+                                            &method,
+                                            &path,
+                                            &bridge_headers,
+                                            bridge_body,
+                                            None,
+                                            bridge_ctx,
+                                        )
+                                    };
+                                    match build_result {
                                         Ok(request) => request,
                                         Err(err) => {
                                             warn!("Bootstrap request build failed: {}", err);

--- a/crates/edge/src/quic_listener/forwarding.rs
+++ b/crates/edge/src/quic_listener/forwarding.rs
@@ -132,6 +132,7 @@ impl QUICListener {
         detail
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn build_http1_websocket_tunnel_request(
         endpoint: &BackendEndpoint,
         host_policy: &UpstreamHostPolicy,
@@ -182,6 +183,7 @@ impl QUICListener {
         Ok(request)
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn forward_http1_websocket_tunnel(
         endpoint: BackendEndpoint,
         host_policy: UpstreamHostPolicy,
@@ -1286,9 +1288,11 @@ impl QUICListener {
                                         };
 
                                     let forward_success: ForwardSuccess = if websocket_h1_tunnel {
-                                        let body_rx = websocket_tunnel_body_rx.expect(
-                                            "websocket H1 tunnels require a downstream body channel",
-                                        );
+                                        let Some(body_rx) = websocket_tunnel_body_rx else {
+                                            return Err(ProxyError::Transport(
+                                                "websocket H1 tunnels require a downstream body channel".into(),
+                                            ));
+                                        };
                                         Self::forward_http1_websocket_tunnel(
                                             backend_endpoint.clone(),
                                             upstream_policy.host.0.clone(),
@@ -2203,9 +2207,14 @@ impl QUICListener {
                                 let tunnel_mode = tunnel_response;
                                 let fut = async move {
                                     use http_body_util::BodyExt;
-                                    let mut body: hyper::body::Incoming = response_body.expect(
-                                        "non-tunnel responses must carry an HTTP body stream",
-                                    );
+                                    let Some(mut body) = response_body else {
+                                        let _ = chunk_tx
+                                            .send(ResponseChunk::Error(ProxyError::Transport(
+                                                "non-tunnel responses must carry an HTTP body stream".into(),
+                                            )))
+                                            .await;
+                                        return;
+                                    };
                                     let mut response_bytes_received: usize = 0;
                                     let mut buffered_chunks: Vec<Bytes> = Vec::new();
                                     let mut buffered_trailers: Option<Vec<(Vec<u8>, Vec<u8>)>> =

--- a/crates/edge/src/quic_listener/forwarding.rs
+++ b/crates/edge/src/quic_listener/forwarding.rs
@@ -132,6 +132,170 @@ impl QUICListener {
         detail
     }
 
+    fn build_http1_websocket_tunnel_request(
+        endpoint: &BackendEndpoint,
+        host_policy: &UpstreamHostPolicy,
+        forwarded_policy: &ForwardedHeaderPolicy,
+        path: &str,
+        headers: &[quiche::h3::Header],
+        client_addr: SocketAddr,
+        request_authority: Option<&str>,
+        request_id: u64,
+        traceparent: Option<&str>,
+    ) -> Result<Request<BoxBody<Bytes, std::convert::Infallible>>, ProxyError> {
+        let mut request_headers = headers.to_vec();
+        let has_upgrade = request_headers
+            .iter()
+            .any(|header| header.name().eq_ignore_ascii_case(b"upgrade"));
+        if !has_upgrade {
+            request_headers.push(quiche::h3::Header::new(b"upgrade", b"websocket"));
+        }
+        let has_connection = request_headers
+            .iter()
+            .any(|header| header.name().eq_ignore_ascii_case(b"connection"));
+        if !has_connection {
+            request_headers.push(quiche::h3::Header::new(b"connection", b"upgrade"));
+        }
+
+        let mut request = build_h2_request_for_endpoint_with_host_policy(
+            endpoint,
+            host_policy,
+            forwarded_policy,
+            "GET",
+            path,
+            &request_headers,
+            BoxBody::new(Full::new(Bytes::new())),
+            None,
+            ForwardedContext {
+                client_addr,
+                request_authority,
+                request_id,
+                traceparent,
+            },
+        )
+        .map_err(ProxyError::from)?;
+
+        let request_path = if path.is_empty() { "/" } else { path };
+        let path_uri = http::Uri::try_from(request_path)
+            .map_err(|_| ProxyError::Transport("invalid websocket request path".into()))?;
+        *request.uri_mut() = path_uri;
+        Ok(request)
+    }
+
+    async fn forward_http1_websocket_tunnel(
+        endpoint: BackendEndpoint,
+        host_policy: UpstreamHostPolicy,
+        forwarded_policy: ForwardedHeaderPolicy,
+        path: String,
+        headers: Vec<quiche::h3::Header>,
+        client_addr: SocketAddr,
+        request_authority: Option<String>,
+        request_id: u64,
+        traceparent: Option<String>,
+        mut body_rx: mpsc::Receiver<Bytes>,
+        backend_timeout: Duration,
+    ) -> ForwardResult {
+        let request = Self::build_http1_websocket_tunnel_request(
+            &endpoint,
+            &host_policy,
+            &forwarded_policy,
+            &path,
+            &headers,
+            client_addr,
+            request_authority.as_deref(),
+            request_id,
+            traceparent.as_deref(),
+        )?;
+
+        let stream = tokio::time::timeout(
+            backend_timeout,
+            tokio::net::TcpStream::connect(endpoint.authority()),
+        )
+        .await
+        .map_err(|_| ProxyError::Timeout)?
+        .map_err(|err| ProxyError::Transport(err.to_string()))?;
+        let io = TokioIo::new(stream);
+        let (mut sender, conn) = client_http1::handshake(io)
+            .await
+            .map_err(|err| ProxyError::Transport(err.to_string()))?;
+        tokio::spawn(async move {
+            let _ = conn.with_upgrades().await;
+        });
+
+        let mut response = tokio::time::timeout(backend_timeout, sender.send_request(request))
+            .await
+            .map_err(|_| ProxyError::Timeout)?
+            .map_err(|err| ProxyError::Transport(err.to_string()))?;
+
+        if response.status() != StatusCode::SWITCHING_PROTOCOLS {
+            let status = response.status();
+            let headers = response.headers().clone();
+            return Ok(ForwardSuccess::Response {
+                status,
+                headers,
+                body: response.into_body(),
+            });
+        }
+
+        let upgraded = upgrade::on(&mut response);
+        let headers = response.headers().clone();
+        let (chunk_tx, chunk_rx) = mpsc::channel(RESPONSE_CHUNK_CHANNEL_CAPACITY);
+        let fut = async move {
+            let upgraded = match upgraded.await {
+                Ok(upgraded) => upgraded,
+                Err(err) => {
+                    let _ = chunk_tx
+                        .send(ResponseChunk::Error(ProxyError::Transport(err.to_string())))
+                        .await;
+                    return;
+                }
+            };
+            let io = TokioIo::new(upgraded);
+            let (mut reader, mut writer) = tokio::io::split(io);
+            let write_fut = async {
+                while let Some(chunk) = body_rx.recv().await {
+                    writer.write_all(&chunk).await?;
+                }
+                writer.shutdown().await
+            };
+            let read_fut = async {
+                let mut buf = [0u8; RESPONSE_CHUNK_BYTES_LIMIT];
+                loop {
+                    match reader.read(&mut buf).await {
+                        Ok(0) => return Ok::<(), std::io::Error>(()),
+                        Ok(read) => {
+                            if chunk_tx
+                                .send(ResponseChunk::Data(Bytes::copy_from_slice(&buf[..read])))
+                                .await
+                                .is_err()
+                            {
+                                return Ok(());
+                            }
+                        }
+                        Err(err) => return Err(err),
+                    }
+                }
+            };
+            match tokio::try_join!(write_fut, read_fut) {
+                Ok(((), ())) => {
+                    let _ = chunk_tx.send(ResponseChunk::End).await;
+                }
+                Err(err) => {
+                    let _ = chunk_tx
+                        .send(ResponseChunk::Error(ProxyError::Transport(err.to_string())))
+                        .await;
+                }
+            }
+        };
+        let _ = spawn_async_task(fut, "ws-h1-tunnel");
+
+        Ok(ForwardSuccess::Tunnel {
+            status: StatusCode::OK,
+            headers,
+            response_chunk_rx: chunk_rx,
+        })
+    }
+
     fn is_internal_pool_control_error(error: &PoolError) -> bool {
         matches!(
             error,
@@ -639,6 +803,14 @@ impl QUICListener {
                     let path = request.path;
                     let authority = request.authority;
                     let content_length = request.content_length;
+                    let websocket_tunnel = request.websocket_tunnel;
+                    let tunnel_mode = if websocket_tunnel {
+                        TunnelMode::Websocket
+                    } else if is_connect_method(&method) {
+                        TunnelMode::Connect
+                    } else {
+                        TunnelMode::None
+                    };
 
                     metrics.inc_total();
                     let request_start = Instant::now();
@@ -674,8 +846,9 @@ impl QUICListener {
                             .and_then(|header| std::str::from_utf8(header.value()).ok())
                             .map(str::to_string)
                     };
+                    let route_method = if websocket_tunnel { "GET" } else { &method };
                     let resolved = Self::resolve_backend(
-                        &method,
+                        route_method,
                         &path,
                         authority.as_deref(),
                         Some(sticky_cid_key.as_str()),
@@ -942,16 +1115,6 @@ impl QUICListener {
                                     )
                                 },
                             );
-                            let bodyless_mode = is_bodyless_request_mode(&method, content_length);
-                            let (tx, boxed, request_fin_received) = if bodyless_mode {
-                                (None, BoxBody::new(Full::new(Bytes::new())), true)
-                            } else {
-                                // Create a channel body so quiche Data chunks stream
-                                // directly into the in-flight H2 request.
-                                let (tx, channel_body) =
-                                    ChannelBody::channel(REQUEST_CHUNK_CHANNEL_CAPACITY);
-                                (Some(tx), channel_body.boxed(), false)
-                            };
                             let backend_endpoint = match backend_endpoints.get(&addr).cloned() {
                                 Some(endpoint) => endpoint,
                                 None => {
@@ -977,6 +1140,29 @@ impl QUICListener {
                                     continue;
                                 }
                             };
+                            let websocket_h1_tunnel = websocket_tunnel
+                                && backend_endpoint.scheme() == BackendScheme::Http;
+                            let bodyless_mode = !is_tunnel_mode(tunnel_mode)
+                                && is_bodyless_request_mode(&method, content_length);
+                            let (tx, websocket_tunnel_body_rx, boxed, request_fin_received) =
+                                if bodyless_mode {
+                                    (None, None, BoxBody::new(Full::new(Bytes::new())), true)
+                                } else if websocket_h1_tunnel {
+                                    let (tx, rx) =
+                                        mpsc::channel::<Bytes>(REQUEST_CHUNK_CHANNEL_CAPACITY);
+                                    (
+                                        Some(tx),
+                                        Some(rx),
+                                        BoxBody::new(Full::new(Bytes::new())),
+                                        false,
+                                    )
+                                } else {
+                                    // Create a channel body so quiche Data chunks stream
+                                    // directly into the in-flight request.
+                                    let (tx, channel_body) =
+                                        ChannelBody::channel(REQUEST_CHUNK_CHANNEL_CAPACITY);
+                                    (Some(tx), None, channel_body.boxed(), false)
+                                };
                             let upstream_policy = upstream_policies
                                 .get(&upstream_name)
                                 .cloned()
@@ -1030,29 +1216,35 @@ impl QUICListener {
                             let backend_endpoints = Arc::clone(&backend_endpoints);
                             let backend_resolutions = Arc::clone(&backend_resolution_store);
                             let send_metrics = Arc::clone(&metrics);
-                            let allow_hedge = bodyless_mode
+                            let allow_hedge = !is_tunnel_mode(tunnel_mode)
+                                && bodyless_mode
                                 && resilience.hedging_allowed_for(&method, &upstream_name, true);
                             let hedge_delay = resilience.hedging_delay;
                             let alternate_backend =
                                 Self::pick_alternate_backend(&upstream_pool, idx);
-                            let forward_meta = bodyless_mode.then(|| {
-                                Arc::new(ForwardRequestMeta {
-                                    method: Arc::<str>::from(method.as_str()),
-                                    path: Arc::<str>::from(path.as_str()),
-                                    authority: authority.as_deref().map(Arc::<str>::from),
-                                    headers: Arc::new(list.clone()),
-                                    client_addr: connection.peer_address,
-                                    request_id,
-                                    traceparent: traceparent.as_deref().map(Arc::<str>::from),
-                                    host_policy: upstream_policy.host.0.clone(),
-                                    forwarded_header_policy: upstream_policy
-                                        .forwarded_headers
-                                        .0
-                                        .clone(),
-                                })
-                            });
+                            let forward_meta = (!is_tunnel_mode(tunnel_mode) && bodyless_mode)
+                                .then(|| {
+                                    Arc::new(ForwardRequestMeta {
+                                        method: Arc::<str>::from(method.as_str()),
+                                        path: Arc::<str>::from(path.as_str()),
+                                        authority: authority.as_deref().map(Arc::<str>::from),
+                                        headers: Arc::new(list.clone()),
+                                        client_addr: connection.peer_address,
+                                        request_id,
+                                        traceparent: traceparent.as_deref().map(Arc::<str>::from),
+                                        host_policy: upstream_policy.host.0.clone(),
+                                        forwarded_header_policy: upstream_policy
+                                            .forwarded_headers
+                                            .0
+                                            .clone(),
+                                    })
+                                });
                             let trace_span_for_upstream = trace_span.clone();
                             let (result_tx, result_rx) = oneshot::channel::<UpstreamResult>();
+                            let client_addr = connection.peer_address;
+                            let path_for_upstream = path.clone();
+                            let authority_for_upstream = authority.clone();
+                            let traceparent_for_upstream = traceparent.clone();
                             let fut = async move {
                                 let mut hedge_telemetry = crate::HedgeTelemetry::default();
                                 let mut retry_count: u8 = 0;
@@ -1093,7 +1285,26 @@ impl QUICListener {
                                             Ok(send_result??)
                                         };
 
-                                    let response: Response<Incoming> = if allow_hedge {
+                                    let forward_success: ForwardSuccess = if websocket_h1_tunnel {
+                                        let body_rx = websocket_tunnel_body_rx.expect(
+                                            "websocket H1 tunnels require a downstream body channel",
+                                        );
+                                        Self::forward_http1_websocket_tunnel(
+                                            backend_endpoint.clone(),
+                                            upstream_policy.host.0.clone(),
+                                            upstream_policy.forwarded_headers.0.clone(),
+                                            path_for_upstream.clone(),
+                                            list.clone(),
+                                            client_addr,
+                                            authority_for_upstream.clone(),
+                                            request_id,
+                                            traceparent_for_upstream.clone(),
+                                            body_rx,
+                                            backend_timeout,
+                                        )
+                                        .await?
+                                    } else {
+                                        let response: Response<Incoming> = if allow_hedge {
                                         let hedge_candidate = alternate_backend
                                             .clone()
                                             .and_then(|(backend, _idx)| {
@@ -1224,8 +1435,14 @@ impl QUICListener {
                                         }
                                     };
 
-                                    let (parts, body) = response.into_parts();
-                                    Ok((parts.status, parts.headers, body))
+                                        let (parts, body) = response.into_parts();
+                                        ForwardSuccess::Response {
+                                            status: parts.status,
+                                            headers: parts.headers,
+                                            body,
+                                        }
+                                    };
+                                    Ok(forward_success)
                                 }
                                 .await;
                                 // Ignore send error: receiver dropped means the stream was reset.
@@ -1365,6 +1582,7 @@ impl QUICListener {
                             start: request_start,
                             total_request_deadline: request_start + backend_total_request_timeout,
                             bodyless_mode,
+                            tunnel_mode,
                             retry_count: 0,
                             error_kind: None,
                             phase: StreamPhase::ReceivingRequest,
@@ -1766,20 +1984,33 @@ impl QUICListener {
                     };
                 }
                 match forward_result.forward {
-                    Ok((status, resp_headers, body)) => {
+                    Ok(success) => {
+                        let (status, resp_headers, response_body, prebuilt_response_chunk_rx) =
+                            match success {
+                                ForwardSuccess::Response {
+                                    status,
+                                    headers,
+                                    body,
+                                } => (status, headers, Some(body), None),
+                                ForwardSuccess::Tunnel {
+                                    status,
+                                    headers,
+                                    response_chunk_rx,
+                                } => (status, headers, None, Some(response_chunk_rx)),
+                            };
                         let suppress_downstream_body = streams
                             .get(&stream_id)
                             .is_some_and(|req| is_head_method(&req.method));
-                        let connect_tunnel = streams
+                        let tunnel_response = streams
                             .get(&stream_id)
-                            .is_some_and(|req| is_connect_tunnel_response(&req.method, status));
+                            .is_some_and(|req| is_tunnel_response(req.tunnel_mode, status));
                         // If upstream advertised a response length beyond our hard cap,
                         // fail fast with 503 before sending any downstream headers/body.
                         let upstream_content_length = resp_headers
                             .get(http::header::CONTENT_LENGTH)
                             .and_then(|v| v.to_str().ok())
                             .and_then(|v| v.parse::<usize>().ok());
-                        if !connect_tunnel
+                        if !tunnel_response
                             && !suppress_downstream_body
                             && upstream_content_length
                                 .is_some_and(|len| len > max_response_body_bytes)
@@ -1838,10 +2069,10 @@ impl QUICListener {
                         ));
 
                         let defer_headers_until_body_validated = upstream_content_length.is_none()
-                            && !connect_tunnel
+                            && !tunnel_response
                             && !suppress_downstream_body;
                         let immediate_end = suppress_downstream_body
-                            || (!connect_tunnel
+                            || (!tunnel_response
                                 && (upstream_content_length == Some(0)
                                     || status == http::StatusCode::NO_CONTENT
                                     || status == http::StatusCode::NOT_MODIFIED));
@@ -1951,63 +2182,74 @@ impl QUICListener {
                             // Enforces body deadlines and a hard running body-size cap. For
                             // unknown-length responses it additionally prebuffers until size
                             // validation completes before emitting headers.
-                            let (chunk_tx, chunk_rx) =
-                                mpsc::channel::<ResponseChunk>(RESPONSE_CHUNK_CHANNEL_CAPACITY);
-                            let fail_tx = chunk_tx.clone();
-                            // `backend_body_total_timeout` is used as a pre-first-byte guard:
-                            // once the upstream starts making body progress, the idle timeout
-                            // governs pacing and the stream may continue until request deadline.
-                            let first_byte_deadline =
-                                tokio::time::Instant::now() + backend_body_total_timeout;
-                            let deferred_status = status;
-                            let deferred_headers = owned_h3_headers.clone();
-                            let tunnel_mode = connect_tunnel;
-                            let fut = async move {
-                                use http_body_util::BodyExt;
-                                let mut body: hyper::body::Incoming = body;
-                                let mut response_bytes_received: usize = 0;
-                                let mut buffered_chunks: Vec<Bytes> = Vec::new();
-                                let mut buffered_trailers: Option<Vec<(Vec<u8>, Vec<u8>)>> = None;
-                                let mut saw_body_progress = false;
-                                loop {
-                                    let frame_fut = BodyExt::frame(&mut body);
-                                    let now = tokio::time::Instant::now();
-                                    if !saw_body_progress && now >= first_byte_deadline {
-                                        let _ = chunk_tx
-                                            .send(ResponseChunk::Error(ProxyError::Timeout))
-                                            .await;
-                                        return;
-                                    }
-                                    let wait_timeout = if saw_body_progress {
-                                        backend_body_idle_timeout
-                                    } else {
-                                        first_byte_deadline
-                                            .saturating_duration_since(now)
-                                            .min(backend_body_idle_timeout)
-                                    };
-                                    let result =
-                                        tokio::time::timeout(wait_timeout, frame_fut).await;
-                                    match result {
-                                        Err(_elapsed) => {
-                                            // Body read idle timeout — signal timeout to flush loop.
+                            if let Some(chunk_rx) = prebuilt_response_chunk_rx {
+                                if let Some(req) = streams.get_mut(&stream_id) {
+                                    req.response_chunk_rx = Some(chunk_rx);
+                                    req.response_headers_sent = true;
+                                    req.phase = StreamPhase::SendingResponse;
+                                    req.response_status = Some(status.as_u16());
+                                }
+                            } else {
+                                let (chunk_tx, chunk_rx) =
+                                    mpsc::channel::<ResponseChunk>(RESPONSE_CHUNK_CHANNEL_CAPACITY);
+                                let fail_tx = chunk_tx.clone();
+                                // `backend_body_total_timeout` is used as a pre-first-byte guard:
+                                // once the upstream starts making body progress, the idle timeout
+                                // governs pacing and the stream may continue until request deadline.
+                                let first_byte_deadline =
+                                    tokio::time::Instant::now() + backend_body_total_timeout;
+                                let deferred_status = status;
+                                let deferred_headers = owned_h3_headers.clone();
+                                let tunnel_mode = tunnel_response;
+                                let fut = async move {
+                                    use http_body_util::BodyExt;
+                                    let mut body: hyper::body::Incoming = response_body.expect(
+                                        "non-tunnel responses must carry an HTTP body stream",
+                                    );
+                                    let mut response_bytes_received: usize = 0;
+                                    let mut buffered_chunks: Vec<Bytes> = Vec::new();
+                                    let mut buffered_trailers: Option<Vec<(Vec<u8>, Vec<u8>)>> =
+                                        None;
+                                    let mut saw_body_progress = false;
+                                    loop {
+                                        let frame_fut = BodyExt::frame(&mut body);
+                                        let now = tokio::time::Instant::now();
+                                        if !saw_body_progress && now >= first_byte_deadline {
                                             let _ = chunk_tx
                                                 .send(ResponseChunk::Error(ProxyError::Timeout))
                                                 .await;
                                             return;
                                         }
-                                        Ok(Some(Ok(f))) => match f.into_data() {
-                                            Ok(data) => {
-                                                if !data.is_empty() {
-                                                    saw_body_progress = true;
-                                                }
-                                                if !tunnel_mode
-                                                    && response_size_exceeded_after_chunk(
-                                                        &mut response_bytes_received,
-                                                        data.len(),
-                                                        max_response_body_bytes,
-                                                    )
-                                                {
-                                                    let _ = chunk_tx
+                                        let wait_timeout = if saw_body_progress {
+                                            backend_body_idle_timeout
+                                        } else {
+                                            first_byte_deadline
+                                                .saturating_duration_since(now)
+                                                .min(backend_body_idle_timeout)
+                                        };
+                                        let result =
+                                            tokio::time::timeout(wait_timeout, frame_fut).await;
+                                        match result {
+                                            Err(_elapsed) => {
+                                                // Body read idle timeout — signal timeout to flush loop.
+                                                let _ = chunk_tx
+                                                    .send(ResponseChunk::Error(ProxyError::Timeout))
+                                                    .await;
+                                                return;
+                                            }
+                                            Ok(Some(Ok(f))) => match f.into_data() {
+                                                Ok(data) => {
+                                                    if !data.is_empty() {
+                                                        saw_body_progress = true;
+                                                    }
+                                                    if !tunnel_mode
+                                                        && response_size_exceeded_after_chunk(
+                                                            &mut response_bytes_received,
+                                                            data.len(),
+                                                            max_response_body_bytes,
+                                                        )
+                                                    {
+                                                        let _ = chunk_tx
                                                         .send(ResponseChunk::Error(ProxyError::Pool(
                                                             PoolError::BackendOverloaded(
                                                                 "upstream response body too large"
@@ -2015,10 +2257,10 @@ impl QUICListener {
                                                             ),
                                                         )))
                                                         .await;
-                                                    return;
-                                                }
-                                                if defer_headers_until_body_validated {
-                                                    if response_bytes_received
+                                                        return;
+                                                    }
+                                                    if defer_headers_until_body_validated {
+                                                        if response_bytes_received
                                                         > unknown_length_response_prebuffer_bytes
                                                     {
                                                         let _ = chunk_tx
@@ -2031,117 +2273,122 @@ impl QUICListener {
                                                             .await;
                                                         return;
                                                     }
-                                                    for start in (0..data.len())
-                                                        .step_by(RESPONSE_CHUNK_BYTES_LIMIT)
-                                                    {
-                                                        let end = (start
-                                                            + RESPONSE_CHUNK_BYTES_LIMIT)
-                                                            .min(data.len());
-                                                        buffered_chunks
-                                                            .push(data.slice(start..end));
-                                                    }
-                                                } else {
-                                                    for start in (0..data.len())
-                                                        .step_by(RESPONSE_CHUNK_BYTES_LIMIT)
-                                                    {
-                                                        let end = (start
-                                                            + RESPONSE_CHUNK_BYTES_LIMIT)
-                                                            .min(data.len());
-                                                        if chunk_tx
-                                                            .send(ResponseChunk::Data(
-                                                                data.slice(start..end),
-                                                            ))
-                                                            .await
-                                                            .is_err()
+                                                        for start in (0..data.len())
+                                                            .step_by(RESPONSE_CHUNK_BYTES_LIMIT)
                                                         {
-                                                            return;
+                                                            let end = (start
+                                                                + RESPONSE_CHUNK_BYTES_LIMIT)
+                                                                .min(data.len());
+                                                            buffered_chunks
+                                                                .push(data.slice(start..end));
+                                                        }
+                                                    } else {
+                                                        for start in (0..data.len())
+                                                            .step_by(RESPONSE_CHUNK_BYTES_LIMIT)
+                                                        {
+                                                            let end = (start
+                                                                + RESPONSE_CHUNK_BYTES_LIMIT)
+                                                                .min(data.len());
+                                                            if chunk_tx
+                                                                .send(ResponseChunk::Data(
+                                                                    data.slice(start..end),
+                                                                ))
+                                                                .await
+                                                                .is_err()
+                                                            {
+                                                                return;
+                                                            }
                                                         }
                                                     }
                                                 }
-                                            }
-                                            Err(frame) => {
-                                                if let Ok(trailers) = frame.into_trailers() {
-                                                    let trailer_headers =
-                                                        collect_h3_trailers(&trailers);
-                                                    if !trailer_headers.is_empty() {
-                                                        if defer_headers_until_body_validated {
-                                                            buffered_trailers =
-                                                                Some(trailer_headers);
-                                                        } else if chunk_tx
-                                                            .send(ResponseChunk::Trailers {
-                                                                headers: trailer_headers,
-                                                            })
-                                                            .await
-                                                            .is_err()
-                                                        {
-                                                            return;
+                                                Err(frame) => {
+                                                    if let Ok(trailers) = frame.into_trailers() {
+                                                        let trailer_headers =
+                                                            collect_h3_trailers(&trailers);
+                                                        if !trailer_headers.is_empty() {
+                                                            if defer_headers_until_body_validated {
+                                                                buffered_trailers =
+                                                                    Some(trailer_headers);
+                                                            } else if chunk_tx
+                                                                .send(ResponseChunk::Trailers {
+                                                                    headers: trailer_headers,
+                                                                })
+                                                                .await
+                                                                .is_err()
+                                                            {
+                                                                return;
+                                                            }
                                                         }
                                                     }
                                                 }
+                                            },
+                                            Ok(Some(Err(_))) => {
+                                                let _ = chunk_tx
+                                                    .send(ResponseChunk::Error(
+                                                        ProxyError::Transport(
+                                                            "upstream body error".into(),
+                                                        ),
+                                                    ))
+                                                    .await;
+                                                return;
                                             }
-                                        },
-                                        Ok(Some(Err(_))) => {
-                                            let _ = chunk_tx
-                                                .send(ResponseChunk::Error(ProxyError::Transport(
-                                                    "upstream body error".into(),
-                                                )))
-                                                .await;
-                                            return;
-                                        }
-                                        Ok(None) => {
-                                            if defer_headers_until_body_validated {
-                                                if chunk_tx
-                                                    .send(ResponseChunk::Start {
-                                                        status: deferred_status,
-                                                        headers: deferred_headers,
-                                                    })
-                                                    .await
-                                                    .is_err()
-                                                {
-                                                    return;
-                                                }
-                                                for chunk in buffered_chunks {
+                                            Ok(None) => {
+                                                if defer_headers_until_body_validated {
                                                     if chunk_tx
-                                                        .send(ResponseChunk::Data(chunk))
+                                                        .send(ResponseChunk::Start {
+                                                            status: deferred_status,
+                                                            headers: deferred_headers,
+                                                        })
                                                         .await
                                                         .is_err()
                                                     {
                                                         return;
                                                     }
+                                                    for chunk in buffered_chunks {
+                                                        if chunk_tx
+                                                            .send(ResponseChunk::Data(chunk))
+                                                            .await
+                                                            .is_err()
+                                                        {
+                                                            return;
+                                                        }
+                                                    }
                                                 }
-                                            }
-                                            if let Some(headers) = buffered_trailers
-                                                && chunk_tx
-                                                    .send(ResponseChunk::Trailers { headers })
-                                                    .await
-                                                    .is_err()
-                                            {
+                                                if let Some(headers) = buffered_trailers
+                                                    && chunk_tx
+                                                        .send(ResponseChunk::Trailers { headers })
+                                                        .await
+                                                        .is_err()
+                                                {
+                                                    return;
+                                                }
+                                                let _ = chunk_tx.send(ResponseChunk::End).await;
                                                 return;
                                             }
-                                            let _ = chunk_tx.send(ResponseChunk::End).await;
-                                            return;
                                         }
                                     }
+                                };
+                                let request_span = streams
+                                    .get(&stream_id)
+                                    .and_then(|req| req.trace_span.clone());
+                                let spawned = match request_span {
+                                    Some(span) => {
+                                        spawn_async_task(fut.instrument(span), "body-pump")
+                                    }
+                                    None => spawn_async_task(fut, "body-pump"),
+                                };
+                                if !spawned {
+                                    let _ = fail_tx.try_send(ResponseChunk::Error(
+                                        ProxyError::Transport("runtime unavailable".into()),
+                                    ));
                                 }
-                            };
-                            let request_span = streams
-                                .get(&stream_id)
-                                .and_then(|req| req.trace_span.clone());
-                            let spawned = match request_span {
-                                Some(span) => spawn_async_task(fut.instrument(span), "body-pump"),
-                                None => spawn_async_task(fut, "body-pump"),
-                            };
-                            if !spawned {
-                                let _ = fail_tx.try_send(ResponseChunk::Error(
-                                    ProxyError::Transport("runtime unavailable".into()),
-                                ));
-                            }
 
-                            if let Some(req) = streams.get_mut(&stream_id) {
-                                req.response_chunk_rx = Some(chunk_rx);
-                                req.response_headers_sent = !defer_headers_until_body_validated;
-                                req.phase = StreamPhase::SendingResponse;
-                                req.response_status = Some(status.as_u16());
+                                if let Some(req) = streams.get_mut(&stream_id) {
+                                    req.response_chunk_rx = Some(chunk_rx);
+                                    req.response_headers_sent = !defer_headers_until_body_validated;
+                                    req.phase = StreamPhase::SendingResponse;
+                                    req.response_status = Some(status.as_u16());
+                                }
                             }
                         }
 

--- a/crates/edge/src/quic_listener/forwarding.rs
+++ b/crates/edge/src/quic_listener/forwarding.rs
@@ -20,23 +20,39 @@ impl ForwardRequestMeta {
         &self,
         endpoint: &BackendEndpoint,
     ) -> Result<Request<BoxBody<Bytes, std::convert::Infallible>>, ProxyError> {
-        build_h2_request_for_endpoint_with_host_policy(
-            endpoint,
-            &self.host_policy,
-            &self.forwarded_header_policy,
-            &self.method,
-            &self.path,
-            self.headers.as_slice(),
-            BoxBody::new(Full::new(Bytes::new())),
-            Some(0),
-            ForwardedContext {
-                client_addr: self.client_addr,
-                request_authority: self.authority.as_deref(),
-                request_id: self.request_id,
-                traceparent: self.traceparent.as_deref(),
-            },
-        )
-        .map_err(ProxyError::from)
+        let ctx = ForwardedContext {
+            client_addr: self.client_addr,
+            request_authority: self.authority.as_deref(),
+            request_id: self.request_id,
+            traceparent: self.traceparent.as_deref(),
+        };
+        if endpoint.scheme() == BackendScheme::Http {
+            build_h1_request_for_endpoint_with_host_policy(
+                endpoint,
+                &self.host_policy,
+                &self.forwarded_header_policy,
+                &self.method,
+                &self.path,
+                self.headers.as_slice(),
+                BoxBody::new(Full::new(Bytes::new())),
+                Some(0),
+                ctx,
+            )
+            .map_err(ProxyError::from)
+        } else {
+            build_h2_request_for_endpoint_with_host_policy(
+                endpoint,
+                &self.host_policy,
+                &self.forwarded_header_policy,
+                &self.method,
+                &self.path,
+                self.headers.as_slice(),
+                BoxBody::new(Full::new(Bytes::new())),
+                Some(0),
+                ctx,
+            )
+            .map_err(ProxyError::from)
+        }
     }
 }
 
@@ -158,7 +174,7 @@ impl QUICListener {
             request_headers.push(quiche::h3::Header::new(b"connection", b"upgrade"));
         }
 
-        let mut request = build_h2_request_for_endpoint_with_host_policy(
+        build_h1_request_for_endpoint_with_host_policy(
             endpoint,
             host_policy,
             forwarded_policy,
@@ -174,13 +190,7 @@ impl QUICListener {
                 traceparent,
             },
         )
-        .map_err(ProxyError::from)?;
-
-        let request_path = if path.is_empty() { "/" } else { path };
-        let path_uri = http::Uri::try_from(request_path)
-            .map_err(|_| ProxyError::Transport("invalid websocket request path".into()))?;
-        *request.uri_mut() = path_uri;
-        Ok(request)
+        .map_err(ProxyError::from)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1169,22 +1179,42 @@ impl QUICListener {
                                 .get(&upstream_name)
                                 .cloned()
                                 .unwrap_or_default();
-                            let request = match build_h2_request_for_endpoint_with_host_policy(
-                                &backend_endpoint,
-                                &upstream_policy.host.0,
-                                &upstream_policy.forwarded_headers.0,
-                                &method,
-                                &path,
-                                &list,
-                                boxed,
-                                None,
-                                ForwardedContext {
-                                    client_addr: connection.peer_address,
-                                    request_authority: authority.as_deref(),
-                                    request_id,
-                                    traceparent: traceparent.as_deref(),
-                                },
-                            ) {
+                            let build_result = if backend_endpoint.scheme() == BackendScheme::Http {
+                                build_h1_request_for_endpoint_with_host_policy(
+                                    &backend_endpoint,
+                                    &upstream_policy.host.0,
+                                    &upstream_policy.forwarded_headers.0,
+                                    &method,
+                                    &path,
+                                    &list,
+                                    boxed,
+                                    None,
+                                    ForwardedContext {
+                                        client_addr: connection.peer_address,
+                                        request_authority: authority.as_deref(),
+                                        request_id,
+                                        traceparent: traceparent.as_deref(),
+                                    },
+                                )
+                            } else {
+                                build_h2_request_for_endpoint_with_host_policy(
+                                    &backend_endpoint,
+                                    &upstream_policy.host.0,
+                                    &upstream_policy.forwarded_headers.0,
+                                    &method,
+                                    &path,
+                                    &list,
+                                    boxed,
+                                    None,
+                                    ForwardedContext {
+                                        client_addr: connection.peer_address,
+                                        request_authority: authority.as_deref(),
+                                        request_id,
+                                        traceparent: traceparent.as_deref(),
+                                    },
+                                )
+                            };
+                            let request = match build_result {
                                 Ok(request) => request,
                                 Err(err) => {
                                     drop(upstream_permit);

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -39,6 +39,7 @@ use rustls::{
 use rustls_pki_types::pem::PemObject;
 use serde_json::json;
 use socket2::{Domain, Protocol, Socket, Type};
+use spooky_bridge::h3_to_h1::build_h1_request_for_endpoint_with_host_policy;
 use spooky_bridge::h3_to_h2::{ForwardedContext, build_h2_request_for_endpoint_with_host_policy};
 use spooky_errors::{PoolError, ProxyError, is_retryable};
 use spooky_lb::{HealthFailureReason, HealthTransition, UpstreamPool};

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -23,6 +23,9 @@ use bytes::Bytes;
 use http::{Request, Response, StatusCode};
 use http_body_util::{BodyExt, Full, combinators::BoxBody};
 use hyper::body::{Body, Frame, Incoming};
+use hyper::client::conn::http1 as client_http1;
+use hyper::upgrade;
+use hyper_util::rt::TokioIo;
 use log::{debug, error, info, warn};
 use quiche::Config;
 use quiche::h3::NameValue;
@@ -41,6 +44,7 @@ use spooky_errors::{PoolError, ProxyError, is_retryable};
 use spooky_lb::{HealthFailureReason, HealthTransition, UpstreamPool};
 use spooky_transport::h2_client::{SharedDnsResolver, TlsClientConfig};
 use spooky_transport::transport_pool::{BackendTransportKind, UpstreamTransportPool};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::runtime::Handle;
 use tokio::sync::{
     Semaphore, mpsc,
@@ -60,6 +64,7 @@ use spooky_config::{
     },
 };
 
+use crate::types::{ForwardSuccess, TunnelMode};
 use crate::{
     ChannelBody, ForwardResult, HealthClassification, Metrics, OverloadShedReason, QUICListener,
     QuicConnection, REQUEST_ID_COUNTER, RequestEnvelope, ResponseChunk, RetryReason, RouteOutcome,
@@ -226,12 +231,21 @@ fn is_bodyless_request_mode(method: &str, content_length: Option<usize>) -> bool
         && (method.eq_ignore_ascii_case("GET") || is_head_method(method))
 }
 
+fn is_tunnel_mode(tunnel_mode: TunnelMode) -> bool {
+    tunnel_mode != TunnelMode::None
+}
+
+fn is_tunnel_response(tunnel_mode: TunnelMode, status: StatusCode) -> bool {
+    is_tunnel_mode(tunnel_mode) && status.is_success()
+}
+
+#[cfg(test)]
 fn is_connect_tunnel_response(method: &str, status: StatusCode) -> bool {
     is_connect_method(method) && status.is_success()
 }
 
 fn can_poll_upstream_result(req: &RequestEnvelope) -> bool {
-    if is_connect_method(&req.method)
+    if is_tunnel_mode(req.tunnel_mode)
         && (req.phase == StreamPhase::ReceivingRequest
             || req.phase == StreamPhase::AwaitingUpstream)
     {
@@ -845,10 +859,13 @@ impl QUICListener {
                     ))
                 })?;
         let quic_config = Self::build_quic_config(&config)?;
-        let h3_config =
-            Arc::new(quiche::h3::Config::new().map_err(|err| {
+        let h3_config = Arc::new({
+            let mut config = quiche::h3::Config::new().map_err(|err| {
                 ProxyError::Transport(format!("failed to create h3 config: {err}"))
-            })?);
+            })?;
+            config.enable_extended_connect(true);
+            config
+        });
         let backend_timeout = Duration::from_millis(config.performance.backend_timeout_ms);
         let backend_body_idle_timeout =
             Duration::from_millis(config.performance.backend_body_idle_timeout_ms);

--- a/crates/edge/src/quic_listener/tests.rs
+++ b/crates/edge/src/quic_listener/tests.rs
@@ -1171,6 +1171,7 @@ fn connect_can_poll_upstream_before_request_fin() {
     let (_tx, rx) = oneshot::channel::<crate::UpstreamResult>();
     let mut req = make_envelope(StreamPhase::ReceivingRequest);
     req.method = "CONNECT".to_string();
+    req.tunnel_mode = crate::types::TunnelMode::Connect;
     req.request_fin_received = false;
     req.upstream_result_rx = Some(rx);
     assert!(can_poll_upstream_result(&req));
@@ -1789,6 +1790,7 @@ fn make_envelope(phase: StreamPhase) -> RequestEnvelope {
         bodyless_mode: false,
         retry_count: 0,
         error_kind: None,
+        tunnel_mode: crate::types::TunnelMode::None,
         phase,
         request_fin_received: false,
         upstream_result_rx: None,

--- a/crates/edge/src/quic_listener/validation.rs
+++ b/crates/edge/src/quic_listener/validation.rs
@@ -398,6 +398,7 @@ struct NormalizedAuthority {
     port: Option<u16>,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn validate_request_parts(
     method: String,
     path: String,

--- a/crates/edge/src/quic_listener/validation.rs
+++ b/crates/edge/src/quic_listener/validation.rs
@@ -732,21 +732,38 @@ mod tests {
     }
 
     #[test]
-    fn rejects_http3_connection_upgrade_requests() {
+    fn rejects_http3_upgrade_for_non_websocket_protocols() {
         let resilience = runtime_resilience();
         let headers = vec![
             h3_header(b":method", b"GET"),
             h3_header(b":path", b"/"),
             h3_header(b":authority", b"example.com"),
+            h3_header(b"connection", b"Upgrade"),
+            h3_header(b"upgrade", b"h2c"),
+        ];
+
+        let err = validate_request_headers(&headers, &resilience)
+            .expect_err("HTTP/3 Upgrade requests for non-websocket protocols must be rejected");
+        assert_eq!(err.0, http::StatusCode::BAD_REQUEST);
+        assert_eq!(err.1, b"HTTP/3 does not support Upgrade requests\n");
+        assert!(!err.2);
+    }
+
+    #[test]
+    fn accepts_http3_websocket_legacy_upgrade_as_tunnel() {
+        let resilience = runtime_resilience();
+        let headers = vec![
+            h3_header(b":method", b"GET"),
+            h3_header(b":path", b"/ws"),
+            h3_header(b":authority", b"example.com"),
             h3_header(b"connection", b"keep-alive, Upgrade"),
             h3_header(b"upgrade", b"websocket"),
         ];
 
-        let err = validate_request_headers(&headers, &resilience)
-            .expect_err("HTTP/3 Upgrade requests must be rejected");
-        assert_eq!(err.0, http::StatusCode::BAD_REQUEST);
-        assert_eq!(err.1, b"HTTP/3 does not support Upgrade requests\n");
-        assert!(!err.2);
+        let result = validate_request_headers(&headers, &resilience)
+            .expect("HTTP/3 WebSocket legacy upgrade should be accepted as a tunnel");
+        assert!(result.websocket_tunnel, "websocket_tunnel flag must be set");
+        assert_eq!(result.method, "GET");
     }
 
     #[test]

--- a/crates/edge/src/quic_listener/validation.rs
+++ b/crates/edge/src/quic_listener/validation.rs
@@ -6,6 +6,7 @@ pub(super) struct RequestValidationResult {
     pub(super) path: String,
     pub(super) authority: Option<String>,
     pub(super) content_length: Option<usize>,
+    pub(super) websocket_tunnel: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -21,7 +22,8 @@ pub(super) fn validate_request_headers(
     if list.len() > resilience.max_headers_count {
         return Err((
             http::StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE,
-            b"too many request headers\n",
+            b"too many request headers
+",
             false,
         ));
     }
@@ -32,6 +34,7 @@ pub(super) fn validate_request_headers(
     let mut authority = None::<String>;
     let mut host = None::<String>;
     let mut scheme_seen = false;
+    let mut protocol = None::<String>;
     let mut h3_upgrade_requested = false;
 
     for header in list {
@@ -39,7 +42,8 @@ pub(super) fn validate_request_headers(
         if header_bytes > resilience.max_headers_bytes {
             return Err((
                 http::StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE,
-                b"request headers exceed size limit\n",
+                b"request headers exceed size limit
+",
                 false,
             ));
         }
@@ -49,56 +53,68 @@ pub(super) fn validate_request_headers(
                 if method.is_some() {
                     return Err((
                         http::StatusCode::BAD_REQUEST,
-                        b"duplicate :method header\n",
+                        b"duplicate :method header
+",
                         false,
                     ));
                 }
                 method = Some(strict_header_value(
                     header.value(),
-                    b"invalid :method header\n",
+                    b"invalid :method header
+",
                 )?);
             }
             b":path" => {
                 if path.is_some() {
                     return Err((
                         http::StatusCode::BAD_REQUEST,
-                        b"duplicate :path header\n",
+                        b"duplicate :path header
+",
                         false,
                     ));
                 }
                 path = Some(strict_header_value(
                     header.value(),
-                    b"invalid :path header\n",
+                    b"invalid :path header
+",
                 )?);
             }
             b":authority" => {
                 if authority.is_some() {
                     return Err((
                         http::StatusCode::BAD_REQUEST,
-                        b"duplicate :authority header\n",
+                        b"duplicate :authority header
+",
                         false,
                     ));
                 }
                 authority = Some(strict_header_value(
                     header.value(),
-                    b"invalid :authority header\n",
+                    b"invalid :authority header
+",
                 )?);
             }
             b"host" => {
                 if host.is_some() {
                     return Err((
                         http::StatusCode::BAD_REQUEST,
-                        b"duplicate host header\n",
+                        b"duplicate host header
+",
                         false,
                     ));
                 }
                 host = Some(strict_header_value(
                     header.value(),
-                    b"invalid host header\n",
+                    b"invalid host header
+",
                 )?);
             }
             b"connection" => {
-                let value = strict_header_value(header.value(), b"invalid connection header\n")?;
+                let value = strict_header_value(
+                    header.value(),
+                    b"invalid connection header
+",
+                )?;
                 if value
                     .split(',')
                     .any(|part| part.trim().eq_ignore_ascii_case("upgrade"))
@@ -107,36 +123,49 @@ pub(super) fn validate_request_headers(
                 }
             }
             b"upgrade" => {
-                let _ = strict_header_value(header.value(), b"invalid upgrade header\n")?;
+                let _ = strict_header_value(
+                    header.value(),
+                    b"invalid upgrade header
+",
+                )?;
                 h3_upgrade_requested = true;
             }
             b":scheme" => {
                 if scheme_seen {
                     return Err((
                         http::StatusCode::BAD_REQUEST,
-                        b"duplicate :scheme header\n",
+                        b"duplicate :scheme header
+",
                         false,
                     ));
                 }
                 scheme_seen = true;
             }
+            b":protocol" => {
+                if protocol.is_some() {
+                    return Err((
+                        http::StatusCode::BAD_REQUEST,
+                        b"duplicate :protocol header
+",
+                        false,
+                    ));
+                }
+                protocol = Some(strict_header_value(
+                    header.value(),
+                    b"invalid :protocol header
+",
+                )?);
+            }
             name if name.starts_with(b":") => {
                 return Err((
                     http::StatusCode::BAD_REQUEST,
-                    b"unsupported pseudo-header\n",
+                    b"unsupported pseudo-header
+",
                     false,
                 ));
             }
             _ => {}
         }
-    }
-
-    if h3_upgrade_requested {
-        return Err((
-            http::StatusCode::BAD_REQUEST,
-            b"HTTP/3 does not support Upgrade requests\n",
-            false,
-        ));
     }
 
     let content_length = parse_h3_content_length(list)?;
@@ -146,33 +175,65 @@ pub(super) fn validate_request_headers(
         None => {
             return Err((
                 http::StatusCode::BAD_REQUEST,
-                b"missing :method header\n",
+                b"missing :method header
+",
                 false,
             ));
         }
     };
+
+    let websocket_tunnel = spooky_bridge::h3_to_h2::h3_websocket_tunnel_requested(&method, list);
+    if protocol.is_some() && !websocket_tunnel {
+        return Err((
+            http::StatusCode::BAD_REQUEST,
+            b"unsupported pseudo-header
+",
+            false,
+        ));
+    }
+    if h3_upgrade_requested && !websocket_tunnel {
+        return Err((
+            http::StatusCode::BAD_REQUEST,
+            b"HTTP/3 does not support Upgrade requests
+",
+            false,
+        ));
+    }
+
     let is_connect = method.eq_ignore_ascii_case("CONNECT");
-    let path = match (is_connect, path) {
-        (true, Some(path)) if path.is_empty() => {
+    let path = match (is_connect, websocket_tunnel, path) {
+        (true, true, Some(path)) => path,
+        (true, true, None) => {
             return Err((
                 http::StatusCode::BAD_REQUEST,
-                b"invalid CONNECT :path header\n",
+                b"missing :path header
+",
                 false,
             ));
         }
-        (true, Some(_)) => {
+        (true, false, Some(path)) if path.is_empty() => {
             return Err((
                 http::StatusCode::BAD_REQUEST,
-                b"invalid CONNECT :path header\n",
+                b"invalid CONNECT :path header
+",
                 false,
             ));
         }
-        (true, None) => "/".to_string(),
-        (false, Some(path)) => path,
-        (false, None) => {
+        (true, false, Some(_)) => {
             return Err((
                 http::StatusCode::BAD_REQUEST,
-                b"missing :path header\n",
+                b"invalid CONNECT :path header
+",
+                false,
+            ));
+        }
+        (true, false, None) => "/".to_string(),
+        (false, _, Some(path)) => path,
+        (false, _, None) => {
+            return Err((
+                http::StatusCode::BAD_REQUEST,
+                b"missing :path header
+",
                 false,
             ));
         }
@@ -184,15 +245,23 @@ pub(super) fn validate_request_headers(
         authority,
         host,
         content_length,
+        websocket_tunnel,
         resilience,
         RequestPartErrors {
-            invalid_method: b"invalid :method header\n",
-            invalid_path: b"invalid :path header\n",
-            invalid_authority: b"invalid :authority header\n",
-            invalid_host: b"invalid host header\n",
-            authority_mismatch: b":authority and host headers must match\n",
-            connect_path_not_allowed: b"invalid CONNECT :path header\n",
-            connect_authority_required: b"CONNECT requires authority host:port\n",
+            invalid_method: b"invalid :method header
+",
+            invalid_path: b"invalid :path header
+",
+            invalid_authority: b"invalid :authority header
+",
+            invalid_host: b"invalid host header
+",
+            authority_mismatch: b":authority and host headers must match
+",
+            connect_path_not_allowed: b"invalid CONNECT :path header
+",
+            connect_authority_required: b"CONNECT requires authority host:port
+",
         },
     )
 }
@@ -258,6 +327,7 @@ pub(super) fn validate_http_request(
         authority,
         host,
         content_length,
+        false,
         resilience,
         RequestPartErrors {
             invalid_method: b"invalid method header\n",
@@ -334,6 +404,7 @@ fn validate_request_parts(
     authority: Option<String>,
     host: Option<String>,
     content_length: Option<usize>,
+    websocket_tunnel: bool,
     resilience: &RuntimeResilience,
     errors: RequestPartErrors,
 ) -> Result<RequestValidationResult, (http::StatusCode, &'static [u8], bool)> {
@@ -343,7 +414,11 @@ fn validate_request_parts(
     }
 
     if is_connect {
-        if !path.is_empty() && path != "/" {
+        if websocket_tunnel {
+            if path.is_empty() || !path.starts_with('/') {
+                return Err((http::StatusCode::BAD_REQUEST, errors.invalid_path, false));
+            }
+        } else if !path.is_empty() && path != "/" {
             return Err((
                 http::StatusCode::BAD_REQUEST,
                 errors.connect_path_not_allowed,
@@ -424,6 +499,7 @@ fn validate_request_parts(
         path,
         authority: authority.or(host),
         content_length,
+        websocket_tunnel,
     })
 }
 

--- a/crates/edge/src/types.rs
+++ b/crates/edge/src/types.rs
@@ -672,9 +672,21 @@ pub struct QuicConnection {
     pub(crate) last_local_error_snapshot: Option<QuicConnectionErrorSnapshot>,
 }
 
-/// Result type returned by the in-flight H2 forwarding task.
-pub type ForwardResult =
-    Result<(http::StatusCode, http::HeaderMap, hyper::body::Incoming), ProxyError>;
+pub enum ForwardSuccess {
+    Response {
+        status: http::StatusCode,
+        headers: http::HeaderMap,
+        body: hyper::body::Incoming,
+    },
+    Tunnel {
+        status: http::StatusCode,
+        headers: http::HeaderMap,
+        response_chunk_rx: mpsc::Receiver<ResponseChunk>,
+    },
+}
+
+/// Result type returned by the in-flight upstream forwarding task.
+pub type ForwardResult = Result<ForwardSuccess, ProxyError>;
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct HedgeTelemetry {
@@ -700,7 +712,7 @@ pub struct UpstreamResult {
 pub enum StreamPhase {
     /// Still receiving request headers/body from the QUIC client.
     ReceivingRequest,
-    /// Request fully received; waiting for the upstream H2 response.
+    /// Request fully received; waiting for the upstream response.
     AwaitingUpstream,
     /// Upstream responded; streaming response back to the QUIC client.
     SendingResponse,
@@ -708,6 +720,13 @@ pub enum StreamPhase {
     Completed,
     /// Stream terminated with an error.
     Failed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TunnelMode {
+    None,
+    Connect,
+    Websocket,
 }
 
 /// A chunk of the upstream response being streamed back to the client.
@@ -767,6 +786,7 @@ pub struct RequestEnvelope {
     pub start: Instant,
     pub total_request_deadline: Instant,
     pub bodyless_mode: bool,
+    pub tunnel_mode: TunnelMode,
 
     pub retry_count: u8,
     pub error_kind: Option<&'static str>,

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -19,7 +19,7 @@ use http_body_util::{BodyExt, Empty, Full, combinators::BoxBody};
 use hyper::{
     Request, Response, Uri,
     body::{Body, Frame, Incoming},
-    client::conn::http2,
+    client::conn::{http1, http2},
     service::service_fn,
 };
 use hyper_util::{
@@ -290,6 +290,72 @@ async fn start_h2_backend() -> SocketAddr {
 
                 let _ = hyper::server::conn::http1::Builder::new()
                     .serve_connection(io, service)
+                    .await;
+            });
+        }
+    });
+
+    addr
+}
+
+async fn start_h1_backend_with_websocket_upgrade() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = match listener.accept().await {
+                Ok(v) => v,
+                Err(_) => break,
+            };
+            tokio::spawn(async move {
+                let io = TokioIo::new(stream);
+                let service = service_fn(|mut req: Request<Incoming>| async move {
+                    let is_upgrade = req
+                        .headers()
+                        .get(http::header::UPGRADE)
+                        .and_then(|value| value.to_str().ok())
+                        .map(|value| value.eq_ignore_ascii_case("websocket"))
+                        .unwrap_or(false)
+                        && req
+                            .headers()
+                            .get(http::header::CONNECTION)
+                            .and_then(|value| value.to_str().ok())
+                            .map(|value| {
+                                value
+                                    .split(',')
+                                    .any(|part| part.trim().eq_ignore_ascii_case("upgrade"))
+                            })
+                            .unwrap_or(false);
+
+                    if !is_upgrade {
+                        return Ok::<_, hyper::Error>(
+                            Response::builder()
+                                .status(StatusCode::BAD_REQUEST)
+                                .body(Full::new(Bytes::from_static(b"missing upgrade\n")))
+                                .unwrap(),
+                        );
+                    }
+
+                    let on_upgrade = hyper::upgrade::on(&mut req);
+                    tokio::spawn(async move {
+                        let _ = on_upgrade.await;
+                    });
+
+                    Ok::<_, hyper::Error>(
+                        Response::builder()
+                            .status(StatusCode::SWITCHING_PROTOCOLS)
+                            .header(http::header::CONNECTION, "upgrade")
+                            .header(http::header::UPGRADE, "websocket")
+                            .header("sec-websocket-accept", "test-accept")
+                            .body(Full::new(Bytes::new()))
+                            .unwrap(),
+                    )
+                });
+
+                let _ = hyper::server::conn::http1::Builder::new()
+                    .serve_connection(io, service)
+                    .with_upgrades()
                     .await;
             });
         }
@@ -992,6 +1058,7 @@ fn run_h3_client_collect_trailers(
 #[derive(Debug, Default)]
 struct H3CollectedResponse {
     status: String,
+    headers: Vec<(String, String)>,
     body: Vec<u8>,
     trailers: Vec<(String, String)>,
     reset: bool,
@@ -1104,6 +1171,11 @@ fn run_h3_client_collect_response(
                                 if header.name() == b":status" {
                                     response.status =
                                         String::from_utf8_lossy(header.value()).to_string();
+                                } else {
+                                    response.headers.push((
+                                        String::from_utf8_lossy(header.name()).to_string(),
+                                        String::from_utf8_lossy(header.value()).to_string(),
+                                    ));
                                 }
                             }
                         } else {
@@ -1713,6 +1785,71 @@ async fn run_bootstrap_h2_client_collect_trailers(
     }
 
     Ok((status, body, trailers))
+}
+
+async fn run_bootstrap_h1_websocket_handshake(
+    addr: SocketAddr,
+    cert_path: &str,
+    path: &str,
+) -> Result<(StatusCode, HeaderMap), String> {
+    let roots = read_test_root_store(cert_path)?;
+    let tls_config = ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    let connector = TlsConnector::from(Arc::new(tls_config));
+
+    let server_name = ServerName::try_from("localhost")
+        .map_err(|err| format!("server name: {err}"))?
+        .to_owned();
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        match TcpStream::connect(addr).await {
+            Ok(stream) => {
+                let tls_stream = connector
+                    .connect(server_name.clone(), stream)
+                    .await
+                    .map_err(|err| format!("tls connect: {err}"))?;
+                let (mut sender, conn) = http1::handshake(TokioIo::new(tls_stream))
+                    .await
+                    .map_err(|err| format!("h1 handshake: {err}"))?;
+                tokio::spawn(async move {
+                    let _ = conn.with_upgrades().await;
+                });
+                sender
+                    .ready()
+                    .await
+                    .map_err(|err| format!("sender ready: {err}"))?;
+
+                let req = Request::builder()
+                    .method("GET")
+                    .uri(
+                        Uri::builder()
+                            .path_and_query(path)
+                            .build()
+                            .map_err(|err| format!("uri build: {err}"))?,
+                    )
+                    .header("host", "localhost")
+                    .header(http::header::CONNECTION, "Upgrade")
+                    .header(http::header::UPGRADE, "websocket")
+                    .header("sec-websocket-key", "dGVzdC1rZXktMTIzNDU2Nzg5MA==")
+                    .header("sec-websocket-version", "13")
+                    .body(Empty::<Bytes>::new())
+                    .map_err(|err| format!("request build: {err}"))?;
+
+                let response = sender
+                    .send_request(req)
+                    .await
+                    .map_err(|err| format!("send request: {err}"))?;
+                return Ok((response.status(), response.headers().clone()));
+            }
+            Err(err) if Instant::now() < deadline => {
+                let _ = err;
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+            Err(err) => return Err(format!("tcp connect: {err}")),
+        }
+    }
 }
 
 async fn run_bootstrap_h2_client_request(

--- a/crates/edge/tests/h3_bridge/protocol.rs
+++ b/crates/edge/tests/h3_bridge/protocol.rs
@@ -592,12 +592,14 @@ fn http3_websocket_upgrade_tunnels_to_http1_upstream() {
     .expect("websocket request failed");
 
     assert_eq!(response.status, "200");
-    assert!(response.body.is_empty(), "websocket handshake should not emit an HTTP body");
     assert!(
-        response
-            .headers
-            .iter()
-            .any(|(name, value)| name.eq_ignore_ascii_case("sec-websocket-accept") && value == "test-accept"),
+        response.body.is_empty(),
+        "websocket handshake should not emit an HTTP body"
+    );
+    assert!(
+        response.headers.iter().any(|(name, value)| name
+            .eq_ignore_ascii_case("sec-websocket-accept")
+            && value == "test-accept"),
         "expected sec-websocket-accept header, got {:?}",
         response.headers
     );

--- a/crates/edge/tests/h3_bridge/protocol.rs
+++ b/crates/edge/tests/h3_bridge/protocol.rs
@@ -55,6 +55,57 @@ fn http3_to_http2_preserves_response_trailers() {
 }
 
 #[test]
+fn bootstrap_http1_websocket_upgrade_preserves_switching_protocols_headers() {
+    if !local_listener_bind_available() {
+        return;
+    }
+    let dir = tempdir().expect("failed to create temp dir");
+    let (cert, key) = write_test_certs(&dir);
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let backend_addr = rt.block_on(start_h1_backend_with_websocket_upgrade());
+    let listen_port = find_free_tcp_port();
+    let config = make_config(
+        u32::from(listen_port),
+        format!("http://{backend_addr}"),
+        cert.clone(),
+        key,
+    );
+    let listener = make_listener_with_bootstrap(config);
+    let listen_addr = listener.socket.local_addr().unwrap();
+    let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
+
+    let bootstrap_addr = SocketAddr::new(listen_addr.ip(), listen_port);
+    let (status, headers) = rt
+        .block_on(run_bootstrap_h1_websocket_handshake(
+            bootstrap_addr,
+            &cert,
+            "/ws",
+        ))
+        .expect("bootstrap websocket handshake failed");
+
+    assert_eq!(status, StatusCode::SWITCHING_PROTOCOLS);
+    assert_eq!(
+        headers
+            .get(http::header::CONNECTION)
+            .and_then(|value| value.to_str().ok()),
+        Some("upgrade")
+    );
+    assert_eq!(
+        headers
+            .get(http::header::UPGRADE)
+            .and_then(|value| value.to_str().ok()),
+        Some("websocket")
+    );
+    assert_eq!(
+        headers
+            .get("sec-websocket-accept")
+            .and_then(|value| value.to_str().ok()),
+        Some("test-accept")
+    );
+}
+
+#[test]
 fn bootstrap_h2_preserves_response_trailers() {
     if !local_listener_bind_available() {
         return;
@@ -510,7 +561,7 @@ fn bootstrap_h2_head_suppresses_response_body() {
 }
 
 #[test]
-fn http3_rejects_upgrade_style_requests() {
+fn http3_websocket_upgrade_tunnels_to_http1_upstream() {
     if !local_listener_bind_available() {
         return;
     }
@@ -518,8 +569,8 @@ fn http3_rejects_upgrade_style_requests() {
     let (cert, key) = write_test_certs(&dir);
 
     let rt = tokio::runtime::Runtime::new().expect("runtime");
-    let backend_addr = rt.block_on(start_h2_backend());
-    let config = make_config(0, backend_addr.to_string(), cert, key);
+    let backend_addr = rt.block_on(start_h1_backend_with_websocket_upgrade());
+    let config = make_config(0, format!("http://{backend_addr}"), cert, key);
     let listener = QUICListener::new(config).expect("failed to create listener");
     let listen_addr = listener.socket.local_addr().unwrap();
     let _listener_task = ListenerTaskGuard::spawn(&rt, listener);
@@ -530,25 +581,27 @@ fn http3_rejects_upgrade_style_requests() {
             quiche::h3::Header::new(b":method", b"GET"),
             quiche::h3::Header::new(b":scheme", b"https"),
             quiche::h3::Header::new(b":authority", b"localhost"),
-            quiche::h3::Header::new(b":path", b"/"),
+            quiche::h3::Header::new(b":path", b"/ws"),
             quiche::h3::Header::new(b"connection", b"Upgrade"),
             quiche::h3::Header::new(b"upgrade", b"websocket"),
+            quiche::h3::Header::new(b"sec-websocket-version", b"13"),
         ],
         true,
         Duration::from_secs(REQUEST_TIMEOUT_SECS),
     )
-    .expect("upgrade-style request failed");
+    .expect("websocket request failed");
 
-    assert_eq!(response.status, "400");
+    assert_eq!(response.status, "200");
+    assert!(response.body.is_empty(), "websocket handshake should not emit an HTTP body");
     assert!(
-        String::from_utf8_lossy(&response.body).contains("Upgrade"),
-        "expected explicit Upgrade rejection body, got {:?}",
-        String::from_utf8_lossy(&response.body)
+        response
+            .headers
+            .iter()
+            .any(|(name, value)| name.eq_ignore_ascii_case("sec-websocket-accept") && value == "test-accept"),
+        "expected sec-websocket-accept header, got {:?}",
+        response.headers
     );
-    assert!(
-        !response.reset,
-        "upgrade rejection should be an HTTP response"
-    );
+    assert!(!response.reset, "websocket tunnel should complete cleanly");
 }
 
 #[test]


### PR DESCRIPTION
Closes #255 

## Summary

- WebSocket upgrade requests to `http://` upstreams were silently broken: the bridge
  unconditionally stripped `Connection` and `Upgrade` as hop-by-hop headers, and the
  forwarding path never entered tunnel mode for H1 backends. The backend received a
  plain GET and the client never got a `101 Switching Protocols` response.
- Added `h3_websocket_request_kind` detection in the bridge and a new H1 tunnel path
  in forwarding that preserves upgrade headers and manages the duplex stream lifecycle
  for `http://` backends.
- Split `crates/bridge` into `lib.rs` (shared types and utilities), `h3_to_h2.rs`
  (H2/extended-CONNECT path), and `h3_to_h1.rs` (H1 path including legacy WS upgrade)
  to eliminate `BackendScheme::Http` checks leaking into the H2 builder.

## What changed

**`crates/bridge`**
- `lib.rs` — new home for shared types (`ForwardedContext`, `ForwardedHeaderChains`,
  `ForwardedHeaderValues`, `H3WebsocketRequestKind`), shared helpers
  (`resolve_upstream_host_value`, `build_forwarded_header_values`,
  `connection_header_tokens`, `should_strip_request_header`), and websocket detection
  (`h3_websocket_request_kind`, `h3_websocket_tunnel_requested`)
- `h3_to_h2.rs` — H2-only builder; `preserve_legacy_upgrade_headers` flag removed;
  all existing `spooky_bridge::h3_to_h2::*` imports re-exported unchanged
- `h3_to_h1.rs` — new H1 builder with `preserve_upgrade` for legacy WS tunnel; adds
  `TE: trailers` on plain requests, omits it on upgrade tunnels

**`crates/edge`**
- `validation.rs` — `h3_upgrade_requested && !websocket_tunnel` gate allows legacy WS
  upgrade through; non-websocket upgrade headers still rejected with 400
- `forwarding.rs` — `build_http1_websocket_tunnel_request` and
  `forward_http1_websocket_tunnel` added; `websocket_tunnel` flag drives `TunnelMode`
  selection per backend scheme
- `types.rs` — `TunnelMode::Websocket` variant added
- Test fixes: `make_envelope` missing `tunnel_mode` field; stale rejection test replaced
  with separate rejection (non-WS) and acceptance (WS) tests
