### PR TITLE
fix: runtime safety reload hardening

### DIFF
--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -168,13 +168,13 @@ mod tests {
     #[test]
     fn resilience_metrics_increment_correctly() {
         let metrics = Metrics::default();
-        metrics.inc_retry(RetryReason::BackendTimeout);
-        metrics.inc_retry(RetryReason::BudgetDenied);
+        metrics.inc_retry_attempt(RetryReason::BackendTimeout);
+        metrics.inc_retry_denied(RetryReason::BudgetDenied);
         metrics.inc_circuit_breaker_rejected();
         metrics.inc_circuit_breaker_rejected();
         metrics.set_brownout_active(true);
         let output = metrics.render_prometheus();
-        assert!(output.contains("spooky_retries_total 2\n"));
+        assert!(output.contains("spooky_retries_total 1\n"));
         assert!(output.contains("spooky_retry_attempts_total{reason=\"timeout\"} 1\n"));
         assert!(output.contains("spooky_retry_denied_total{reason=\"budget\"} 1\n"));
         assert!(output.contains("spooky_circuit_breaker_rejected_total 2\n"));

--- a/crates/edge/src/metrics/mod.rs
+++ b/crates/edge/src/metrics/mod.rs
@@ -1140,7 +1140,7 @@ impl Metrics {
         self.runtime_panics.fetch_add(1, Ordering::Relaxed);
     }
 
-    pub fn inc_retry(&self, reason: RetryReason) {
+    pub fn inc_retry_attempt(&self, reason: RetryReason) {
         self.retries_total.fetch_add(1, Ordering::Relaxed);
         match reason {
             RetryReason::BackendTimeout => {
@@ -1152,6 +1152,14 @@ impl Metrics {
             RetryReason::BackendPool => {
                 self.retry_reason_pool.fetch_add(1, Ordering::Relaxed);
             }
+            RetryReason::BudgetDenied
+            | RetryReason::NotBodylessMode
+            | RetryReason::NoAlternateBackend => {}
+        }
+    }
+
+    pub fn inc_retry_denied(&self, reason: RetryReason) {
+        match reason {
             RetryReason::BudgetDenied => {
                 self.retry_denied_budget.fetch_add(1, Ordering::Relaxed);
             }
@@ -1163,6 +1171,9 @@ impl Metrics {
                 self.retry_denied_no_alternate
                     .fetch_add(1, Ordering::Relaxed);
             }
+            RetryReason::BackendTimeout
+            | RetryReason::BackendTransport
+            | RetryReason::BackendPool => {}
         }
     }
 

--- a/crates/edge/src/quic_listener/control_api/http.rs
+++ b/crates/edge/src/quic_listener/control_api/http.rs
@@ -203,8 +203,8 @@ impl QUICListener {
                             );
                             return;
                         };
-                        let Some(server_config) = listener_tls_store
-                            .bootstrap_server_config(&primary_listener_label)
+                        let Some(server_config) =
+                            listener_tls_store.bootstrap_server_config(&primary_listener_label)
                         else {
                             error!(
                                 "Control API endpoint missing live TLS config for listener {}",

--- a/crates/edge/src/quic_listener/control_api/http.rs
+++ b/crates/edge/src/quic_listener/control_api/http.rs
@@ -196,12 +196,19 @@ impl QUICListener {
                             state.current_control_api().connection_timeout_ms.max(1),
                         );
                         let listener_tls_store = state.current_listener_tls_store();
+                        let Some(primary_listener_label) = state.current_primary_listener_label()
+                        else {
+                            error!(
+                                "Control API endpoint missing live primary listener label for TLS selection"
+                            );
+                            return;
+                        };
                         let Some(server_config) = listener_tls_store
-                            .bootstrap_server_config(&state.primary_listener_label)
+                            .bootstrap_server_config(&primary_listener_label)
                         else {
                             error!(
                                 "Control API endpoint missing live TLS config for listener {}",
-                                state.primary_listener_label
+                                primary_listener_label
                             );
                             return;
                         };

--- a/crates/edge/src/quic_listener/control_api/http.rs
+++ b/crates/edge/src/quic_listener/control_api/http.rs
@@ -290,7 +290,7 @@ impl QUICListener {
         listener_tls_store: &ListenerTlsReloadStore,
         metrics: &Metrics,
     ) -> Response<Full<Bytes>> {
-        let mut reloaded = Vec::new();
+        let mut staged = Vec::with_capacity(listener_runtime_configs.len());
         for (listener_label, listener_config) in listener_runtime_configs {
             let reloaded_state = match Self::build_listener_tls_reload_state(listener_config) {
                 Ok(state) => state,
@@ -305,31 +305,32 @@ impl QUICListener {
                     );
                 }
             };
-            let generation = match listener_tls_store.replace_listener(
-                listener_label,
-                reloaded_state.inventory.clone(),
-                reloaded_state.bootstrap_server_config,
-            ) {
-                Ok(generation) => generation,
-                Err(err) => {
-                    return Self::json_response(
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        json!({
-                            "reloaded": false,
-                            "listener": listener_label,
-                            "error": err.to_string(),
-                        }),
-                    );
-                }
-            };
+            staged.push((listener_label.clone(), reloaded_state));
+        }
+
+        let generations = match listener_tls_store.replace_listeners(&staged) {
+            Ok(generations) => generations,
+            Err(err) => {
+                return Self::json_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    json!({
+                        "reloaded": false,
+                        "error": err.to_string(),
+                    }),
+                );
+            }
+        };
+
+        let mut reloaded = Vec::with_capacity(staged.len());
+        for (listener_label, reloaded_state) in staged {
             Self::update_listener_tls_expiry_metrics(
                 metrics,
-                listener_label,
+                &listener_label,
                 &reloaded_state.inventory,
             );
             reloaded.push(json!({
                 "listener": listener_label,
-                "generation": generation,
+                "generation": generations.get(&listener_label).copied().unwrap_or(0),
             }));
         }
 

--- a/crates/edge/src/quic_listener/control_api/state.rs
+++ b/crates/edge/src/quic_listener/control_api/state.rs
@@ -95,6 +95,17 @@ impl ControlApiState {
             .unwrap_or_else(|| Arc::clone(&self.metrics))
     }
 
+    pub(super) fn current_primary_listener_label(&self) -> Option<String> {
+        self.current_runtime()
+            .and_then(|runtime| {
+                runtime
+                    .runtime_config
+                    .primary_listener_runtime_config()
+                    .map(|listener| QUICListener::listener_label(&listener))
+            })
+            .or_else(|| Some(self.primary_listener_label.clone()))
+    }
+
     pub(super) fn snapshot_backend_health(&self) -> (usize, usize) {
         if let Some(runtime) = self.current_runtime() {
             let mut healthy = 0usize;

--- a/crates/edge/src/quic_listener/control_api/tests.rs
+++ b/crates/edge/src/quic_listener/control_api/tests.rs
@@ -230,6 +230,37 @@ fn control_api_state_prefers_reloaded_paths_and_auth_token() {
 }
 
 #[test]
+fn control_api_state_uses_live_primary_listener_label_after_runtime_swap() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+    let startup = test_config(cert.clone(), key.clone());
+
+    let mut reloaded = startup.clone();
+    reloaded.listeners = vec![
+        Listen {
+            protocol: "http3".to_string(),
+            port: 9890,
+            address: "127.0.0.1".to_string(),
+            tls: Tls {
+                cert: cert.clone(),
+                key: key.clone(),
+                certificates: vec![],
+                client_auth: ClientAuth::default(),
+            },
+        },
+        startup.listen.clone(),
+    ];
+
+    let state = control_api_state_with_runtime_bundle(&startup, &reloaded);
+
+    assert_eq!(state.primary_listener_label, "127.0.0.1:9889");
+    assert_eq!(
+        state.current_primary_listener_label().as_deref(),
+        Some("127.0.0.1:9890")
+    );
+}
+
+#[test]
 fn validate_control_api_reload_compatibility_allows_bind_change_when_socket_is_free() {
     let dir = tempdir().expect("tempdir");
     let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");

--- a/crates/edge/src/quic_listener/control_api/tests.rs
+++ b/crates/edge/src/quic_listener/control_api/tests.rs
@@ -523,3 +523,61 @@ async fn runtime_bundle_cert_reload_ignores_unrelated_config_drift_and_bundle_sw
         "expected cert reload to rotate the live listener TLS generation"
     );
 }
+
+#[tokio::test]
+async fn reload_listener_certs_is_atomic_when_any_listener_reload_fails() {
+    let dir = tempdir().expect("tempdir");
+    let (cert1, key1) = write_test_cert_for_name(dir.path(), "server-one", "api.example.com");
+    let (cert2, key2) = write_test_cert_for_name(dir.path(), "server-two", "admin.example.com");
+    let mut config = test_config(cert1.clone(), key1.clone());
+    config.listeners = vec![
+        Listen {
+            protocol: "http3".to_string(),
+            port: 9889,
+            address: "127.0.0.1".to_string(),
+            tls: Tls {
+                cert: cert1,
+                key: key1,
+                certificates: vec![],
+                client_auth: ClientAuth::default(),
+            },
+        },
+        Listen {
+            protocol: "http3".to_string(),
+            port: 9890,
+            address: "127.0.0.1".to_string(),
+            tls: Tls {
+                cert: cert2.clone(),
+                key: key2,
+                certificates: vec![],
+                client_auth: ClientAuth::default(),
+            },
+        },
+    ];
+
+    let bundle = runtime_bundle_from_config("current.yaml", &config);
+    let generations_before = bundle.shared_state.listener_tls_store.generations();
+
+    std::fs::write(&cert2, "not a valid certificate").expect("corrupt cert");
+
+    let response = QUICListener::reload_listener_certs(
+        bundle.shared_state.listener_runtime_configs.as_ref(),
+        bundle.shared_state.listener_tls_store.as_ref(),
+        bundle.shared_state.metrics.as_ref(),
+    );
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+    let body = response
+        .into_body()
+        .collect()
+        .await
+        .expect("collect response body")
+        .to_bytes();
+    let payload: serde_json::Value = serde_json::from_slice(&body).expect("response json");
+    assert_eq!(payload["reloaded"], serde_json::Value::Bool(false));
+
+    assert_eq!(
+        bundle.shared_state.listener_tls_store.generations(),
+        generations_before
+    );
+}

--- a/crates/edge/src/quic_listener/control_api/watchdog.rs
+++ b/crates/edge/src/quic_listener/control_api/watchdog.rs
@@ -176,21 +176,31 @@ impl QUICListener {
                     let status = command.status().await;
                     match status {
                         Ok(status) => {
-                            info!(
-                                "Watchdog restart hook exited with status {}",
-                                status
-                                    .code()
-                                    .map(|code| code.to_string())
-                                    .unwrap_or_else(|| "signal".to_string())
-                            );
+                            metrics.inc_watchdog_restart_hook();
+                            let exit_status = status
+                                .code()
+                                .map(|code| code.to_string())
+                                .unwrap_or_else(|| "signal".to_string());
+                            if status.success() {
+                                info!(
+                                    "Watchdog restart hook exited successfully with status {}",
+                                    exit_status
+                                );
+                                watchdog.complete_restart_cycle();
+                            } else {
+                                error!(
+                                    "Watchdog restart hook exited unsuccessfully with status {}; keeping restart pending",
+                                    exit_status
+                                );
+                            }
                         }
                         Err(err) => {
-                            error!("Watchdog restart hook execution failed: {}", err);
+                            error!(
+                                "Watchdog restart hook execution failed: {}; keeping restart pending",
+                                err
+                            );
                         }
                     }
-                    metrics.inc_watchdog_restart_hook();
-
-                    watchdog.complete_restart_cycle();
                 }
             },
         );

--- a/crates/edge/src/quic_listener/forwarding.rs
+++ b/crates/edge/src/quic_listener/forwarding.rs
@@ -1521,7 +1521,9 @@ impl QUICListener {
                                                 if !can_retry {
                                                     if !bodyless_mode {
                                                         retry_denial_reason = Some(RetryReason::NotBodylessMode);
-                                                    } else if !is_retryable_err || !budget_ok {
+                                                    } else if !is_retryable_err {
+                                                        retry_denial_reason = None;
+                                                    } else if !budget_ok {
                                                         retry_denial_reason = Some(RetryReason::BudgetDenied);
                                                     } else {
                                                         retry_denial_reason = Some(RetryReason::NoAlternateBackend);

--- a/crates/edge/src/quic_listener/forwarding.rs
+++ b/crates/edge/src/quic_listener/forwarding.rs
@@ -2084,10 +2084,10 @@ impl QUICListener {
                     metrics.observe_hedge_primary_late_ms(forward_result.hedge.primary_late_ms);
                 }
                 if let Some(reason) = forward_result.retry_attempt_reason {
-                    metrics.inc_retry(reason);
+                    metrics.inc_retry_attempt(reason);
                 }
                 if let Some(reason) = forward_result.retry_denial_reason {
-                    metrics.inc_retry(reason);
+                    metrics.inc_retry_denied(reason);
                 }
 
                 if let Some(req) = streams.get_mut(&stream_id) {

--- a/crates/edge/src/resilience.rs
+++ b/crates/edge/src/resilience.rs
@@ -343,7 +343,7 @@ impl RetryBudget {
 
     pub fn allow_retry(&self, route: &str) -> Result<(), RetryReason> {
         if !self.enabled {
-            return Err(RetryReason::BudgetDenied);
+            return Ok(());
         }
 
         let ratio = self
@@ -708,6 +708,13 @@ mod tests {
         rb.mark_primary("api");
         assert!(rb.allow_retry("api").is_ok());
         assert!(rb.allow_retry("api").is_err());
+    }
+
+    #[test]
+    fn retry_budget_disabled_allows_retries() {
+        let rb = RetryBudget::new(false, 0, HashMap::new());
+        assert!(rb.allow_retry("api").is_ok());
+        assert!(rb.allow_retry("api").is_ok());
     }
 
     #[test]

--- a/crates/edge/src/types.rs
+++ b/crates/edge/src/types.rs
@@ -384,6 +384,39 @@ impl ListenerTlsReloadStore {
         Ok(state.generation)
     }
 
+    pub fn replace_listeners(
+        &self,
+        updates: &[(String, ListenerTlsReloadState)],
+    ) -> Result<HashMap<String, u64>, ProxyError> {
+        let mut listeners = self.listeners.write().map_err(|_| {
+            ProxyError::Transport("listener TLS reload store lock poisoned".to_string())
+        })?;
+
+        for (listener, _) in updates {
+            if !listeners.contains_key(listener) {
+                return Err(ProxyError::Transport(format!(
+                    "listener TLS reload requested for unknown listener '{}'",
+                    listener
+                )));
+            }
+        }
+
+        let mut generations = HashMap::with_capacity(updates.len());
+        for (listener, update) in updates {
+            let state = listeners.get_mut(listener).ok_or_else(|| {
+                ProxyError::Transport(format!(
+                    "listener TLS reload requested for unknown listener '{}'",
+                    listener
+                ))
+            })?;
+            state.generation = state.generation.saturating_add(1);
+            state.inventory = update.inventory.clone();
+            state.bootstrap_server_config = Arc::clone(&update.bootstrap_server_config);
+            generations.insert(listener.clone(), state.generation);
+        }
+        Ok(generations)
+    }
+
     pub fn snapshot(&self) -> HashMap<String, ListenerTlsInventory> {
         self.listeners
             .read()

--- a/crates/transport/tests/h1_pool.rs
+++ b/crates/transport/tests/h1_pool.rs
@@ -49,6 +49,11 @@ impl ConcurrencyTracker {
     }
 }
 
+fn loopback_bind_restricted(err: &std::io::Error) -> bool {
+    err.kind() == std::io::ErrorKind::PermissionDenied
+        || matches!(err.raw_os_error(), Some(1) | Some(13))
+}
+
 async fn start_h1_server(tracker: Arc<ConcurrencyTracker>) -> std::io::Result<u16> {
     let listener = TcpListener::bind("127.0.0.1:0").await?;
     let port = listener.local_addr()?.port();
@@ -84,7 +89,11 @@ async fn start_h1_server(tracker: Arc<ConcurrencyTracker>) -> std::io::Result<u1
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn pool_limits_inflight_per_backend() {
     let tracker = Arc::new(ConcurrencyTracker::new());
-    let port = start_h1_server(tracker.clone()).await.unwrap();
+    let port = match start_h1_server(tracker.clone()).await {
+        Ok(port) => port,
+        Err(err) if loopback_bind_restricted(&err) => return,
+        Err(err) => panic!("failed to start h1 test server: {err}"),
+    };
     let backend = format!("127.0.0.1:{port}");
 
     let pool = Arc::new(H1Pool::new(
@@ -157,7 +166,11 @@ async fn pool_rejects_unknown_backend() {
 #[tokio::test]
 async fn pool_reports_overload_when_inflight_is_exhausted() {
     let tracker = Arc::new(ConcurrencyTracker::new());
-    let port = start_h1_server(tracker).await.unwrap();
+    let port = match start_h1_server(tracker).await {
+        Ok(port) => port,
+        Err(err) if loopback_bind_restricted(&err) => return,
+        Err(err) => panic!("failed to start h1 test server: {err}"),
+    };
     let backend = format!("127.0.0.1:{port}");
     let pool = Arc::new(H1Pool::new(
         vec![backend.clone()],

--- a/crates/transport/tests/h2_pool.rs
+++ b/crates/transport/tests/h2_pool.rs
@@ -50,6 +50,11 @@ impl ConcurrencyTracker {
     }
 }
 
+fn loopback_bind_restricted(err: &std::io::Error) -> bool {
+    err.kind() == std::io::ErrorKind::PermissionDenied
+        || matches!(err.raw_os_error(), Some(1) | Some(13))
+}
+
 async fn start_h2_server(tracker: Arc<ConcurrencyTracker>) -> std::io::Result<u16> {
     let listener = TcpListener::bind("127.0.0.1:0").await?;
     let port = listener.local_addr()?.port();
@@ -85,7 +90,11 @@ async fn start_h2_server(tracker: Arc<ConcurrencyTracker>) -> std::io::Result<u1
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn pool_limits_inflight_per_backend() {
     let tracker = Arc::new(ConcurrencyTracker::new());
-    let port = start_h2_server(tracker.clone()).await.unwrap();
+    let port = match start_h2_server(tracker.clone()).await {
+        Ok(port) => port,
+        Err(err) if loopback_bind_restricted(&err) => return,
+        Err(err) => panic!("failed to start h2 test server: {err}"),
+    };
     let backend = format!("127.0.0.1:{port}");
 
     let pool = Arc::new(
@@ -164,7 +173,11 @@ async fn pool_rejects_unknown_backend() {
 #[tokio::test]
 async fn pool_reports_overload_when_inflight_is_exhausted() {
     let tracker = Arc::new(ConcurrencyTracker::new());
-    let port = start_h2_server(tracker).await.unwrap();
+    let port = match start_h2_server(tracker).await {
+        Ok(port) => port,
+        Err(err) if loopback_bind_restricted(&err) => return,
+        Err(err) => panic!("failed to start h2 test server: {err}"),
+    };
     let backend = format!("127.0.0.1:{port}");
     let pool = Arc::new(
         H2Pool::new(

--- a/scripts/lb-consistent-hash.sh
+++ b/scripts/lb-consistent-hash.sh
@@ -6,6 +6,8 @@ source "$(dirname "$0")/common.sh"
 ensure_bins
 
 cat > /tmp/spooky-lb-ch.yaml <<'YAML'
+version: 1
+
 listen:
     protocol: http3
     port: 9889
@@ -14,28 +16,31 @@ listen:
         cert: "certs/proxy-cert.pem"
         key: "certs/proxy-key-pkcs8.pem"
 
-backends:
-    -   id: "backend1"
-        address: "127.0.0.1:8081"
-        weight: 1
-        health_check:
-            path: "/health"
-            interval: 5000
-    -   id: "backend2"
-        address: "127.0.0.1:8082"
-        weight: 1
-        health_check:
-            path: "/health"
-            interval: 5000
-    -   id: "backend3"
-        address: "127.0.0.1:8083"
-        weight: 1
-        health_check:
-            path: "/health"
-            interval: 5000
-
-load_balancing:
-    type: consistent-hash
+upstream:
+    default:
+        load_balancing:
+            type: consistent-hash
+        route:
+            path_prefix: "/"
+        backends:
+            -   id: "backend1"
+                address: "http://127.0.0.1:8081"
+                weight: 1
+                health_check:
+                    path: "/health"
+                    interval: 5000
+            -   id: "backend2"
+                address: "http://127.0.0.1:8082"
+                weight: 1
+                health_check:
+                    path: "/health"
+                    interval: 5000
+            -   id: "backend3"
+                address: "http://127.0.0.1:8083"
+                weight: 1
+                health_check:
+                    path: "/health"
+                    interval: 5000
 
 log:
   level: info

--- a/scripts/lb-random.sh
+++ b/scripts/lb-random.sh
@@ -6,6 +6,8 @@ source "$(dirname "$0")/common.sh"
 ensure_bins
 
 cat > /tmp/spooky-lb-random.yaml <<'YAML'
+version: 1
+
 listen:
     protocol: http3
     port: 9889
@@ -14,28 +16,31 @@ listen:
         cert: "certs/proxy-cert.pem"
         key: "certs/proxy-key-pkcs8.pem"
 
-backends:
-    -   id: "backend1"
-        address: "127.0.0.1:8081"
-        weight: 1
-        health_check:
-            path: "/health"
-            interval: 5000
-    -   id: "backend2"
-        address: "127.0.0.1:8082"
-        weight: 1
-        health_check:
-            path: "/health"
-            interval: 5000
-    -   id: "backend3"
-        address: "127.0.0.1:8083"
-        weight: 1
-        health_check:
-            path: "/health"
-            interval: 5000
-
-load_balancing:
-    type: random
+upstream:
+    default:
+        load_balancing:
+            type: random
+        route:
+            path_prefix: "/"
+        backends:
+            -   id: "backend1"
+                address: "http://127.0.0.1:8081"
+                weight: 1
+                health_check:
+                    path: "/health"
+                    interval: 5000
+            -   id: "backend2"
+                address: "http://127.0.0.1:8082"
+                weight: 1
+                health_check:
+                    path: "/health"
+                    interval: 5000
+            -   id: "backend3"
+                address: "http://127.0.0.1:8083"
+                weight: 1
+                health_check:
+                    path: "/health"
+                    interval: 5000
 
 log:
   level: info

--- a/scripts/lb-round-robin.sh
+++ b/scripts/lb-round-robin.sh
@@ -6,6 +6,8 @@ source "$(dirname "$0")/common.sh"
 ensure_bins
 
 cat > /tmp/spooky-lb-rr.yaml <<'YAML'
+version: 1
+
 listen:
     protocol: http3
     port: 9889
@@ -14,28 +16,31 @@ listen:
         cert: "certs/proxy-cert.pem"
         key: "certs/proxy-key-pkcs8.pem"
 
-backends:
-    -   id: "backend1"
-        address: "127.0.0.1:8081"
-        weight: 1
-        health_check:
-            path: "/health"
-            interval: 5000
-    -   id: "backend2"
-        address: "127.0.0.1:8082"
-        weight: 1
-        health_check:
-            path: "/health"
-            interval: 5000
-    -   id: "backend3"
-        address: "127.0.0.1:8083"
-        weight: 1
-        health_check:
-            path: "/health"
-            interval: 5000
-
-load_balancing:
-    type: round-robin
+upstream:
+    default:
+        load_balancing:
+            type: round-robin
+        route:
+            path_prefix: "/"
+        backends:
+            -   id: "backend1"
+                address: "http://127.0.0.1:8081"
+                weight: 1
+                health_check:
+                    path: "/health"
+                    interval: 5000
+            -   id: "backend2"
+                address: "http://127.0.0.1:8082"
+                weight: 1
+                health_check:
+                    path: "/health"
+                    interval: 5000
+            -   id: "backend3"
+                address: "http://127.0.0.1:8083"
+                weight: 1
+                health_check:
+                    path: "/health"
+                    interval: 5000
 
 log:
   level: info

--- a/scripts/load-matrix.sh
+++ b/scripts/load-matrix.sh
@@ -158,7 +158,10 @@ latest_note="${OUT_BASE}/latest_run_path.txt"
 
 echo -n >"${summary_tsv}"
 
-for profile_dir in "${RUN_DIR}"/profile_*; do
+for profile_dir in "${RUN_DIR}"/*; do
+  if [[ ! -d "${profile_dir}" ]]; then
+    continue
+  fi
   profile="$(basename "${profile_dir}")"
   if [[ ! -f "${profile_dir}/latest.tsv" ]]; then
     continue

--- a/spooky/src/app.rs
+++ b/spooky/src/app.rs
@@ -296,7 +296,10 @@ fn apply_privilege_drop(uid: libc::uid_t, runtime_config: &RuntimeConfig) {
     let group = runtime_config.security.privileges.group.trim();
     match privilege_drop::drop_privileges(user, group) {
         Ok(()) => {
-            info!("Dropped process privileges to user='{}' group='{}'", user, group);
+            info!(
+                "Dropped process privileges to user='{}' group='{}'",
+                user, group
+            );
         }
         Err(err) => {
             fatal_startup_error(

--- a/spooky/src/app.rs
+++ b/spooky/src/app.rs
@@ -17,6 +17,7 @@ use crate::listener_group::{
     ListenerGroupRuntime, collect_finished_listener_groups, log_listener_startup,
     reconcile_listener_groups, spawn_managed_listener_group,
 };
+use crate::privilege_drop;
 use crate::runtime_guard;
 
 #[derive(Parser)]
@@ -197,6 +198,7 @@ async fn run(
     }
 
     log_listener_startup(&runtime_config, &listener_groups);
+    apply_privilege_drop(uid, &runtime_config);
 
     let mut worker_failed = false;
     while !shutdown.load(Ordering::Relaxed) {
@@ -283,4 +285,28 @@ fn fatal_startup_error(message: &str, logger_ready: bool, exit_code: i32) -> ! {
         eprintln!("Error: {}", message);
     }
     std::process::exit(exit_code);
+}
+
+fn apply_privilege_drop(uid: libc::uid_t, runtime_config: &RuntimeConfig) {
+    if uid != 0 || !runtime_config.security.privileges.enabled {
+        return;
+    }
+
+    let user = runtime_config.security.privileges.user.trim();
+    let group = runtime_config.security.privileges.group.trim();
+    match privilege_drop::drop_privileges(user, group) {
+        Ok(()) => {
+            info!("Dropped process privileges to user='{}' group='{}'", user, group);
+        }
+        Err(err) => {
+            fatal_startup_error(
+                &format!(
+                    "Failed to drop process privileges to user='{}' group='{}': {}",
+                    user, group, err
+                ),
+                true,
+                1,
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary 
The PR introduces the following fixes: 
- Fix privilege dropping first
- Correct watchdog restart semantics
- Fix control API TLS reload coupling.
- Make listener cert reload atomic
- Fix retry-budget behaviour
- Fix retry telemetry semantics
- Repair the stale LB example scripts
- Fix `load-matrix.sh` summary discovery
- Add regression coverage