### PR TITLE
fix(observability): correct backend connect metric and 5xx success miscounting

### DIFF
--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -207,13 +207,15 @@ mod tests {
         );
         metrics.inc_backend_dns_refresh_failure();
         metrics.inc_backend_client_rotation("backend.internal:443");
-        metrics.record_backend_connect_attempt(
+        metrics.record_backend_connect(
             "backend.internal:443",
             "backend.internal",
-            &[
-                "10.0.0.10:443".parse().expect("addr one"),
-                "10.0.0.11:443".parse().expect("addr two"),
-            ],
+            "10.0.0.10:443".parse().expect("addr one"),
+        );
+        metrics.record_backend_connect(
+            "backend.internal:443",
+            "backend.internal",
+            "10.0.0.11:443".parse().expect("addr two"),
         );
 
         let output = metrics.render_prometheus();

--- a/crates/edge/src/metrics/mod.rs
+++ b/crates/edge/src/metrics/mod.rs
@@ -670,28 +670,20 @@ impl Metrics {
         }
     }
 
-    pub fn record_backend_connect_attempt(
+    pub fn record_backend_connect(
         &self,
         backend: &str,
         hostname: &str,
-        resolved_addrs: &[std::net::SocketAddr],
+        resolved_addr: std::net::SocketAddr,
     ) {
-        let labels = if resolved_addrs.is_empty() {
-            vec!["unresolved".to_string()]
-        } else {
-            resolved_addrs.iter().map(ToString::to_string).collect()
-        };
-
         if let Ok(mut guard) = self.backend_connect_attempts.write() {
-            for resolved_addr in labels {
-                *guard
-                    .entry(BackendConnectAttemptKey {
-                        backend: backend.to_string(),
-                        hostname: hostname.to_string(),
-                        resolved_addr,
-                    })
-                    .or_default() += 1;
-            }
+            *guard
+                .entry(BackendConnectAttemptKey {
+                    backend: backend.to_string(),
+                    hostname: hostname.to_string(),
+                    resolved_addr: resolved_addr.to_string(),
+                })
+                .or_default() += 1;
         }
     }
 

--- a/crates/edge/src/metrics/prometheus.rs
+++ b/crates/edge/src/metrics/prometheus.rs
@@ -618,7 +618,7 @@ impl Metrics {
         );
         out.push_str("# TYPE spooky_backend_client_rotations counter\n");
         out.push_str(
-            "# HELP spooky_backend_connect_attempt_total Observed backend send attempts grouped by backend identity, hostname, and retained resolved address.\n",
+            "# HELP spooky_backend_connect_attempt_total Observed upstream socket connects grouped by backend identity, hostname, and resolved address.\n",
         );
         out.push_str("# TYPE spooky_backend_connect_attempt_total counter\n");
         for (backend, state) in self.snapshot_backend_dns_state() {

--- a/crates/edge/src/quic_listener/bootstrap_tls.rs
+++ b/crates/edge/src/quic_listener/bootstrap_tls.rs
@@ -304,7 +304,7 @@ impl QUICListener {
                             let alt = alt_svc_conn.clone();
                             let transport_pool = Arc::clone(&transport_pool);
                             let backend_endpoints = Arc::clone(&backend_endpoints);
-                            let backend_resolution_store = Arc::clone(&backend_resolution_store);
+                            let _backend_resolution_store = Arc::clone(&backend_resolution_store);
                             let upstream_policies = Arc::clone(&upstream_policies);
                             let metrics = Arc::clone(&metrics);
                             let resilience = Arc::clone(&resilience);
@@ -710,7 +710,16 @@ impl QUICListener {
                                     )
                                     .await
                                     {
-                                        Ok(Ok(s)) => s,
+                                        Ok(Ok(s)) => {
+                                            if let Ok(resolved_addr) = s.peer_addr() {
+                                                metrics.record_backend_connect(
+                                                    &backend_target,
+                                                    endpoint.authority_host(),
+                                                    resolved_addr,
+                                                );
+                                            }
+                                            s
+                                        }
                                         Ok(Err(err)) => {
                                             warn!("Bootstrap WebSocket connect error: {}", err);
                                             return Ok(Response::builder()
@@ -800,11 +809,6 @@ impl QUICListener {
                                         }
                                     }
                                 } else {
-                                    Self::record_backend_connect_attempt(
-                                        &metrics,
-                                        &backend_resolution_store,
-                                        &backend_addr,
-                                    );
                                     match tokio::time::timeout(
                                         backend_timeout,
                                         transport_pool.send(&backend_addr, upstream_req),

--- a/crates/edge/src/quic_listener/forwarding.rs
+++ b/crates/edge/src/quic_listener/forwarding.rs
@@ -206,6 +206,7 @@ impl QUICListener {
         traceparent: Option<String>,
         mut body_rx: mpsc::Receiver<Bytes>,
         backend_timeout: Duration,
+        metrics: Arc<Metrics>,
     ) -> ForwardResult {
         let request = Self::build_http1_websocket_tunnel_request(
             &endpoint,
@@ -226,6 +227,14 @@ impl QUICListener {
         .await
         .map_err(|_| ProxyError::Timeout)?
         .map_err(|err| ProxyError::Transport(err.to_string()))?;
+        let resolved_addr = stream
+            .peer_addr()
+            .map_err(|err| ProxyError::Transport(err.to_string()))?;
+        metrics.record_backend_connect(
+            endpoint.authority(),
+            endpoint.authority_host(),
+            resolved_addr,
+        );
         let io = TokioIo::new(stream);
         let (mut sender, conn) = client_http1::handshake(io)
             .await
@@ -1246,8 +1255,7 @@ impl QUICListener {
                             let retry_budget = Arc::clone(&resilience.retry_budget);
                             let route_name = upstream_name.clone();
                             let backend_endpoints = Arc::clone(&backend_endpoints);
-                            let backend_resolutions = Arc::clone(&backend_resolution_store);
-                            let send_metrics = Arc::clone(&metrics);
+                            let _backend_resolutions = Arc::clone(&backend_resolution_store);
                             let allow_hedge = !is_tunnel_mode(tunnel_mode)
                                 && bodyless_mode
                                 && resilience.hedging_allowed_for(&method, &upstream_name, true);
@@ -1277,6 +1285,7 @@ impl QUICListener {
                             let path_for_upstream = path.clone();
                             let authority_for_upstream = authority.clone();
                             let traceparent_for_upstream = traceparent.clone();
+                            let upstream_metrics = Arc::clone(&metrics);
                             let fut = async move {
                                 let mut hedge_telemetry = crate::HedgeTelemetry::default();
                                 let mut retry_count: u8 = 0;
@@ -1291,19 +1300,12 @@ impl QUICListener {
                                             BoxBody<Bytes, std::convert::Infallible>,
                                         >,
                                          cb: Arc<crate::resilience::CircuitBreakers>,
-                                         transport: Arc<UpstreamTransportPool>,
-                                         metrics: Arc<Metrics>,
-                                         backend_resolutions: Arc<RuntimeBackendResolutionStore>| async move {
+                                         transport: Arc<UpstreamTransportPool>| async move {
                                             if !cb.allow_request(&backend) {
                                                 return Err(ProxyError::Pool(
                                                     PoolError::CircuitOpen(backend),
                                                 ));
                                             }
-                                            Self::record_backend_connect_attempt(
-                                                &metrics,
-                                                &backend_resolutions,
-                                                &backend,
-                                            );
                                             let send_result = tokio::time::timeout(
                                                 backend_timeout,
                                                 transport.send(&backend, req),
@@ -1335,6 +1337,7 @@ impl QUICListener {
                                             traceparent_for_upstream.clone(),
                                             body_rx,
                                             backend_timeout,
+                                            Arc::clone(&upstream_metrics),
                                         )
                                         .await?
                                     } else {
@@ -1359,8 +1362,6 @@ impl QUICListener {
                                                 request,
                                                 Arc::clone(&cb),
                                                 Arc::clone(&transport),
-                                                Arc::clone(&send_metrics),
-                                                Arc::clone(&backend_resolutions),
                                             );
                                             tokio::pin!(primary_fut);
                                             let hedge_sleep = tokio::time::sleep(hedge_delay);
@@ -1378,9 +1379,7 @@ impl QUICListener {
                                                     hedge_request,
                                                     Arc::clone(&cb),
                                                     Arc::clone(&transport),
-                                                    Arc::clone(&send_metrics),
-                                                    Arc::clone(&backend_resolutions),
-                                                );
+                                                        );
                                                 tokio::pin!(hedge_fut);
                                                 tokio::select! {
                                                     result = &mut primary_fut => {
@@ -1405,8 +1404,6 @@ impl QUICListener {
                                                 request,
                                                 Arc::clone(&cb),
                                                 Arc::clone(&transport),
-                                                Arc::clone(&send_metrics),
-                                                Arc::clone(&backend_resolutions),
                                             )
                                             .await?
                                         }
@@ -1416,8 +1413,6 @@ impl QUICListener {
                                             request,
                                             Arc::clone(&cb),
                                             Arc::clone(&transport),
-                                            Arc::clone(&send_metrics),
-                                            Arc::clone(&backend_resolutions),
                                         )
                                         .await
                                         {
@@ -1458,9 +1453,7 @@ impl QUICListener {
                                                         retry_request,
                                                         Arc::clone(&cb),
                                                         Arc::clone(&transport),
-                                                        Arc::clone(&send_metrics),
-                                                        Arc::clone(&backend_resolutions),
-                                                    )
+                                                                    )
                                                     .await?
                                                 } else {
                                                     return Err(primary_err);

--- a/crates/edge/src/quic_listener/forwarding.rs
+++ b/crates/edge/src/quic_listener/forwarding.rs
@@ -324,6 +324,14 @@ impl QUICListener {
         )
     }
 
+    fn request_metrics_outcome_for_status(status: StatusCode) -> (bool, RouteOutcome) {
+        if status.is_server_error() {
+            (false, RouteOutcome::Failure)
+        } else {
+            (true, RouteOutcome::Success)
+        }
+    }
+
     pub(super) fn pick_alternate_backend(
         upstream_pool: &Arc<RwLock<UpstreamPool>>,
         primary_index: usize,
@@ -2424,7 +2432,7 @@ impl QUICListener {
                             }
                         }
 
-                        // Update health/metrics for successful upstream response.
+                        // Update health/metrics for upstream response.
                         if let Some(req) = streams.get(&stream_id) {
                             if let (Some(addr), Some(idx)) = (&req.backend_addr, req.backend_index)
                                 && let Some(pool) = req.upstream_pool.as_ref()
@@ -2447,13 +2455,15 @@ impl QUICListener {
                                     Self::log_health_transition(addr, t);
                                 }
                             }
-                            metrics.inc_success();
+                            let (is_success, route_outcome) =
+                                Self::request_metrics_outcome_for_status(status);
+                            if is_success {
+                                metrics.inc_success();
+                            } else {
+                                metrics.inc_failure();
+                            }
                             let route_label = req.upstream_name.as_deref().unwrap_or("unrouted");
-                            metrics.record_route(
-                                route_label,
-                                req.start.elapsed(),
-                                RouteOutcome::Success,
-                            );
+                            metrics.record_route(route_label, req.start.elapsed(), route_outcome);
                             resilience
                                 .adaptive_admission
                                 .observe(req.start.elapsed(), false);
@@ -3047,6 +3057,28 @@ mod tests {
             QUICListener::classify_upstream_failure_reason(false, "request timed out"),
             (HealthFailureReason::Timeout, "timeout")
         );
+    }
+
+    #[test]
+    fn request_metrics_treat_server_error_as_failure() {
+        let (is_success, route_outcome) =
+            QUICListener::request_metrics_outcome_for_status(StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(!is_success);
+        match route_outcome {
+            RouteOutcome::Failure => {}
+            _ => panic!("unexpected route outcome"),
+        }
+    }
+
+    #[test]
+    fn request_metrics_treat_success_response_as_success() {
+        let (is_success, route_outcome) =
+            QUICListener::request_metrics_outcome_for_status(StatusCode::OK);
+        assert!(is_success);
+        match route_outcome {
+            RouteOutcome::Success => {}
+            _ => panic!("unexpected route outcome"),
+        }
     }
 
     #[derive(Debug)]

--- a/crates/edge/src/quic_listener/health_check.rs
+++ b/crates/edge/src/quic_listener/health_check.rs
@@ -5,7 +5,7 @@ impl QUICListener {
         upstream_pools: HashMap<String, Arc<RwLock<UpstreamPool>>>,
         transport_pool: Arc<UpstreamTransportPool>,
         backend_endpoints: Arc<HashMap<String, BackendEndpoint>>,
-        backend_resolution_store: Arc<RuntimeBackendResolutionStore>,
+        _backend_resolution_store: Arc<RuntimeBackendResolutionStore>,
         metrics: Arc<Metrics>,
         task_registry: Arc<RuntimeTaskRegistry>,
     ) {
@@ -84,7 +84,7 @@ impl QUICListener {
 
         for (base_interval_ms, mut jobs) in grouped_jobs {
             let transport_pool = Arc::clone(&transport_pool);
-            let backend_resolution_store = Arc::clone(&backend_resolution_store);
+            let _backend_resolution_store = Arc::clone(&_backend_resolution_store);
             let task_metrics = Arc::clone(&metrics);
             let handle = handle.clone();
             let supervise_metrics = Arc::clone(&task_metrics);
@@ -115,11 +115,6 @@ impl QUICListener {
                                 Err(_) => continue,
                             };
 
-                            Self::record_backend_connect_attempt(
-                                &task_metrics,
-                                &backend_resolution_store,
-                                &job.backend_identity,
-                            );
                             let result = tokio::time::timeout(
                                 job.timeout,
                                 transport_pool.send(&job.backend_identity, request),

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -461,20 +461,13 @@ impl QUICListener {
         }
     }
 
-    fn record_backend_connect_attempt(
+    fn record_backend_connect(
         metrics: &Metrics,
-        backend_resolution_store: &RuntimeBackendResolutionStore,
         backend: &str,
+        hostname: &str,
+        resolved_addr: StdSocketAddr,
     ) {
-        if let Some(resolution) = backend_resolution_store.get(backend) {
-            metrics.record_backend_connect_attempt(
-                backend,
-                &resolution.authority_host,
-                &resolution.resolved_addrs,
-            );
-        } else {
-            metrics.record_backend_connect_attempt(backend, backend, &[]);
-        }
+        metrics.record_backend_connect(backend, hostname, resolved_addr);
     }
 
     pub fn build_shared_state(config: &RuntimeConfig) -> Result<SharedRuntimeState, ProxyError> {
@@ -610,11 +603,26 @@ impl QUICListener {
             }
         }
 
+        let mut route_labels = config.upstreams.keys().cloned().collect::<Vec<_>>();
+        route_labels.push("unrouted".to_string());
+        let routing_index = Arc::new(RouteIndex::from_upstreams(&config.upstreams_as_config()));
+        let metrics = Arc::new(Metrics::new(worker_slots, route_labels));
         let backend_dns_resolver = SharedDnsResolver::new();
         let backend_resolution_store =
             Arc::new(RuntimeBackendResolutionStore::new(backend_resolutions));
+        let connect_metrics = Arc::clone(&metrics);
+        let connect_observer: spooky_transport::h2_client::ConnectObserver = Arc::new(
+            move |observation: spooky_transport::h2_client::ConnectObservation| {
+                Self::record_backend_connect(
+                    &connect_metrics,
+                    &observation.backend,
+                    &observation.hostname,
+                    observation.resolved_addr,
+                );
+            },
+        );
         let transport_pool = Arc::new(
-            UpstreamTransportPool::new(
+            UpstreamTransportPool::new_with_observer(
                 backend_transports,
                 backend_tls_configs,
                 max_inflight_per_backend,
@@ -622,6 +630,7 @@ impl QUICListener {
                 Duration::from_millis(config.performance.h2_pool_idle_timeout_ms),
                 Duration::from_millis(config.performance.backend_connect_timeout_ms),
                 backend_dns_resolver.clone(),
+                Some(connect_observer),
             )
             .map_err(ProxyError::Tls)?,
         );
@@ -676,10 +685,6 @@ impl QUICListener {
             global_inflight_limit,
         ));
         let watchdog = Arc::new(WatchdogCoordinator::new(&config.resilience.watchdog));
-        let mut route_labels = config.upstreams.keys().cloned().collect::<Vec<_>>();
-        route_labels.push("unrouted".to_string());
-        let routing_index = Arc::new(RouteIndex::from_upstreams(&config.upstreams_as_config()));
-        let metrics = Arc::new(Metrics::new(worker_slots, route_labels));
         for (listener_label, inventory) in listener_tls_store.snapshot() {
             Self::update_listener_tls_expiry_metrics(&metrics, &listener_label, &inventory);
         }

--- a/crates/transport/src/h1_client.rs
+++ b/crates/transport/src/h1_client.rs
@@ -1,31 +1,26 @@
 use http_body_util::combinators::BoxBody;
 use hyper::Request;
 use hyper::body::Bytes;
-use hyper_util::client::legacy::{Client, connect::HttpConnector};
+use hyper_util::client::legacy::Client;
 use std::convert::Infallible;
 
 use crate::h2_client::{
-    DEFAULT_CONNECT_TIMEOUT, DEFAULT_MAX_IDLE_PER_HOST, DEFAULT_POOL_IDLE_TIMEOUT,
-    SharedDnsResolver, TokioExecutor,
+    ConnectObserver, DEFAULT_CONNECT_TIMEOUT, DEFAULT_MAX_IDLE_PER_HOST, DEFAULT_POOL_IDLE_TIMEOUT,
+    ObservedHttpConnector, SharedDnsResolver, TokioExecutor, build_observed_http_connector,
 };
 
 pub struct H1Client {
-    client: Client<HttpConnector<SharedDnsResolver>, BoxBody<Bytes, Infallible>>,
+    client: Client<ObservedHttpConnector, BoxBody<Bytes, Infallible>>,
 }
 
 impl Default for H1Client {
     fn default() -> Self {
-        let dns_resolver = SharedDnsResolver::new();
-        let mut http = HttpConnector::new_with_resolver(dns_resolver);
-        http.enforce_http(true);
-        http.set_connect_timeout(Some(DEFAULT_CONNECT_TIMEOUT));
-
-        let client = Client::builder(TokioExecutor)
-            .pool_max_idle_per_host(DEFAULT_MAX_IDLE_PER_HOST)
-            .pool_idle_timeout(DEFAULT_POOL_IDLE_TIMEOUT)
-            .build(http);
-
-        Self { client }
+        Self::new(
+            DEFAULT_MAX_IDLE_PER_HOST,
+            DEFAULT_POOL_IDLE_TIMEOUT,
+            DEFAULT_CONNECT_TIMEOUT,
+            SharedDnsResolver::new(),
+        )
     }
 }
 
@@ -36,9 +31,24 @@ impl H1Client {
         connect_timeout: std::time::Duration,
         dns_resolver: SharedDnsResolver,
     ) -> Self {
-        let mut http = HttpConnector::new_with_resolver(dns_resolver);
-        http.enforce_http(true);
-        http.set_connect_timeout(Some(connect_timeout));
+        Self::new_with_observer(
+            max_idle_per_host,
+            pool_idle_timeout,
+            connect_timeout,
+            dns_resolver,
+            None,
+        )
+    }
+
+    pub fn new_with_observer(
+        max_idle_per_host: usize,
+        pool_idle_timeout: std::time::Duration,
+        connect_timeout: std::time::Duration,
+        dns_resolver: SharedDnsResolver,
+        connect_observer: Option<ConnectObserver>,
+    ) -> Self {
+        let http =
+            build_observed_http_connector(dns_resolver, true, connect_timeout, connect_observer);
 
         let client = Client::builder(TokioExecutor)
             .pool_max_idle_per_host(max_idle_per_host)

--- a/crates/transport/src/h1_pool.rs
+++ b/crates/transport/src/h1_pool.rs
@@ -11,7 +11,7 @@ use hyper::body::{Bytes, Incoming};
 use tokio::sync::{Semaphore, TryAcquireError};
 
 use crate::h1_client::H1Client;
-use crate::h2_client::SharedDnsResolver;
+use crate::h2_client::{ConnectObserver, SharedDnsResolver};
 pub use spooky_errors::PoolError;
 
 struct BackendClientState {
@@ -29,6 +29,7 @@ pub struct H1Pool {
     pool_idle_timeout: Duration,
     connect_timeout: Duration,
     dns_resolver: SharedDnsResolver,
+    connect_observer: Option<ConnectObserver>,
 }
 
 impl H1Pool {
@@ -43,15 +44,39 @@ impl H1Pool {
     where
         I: IntoIterator<Item = String>,
     {
+        Self::new_with_observer(
+            backends,
+            max_inflight,
+            max_idle_per_backend,
+            pool_idle_timeout,
+            connect_timeout,
+            dns_resolver,
+            None,
+        )
+    }
+
+    pub fn new_with_observer<I>(
+        backends: I,
+        max_inflight: usize,
+        max_idle_per_backend: usize,
+        pool_idle_timeout: Duration,
+        connect_timeout: Duration,
+        dns_resolver: SharedDnsResolver,
+        connect_observer: Option<ConnectObserver>,
+    ) -> Self
+    where
+        I: IntoIterator<Item = String>,
+    {
         let inflight = max_inflight.max(1);
         let max_idle_per_backend = max_idle_per_backend.max(1);
         let mut map = HashMap::new();
         for backend in backends {
-            let client = Arc::new(H1Client::new(
+            let client = Arc::new(H1Client::new_with_observer(
                 max_idle_per_backend,
                 pool_idle_timeout,
                 connect_timeout,
                 dns_resolver.clone(),
+                connect_observer.clone(),
             ));
             map.insert(
                 backend,
@@ -68,6 +93,7 @@ impl H1Pool {
             pool_idle_timeout,
             connect_timeout,
             dns_resolver,
+            connect_observer,
         }
     }
 
@@ -102,11 +128,12 @@ impl H1Pool {
             return Ok(false);
         };
 
-        let client = Arc::new(H1Client::new(
+        let client = Arc::new(H1Client::new_with_observer(
             self.max_idle_per_backend,
             self.pool_idle_timeout,
             self.connect_timeout,
             self.dns_resolver.clone(),
+            self.connect_observer.clone(),
         ));
 
         let mut state = handle

--- a/crates/transport/src/h2_client.rs
+++ b/crates/transport/src/h2_client.rs
@@ -246,6 +246,8 @@ pub struct H2Client {
 
 impl Default for H2Client {
     fn default() -> Self {
+        // infallible: default TLS config uses well-known roots and no custom certs
+        #[allow(clippy::expect_used)]
         Self::new(
             DEFAULT_MAX_IDLE_PER_HOST,
             DEFAULT_POOL_IDLE_TIMEOUT,

--- a/crates/transport/src/h2_client.rs
+++ b/crates/transport/src/h2_client.rs
@@ -347,17 +347,6 @@ where
     addrs
 }
 
-fn default_tls_config() -> ClientConfig {
-    let mut roots = RootCertStore::empty();
-    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-
-    let mut cfg = ClientConfig::builder()
-        .with_root_certificates(roots)
-        .with_no_client_auth();
-    cfg.enable_sni = true;
-    cfg
-}
-
 fn build_tls_config(tls: &TlsClientConfig) -> Result<ClientConfig, String> {
     if !tls.verify_certificates {
         warn!(

--- a/crates/transport/src/h2_client.rs
+++ b/crates/transport/src/h2_client.rs
@@ -15,6 +15,7 @@ use std::{
 
 use http_body_util::combinators::BoxBody;
 use hyper::body::Bytes;
+use hyper::http::Uri;
 use hyper::{Request, rt::Executor};
 use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
 use hyper_util::client::legacy::{
@@ -24,6 +25,7 @@ use hyper_util::client::legacy::{
         dns::{GaiResolver, Name},
     },
 };
+use hyper_util::rt::TokioIo;
 
 use log::warn;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
@@ -59,6 +61,15 @@ pub(crate) const DEFAULT_MAX_IDLE_PER_HOST: usize = 64;
 pub(crate) const DEFAULT_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
 pub(crate) const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
+#[derive(Debug, Clone)]
+pub struct ConnectObservation {
+    pub backend: String,
+    pub hostname: String,
+    pub resolved_addr: SocketAddr,
+}
+
+pub type ConnectObserver = Arc<dyn Fn(ConnectObservation) + Send + Sync>;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DnsCacheUpdate {
     pub host: String,
@@ -80,6 +91,66 @@ impl DnsCacheUpdate {
 pub struct SharedDnsResolver {
     cache: Arc<RwLock<HashMap<String, Vec<SocketAddr>>>>,
     fallback: GaiResolver,
+}
+
+#[derive(Clone)]
+pub(crate) struct ObservedHttpConnector {
+    inner: HttpConnector<SharedDnsResolver>,
+    observer: Option<ConnectObserver>,
+}
+
+impl ObservedHttpConnector {
+    fn new(inner: HttpConnector<SharedDnsResolver>, observer: Option<ConnectObserver>) -> Self {
+        Self { inner, observer }
+    }
+}
+
+pub(crate) fn build_observed_http_connector(
+    dns_resolver: SharedDnsResolver,
+    enforce_http: bool,
+    connect_timeout: Duration,
+    connect_observer: Option<ConnectObserver>,
+) -> ObservedHttpConnector {
+    let mut http = HttpConnector::new_with_resolver(dns_resolver);
+    http.enforce_http(enforce_http);
+    http.set_connect_timeout(Some(connect_timeout));
+    ObservedHttpConnector::new(http, connect_observer)
+}
+
+impl Service<Uri> for ObservedHttpConnector {
+    type Response = TokioIo<tokio::net::TcpStream>;
+    type Error = <HttpConnector<SharedDnsResolver> as Service<Uri>>::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, dst: Uri) -> Self::Future {
+        let mut inner = self.inner.clone();
+        let observer = self.observer.clone();
+        Box::pin(async move {
+            let stream = inner.call(dst.clone()).await?;
+            if let Some(observer) = observer
+                && let Ok(resolved_addr) = stream.inner().peer_addr()
+            {
+                let backend = dst
+                    .authority()
+                    .map(|authority: &hyper::http::uri::Authority| authority.as_str().to_string())
+                    .unwrap_or_else(|| dst.to_string());
+                let hostname = dst
+                    .host()
+                    .map(ToString::to_string)
+                    .unwrap_or_else(|| backend.clone());
+                observer(ConnectObservation {
+                    backend,
+                    hostname,
+                    resolved_addr,
+                });
+            }
+            Ok(stream)
+        })
+    }
 }
 
 impl SharedDnsResolver {
@@ -170,29 +241,19 @@ impl Service<Name> for SharedDnsResolver {
 }
 
 pub struct H2Client {
-    client: Client<HttpsConnector<HttpConnector<SharedDnsResolver>>, BoxBody<Bytes, Infallible>>,
+    client: Client<HttpsConnector<ObservedHttpConnector>, BoxBody<Bytes, Infallible>>,
 }
 
 impl Default for H2Client {
     fn default() -> Self {
-        let dns_resolver = SharedDnsResolver::new();
-        let mut http = HttpConnector::new_with_resolver(dns_resolver);
-        http.enforce_http(false);
-        http.set_connect_timeout(Some(DEFAULT_CONNECT_TIMEOUT));
-
-        let https = HttpsConnectorBuilder::new()
-            .with_tls_config(default_tls_config())
-            .https_or_http()
-            .enable_http2()
-            .wrap_connector(http);
-
-        let client = Client::builder(TokioExecutor)
-            .http2_only(true)
-            .pool_max_idle_per_host(DEFAULT_MAX_IDLE_PER_HOST)
-            .pool_idle_timeout(DEFAULT_POOL_IDLE_TIMEOUT)
-            .build(https);
-
-        Self { client }
+        Self::new(
+            DEFAULT_MAX_IDLE_PER_HOST,
+            DEFAULT_POOL_IDLE_TIMEOUT,
+            DEFAULT_CONNECT_TIMEOUT,
+            TlsClientConfig::default(),
+            SharedDnsResolver::new(),
+        )
+        .expect("default H2 client should build")
     }
 }
 
@@ -217,9 +278,26 @@ impl H2Client {
         tls: TlsClientConfig,
         dns_resolver: SharedDnsResolver,
     ) -> Result<Self, String> {
-        let mut http = HttpConnector::new_with_resolver(dns_resolver);
-        http.enforce_http(false);
-        http.set_connect_timeout(Some(connect_timeout));
+        Self::new_with_observer(
+            max_idle_per_host,
+            pool_idle_timeout,
+            connect_timeout,
+            tls,
+            dns_resolver,
+            None,
+        )
+    }
+
+    pub fn new_with_observer(
+        max_idle_per_host: usize,
+        pool_idle_timeout: Duration,
+        connect_timeout: Duration,
+        tls: TlsClientConfig,
+        dns_resolver: SharedDnsResolver,
+        connect_observer: Option<ConnectObserver>,
+    ) -> Result<Self, String> {
+        let http =
+            build_observed_http_connector(dns_resolver, false, connect_timeout, connect_observer);
 
         let tls_config = build_tls_config(&tls)?;
         let https = HttpsConnectorBuilder::new()

--- a/crates/transport/src/h2_pool.rs
+++ b/crates/transport/src/h2_pool.rs
@@ -10,7 +10,7 @@ use hyper::Request;
 use hyper::body::{Bytes, Incoming};
 use tokio::sync::{Semaphore, TryAcquireError};
 
-use crate::h2_client::{H2Client, SharedDnsResolver, TlsClientConfig};
+use crate::h2_client::{ConnectObserver, H2Client, SharedDnsResolver, TlsClientConfig};
 pub use spooky_errors::PoolError;
 
 struct BackendClientState {
@@ -34,6 +34,7 @@ pub struct H2Pool {
     pool_idle_timeout: Duration,
     connect_timeout: Duration,
     dns_resolver: SharedDnsResolver,
+    connect_observer: Option<ConnectObserver>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -55,17 +56,43 @@ impl H2Pool {
     where
         I: IntoIterator<Item = String>,
     {
+        Self::new_with_observer(
+            backends,
+            backend_tls,
+            max_inflight,
+            max_idle_per_backend,
+            pool_idle_timeout,
+            connect_timeout,
+            dns_resolver,
+            None,
+        )
+    }
+
+    pub fn new_with_observer<I>(
+        backends: I,
+        backend_tls: HashMap<String, TlsClientConfig>,
+        max_inflight: usize,
+        max_idle_per_backend: usize,
+        pool_idle_timeout: Duration,
+        connect_timeout: Duration,
+        dns_resolver: SharedDnsResolver,
+        connect_observer: Option<ConnectObserver>,
+    ) -> Result<Self, String>
+    where
+        I: IntoIterator<Item = String>,
+    {
         let inflight = max_inflight.max(1);
         let max_idle_per_backend = max_idle_per_backend.max(1);
         let mut map = HashMap::new();
         for backend in backends {
             let tls = backend_tls.get(&backend).cloned().unwrap_or_default();
-            let client = Arc::new(H2Client::new(
+            let client = Arc::new(H2Client::new_with_observer(
                 max_idle_per_backend,
                 pool_idle_timeout,
                 connect_timeout,
                 tls.clone(),
                 dns_resolver.clone(),
+                connect_observer.clone(),
             )?);
             map.insert(
                 backend,
@@ -85,6 +112,7 @@ impl H2Pool {
             pool_idle_timeout,
             connect_timeout,
             dns_resolver,
+            connect_observer,
         })
     }
 
@@ -100,12 +128,13 @@ impl H2Pool {
             return Ok(None);
         };
 
-        let client = Arc::new(H2Client::new(
+        let client = Arc::new(H2Client::new_with_observer(
             self.max_idle_per_backend,
             self.pool_idle_timeout,
             self.connect_timeout,
             handle.tls.clone(),
             self.dns_resolver.clone(),
+            self.connect_observer.clone(),
         )?);
 
         let mut state = handle

--- a/crates/transport/src/h2_pool.rs
+++ b/crates/transport/src/h2_pool.rs
@@ -68,6 +68,7 @@ impl H2Pool {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new_with_observer<I>(
         backends: I,
         backend_tls: HashMap<String, TlsClientConfig>,

--- a/crates/transport/src/transport_pool.rs
+++ b/crates/transport/src/transport_pool.rs
@@ -5,7 +5,7 @@ use hyper::Request;
 use hyper::body::{Bytes, Incoming};
 
 use crate::h1_pool::H1Pool;
-use crate::h2_client::{SharedDnsResolver, TlsClientConfig};
+use crate::h2_client::{ConnectObserver, SharedDnsResolver, TlsClientConfig};
 use crate::h2_pool::H2Pool;
 pub use spooky_errors::PoolError;
 
@@ -34,6 +34,31 @@ impl UpstreamTransportPool {
     where
         I: IntoIterator<Item = (String, BackendTransportKind)>,
     {
+        Self::new_with_observer(
+            backends,
+            backend_tls,
+            max_inflight,
+            max_idle_per_backend,
+            pool_idle_timeout,
+            connect_timeout,
+            dns_resolver,
+            None,
+        )
+    }
+
+    pub fn new_with_observer<I>(
+        backends: I,
+        backend_tls: HashMap<String, TlsClientConfig>,
+        max_inflight: usize,
+        max_idle_per_backend: usize,
+        pool_idle_timeout: Duration,
+        connect_timeout: Duration,
+        dns_resolver: SharedDnsResolver,
+        connect_observer: Option<ConnectObserver>,
+    ) -> Result<Self, String>
+    where
+        I: IntoIterator<Item = (String, BackendTransportKind)>,
+    {
         let mut backend_kinds = HashMap::new();
         let mut h1_backends = Vec::new();
         let mut h2_backends = Vec::new();
@@ -46,15 +71,16 @@ impl UpstreamTransportPool {
             }
         }
 
-        let h1_pool = H1Pool::new(
+        let h1_pool = H1Pool::new_with_observer(
             h1_backends,
             max_inflight,
             max_idle_per_backend,
             pool_idle_timeout,
             connect_timeout,
             dns_resolver.clone(),
+            connect_observer.clone(),
         );
-        let h2_pool = H2Pool::new(
+        let h2_pool = H2Pool::new_with_observer(
             h2_backends,
             backend_tls,
             max_inflight,
@@ -62,6 +88,7 @@ impl UpstreamTransportPool {
             pool_idle_timeout,
             connect_timeout,
             dns_resolver,
+            connect_observer,
         )?;
 
         Ok(Self {

--- a/crates/transport/src/transport_pool.rs
+++ b/crates/transport/src/transport_pool.rs
@@ -46,6 +46,7 @@ impl UpstreamTransportPool {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new_with_observer<I>(
         backends: I,
         backend_tls: HashMap<String, TlsClientConfig>,


### PR DESCRIPTION
## Summary

- **Closes #256** — `spooky_backend_connect_attempt_total` was incremented before every `transport.send()` call, once per retained resolved address, making H1 keep-alive reuse look like new connections and inflating cardinality. The metric now fires via a `ConnectObserver` callback inside the transport layer's HTTP connector, wired to the actual TCP connect. The resolved address is taken from `peer_addr()` on the established stream, so the label reflects the concrete IP that was dialed.

- **Closes #257** — Once an upstream response arrived, the forwarding path unconditionally called `metrics.inc_success()` and recorded `RouteOutcome::Success` regardless of status code. Backend `5xx` responses now map to `metrics.inc_failure()` and `RouteOutcome::Failure`, aligning request metrics with the health classification model that was already treating `5xx` as failures.
