### PR TITLE
fix(control-api): keep runtime-bundle cert reload on the cert-only path

### DIFF
--- a/crates/edge/src/quic_listener/control_api/http.rs
+++ b/crates/edge/src/quic_listener/control_api/http.rs
@@ -273,7 +273,7 @@ impl QUICListener {
         }
     }
 
-    fn reload_listener_certs(
+    pub(super) fn reload_listener_certs(
         listener_runtime_configs: &HashMap<String, ListenerRuntimeConfig>,
         listener_tls_store: &ListenerTlsReloadStore,
         metrics: &Metrics,

--- a/crates/edge/src/quic_listener/control_api/http.rs
+++ b/crates/edge/src/quic_listener/control_api/http.rs
@@ -273,6 +273,63 @@ impl QUICListener {
         }
     }
 
+    fn reload_listener_certs(
+        listener_runtime_configs: &HashMap<String, ListenerRuntimeConfig>,
+        listener_tls_store: &ListenerTlsReloadStore,
+        metrics: &Metrics,
+    ) -> Response<Full<Bytes>> {
+        let mut reloaded = Vec::new();
+        for (listener_label, listener_config) in listener_runtime_configs {
+            let reloaded_state = match Self::build_listener_tls_reload_state(listener_config) {
+                Ok(state) => state,
+                Err(err) => {
+                    return Self::json_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        json!({
+                            "reloaded": false,
+                            "listener": listener_label,
+                            "error": err.to_string(),
+                        }),
+                    );
+                }
+            };
+            let generation = match listener_tls_store.replace_listener(
+                listener_label,
+                reloaded_state.inventory.clone(),
+                reloaded_state.bootstrap_server_config,
+            ) {
+                Ok(generation) => generation,
+                Err(err) => {
+                    return Self::json_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        json!({
+                            "reloaded": false,
+                            "listener": listener_label,
+                            "error": err.to_string(),
+                        }),
+                    );
+                }
+            };
+            Self::update_listener_tls_expiry_metrics(
+                metrics,
+                listener_label,
+                &reloaded_state.inventory,
+            );
+            reloaded.push(json!({
+                "listener": listener_label,
+                "generation": generation,
+            }));
+        }
+
+        Self::json_response(
+            StatusCode::ACCEPTED,
+            json!({
+                "reloaded": true,
+                "listeners": reloaded,
+            }),
+        )
+    }
+
     pub(super) fn handle_control_api_request(
         req: Request<Incoming>,
         state: &ControlApiState,
@@ -399,55 +456,10 @@ impl QUICListener {
             let live_tls_store = state.current_listener_tls_store();
             let live_listener_configs = state.current_listener_runtime_configs();
             let live_metrics = state.current_metrics();
-            let mut reloaded = Vec::new();
-            for (listener_label, listener_config) in live_listener_configs.iter() {
-                let reloaded_state = match Self::build_listener_tls_reload_state(listener_config) {
-                    Ok(state) => state,
-                    Err(err) => {
-                        return Self::json_response(
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            json!({
-                                "reloaded": false,
-                                "listener": listener_label,
-                                "error": err.to_string(),
-                            }),
-                        );
-                    }
-                };
-                let generation = match live_tls_store.replace_listener(
-                    listener_label,
-                    reloaded_state.inventory.clone(),
-                    reloaded_state.bootstrap_server_config,
-                ) {
-                    Ok(generation) => generation,
-                    Err(err) => {
-                        return Self::json_response(
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            json!({
-                                "reloaded": false,
-                                "listener": listener_label,
-                                "error": err.to_string(),
-                            }),
-                        );
-                    }
-                };
-                Self::update_listener_tls_expiry_metrics(
-                    &live_metrics,
-                    listener_label,
-                    &reloaded_state.inventory,
-                );
-                reloaded.push(json!({
-                    "listener": listener_label,
-                    "generation": generation,
-                }));
-            }
-
-            return Self::json_response(
-                StatusCode::ACCEPTED,
-                json!({
-                    "reloaded": true,
-                    "listeners": reloaded,
-                }),
+            return Self::reload_listener_certs(
+                live_listener_configs.as_ref(),
+                live_tls_store.as_ref(),
+                live_metrics.as_ref(),
             );
         }
 
@@ -618,9 +630,25 @@ impl QUICListener {
             return Self::json_response(StatusCode::OK, response);
         }
 
-        if req.method() == Method::POST
-            && (path == paths.reload_certs_path.as_str() || path == paths.reload_path.as_str())
-        {
+        if req.method() == Method::POST && path == paths.reload_certs_path.as_str() {
+            if !Self::control_api_is_authorized(&req, state) {
+                return Self::json_response(
+                    StatusCode::UNAUTHORIZED,
+                    json!({
+                        "reloaded": false,
+                        "error": "unauthorized",
+                    }),
+                );
+            }
+
+            return Self::reload_listener_certs(
+                shared_state.listener_runtime_configs.as_ref(),
+                shared_state.listener_tls_store.as_ref(),
+                shared_state.metrics.as_ref(),
+            );
+        }
+
+        if req.method() == Method::POST && path == paths.reload_path.as_str() {
             if !Self::control_api_is_authorized(&req, state) {
                 return Self::json_response(
                     StatusCode::UNAUTHORIZED,

--- a/crates/edge/src/quic_listener/control_api/tests.rs
+++ b/crates/edge/src/quic_listener/control_api/tests.rs
@@ -1,5 +1,6 @@
 use super::state::ControlApiState;
 use super::*;
+use http_body_util::BodyExt;
 use spooky_config::{
     config::{
         Backend, ClientAuth, Config as SpookyConfigConfig, Listen, LoadBalancing, Log,
@@ -116,6 +117,30 @@ fn control_api_state_with_runtime_bundle(
         started_at: Instant::now(),
         runtime_bundle: Some(Arc::new(RuntimeBundleHandle::new(reloaded_bundle))),
     }
+}
+
+fn runtime_bundle_control_api_state(
+    bundle: RuntimeBundle,
+) -> (ControlApiState, Arc<RuntimeBundleHandle>) {
+    let listener_config = bundle
+        .runtime_config
+        .primary_listener_runtime_config()
+        .expect("listener runtime config");
+    let runtime_handle = Arc::new(RuntimeBundleHandle::new(bundle.clone()));
+    let state = ControlApiState {
+        control_api: bundle.runtime_config.observability.control_api.clone(),
+        metrics: Arc::clone(&bundle.shared_state.metrics),
+        resilience: Arc::clone(&bundle.shared_state.resilience),
+        watchdog: Arc::clone(&bundle.shared_state.watchdog),
+        upstream_pools: bundle.shared_state.upstream_pools.clone(),
+        listener_runtime_configs: Arc::clone(&bundle.shared_state.listener_runtime_configs),
+        listener_tls_store: Arc::clone(&bundle.shared_state.listener_tls_store),
+        primary_listener_label: QUICListener::listener_label(&listener_config),
+        expected_workers: 1,
+        started_at: Instant::now(),
+        runtime_bundle: Some(Arc::clone(&runtime_handle)),
+    };
+    (state, runtime_handle)
 }
 
 #[test]
@@ -389,5 +414,81 @@ fn validate_startup_owned_reload_compatibility_rejects_control_plane_thread_chan
         issues
             .iter()
             .any(|issue| issue.contains("performance.control_plane_threads"))
+    );
+}
+
+#[tokio::test]
+async fn runtime_bundle_cert_reload_ignores_unrelated_config_drift_and_bundle_swap() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+    let mut live = test_config(cert.clone(), key.clone());
+    live.observability.metrics.enabled = true;
+    live.observability.metrics.path = "/metrics-live".to_string();
+
+    let live_bundle = runtime_bundle_from_config("live.yaml", &live);
+    let (state, runtime_handle) = runtime_bundle_control_api_state(live_bundle);
+
+    let mut drifted = live.clone();
+    drifted.observability.metrics.path = "/metrics-drifted".to_string();
+    drifted.performance.control_plane_threads =
+        live.performance.control_plane_threads.saturating_add(1);
+    let drifted_bundle = runtime_bundle_from_config("drifted.yaml", &drifted);
+    let full_reload_issues = QUICListener::validate_startup_owned_reload_compatibility(
+        runtime_handle.current().as_ref(),
+        &drifted_bundle,
+    );
+    assert!(
+        full_reload_issues
+            .iter()
+            .any(|issue| issue.contains("performance.control_plane_threads")),
+        "expected a full reload blocker from on-disk drift, got: {full_reload_issues:?}"
+    );
+
+    let generation_before = runtime_handle.generation();
+    let tls_generation_before = runtime_handle
+        .current()
+        .shared_state
+        .listener_tls_store
+        .generation(&state.primary_listener_label)
+        .unwrap_or(0);
+
+    let response = QUICListener::reload_listener_certs(
+        runtime_handle
+            .current()
+            .shared_state
+            .listener_runtime_configs
+            .as_ref(),
+        runtime_handle
+            .current()
+            .shared_state
+            .listener_tls_store
+            .as_ref(),
+        runtime_handle.current().shared_state.metrics.as_ref(),
+    );
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+    let body = response
+        .into_body()
+        .collect()
+        .await
+        .expect("collect response body")
+        .to_bytes();
+    let payload: serde_json::Value = serde_json::from_slice(&body).expect("response json");
+    assert_eq!(payload["reloaded"], serde_json::Value::Bool(true));
+
+    let current_runtime = runtime_handle.current();
+    assert_eq!(current_runtime.generation, generation_before);
+    assert_eq!(
+        current_runtime.runtime_config.observability.metrics.path,
+        "/metrics-live"
+    );
+    assert!(
+        current_runtime
+            .shared_state
+            .listener_tls_store
+            .generation(&state.primary_listener_label)
+            .unwrap_or(0)
+            > tls_generation_before,
+        "expected cert reload to rotate the live listener TLS generation"
     );
 }


### PR DESCRIPTION
Fixes: #258

## Summary

- route runtime-bundle `POST /admin/runtime/reload-certs` through a dedicated cert-only reload path
- prevent cert reloads from re-reading the full config, rebuilding shared state, or swapping the runtime bundle
- add regression coverage proving unrelated config drift does not get applied or block cert-only reloads

## Problem

In runtime-bundle mode, the control API handled `reload` and `reload-certs` in the same branch. That made `POST /admin/runtime/reload-certs` behave like a full config reload:

- it re-read the full config
- rebuilt shared state
- ran runtime reload compatibility checks
- started a new generation of background tasks
- swapped the runtime bundle

This was wrong for certificate rotation. A cert reload could silently apply unrelated config drift or fail because of unrelated full-reload blockers.

## Fix

- extracted a shared `reload_listener_certs` helper for the live TLS reload flow
- wired non-runtime-bundle `reload-certs` through that helper
- wired runtime-bundle `reload-certs` through the same helper instead of the full reload branch
- kept full runtime bundle replacement behavior only on `POST /admin/runtime/reload`

## Tests

Added regression coverage to verify that in runtime-bundle mode:

- cert-only reload succeeds when unrelated config drift would block a full reload
- runtime bundle generation does not change during cert-only reload
- unrelated runtime settings are not applied by cert-only reload
- live listener TLS generation still advances on cert reload
