### PR TITLE
feat(observability): add richer request metrics and structured startup logs

### DIFF
--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -31,15 +31,36 @@ mod tests {
     fn metrics_render_includes_route_percentiles() {
         let metrics = Metrics::new(1, [String::from("api_pool")]);
         metrics.record_route("api_pool", Duration::from_millis(12), RouteOutcome::Success);
+        metrics.record_request_result(
+            "api_pool",
+            Some("https://10.0.0.10:443"),
+            Some(200),
+            RouteOutcome::Success,
+            Duration::from_millis(12),
+        );
         metrics.record_route(
             "api_pool",
             Duration::from_millis(320),
             RouteOutcome::Timeout,
         );
+        metrics.record_request_result(
+            "api_pool",
+            Some("https://10.0.0.10:443"),
+            Some(503),
+            RouteOutcome::Timeout,
+            Duration::from_millis(320),
+        );
         metrics.record_route(
             "api_pool",
             Duration::from_millis(900),
             RouteOutcome::BackendError,
+        );
+        metrics.record_request_result(
+            "api_pool",
+            Some("https://10.0.0.11:443"),
+            Some(502),
+            RouteOutcome::BackendError,
+            Duration::from_millis(900),
         );
 
         let output = metrics.render_prometheus();
@@ -47,6 +68,21 @@ mod tests {
         assert!(output.contains("spooky_route_latency_ms_p50{route=\"api_pool\"}"));
         assert!(output.contains("spooky_route_latency_ms_p95{route=\"api_pool\"}"));
         assert!(output.contains("spooky_route_latency_ms_p99{route=\"api_pool\"}"));
+        assert!(output.contains(
+            "spooky_upstream_requests_total{upstream=\"api_pool\",status_class=\"2xx\",outcome=\"success\"} 1"
+        ));
+        assert!(output.contains(
+            "spooky_upstream_requests_total{upstream=\"api_pool\",status_class=\"5xx\",outcome=\"timeout\"} 1"
+        ));
+        assert!(output.contains(
+            "spooky_backend_requests_total{upstream=\"api_pool\",backend=\"https://10.0.0.11:443\",status_class=\"5xx\",outcome=\"backend_error\"} 1"
+        ));
+        assert!(output.contains(
+            "spooky_upstream_request_latency_ms_bucket{upstream=\"api_pool\",outcome=\"success\",le=\"25\"} 1"
+        ));
+        assert!(output.contains(
+            "spooky_upstream_request_latency_ms_count{upstream=\"api_pool\",outcome=\"backend_error\"} 1"
+        ));
     }
 
     #[test]

--- a/crates/edge/src/metrics/mod.rs
+++ b/crates/edge/src/metrics/mod.rs
@@ -95,6 +95,9 @@ pub struct Metrics {
     backend_dns_state: RwLock<HashMap<String, BackendDnsState>>,
     backend_rotation_state: RwLock<HashMap<String, BackendRotationState>>,
     backend_connect_attempts: RwLock<HashMap<BackendConnectAttemptKey, u64>>,
+    upstream_request_counts: RwLock<HashMap<UpstreamRequestCountKey, u64>>,
+    backend_request_counts: RwLock<HashMap<BackendRequestCountKey, u64>>,
+    upstream_request_latency: RwLock<HashMap<UpstreamRequestLatencyKey, RequestLatencyStats>>,
     downstream_tls_handshake_failures: RwLock<HashMap<DownstreamTlsHandshakeFailureKey, u64>>,
     downstream_tls_cert_selections: RwLock<HashMap<DownstreamTlsCertSelectionKey, u64>>,
     downstream_tls_alpn_negotiated: RwLock<HashMap<DownstreamTlsAlpnKey, u64>>,
@@ -118,6 +121,27 @@ pub(crate) struct BackendConnectAttemptKey {
     pub(crate) backend: String,
     pub(crate) hostname: String,
     pub(crate) resolved_addr: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct UpstreamRequestCountKey {
+    pub(crate) upstream: String,
+    pub(crate) status_class: String,
+    pub(crate) outcome: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct BackendRequestCountKey {
+    pub(crate) upstream: String,
+    pub(crate) backend: String,
+    pub(crate) status_class: String,
+    pub(crate) outcome: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct UpstreamRequestLatencyKey {
+    pub(crate) upstream: String,
+    pub(crate) outcome: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -175,6 +199,13 @@ struct WorkerStats {
     ingress_packets_total: u64,
     ingress_queue_drops: u64,
     ingress_queue_drop_bytes: u64,
+}
+
+#[derive(Default, Clone)]
+pub(crate) struct RequestLatencyStats {
+    pub(crate) latency_buckets: [u64; LATENCY_BUCKETS_MS.len() + 1],
+    pub(crate) latency_ms_sum: u64,
+    pub(crate) count: u64,
 }
 
 struct RouteStatsAtomic {
@@ -251,12 +282,44 @@ impl WorkerStatsAtomic {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
 pub enum RouteOutcome {
     Success,
     Failure,
     Timeout,
     BackendError,
     OverloadShed,
+}
+
+fn normalize_metric_label(raw: &str, fallback: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        fallback.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn status_class_label(status: Option<u16>) -> &'static str {
+    match status {
+        Some(100..=199) => "1xx",
+        Some(200..=299) => "2xx",
+        Some(300..=399) => "3xx",
+        Some(400..=499) => "4xx",
+        Some(500..=599) => "5xx",
+        Some(_) => "other",
+        None => "unknown",
+    }
+}
+
+fn route_outcome_label(outcome: RouteOutcome) -> &'static str {
+    match outcome {
+        RouteOutcome::Success => "success",
+        RouteOutcome::Failure => "failure",
+        RouteOutcome::Timeout => "timeout",
+        RouteOutcome::BackendError => "backend_error",
+        RouteOutcome::OverloadShed => "overload_shed",
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -419,6 +482,9 @@ impl Metrics {
             backend_dns_state: RwLock::new(HashMap::new()),
             backend_rotation_state: RwLock::new(HashMap::new()),
             backend_connect_attempts: RwLock::new(HashMap::new()),
+            upstream_request_counts: RwLock::new(HashMap::new()),
+            backend_request_counts: RwLock::new(HashMap::new()),
+            upstream_request_latency: RwLock::new(HashMap::new()),
             downstream_tls_handshake_failures: RwLock::new(HashMap::new()),
             downstream_tls_cert_selections: RwLock::new(HashMap::new()),
             downstream_tls_alpn_negotiated: RwLock::new(HashMap::new()),
@@ -687,6 +753,55 @@ impl Metrics {
         }
     }
 
+    pub fn record_request_result(
+        &self,
+        upstream: &str,
+        backend: Option<&str>,
+        status: Option<u16>,
+        outcome: RouteOutcome,
+        latency: Duration,
+    ) {
+        let upstream = normalize_metric_label(upstream, "unrouted");
+        let backend = normalize_metric_label(backend.unwrap_or("__none__"), "__none__");
+        let status_class = status_class_label(status).to_string();
+        let outcome = route_outcome_label(outcome).to_string();
+
+        if let Ok(mut guard) = self.upstream_request_counts.write() {
+            *guard
+                .entry(UpstreamRequestCountKey {
+                    upstream: upstream.clone(),
+                    status_class: status_class.clone(),
+                    outcome: outcome.clone(),
+                })
+                .or_default() += 1;
+        }
+
+        if let Ok(mut guard) = self.backend_request_counts.write() {
+            *guard
+                .entry(BackendRequestCountKey {
+                    upstream: upstream.clone(),
+                    backend,
+                    status_class,
+                    outcome: outcome.clone(),
+                })
+                .or_default() += 1;
+        }
+
+        let latency_ms = latency.as_millis() as u64;
+        let bucket = LATENCY_BUCKETS_MS
+            .iter()
+            .position(|cutoff| latency_ms <= *cutoff)
+            .unwrap_or(LATENCY_BUCKETS_MS.len());
+        if let Ok(mut guard) = self.upstream_request_latency.write() {
+            let stats = guard
+                .entry(UpstreamRequestLatencyKey { upstream, outcome })
+                .or_default();
+            stats.count = stats.count.saturating_add(1);
+            stats.latency_ms_sum = stats.latency_ms_sum.saturating_add(latency_ms);
+            stats.latency_buckets[bucket] = stats.latency_buckets[bucket].saturating_add(1);
+        }
+    }
+
     pub(crate) fn snapshot_backend_dns_state(&self) -> Vec<(String, BackendDnsState)> {
         self.backend_dns_state
             .read()
@@ -728,6 +843,65 @@ impl Metrics {
                         .cmp(&right.backend)
                         .then_with(|| left.hostname.cmp(&right.hostname))
                         .then_with(|| left.resolved_addr.cmp(&right.resolved_addr))
+                });
+                entries
+            })
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn snapshot_upstream_request_counts(&self) -> Vec<(UpstreamRequestCountKey, u64)> {
+        self.upstream_request_counts
+            .read()
+            .map(|guard| {
+                let mut entries = guard
+                    .iter()
+                    .map(|(key, value)| (key.clone(), *value))
+                    .collect::<Vec<_>>();
+                entries.sort_by(|(left, _), (right, _)| {
+                    left.upstream
+                        .cmp(&right.upstream)
+                        .then_with(|| left.status_class.cmp(&right.status_class))
+                        .then_with(|| left.outcome.cmp(&right.outcome))
+                });
+                entries
+            })
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn snapshot_backend_request_counts(&self) -> Vec<(BackendRequestCountKey, u64)> {
+        self.backend_request_counts
+            .read()
+            .map(|guard| {
+                let mut entries = guard
+                    .iter()
+                    .map(|(key, value)| (key.clone(), *value))
+                    .collect::<Vec<_>>();
+                entries.sort_by(|(left, _), (right, _)| {
+                    left.upstream
+                        .cmp(&right.upstream)
+                        .then_with(|| left.backend.cmp(&right.backend))
+                        .then_with(|| left.status_class.cmp(&right.status_class))
+                        .then_with(|| left.outcome.cmp(&right.outcome))
+                });
+                entries
+            })
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn snapshot_upstream_request_latency(
+        &self,
+    ) -> Vec<(UpstreamRequestLatencyKey, RequestLatencyStats)> {
+        self.upstream_request_latency
+            .read()
+            .map(|guard| {
+                let mut entries = guard
+                    .iter()
+                    .map(|(key, value)| (key.clone(), value.clone()))
+                    .collect::<Vec<_>>();
+                entries.sort_by(|(left, _), (right, _)| {
+                    left.upstream
+                        .cmp(&right.upstream)
+                        .then_with(|| left.outcome.cmp(&right.outcome))
                 });
                 entries
             })

--- a/crates/edge/src/metrics/prometheus.rs
+++ b/crates/edge/src/metrics/prometheus.rs
@@ -649,6 +649,61 @@ impl Metrics {
             ));
         }
         out.push_str(
+            "# HELP spooky_upstream_requests_total Total completed requests grouped by upstream, status class, and outcome.\n",
+        );
+        out.push_str("# TYPE spooky_upstream_requests_total counter\n");
+        for (key, count) in self.snapshot_upstream_request_counts() {
+            out.push_str(&format!(
+                "spooky_upstream_requests_total{{upstream=\"{}\",status_class=\"{}\",outcome=\"{}\"}} {}\n",
+                escape_prometheus_label(&key.upstream),
+                escape_prometheus_label(&key.status_class),
+                escape_prometheus_label(&key.outcome),
+                count
+            ));
+        }
+        out.push_str(
+            "# HELP spooky_backend_requests_total Total completed requests grouped by upstream, backend, status class, and outcome.\n",
+        );
+        out.push_str("# TYPE spooky_backend_requests_total counter\n");
+        for (key, count) in self.snapshot_backend_request_counts() {
+            out.push_str(&format!(
+                "spooky_backend_requests_total{{upstream=\"{}\",backend=\"{}\",status_class=\"{}\",outcome=\"{}\"}} {}\n",
+                escape_prometheus_label(&key.upstream),
+                escape_prometheus_label(&key.backend),
+                escape_prometheus_label(&key.status_class),
+                escape_prometheus_label(&key.outcome),
+                count
+            ));
+        }
+        out.push_str(
+            "# HELP spooky_upstream_request_latency_ms Upstream request latency histogram grouped by upstream and final outcome.\n",
+        );
+        out.push_str("# TYPE spooky_upstream_request_latency_ms histogram\n");
+        for (key, stats) in self.snapshot_upstream_request_latency() {
+            let upstream = escape_prometheus_label(&key.upstream);
+            let outcome = escape_prometheus_label(&key.outcome);
+            let mut cumulative = 0u64;
+            for (idx, bucket_value) in stats.latency_buckets.iter().enumerate() {
+                cumulative = cumulative.saturating_add(*bucket_value);
+                let le = LATENCY_BUCKETS_MS
+                    .get(idx)
+                    .map(u64::to_string)
+                    .unwrap_or_else(|| "+Inf".to_string());
+                out.push_str(&format!(
+                    "spooky_upstream_request_latency_ms_bucket{{upstream=\"{}\",outcome=\"{}\",le=\"{}\"}} {}\n",
+                    upstream, outcome, le, cumulative
+                ));
+            }
+            out.push_str(&format!(
+                "spooky_upstream_request_latency_ms_sum{{upstream=\"{}\",outcome=\"{}\"}} {}\n",
+                upstream, outcome, stats.latency_ms_sum
+            ));
+            out.push_str(&format!(
+                "spooky_upstream_request_latency_ms_count{{upstream=\"{}\",outcome=\"{}\"}} {}\n",
+                upstream, outcome, stats.count
+            ));
+        }
+        out.push_str(
             "# HELP spooky_route_latency_sample_every Route latency histogram sampling interval (1 = every request).\n",
         );
         out.push_str("# TYPE spooky_route_latency_sample_every gauge\n");

--- a/crates/edge/src/quic_listener/bootstrap_tls.rs
+++ b/crates/edge/src/quic_listener/bootstrap_tls.rs
@@ -156,9 +156,16 @@ impl QUICListener {
 
         spawn_supervised_async_task(&handle, "bootstrap-tls-listener", None, async move {
             info!(
-                "Bootstrap TLS listener on https://{} (TCP+TLS) — advertising Alt-Svc: {} (max_connections={}, connection_timeout_ms={})",
+                "Bootstrap TLS listener ready bind=https://{} protocol=tcp+tls",
                 bind,
-                alt_svc_value,
+            );
+            info!(
+                "Bootstrap TLS listener alt_svc bind={} value={}",
+                bind, alt_svc_value,
+            );
+            info!(
+                "Bootstrap TLS listener limits bind={} max_connections={} connection_timeout_ms={}",
+                bind,
                 max_connections,
                 connection_timeout.as_millis()
             );

--- a/crates/edge/src/quic_listener/control_api/http.rs
+++ b/crates/edge/src/quic_listener/control_api/http.rs
@@ -127,13 +127,18 @@ impl QUICListener {
                         match Self::bind_tcp_listener(&desired_bind, None, "control API endpoint") {
                             Ok(listener) => {
                                 let paths = ControlApiPaths::from_endpoint(&endpoint);
+                                info!("Control API endpoint ready bind=https://{}", desired_bind,);
                                 info!(
-                                    "Control API endpoint listening on https://{}{} (ready={}, runtime={}, reload_certs={}, max_connections={}, connection_timeout_ms={})",
+                                    "Control API endpoint paths bind={} health={} ready={} runtime={} reload_certs={}",
                                     desired_bind,
                                     paths.health_path,
                                     paths.ready_path,
                                     paths.runtime_path,
                                     paths.reload_certs_path,
+                                );
+                                info!(
+                                    "Control API endpoint limits bind={} max_connections={} connection_timeout_ms={}",
+                                    desired_bind,
                                     endpoint.max_connections.max(1),
                                     endpoint.connection_timeout_ms.max(1)
                                 );

--- a/crates/edge/src/quic_listener/forwarding.rs
+++ b/crates/edge/src/quic_listener/forwarding.rs
@@ -432,6 +432,21 @@ impl QUICListener {
         }
     }
 
+    fn record_request_observation(
+        metrics: &Metrics,
+        req: &RequestEnvelope,
+        status: Option<u16>,
+        outcome: RouteOutcome,
+    ) {
+        metrics.record_request_result(
+            req.upstream_name.as_deref().unwrap_or("unrouted"),
+            req.backend_addr.as_deref(),
+            status,
+            outcome,
+            req.start.elapsed(),
+        );
+    }
+
     /// Handle an already-resolved `ForwardResult`, applying health transitions
     /// and sending the H3 response.
     #[allow(clippy::too_many_arguments)]
@@ -455,6 +470,16 @@ impl QUICListener {
             _ => {
                 metrics.inc_failure();
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::Failure);
+                Self::record_request_observation(
+                    metrics,
+                    req,
+                    Some(if req.method.is_empty() || req.path.is_empty() {
+                        http::StatusCode::BAD_REQUEST.as_u16()
+                    } else {
+                        http::StatusCode::SERVICE_UNAVAILABLE.as_u16()
+                    }),
+                    RouteOutcome::Failure,
+                );
                 return Self::send_simple_response(
                     h3,
                     quic,
@@ -483,6 +508,12 @@ impl QUICListener {
                 metrics.inc_failure();
                 metrics.inc_backend_error();
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::BackendError);
+                Self::record_request_observation(
+                    metrics,
+                    req,
+                    Some(http::StatusCode::BAD_GATEWAY.as_u16()),
+                    RouteOutcome::BackendError,
+                );
                 Self::send_simple_response(
                     h3,
                     quic,
@@ -495,6 +526,12 @@ impl QUICListener {
                 error!("Bridge error: {:?}", err);
                 metrics.inc_failure();
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::Failure);
+                Self::record_request_observation(
+                    metrics,
+                    req,
+                    Some(http::StatusCode::BAD_REQUEST.as_u16()),
+                    RouteOutcome::Failure,
+                );
                 Self::log_access(req, 400);
                 Self::send_simple_response(
                     h3,
@@ -513,6 +550,12 @@ impl QUICListener {
                     metrics.inc_overload_shed_reason(OverloadShedReason::BackendInflight);
                 }
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::OverloadShed);
+                Self::record_request_observation(
+                    metrics,
+                    req,
+                    Some(http::StatusCode::SERVICE_UNAVAILABLE.as_u16()),
+                    RouteOutcome::OverloadShed,
+                );
                 Self::log_access(req, 503);
                 Self::send_overload_response(
                     h3,
@@ -527,6 +570,12 @@ impl QUICListener {
                 metrics.inc_circuit_breaker_rejected();
                 metrics.inc_overload_shed_reason(OverloadShedReason::CircuitOpen);
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::OverloadShed);
+                Self::record_request_observation(
+                    metrics,
+                    req,
+                    Some(http::StatusCode::SERVICE_UNAVAILABLE.as_u16()),
+                    RouteOutcome::OverloadShed,
+                );
                 Self::log_access(req, 503);
                 Self::send_overload_response(
                     h3,
@@ -559,6 +608,12 @@ impl QUICListener {
                 metrics.inc_failure();
                 metrics.inc_backend_error();
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::BackendError);
+                Self::record_request_observation(
+                    metrics,
+                    req,
+                    Some(http::StatusCode::BAD_GATEWAY.as_u16()),
+                    RouteOutcome::BackendError,
+                );
                 Self::log_access(req, 502);
                 Self::send_simple_response(
                     h3,
@@ -588,6 +643,12 @@ impl QUICListener {
                 metrics.inc_failure();
                 metrics.inc_backend_error();
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::BackendError);
+                Self::record_request_observation(
+                    metrics,
+                    req,
+                    Some(http::StatusCode::BAD_GATEWAY.as_u16()),
+                    RouteOutcome::BackendError,
+                );
                 Self::log_access(req, 502);
                 Self::send_simple_response(
                     h3,
@@ -612,6 +673,12 @@ impl QUICListener {
                 metrics.inc_failure();
                 metrics.inc_backend_error();
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::BackendError);
+                Self::record_request_observation(
+                    metrics,
+                    req,
+                    Some(http::StatusCode::BAD_GATEWAY.as_u16()),
+                    RouteOutcome::BackendError,
+                );
                 Self::log_access(req, 502);
                 Self::send_simple_response(
                     h3,
@@ -626,6 +693,12 @@ impl QUICListener {
                 metrics.inc_failure();
                 metrics.inc_backend_error();
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::BackendError);
+                Self::record_request_observation(
+                    metrics,
+                    req,
+                    Some(http::StatusCode::BAD_GATEWAY.as_u16()),
+                    RouteOutcome::BackendError,
+                );
                 Self::log_access(req, 502);
                 Self::send_simple_response(
                     h3,
@@ -649,6 +722,12 @@ impl QUICListener {
                 metrics.inc_failure();
                 metrics.inc_timeout();
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::Timeout);
+                Self::record_request_observation(
+                    metrics,
+                    req,
+                    Some(http::StatusCode::SERVICE_UNAVAILABLE.as_u16()),
+                    RouteOutcome::Timeout,
+                );
                 Self::log_access(req, 503);
                 Self::send_simple_response(
                     h3,
@@ -663,6 +742,12 @@ impl QUICListener {
                 metrics.inc_health_failure(HealthFailureReason::Tls);
                 metrics.inc_failure();
                 metrics.record_route(route_label, start.elapsed(), RouteOutcome::Failure);
+                Self::record_request_observation(
+                    metrics,
+                    req,
+                    Some(http::StatusCode::INTERNAL_SERVER_ERROR.as_u16()),
+                    RouteOutcome::Failure,
+                );
                 Self::log_access(req, 500);
                 Self::send_simple_response(
                     h3,
@@ -2464,6 +2549,12 @@ impl QUICListener {
                             }
                             let route_label = req.upstream_name.as_deref().unwrap_or("unrouted");
                             metrics.record_route(route_label, req.start.elapsed(), route_outcome);
+                            Self::record_request_observation(
+                                metrics,
+                                req,
+                                Some(status.as_u16()),
+                                route_outcome,
+                            );
                             resilience
                                 .adaptive_admission
                                 .observe(req.start.elapsed(), false);
@@ -2564,6 +2655,12 @@ impl QUICListener {
                                         req.start.elapsed(),
                                         RouteOutcome::BackendError,
                                     );
+                                    Self::record_request_observation(
+                                        metrics,
+                                        req,
+                                        Some(status.as_u16()),
+                                        RouteOutcome::BackendError,
+                                    );
                                     resilience
                                         .adaptive_admission
                                         .observe(req.start.elapsed(), true);
@@ -2593,6 +2690,12 @@ impl QUICListener {
                                     metrics.record_route(
                                         route_label,
                                         req.start.elapsed(),
+                                        RouteOutcome::BackendError,
+                                    );
+                                    Self::record_request_observation(
+                                        metrics,
+                                        req,
+                                        req.response_status,
                                         RouteOutcome::BackendError,
                                     );
                                     resilience
@@ -2635,6 +2738,12 @@ impl QUICListener {
                                         req.start.elapsed(),
                                         RouteOutcome::BackendError,
                                     );
+                                    Self::record_request_observation(
+                                        metrics,
+                                        req,
+                                        req.response_status,
+                                        RouteOutcome::BackendError,
+                                    );
                                     resilience
                                         .adaptive_admission
                                         .observe(req.start.elapsed(), true);
@@ -2666,6 +2775,12 @@ impl QUICListener {
                                 metrics.record_route(
                                     route_label,
                                     req.start.elapsed(),
+                                    RouteOutcome::BackendError,
+                                );
+                                Self::record_request_observation(
+                                    metrics,
+                                    req,
+                                    req.response_status,
                                     RouteOutcome::BackendError,
                                 );
                                 resilience
@@ -2722,6 +2837,14 @@ impl QUICListener {
                                         req.start.elapsed(),
                                         RouteOutcome::Timeout,
                                     );
+                                    Self::record_request_observation(
+                                        metrics,
+                                        req,
+                                        req.response_status.or(Some(
+                                            http::StatusCode::SERVICE_UNAVAILABLE.as_u16(),
+                                        )),
+                                        RouteOutcome::Timeout,
+                                    );
                                     resilience
                                         .adaptive_admission
                                         .observe(req.start.elapsed(), true);
@@ -2752,6 +2875,14 @@ impl QUICListener {
                                         req.start.elapsed(),
                                         RouteOutcome::OverloadShed,
                                     );
+                                    Self::record_request_observation(
+                                        metrics,
+                                        req,
+                                        req.response_status.or(Some(
+                                            http::StatusCode::SERVICE_UNAVAILABLE.as_u16(),
+                                        )),
+                                        RouteOutcome::OverloadShed,
+                                    );
                                     resilience
                                         .adaptive_admission
                                         .observe(req.start.elapsed(), true);
@@ -2769,6 +2900,13 @@ impl QUICListener {
                                     metrics.record_route(
                                         route_label,
                                         req.start.elapsed(),
+                                        RouteOutcome::BackendError,
+                                    );
+                                    Self::record_request_observation(
+                                        metrics,
+                                        req,
+                                        req.response_status
+                                            .or(Some(http::StatusCode::BAD_GATEWAY.as_u16())),
                                         RouteOutcome::BackendError,
                                     );
                                     resilience

--- a/crates/edge/src/quic_listener/metrics_endpoint.rs
+++ b/crates/edge/src/quic_listener/metrics_endpoint.rs
@@ -111,9 +111,12 @@ impl QUICListener {
                         match Self::bind_tcp_listener(&desired_bind, None, "metrics endpoint") {
                             Ok(listener) => {
                                 info!(
-                                    "Metrics endpoint listening on http://{}{} (max_connections={}, connection_timeout_ms={})",
+                                    "Metrics endpoint ready bind=http://{}{}",
+                                    desired_bind, endpoint.path,
+                                );
+                                info!(
+                                    "Metrics endpoint limits bind={} max_connections={} connection_timeout_ms={}",
                                     desired_bind,
-                                    endpoint.path,
                                     endpoint.max_connections.max(1),
                                     endpoint.connection_timeout_ms.max(1)
                                 );

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -487,29 +487,42 @@ impl QUICListener {
             .saturating_mul(worker_threads);
 
         info!(
-            "Performance profile: worker_threads={} control_plane_threads={} reuseport={} pin_workers={} global_inflight_limit={} per_upstream_inflight_limit={} per_backend_inflight_limit={} max_active_connections={} backend_connect_timeout_ms={} backend_timeout_ms={} backend_body_idle_timeout_ms={} backend_body_total_timeout_ms={} backend_total_request_timeout_ms={} client_body_idle_timeout_ms={} max_request_body_bytes={} max_response_body_bytes={} request_buffer_global_cap_bytes={} unknown_length_response_prebuffer_bytes={} udp_recv_buffer_bytes={} udp_send_buffer_bytes={} h2_pool_max_idle_per_backend={} h2_pool_idle_timeout_ms={}",
+            "Runtime performance concurrency worker_threads={} control_plane_threads={} packet_shards_per_worker={} reuseport={} pin_workers={}",
             worker_threads,
             config.performance.control_plane_threads.max(1),
+            shard_count,
             config.performance.reuseport,
             config.performance.pin_workers,
+        );
+        info!(
+            "Runtime performance inflight_limits global_inflight_limit={} per_upstream_inflight_limit={} per_backend_inflight_limit={} max_active_connections={}",
             global_inflight_limit,
             per_upstream_limit,
             config.performance.per_backend_inflight_limit,
             config.performance.max_active_connections,
+        );
+        info!(
+            "Runtime performance upstream_timeouts backend_connect_timeout_ms={} backend_timeout_ms={} backend_body_idle_timeout_ms={} backend_body_total_timeout_ms={} backend_total_request_timeout_ms={}",
             config.performance.backend_connect_timeout_ms,
             config.performance.backend_timeout_ms,
             config.performance.backend_body_idle_timeout_ms,
             config.performance.backend_body_total_timeout_ms,
             config.performance.backend_total_request_timeout_ms,
+        );
+        info!(
+            "Runtime performance request_limits client_body_idle_timeout_ms={} max_request_body_bytes={} max_response_body_bytes={} request_buffer_global_cap_bytes={} unknown_length_response_prebuffer_bytes={}",
             config.performance.client_body_idle_timeout_ms,
             config.performance.max_request_body_bytes,
             config.performance.max_response_body_bytes,
             config.performance.request_buffer_global_cap_bytes,
             config.performance.unknown_length_response_prebuffer_bytes,
+        );
+        info!(
+            "Runtime performance transport_buffers udp_recv_buffer_bytes={} udp_send_buffer_bytes={} h2_pool_max_idle_per_backend={} h2_pool_idle_timeout_ms={}",
             config.performance.udp_recv_buffer_bytes,
             config.performance.udp_send_buffer_bytes,
             config.performance.h2_pool_max_idle_per_backend,
-            config.performance.h2_pool_idle_timeout_ms
+            config.performance.h2_pool_idle_timeout_ms,
         );
 
         let listener_runtime_configs = config

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -73,8 +73,9 @@ Configuration validation is performed automatically at startup before the QUIC l
 **Valid Configuration**:
 ```
 Configuration validation successful
-Spooky is starting
-Listening on 0.0.0.0:9889
+Spooky startup phase=begin
+Spooky listener topology listeners=1 packet_shards_per_worker=1 reuseport=true pin_workers=false
+Listener 0 binds udp=0.0.0.0:9889 tcp_bootstrap=0.0.0.0:9889
 ```
 
 **Invalid Configuration**:
@@ -113,8 +114,10 @@ Spooky uses the `env_logger` logging implementation with timestamped output. All
 ### Log Output Examples
 
 ```
-[2026-02-18 14:23:45] [INFO] [spooky] Spooky is starting
-[2026-02-18 14:23:45] [DEBUG] [spooky_edge::quic_listener] Listening on 0.0.0.0:9889
+[2026-02-18 14:23:45] [INFO] [spooky::listener_group] Spooky startup phase=begin
+[2026-02-18 14:23:45] [INFO] [spooky::listener_group] Spooky listener topology listeners=1 packet_shards_per_worker=1 reuseport=true pin_workers=false
+[2026-02-18 14:23:45] [INFO] [spooky::listener_group] Listener 0 binds udp=0.0.0.0:9889 tcp_bootstrap=0.0.0.0:9889
+[2026-02-18 14:23:45] [INFO] [spooky_edge::quic_listener] Runtime performance concurrency worker_threads=1 control_plane_threads=2 packet_shards_per_worker=1 reuseport=true pin_workers=false
 [2026-02-18 14:23:45] [DEBUG] [spooky_edge::quic_listener] Certificate loaded successfully
 [2026-02-18 14:23:50] [INFO] [spooky_edge::quic_listener] Length of data received: 1200
 [2026-02-18 14:23:50] [DEBUG] [spooky_edge::quic_listener] Packet DCID (len=8): [00 01 02 03 04 05 06 07], type: Initial, active connections: 1

--- a/docs/howto/03-run.md
+++ b/docs/howto/03-run.md
@@ -239,7 +239,7 @@ When Spooky starts, it follows this order:
 8. Drops privileges if running as root and `security.privileges.enabled=true`
 9. Spawns worker threads (data plane)
 10. Spawns control-plane tasks (health checks, metrics)
-11. Logs "Spooky is starting" — ready to accept connections
+11. Emits structured startup logs for topology, worker layout, and runtime settings — ready to accept connections
 
 ---
 

--- a/docs/reference/metrics-reference.md
+++ b/docs/reference/metrics-reference.md
@@ -18,6 +18,42 @@ This page documents the major built-in Prometheus metrics families currently exp
 | `spooky_request_validation_rejects` | counter | Requests rejected by protocol validation |
 | `spooky_policy_denied` | counter | Requests denied by runtime method/path policy |
 
+## Request Breakdown Metrics
+
+These families are the primary source for production dashboards because they preserve request totals while adding low-cardinality dimensions.
+
+| Metric | Type | Meaning |
+| --- | --- | --- |
+| `spooky_upstream_requests_total{upstream,status_class,outcome}` | counter | Completed requests grouped by upstream, response status class, and final outcome |
+| `spooky_backend_requests_total{upstream,backend,status_class,outcome}` | counter | Completed requests grouped by upstream and selected backend |
+
+Expected label values:
+
+- `status_class`: `1xx`, `2xx`, `3xx`, `4xx`, `5xx`, `other`, `unknown`
+- `outcome`: `success`, `failure`, `timeout`, `backend_error`, `overload_shed`
+
+Use these for questions like:
+
+- which upstream is producing 5xx responses?
+- which backend is taking most of the failed traffic?
+- are failures mostly timeouts, backend errors, or overload shedding?
+
+## Latency Metrics
+
+| Metric | Type | Meaning |
+| --- | --- | --- |
+| `spooky_upstream_request_latency_ms_bucket{upstream,outcome,le}` | histogram bucket | End-to-end request latency grouped by upstream and final outcome |
+| `spooky_upstream_request_latency_ms_sum{upstream,outcome}` | histogram sum | Sum of request latency observations in milliseconds |
+| `spooky_upstream_request_latency_ms_count{upstream,outcome}` | histogram count | Count of latency observations |
+| `spooky_route_latency_ms_p50{route}` | gauge | Approximate p50 route latency |
+| `spooky_route_latency_ms_p95{route}` | gauge | Approximate p95 route latency |
+| `spooky_route_latency_ms_p99{route}` | gauge | Approximate p99 route latency |
+
+Practical note:
+
+- if you only grep `spooky_requests_total` and `spooky_requests_success`, you are looking at the coarse top-level counters rather than the richer labeled families above
+- for Grafana and Prometheus alerting, prefer the labeled upstream/backend metrics and the histogram family
+
 ## Early Data Metrics
 
 | Metric | Type | Meaning |
@@ -122,6 +158,8 @@ This page documents the major built-in Prometheus metrics families currently exp
 ## Golden Signals To Watch First
 
 - request success/failure counters
+- request totals by upstream and backend outcome
+- upstream request latency histogram percentiles from PromQL
 - route latency percentiles
 - overload shed counts by reason
 - backend timeout and backend error counters
@@ -131,6 +169,9 @@ This page documents the major built-in Prometheus metrics families currently exp
 
 ## First Alerts To Add
 
+- `sum by (upstream) (rate(spooky_upstream_requests_total{status_class="5xx"}[5m]))`
+- `sum by (backend) (rate(spooky_backend_requests_total{outcome="backend_error"}[5m]))`
+- `histogram_quantile(0.95, sum by (le, upstream) (rate(spooky_upstream_request_latency_ms_bucket[5m])))`
 - sustained growth in `spooky_overload_shed_by_reason_total`
 - rising `spooky_backend_timeouts`
 - rising `spooky_downstream_tls_handshake_failure_total`

--- a/spooky/src/listener_group.rs
+++ b/spooky/src/listener_group.rs
@@ -603,9 +603,9 @@ pub(crate) fn log_listener_startup(
     listener_groups: &[ListenerGroupRuntime],
 ) {
     let shard_count = runtime_config.performance.packet_shards_per_worker.max(1);
-    info!("Spooky is starting");
+    info!("Spooky startup phase=begin");
     info!(
-        "Ingress listeners={} packet_shards_per_worker={} reuseport={} pin_workers={}",
+        "Spooky listener topology listeners={} packet_shards_per_worker={} reuseport={} pin_workers={}",
         runtime_config.listeners.len(),
         shard_count,
         runtime_config.performance.reuseport,
@@ -613,16 +613,20 @@ pub(crate) fn log_listener_startup(
     );
     for listener in &runtime_config.listeners {
         info!(
-            "Listener {}: HTTP/3 (QUIC) on UDP {}:{}, HTTP/1.1+HTTP/2 bootstrap (TLS) on TCP {}:{} with Alt-Svc upgrade",
+            "Listener {} binds udp={}:{} tcp_bootstrap={}:{}",
             listener.index,
             listener.listen.address,
             listener.listen.port,
             listener.listen.address,
             listener.listen.port,
         );
+        info!(
+            "Listener {} protocols downstream_quic=true bootstrap_http1=true bootstrap_http2=true alt_svc_upgrade=true",
+            listener.index,
+        );
     }
     info!(
-        "Data-plane workers={} packet_shards_per_worker={} reuseport={} pin_workers={}",
+        "Spooky data-plane workers={} packet_shards_per_worker={} reuseport={} pin_workers={}",
         listener_groups
             .iter()
             .map(group_signature_worker_count)


### PR DESCRIPTION
## Summary

- add richer Prometheus request breakdown metrics by upstream, backend, status class, and outcome
- add upstream request latency histograms for Prometheus/Grafana dashboards
- split dense startup and endpoint bind logs into smaller structured lifecycle events
- refresh observability and startup-log documentation to match the current runtime output

## What changed

### Metrics

Added new Prometheus metric families:

- `spooky_upstream_requests_total{upstream,status_class,outcome}`
- `spooky_backend_requests_total{upstream,backend,status_class,outcome}`
- `spooky_upstream_request_latency_ms_bucket{upstream,outcome,le}`
- `spooky_upstream_request_latency_ms_sum{upstream,outcome}`
- `spooky_upstream_request_latency_ms_count{upstream,outcome}`

These are recorded from the request completion paths so operators can answer:

- which upstream is failing?
- which backend is failing?
- are failures mostly 5xx, timeouts, backend errors, or overload shedding?
- what is the upstream latency distribution by outcome?

The existing coarse counters remain in place.

### Logging

Split oversized startup and endpoint lifecycle log lines into narrower structured events:

- runtime performance settings are emitted in grouped startup events
- listener topology is logged as separate bind/protocol events
- bootstrap TLS startup is split into readiness, Alt-Svc, and limit events
- control API startup is split into readiness, path, and limit events
- metrics endpoint startup is split into readiness and limit events

This keeps the same operational data while making the logs easier to ingest and reason about in production systems.

### Documentation

Updated docs to match the new observability surface:

- documented the richer request breakdown and latency metric families
- added guidance on using the labeled metrics for dashboards and alerts
- refreshed stale startup-log examples that still referred to the old single-line startup output
