### PR TITLE
refactor(edge): extract shared route resolution and backend selection pipeline

### DIFF
--- a/crates/edge/src/quic_listener/bootstrap_tls.rs
+++ b/crates/edge/src/quic_listener/bootstrap_tls.rs
@@ -389,17 +389,24 @@ impl QUICListener {
                                         .and_then(|value| value.to_str().ok())
                                         .map(str::to_string)
                                 };
-                                let resolved = Self::resolve_backend(
-                                    &method,
-                                    &path,
-                                    authority.as_deref(),
-                                    None,
-                                    &upstream_pools,
-                                    &routing_index,
-                                    Some(&lb_header_lookup),
-                                );
-                                let (backend_addr, upstream_name) = match resolved {
-                                    Ok(value) => (value.backend_addr, value.upstream_name),
+                                let (backend_addr, upstream_name) = match {
+                                    let resolution_request =
+                                        super::forwarding::SharedRouteResolutionRequest::new(
+                                            &method,
+                                            &path,
+                                            authority.as_deref(),
+                                            None,
+                                            Some(&lb_header_lookup),
+                                        );
+                                    Self::resolve_backend_request(
+                                        &resolution_request,
+                                        &upstream_pools,
+                                        &routing_index,
+                                    )
+                                } {
+                                    Ok(value) => {
+                                        (value.backend.backend_addr, value.route.upstream_name)
+                                    }
                                     Err(ProxyError::Transport(reason)) => {
                                         let (status, body) =
                                             bootstrap_resolution_error_response(&reason);

--- a/crates/edge/src/quic_listener/bootstrap_tls.rs
+++ b/crates/edge/src/quic_listener/bootstrap_tls.rs
@@ -390,15 +390,17 @@ impl QUICListener {
                                 };
                                 let (backend_addr, upstream_name, upstream_policy) =
                                     match Self::resolve_bootstrap_target(
-                                        &method,
-                                        &path,
-                                        authority.as_deref(),
-                                        Some(&lb_header_lookup),
-                                        &routing_index,
-                                        &upstream_pools,
-                                        &upstream_policies,
-                                        &metrics,
-                                        Duration::from_millis(0),
+                                        super::forwarding::BootstrapResolutionInput {
+                                            method: &method,
+                                            path: &path,
+                                            authority: authority.as_deref(),
+                                            header_lookup: Some(&lb_header_lookup),
+                                            routing_index: &routing_index,
+                                            upstream_pools: &upstream_pools,
+                                            upstream_policies: &upstream_policies,
+                                            metrics: &metrics,
+                                            elapsed: Duration::from_millis(0),
+                                        },
                                     ) {
                                         Ok(value) => (
                                             value.backend_addr,

--- a/crates/edge/src/quic_listener/bootstrap_tls.rs
+++ b/crates/edge/src/quic_listener/bootstrap_tls.rs
@@ -40,8 +40,7 @@ use super::{
         AdmissionPolicyDecision, admission_rejection_response,
         evaluate_forwarding_pre_admission_policy,
     },
-    bootstrap_resolution_error_response, boxed_full, connection_header_tokens, is_head_method,
-    is_websocket_upgrade_request,
+    boxed_full, connection_header_tokens, is_head_method, is_websocket_upgrade_request,
     runtime_endpoint::RuntimeConnectionSlotGuard,
     runtime_handle, should_strip_bootstrap_response_header, spawn_supervised_async_task,
     validate_http_request,
@@ -389,7 +388,7 @@ impl QUICListener {
                                         .and_then(|value| value.to_str().ok())
                                         .map(str::to_string)
                                 };
-                                let (backend_addr, upstream_name, upstream_policy) = match {
+                                let (backend_addr, upstream_name, upstream_policy) = {
                                     let resolution_request =
                                         super::forwarding::SharedRouteResolutionRequest::new(
                                             &method,
@@ -398,37 +397,30 @@ impl QUICListener {
                                             None,
                                             Some(&lb_header_lookup),
                                         );
-                                    Self::resolve_backend_request(
+                                    match Self::resolve_backend_request(
                                         &resolution_request,
                                         &upstream_pools,
                                         &upstream_policies,
                                         &routing_index,
-                                    )
-                                } {
-                                    Ok(value) => (
-                                        value.backend.backend_addr,
-                                        value.route.upstream_name,
-                                        value.route.upstream_policy,
-                                    ),
-                                    Err(ProxyError::Transport(reason)) => {
-                                        let (status, body) =
-                                            bootstrap_resolution_error_response(&reason);
-                                        if status == StatusCode::BAD_GATEWAY
-                                            && body == b"route/backend resolution failed\n"
-                                        {
-                                            warn!(
-                                                "Bootstrap route/backend resolution failed: {}",
-                                                reason
+                                    ) {
+                                        Ok(value) => (
+                                            value.backend.backend_addr,
+                                            value.route.upstream_name,
+                                            value.route.upstream_policy,
+                                        ),
+                                        Err(err) => {
+                                            Self::observe_route_resolution_failure(
+                                                &resolution_request,
+                                                &err,
+                                                &metrics,
+                                                Duration::from_millis(0),
                                             );
+                                            let (status, body) =
+                                                Self::bootstrap_route_resolution_error_response(
+                                                    &err,
+                                                );
+                                            return bootstrap_error(status, body);
                                         }
-                                        return bootstrap_error(status, body);
-                                    }
-                                    Err(err) => {
-                                        warn!("Bootstrap route/backend resolution failed: {}", err);
-                                        return bootstrap_error(
-                                            StatusCode::BAD_GATEWAY,
-                                            b"route/backend resolution failed\n",
-                                        );
                                     }
                                 };
 

--- a/crates/edge/src/quic_listener/bootstrap_tls.rs
+++ b/crates/edge/src/quic_listener/bootstrap_tls.rs
@@ -388,41 +388,31 @@ impl QUICListener {
                                         .and_then(|value| value.to_str().ok())
                                         .map(str::to_string)
                                 };
-                                let (backend_addr, upstream_name, upstream_policy) = {
-                                    let resolution_request =
-                                        super::forwarding::SharedRouteResolutionRequest::new(
-                                            &method,
-                                            &path,
-                                            authority.as_deref(),
-                                            None,
-                                            Some(&lb_header_lookup),
-                                        );
-                                    match Self::resolve_backend_request(
-                                        &resolution_request,
+                                let (backend_addr, upstream_name, upstream_policy) =
+                                    match Self::resolve_bootstrap_target(
+                                        &method,
+                                        &path,
+                                        authority.as_deref(),
+                                        Some(&lb_header_lookup),
+                                        &routing_index,
                                         &upstream_pools,
                                         &upstream_policies,
-                                        &routing_index,
+                                        &metrics,
+                                        Duration::from_millis(0),
                                     ) {
                                         Ok(value) => (
-                                            value.backend.backend_addr,
-                                            value.route.upstream_name,
-                                            value.route.upstream_policy,
+                                            value.backend_addr,
+                                            value.upstream_name,
+                                            value.upstream_policy,
                                         ),
                                         Err(err) => {
-                                            Self::observe_route_resolution_failure(
-                                                &resolution_request,
-                                                &err,
-                                                &metrics,
-                                                Duration::from_millis(0),
-                                            );
                                             let (status, body) =
                                                 Self::bootstrap_route_resolution_error_response(
                                                     &err,
                                                 );
                                             return bootstrap_error(status, body);
                                         }
-                                    }
-                                };
+                                    };
 
                                 let admission = evaluate_forwarding_pre_admission_policy(
                                     &upstream_policy,

--- a/crates/edge/src/quic_listener/bootstrap_tls.rs
+++ b/crates/edge/src/quic_listener/bootstrap_tls.rs
@@ -389,7 +389,7 @@ impl QUICListener {
                                         .and_then(|value| value.to_str().ok())
                                         .map(str::to_string)
                                 };
-                                let (backend_addr, upstream_name) = match {
+                                let (backend_addr, upstream_name, upstream_policy) = match {
                                     let resolution_request =
                                         super::forwarding::SharedRouteResolutionRequest::new(
                                             &method,
@@ -401,12 +401,15 @@ impl QUICListener {
                                     Self::resolve_backend_request(
                                         &resolution_request,
                                         &upstream_pools,
+                                        &upstream_policies,
                                         &routing_index,
                                     )
                                 } {
-                                    Ok(value) => {
-                                        (value.backend.backend_addr, value.route.upstream_name)
-                                    }
+                                    Ok(value) => (
+                                        value.backend.backend_addr,
+                                        value.route.upstream_name,
+                                        value.route.upstream_policy,
+                                    ),
                                     Err(ProxyError::Transport(reason)) => {
                                         let (status, body) =
                                             bootstrap_resolution_error_response(&reason);
@@ -429,10 +432,6 @@ impl QUICListener {
                                     }
                                 };
 
-                                let upstream_policy = upstream_policies
-                                    .get(&upstream_name)
-                                    .cloned()
-                                    .unwrap_or_default();
                                 let admission = evaluate_forwarding_pre_admission_policy(
                                     &upstream_policy,
                                     Some(&lb_header_lookup),

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -11,6 +11,7 @@ use std::{convert::Infallible, error::Error as StdError};
 use spooky_config::config::ScopedRateLimitScope;
 
 use self::prepare::{PreparedRequest, StartedAuthRequest};
+pub(in crate::quic_listener) use self::resolve::BootstrapResolutionInput;
 #[cfg(test)]
 pub(in crate::quic_listener) use self::resolve::RouteResolutionRequest as TestRouteResolutionRequest;
 use super::*;

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -11,6 +11,7 @@ use std::{convert::Infallible, error::Error as StdError};
 use spooky_config::config::ScopedRateLimitScope;
 
 use self::prepare::{PreparedRequest, StartedAuthRequest};
+pub(in crate::quic_listener) use self::resolve::RouteResolutionRequest as SharedRouteResolutionRequest;
 use super::*;
 use crate::runtime::connection::{request::PendingForward, stream::StreamAdmissionState};
 

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -11,6 +11,7 @@ use std::{convert::Infallible, error::Error as StdError};
 use spooky_config::config::ScopedRateLimitScope;
 
 use self::prepare::{PreparedRequest, StartedAuthRequest};
+#[allow(unused_imports)]
 pub(in crate::quic_listener) use self::resolve::RouteResolutionRequest as SharedRouteResolutionRequest;
 use super::*;
 use crate::runtime::connection::{request::PendingForward, stream::StreamAdmissionState};

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -11,11 +11,10 @@ use std::{convert::Infallible, error::Error as StdError};
 use spooky_config::config::ScopedRateLimitScope;
 
 use self::prepare::{PreparedRequest, StartedAuthRequest};
-use super::*;
-use crate::runtime::connection::{request::PendingForward, stream::StreamAdmissionState};
-
 #[cfg(test)]
 pub(in crate::quic_listener) use self::resolve::RouteResolutionRequest as TestRouteResolutionRequest;
+use super::*;
+use crate::runtime::connection::{request::PendingForward, stream::StreamAdmissionState};
 
 pub(super) fn abort_stream(req: &mut RequestEnvelope, metrics: &Metrics) -> StreamPhase {
     let phase = req.phase.clone();

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -11,10 +11,11 @@ use std::{convert::Infallible, error::Error as StdError};
 use spooky_config::config::ScopedRateLimitScope;
 
 use self::prepare::{PreparedRequest, StartedAuthRequest};
-#[allow(unused_imports)]
-pub(in crate::quic_listener) use self::resolve::RouteResolutionRequest as SharedRouteResolutionRequest;
 use super::*;
 use crate::runtime::connection::{request::PendingForward, stream::StreamAdmissionState};
+
+#[cfg(test)]
+pub(in crate::quic_listener) use self::resolve::RouteResolutionRequest as TestRouteResolutionRequest;
 
 pub(super) fn abort_stream(req: &mut RequestEnvelope, metrics: &Metrics) -> StreamPhase {
     let phase = req.phase.clone();

--- a/crates/edge/src/quic_listener/forwarding/prepare.rs
+++ b/crates/edge/src/quic_listener/forwarding/prepare.rs
@@ -5,7 +5,7 @@ use tracing::Span;
 
 use super::{
     auth::{AuthStart, auth_failure_mode, fail_open, start_external_auth_task},
-    resolve::ResolvedBackend,
+    resolve::{ResolvedBackend, ResolvedRoute, RouteResolutionRequest, SelectedBackend},
     *,
 };
 use crate::{
@@ -184,27 +184,33 @@ impl QUICListener {
         } else {
             method
         };
-        let resolved = Self::resolve_backend_without_inflight(
+        let resolution_request = RouteResolutionRequest::new(
             route_method,
             path,
             authority,
             Some(sticky_cid_key),
+            Some(&lb_header_lookup),
+        );
+        let resolved = Self::resolve_backend_without_inflight_request(
+            &resolution_request,
             upstream_pools,
             routing_index,
-            Some(&lb_header_lookup),
         );
 
         let prepared = match resolved {
-            Ok(ResolvedBackend {
-                upstream_name,
-                backend_addr,
-                backend_index,
-                upstream_pool,
-                backend_lb,
-                route_path_len,
-                route_host_specific,
-                route_reason,
-            }) => {
+            Ok(ResolvedBackend { route, backend }) => {
+                let ResolvedRoute {
+                    upstream_name,
+                    upstream_pool,
+                    route_path_len,
+                    route_host_specific,
+                    route_reason,
+                } = route;
+                let SelectedBackend {
+                    backend_addr,
+                    backend_index,
+                    backend_lb,
+                } = backend;
                 let upstream_policy = upstream_policies
                     .get(&upstream_name)
                     .cloned()

--- a/crates/edge/src/quic_listener/forwarding/prepare.rs
+++ b/crates/edge/src/quic_listener/forwarding/prepare.rs
@@ -5,7 +5,7 @@ use tracing::Span;
 
 use super::{
     auth::{AuthStart, auth_failure_mode, fail_open, start_external_auth_task},
-    resolve::{ResolvedBackend, ResolvedRoute, RouteResolutionRequest, SelectedBackend},
+    resolve::ForwardingResolvedTarget,
     *,
 };
 use crate::{
@@ -179,40 +179,32 @@ impl QUICListener {
                 .and_then(|header| std::str::from_utf8(header.value()).ok())
                 .map(str::to_string)
         };
-        let route_method = if matches!(tunnel_mode, TunnelMode::Websocket) {
-            "GET"
-        } else {
-            method
-        };
-        let resolution_request = RouteResolutionRequest::new(
-            route_method,
+        let resolved = Self::resolve_forwarding_target(
+            method,
             path,
             authority,
-            Some(sticky_cid_key),
+            tunnel_mode,
+            sticky_cid_key,
             Some(&lb_header_lookup),
-        );
-        let resolved = Self::resolve_backend_without_inflight_request(
-            &resolution_request,
+            routing_index,
             upstream_pools,
             upstream_policies,
-            routing_index,
+            metrics,
+            request_start.elapsed(),
         );
 
         let prepared = match resolved {
-            Ok(ResolvedBackend { route, backend }) => {
-                let ResolvedRoute {
-                    upstream_name,
-                    upstream_pool,
-                    upstream_policy,
-                    route_path_len,
-                    route_host_specific,
-                    route_reason,
-                } = route;
-                let SelectedBackend {
-                    backend_addr,
-                    backend_index,
-                    backend_lb,
-                } = backend;
+            Ok(ForwardingResolvedTarget {
+                upstream_name,
+                upstream_pool,
+                upstream_policy,
+                route_path_len,
+                route_host_specific,
+                route_reason,
+                backend_addr,
+                backend_index,
+                backend_lb,
+            }) => {
                 let admission = evaluate_forwarding_pre_admission_policy(
                     &upstream_policy,
                     Some(&lb_header_lookup),
@@ -356,7 +348,6 @@ impl QUICListener {
                 let bodyless_mode = !is_tunnel_mode(tunnel_mode)
                     && is_bodyless_request_mode(method, content_length);
                 let request_fin_received = bodyless_mode;
-                let route_reason = format!("{route_reason:?}");
                 let external_auth = upstream_policy.upstream_auth.external_auth.clone();
                 let auth_fail_open = external_auth
                     .as_ref()
@@ -408,12 +399,6 @@ impl QUICListener {
                 })
             }
             Err(err) => {
-                Self::observe_route_resolution_failure(
-                    &resolution_request,
-                    &err,
-                    metrics,
-                    request_start.elapsed(),
-                );
                 let (status, body): (http::StatusCode, &[u8]) = match err {
                     ProxyError::Transport(_) => (
                         http::StatusCode::SERVICE_UNAVAILABLE,

--- a/crates/edge/src/quic_listener/forwarding/prepare.rs
+++ b/crates/edge/src/quic_listener/forwarding/prepare.rs
@@ -194,6 +194,7 @@ impl QUICListener {
         let resolved = Self::resolve_backend_without_inflight_request(
             &resolution_request,
             upstream_pools,
+            upstream_policies,
             routing_index,
         );
 
@@ -202,6 +203,7 @@ impl QUICListener {
                 let ResolvedRoute {
                     upstream_name,
                     upstream_pool,
+                    upstream_policy,
                     route_path_len,
                     route_host_specific,
                     route_reason,
@@ -211,10 +213,6 @@ impl QUICListener {
                     backend_index,
                     backend_lb,
                 } = backend;
-                let upstream_policy = upstream_policies
-                    .get(&upstream_name)
-                    .cloned()
-                    .unwrap_or_default();
                 let admission = evaluate_forwarding_pre_admission_policy(
                     &upstream_policy,
                     Some(&lb_header_lookup),

--- a/crates/edge/src/quic_listener/forwarding/prepare.rs
+++ b/crates/edge/src/quic_listener/forwarding/prepare.rs
@@ -408,8 +408,12 @@ impl QUICListener {
                 })
             }
             Err(err) => {
-                metrics.inc_failure();
-                metrics.record_route("unrouted", request_start.elapsed(), RouteOutcome::Failure);
+                Self::observe_route_resolution_failure(
+                    &resolution_request,
+                    &err,
+                    metrics,
+                    request_start.elapsed(),
+                );
                 let (status, body): (http::StatusCode, &[u8]) = match err {
                     ProxyError::Transport(_) => (
                         http::StatusCode::SERVICE_UNAVAILABLE,

--- a/crates/edge/src/quic_listener/forwarding/resolve.rs
+++ b/crates/edge/src/quic_listener/forwarding/resolve.rs
@@ -1,66 +1,85 @@
 use super::*;
 
-pub(crate) struct ResolvedBackend {
+pub(in crate::quic_listener) struct RouteResolutionRequest<'a> {
+    pub(in crate::quic_listener) method: &'a str,
+    pub(in crate::quic_listener) path: &'a str,
+    pub(in crate::quic_listener) authority: Option<&'a str>,
+    pub(in crate::quic_listener) cid_key: Option<&'a str>,
+    pub(in crate::quic_listener) header_lookup: Option<&'a LbHeaderLookup<'a>>,
+}
+
+impl<'a> RouteResolutionRequest<'a> {
+    pub(in crate::quic_listener) fn new(
+        method: &'a str,
+        path: &'a str,
+        authority: Option<&'a str>,
+        cid_key: Option<&'a str>,
+        header_lookup: Option<&'a LbHeaderLookup<'a>>,
+    ) -> Self {
+        Self {
+            method,
+            path,
+            authority,
+            cid_key,
+            header_lookup,
+        }
+    }
+}
+
+pub(crate) struct ResolvedRoute {
     pub(crate) upstream_name: String,
-    pub(crate) backend_addr: String,
-    pub(crate) backend_index: usize,
     pub(crate) upstream_pool: Arc<RwLock<UpstreamPool>>,
-    pub(crate) backend_lb: String,
     pub(crate) route_path_len: usize,
     pub(crate) route_host_specific: bool,
     pub(crate) route_reason: RouteDecisionReason,
 }
 
+pub(crate) struct SelectedBackend {
+    pub(crate) backend_addr: String,
+    pub(crate) backend_index: usize,
+    pub(crate) backend_lb: String,
+}
+
+pub(crate) struct ResolvedBackend {
+    pub(crate) route: ResolvedRoute,
+    pub(crate) backend: SelectedBackend,
+}
+
 impl QUICListener {
     #[allow(clippy::type_complexity)]
     fn resolve_route_target(
-        method: &str,
-        path: &str,
-        authority: Option<&str>,
+        request: &RouteResolutionRequest<'_>,
         upstream_pools: &HashMap<String, Arc<RwLock<UpstreamPool>>>,
         routing_index: &RouteIndex,
-    ) -> Result<
-        (
-            String,
-            Arc<RwLock<UpstreamPool>>,
-            usize,
-            bool,
-            RouteDecisionReason,
-        ),
-        ProxyError,
-    > {
-        if method.is_empty() || path.is_empty() {
+    ) -> Result<ResolvedRoute, ProxyError> {
+        if request.method.is_empty() || request.path.is_empty() {
             return Err(ProxyError::Transport("empty method or path".into()));
         }
 
         let route_decision = routing_index
-            .lookup_with_decision_for_method(path, authority, Some(method))
-            .ok_or_else(|| ProxyError::Transport(format!("no route for {path}")))?;
+            .lookup_with_decision_for_method(request.path, request.authority, Some(request.method))
+            .ok_or_else(|| ProxyError::Transport(format!("no route for {}", request.path)))?;
         let upstream_name = route_decision.upstream.to_string();
         let upstream_pool = upstream_pools
             .get(route_decision.upstream)
             .ok_or_else(|| ProxyError::Transport(format!("pool not found: {upstream_name}")))?
             .clone();
 
-        Ok((
+        Ok(ResolvedRoute {
             upstream_name,
             upstream_pool,
-            route_decision.matched_path_len,
-            route_decision.host_specific,
-            route_decision.reason,
-        ))
+            route_path_len: route_decision.matched_path_len,
+            route_host_specific: route_decision.host_specific,
+            route_reason: route_decision.reason,
+        })
     }
 
     fn select_backend_from_pool(
-        method: &str,
-        path: &str,
-        authority: Option<&str>,
-        cid_key: Option<&str>,
+        request: &RouteResolutionRequest<'_>,
         upstream_pool: &Arc<RwLock<UpstreamPool>>,
-        header_lookup: Option<&LbHeaderLookup<'_>>,
         begin_request: bool,
-    ) -> Result<(usize, String, String), ProxyError> {
-        let (backend_index, lb_type, backend_addr) = {
+    ) -> Result<SelectedBackend, ProxyError> {
+        let (backend_index, backend_lb, backend_addr) = {
             let (read_lb_type, read_fast_selected) = {
                 let pool = upstream_pool
                     .read()
@@ -72,11 +91,11 @@ impl QUICListener {
                 let key = Self::resolve_lb_request_key(
                     lb_type,
                     pool.lb_key(),
-                    method,
-                    path,
-                    authority,
-                    cid_key,
-                    header_lookup,
+                    request.method,
+                    request.path,
+                    request.authority,
+                    request.cid_key,
+                    request.header_lookup,
                 );
                 let fast_selected = if pool.pool.readmit_due() {
                     None
@@ -104,11 +123,11 @@ impl QUICListener {
                 let key = Self::resolve_lb_request_key(
                     lb_type,
                     pool.lb_key(),
-                    method,
-                    path,
-                    authority,
-                    cid_key,
-                    header_lookup,
+                    request.method,
+                    request.path,
+                    request.authority,
+                    request.cid_key,
+                    request.header_lookup,
                 );
                 let idx = if begin_request {
                     pool.pick(key.as_str())
@@ -133,7 +152,11 @@ impl QUICListener {
             }
         };
 
-        Ok((backend_index, lb_type.to_string(), backend_addr))
+        Ok(SelectedBackend {
+            backend_addr,
+            backend_index,
+            backend_lb: backend_lb.to_string(),
+        })
     }
 
     fn log_backend_selection(
@@ -150,86 +173,40 @@ impl QUICListener {
         );
     }
 
-    pub(super) fn resolve_backend_without_inflight(
-        method: &str,
-        path: &str,
-        authority: Option<&str>,
-        cid_key: Option<&str>,
+    fn resolve_backend_internal(
+        request: &RouteResolutionRequest<'_>,
         upstream_pools: &HashMap<String, Arc<RwLock<UpstreamPool>>>,
         routing_index: &RouteIndex,
-        header_lookup: Option<&LbHeaderLookup<'_>>,
+        begin_request: bool,
     ) -> Result<ResolvedBackend, ProxyError> {
-        let (upstream_name, upstream_pool, route_path_len, route_host_specific, route_reason) =
-            Self::resolve_route_target(method, path, authority, upstream_pools, routing_index)?;
-        let (backend_index, backend_lb, backend_addr) = Self::select_backend_from_pool(
-            method,
-            path,
-            authority,
-            cid_key,
-            &upstream_pool,
-            header_lookup,
-            false,
-        )?;
+        let route = Self::resolve_route_target(request, upstream_pools, routing_index)?;
+        let backend = Self::select_backend_from_pool(request, &route.upstream_pool, begin_request)?;
 
         Self::log_backend_selection(
-            &backend_addr,
-            &backend_lb,
-            &upstream_name,
-            route_path_len,
-            route_host_specific,
-            &route_reason,
+            &backend.backend_addr,
+            &backend.backend_lb,
+            &route.upstream_name,
+            route.route_path_len,
+            route.route_host_specific,
+            &route.route_reason,
         );
-        Ok(ResolvedBackend {
-            upstream_name,
-            backend_addr,
-            backend_index,
-            upstream_pool,
-            backend_lb,
-            route_path_len,
-            route_host_specific,
-            route_reason,
-        })
+        Ok(ResolvedBackend { route, backend })
+    }
+
+    pub(super) fn resolve_backend_without_inflight_request(
+        request: &RouteResolutionRequest<'_>,
+        upstream_pools: &HashMap<String, Arc<RwLock<UpstreamPool>>>,
+        routing_index: &RouteIndex,
+    ) -> Result<ResolvedBackend, ProxyError> {
+        Self::resolve_backend_internal(request, upstream_pools, routing_index, false)
     }
 
     /// Resolve routing + LB for a request, returning `(backend_addr, backend_index, pool)`.
-    pub(crate) fn resolve_backend(
-        method: &str,
-        path: &str,
-        authority: Option<&str>,
-        cid_key: Option<&str>,
+    pub(in crate::quic_listener) fn resolve_backend_request(
+        request: &RouteResolutionRequest<'_>,
         upstream_pools: &HashMap<String, Arc<RwLock<UpstreamPool>>>,
         routing_index: &RouteIndex,
-        header_lookup: Option<&LbHeaderLookup<'_>>,
     ) -> Result<ResolvedBackend, ProxyError> {
-        let (upstream_name, upstream_pool, route_path_len, route_host_specific, route_reason) =
-            Self::resolve_route_target(method, path, authority, upstream_pools, routing_index)?;
-        let (backend_index, backend_lb, backend_addr) = Self::select_backend_from_pool(
-            method,
-            path,
-            authority,
-            cid_key,
-            &upstream_pool,
-            header_lookup,
-            true,
-        )?;
-
-        Self::log_backend_selection(
-            &backend_addr,
-            &backend_lb,
-            &upstream_name,
-            route_path_len,
-            route_host_specific,
-            &route_reason,
-        );
-        Ok(ResolvedBackend {
-            upstream_name,
-            backend_addr,
-            backend_index,
-            upstream_pool,
-            backend_lb,
-            route_path_len,
-            route_host_specific,
-            route_reason,
-        })
+        Self::resolve_backend_internal(request, upstream_pools, routing_index, true)
     }
 }

--- a/crates/edge/src/quic_listener/forwarding/resolve.rs
+++ b/crates/edge/src/quic_listener/forwarding/resolve.rs
@@ -66,6 +66,18 @@ pub(in crate::quic_listener) struct BootstrapResolvedTarget {
     pub(in crate::quic_listener) backend_addr: String,
 }
 
+pub(in crate::quic_listener) struct BootstrapResolutionInput<'a> {
+    pub(in crate::quic_listener) method: &'a str,
+    pub(in crate::quic_listener) path: &'a str,
+    pub(in crate::quic_listener) authority: Option<&'a str>,
+    pub(in crate::quic_listener) header_lookup: Option<&'a LbHeaderLookup<'a>>,
+    pub(in crate::quic_listener) routing_index: &'a RouteIndex,
+    pub(in crate::quic_listener) upstream_pools: &'a HashMap<String, Arc<RwLock<UpstreamPool>>>,
+    pub(in crate::quic_listener) upstream_policies: &'a HashMap<String, RuntimeUpstreamPolicy>,
+    pub(in crate::quic_listener) metrics: &'a Metrics,
+    pub(in crate::quic_listener) elapsed: Duration,
+}
+
 struct BackendSelectionPlan {
     lb_type: String,
     lb_key: String,
@@ -237,16 +249,19 @@ impl QUICListener {
     }
 
     pub(in crate::quic_listener) fn resolve_bootstrap_target(
-        method: &str,
-        path: &str,
-        authority: Option<&str>,
-        header_lookup: Option<&LbHeaderLookup<'_>>,
-        routing_index: &RouteIndex,
-        upstream_pools: &HashMap<String, Arc<RwLock<UpstreamPool>>>,
-        upstream_policies: &HashMap<String, RuntimeUpstreamPolicy>,
-        metrics: &Metrics,
-        elapsed: Duration,
+        input: BootstrapResolutionInput<'_>,
     ) -> Result<BootstrapResolvedTarget, ProxyError> {
+        let BootstrapResolutionInput {
+            method,
+            path,
+            authority,
+            header_lookup,
+            routing_index,
+            upstream_pools,
+            upstream_policies,
+            metrics,
+            elapsed,
+        } = input;
         let resolution_request =
             RouteResolutionRequest::new(method, path, authority, None, header_lookup);
         let ResolvedBackend { route, backend } = match Self::resolve_backend_internal(

--- a/crates/edge/src/quic_listener/forwarding/resolve.rs
+++ b/crates/edge/src/quic_listener/forwarding/resolve.rs
@@ -52,7 +52,100 @@ struct BackendSelectionPlan {
     lb_key: String,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RouteResolutionFailureKind {
+    NoRoute,
+    MissingPool,
+    PoolLockPoisoned,
+    NoServers,
+    NoHealthyServers,
+    InvalidServerAddress,
+    OtherTransport,
+    Other,
+}
+
 impl QUICListener {
+    fn classify_route_resolution_transport_reason(reason: &str) -> RouteResolutionFailureKind {
+        if reason.starts_with("no route for ") {
+            return RouteResolutionFailureKind::NoRoute;
+        }
+        if reason.starts_with("pool not found:") {
+            return RouteResolutionFailureKind::MissingPool;
+        }
+        if reason == "upstream pool lock poisoned" {
+            return RouteResolutionFailureKind::PoolLockPoisoned;
+        }
+        if reason == "no servers in upstream" {
+            return RouteResolutionFailureKind::NoServers;
+        }
+        if reason == "no healthy servers" {
+            return RouteResolutionFailureKind::NoHealthyServers;
+        }
+        if reason == "invalid server address" {
+            return RouteResolutionFailureKind::InvalidServerAddress;
+        }
+        RouteResolutionFailureKind::OtherTransport
+    }
+
+    fn classify_route_resolution_failure(err: &ProxyError) -> RouteResolutionFailureKind {
+        match err {
+            ProxyError::Transport(reason) => {
+                Self::classify_route_resolution_transport_reason(reason)
+            }
+            _ => RouteResolutionFailureKind::Other,
+        }
+    }
+
+    fn log_route_resolution_failure(request: &RouteResolutionRequest<'_>, err: &ProxyError) {
+        let authority = request.authority.unwrap_or("-");
+        let failure_kind = Self::classify_route_resolution_failure(err);
+        let message = format!(
+            "route/backend resolution failed method={} path={} authority={} kind={:?}: {}",
+            request.method, request.path, authority, failure_kind, err
+        );
+        match failure_kind {
+            RouteResolutionFailureKind::NoRoute => debug!("{}", message),
+            _ => warn!("{}", message),
+        }
+    }
+
+    pub(in crate::quic_listener) fn observe_route_resolution_failure(
+        request: &RouteResolutionRequest<'_>,
+        err: &ProxyError,
+        metrics: &Metrics,
+        elapsed: Duration,
+    ) {
+        metrics.inc_failure();
+        metrics.record_route("unrouted", elapsed, RouteOutcome::Failure);
+        Self::log_route_resolution_failure(request, err);
+    }
+
+    pub(in crate::quic_listener) fn bootstrap_route_resolution_error_response(
+        err: &ProxyError,
+    ) -> (http::StatusCode, &'static [u8]) {
+        match Self::classify_route_resolution_failure(err) {
+            RouteResolutionFailureKind::NoRoute => (http::StatusCode::BAD_GATEWAY, b"no route\n"),
+            RouteResolutionFailureKind::MissingPool => {
+                (http::StatusCode::BAD_GATEWAY, b"no pool\n")
+            }
+            RouteResolutionFailureKind::PoolLockPoisoned => {
+                (http::StatusCode::BAD_GATEWAY, b"pool error\n")
+            }
+            RouteResolutionFailureKind::NoServers
+            | RouteResolutionFailureKind::InvalidServerAddress => {
+                (http::StatusCode::SERVICE_UNAVAILABLE, b"no backends\n")
+            }
+            RouteResolutionFailureKind::NoHealthyServers => (
+                http::StatusCode::SERVICE_UNAVAILABLE,
+                b"no healthy backends\n",
+            ),
+            RouteResolutionFailureKind::OtherTransport | RouteResolutionFailureKind::Other => (
+                http::StatusCode::BAD_GATEWAY,
+                b"route/backend resolution failed\n",
+            ),
+        }
+    }
+
     #[allow(clippy::type_complexity)]
     fn resolve_route_target(
         request: &RouteResolutionRequest<'_>,
@@ -190,6 +283,7 @@ impl QUICListener {
     }
 
     fn log_backend_selection(
+        request: &RouteResolutionRequest<'_>,
         backend_addr: &str,
         lb_type: &str,
         upstream_name: &str,
@@ -198,8 +292,16 @@ impl QUICListener {
         route_reason: &RouteDecisionReason,
     ) {
         debug!(
-            "Selected backend {} via {} route={} path_len={} host_specific={} reason={:?}",
-            backend_addr, lb_type, upstream_name, route_path_len, route_host_specific, route_reason
+            "Resolved backend method={} path={} authority={} route={} backend={} via={} path_len={} host_specific={} reason={:?}",
+            request.method,
+            request.path,
+            request.authority.unwrap_or("-"),
+            upstream_name,
+            backend_addr,
+            lb_type,
+            route_path_len,
+            route_host_specific,
+            route_reason
         );
     }
 
@@ -215,6 +317,7 @@ impl QUICListener {
         let backend = Self::select_backend_from_pool(request, &route.upstream_pool, begin_request)?;
 
         Self::log_backend_selection(
+            request,
             &backend.backend_addr,
             &backend.backend_lb,
             &route.upstream_name,

--- a/crates/edge/src/quic_listener/forwarding/resolve.rs
+++ b/crates/edge/src/quic_listener/forwarding/resolve.rs
@@ -27,24 +27,24 @@ impl<'a> RouteResolutionRequest<'a> {
     }
 }
 
-pub(crate) struct ResolvedRoute {
-    pub(crate) upstream_name: String,
-    pub(crate) upstream_pool: Arc<RwLock<UpstreamPool>>,
-    pub(crate) upstream_policy: RuntimeUpstreamPolicy,
-    pub(crate) route_path_len: usize,
-    pub(crate) route_host_specific: bool,
-    pub(crate) route_reason: RouteDecisionReason,
+pub(in crate::quic_listener) struct ResolvedRoute {
+    pub(in crate::quic_listener) upstream_name: String,
+    pub(in crate::quic_listener) upstream_pool: Arc<RwLock<UpstreamPool>>,
+    pub(in crate::quic_listener) upstream_policy: RuntimeUpstreamPolicy,
+    pub(in crate::quic_listener) route_path_len: usize,
+    pub(in crate::quic_listener) route_host_specific: bool,
+    pub(in crate::quic_listener) route_reason: RouteDecisionReason,
 }
 
-pub(crate) struct SelectedBackend {
-    pub(crate) backend_addr: String,
-    pub(crate) backend_index: usize,
-    pub(crate) backend_lb: String,
+pub(in crate::quic_listener) struct SelectedBackend {
+    pub(in crate::quic_listener) backend_addr: String,
+    pub(in crate::quic_listener) backend_index: usize,
+    pub(in crate::quic_listener) backend_lb: String,
 }
 
-pub(crate) struct ResolvedBackend {
-    pub(crate) route: ResolvedRoute,
-    pub(crate) backend: SelectedBackend,
+pub(in crate::quic_listener) struct ResolvedBackend {
+    pub(in crate::quic_listener) route: ResolvedRoute,
+    pub(in crate::quic_listener) backend: SelectedBackend,
 }
 
 pub(super) struct ForwardingResolvedTarget {
@@ -127,7 +127,7 @@ impl QUICListener {
         }
     }
 
-    pub(in crate::quic_listener) fn observe_route_resolution_failure(
+    fn observe_route_resolution_failure(
         request: &RouteResolutionRequest<'_>,
         err: &ProxyError,
         metrics: &Metrics,
@@ -248,11 +248,12 @@ impl QUICListener {
     ) -> Result<BootstrapResolvedTarget, ProxyError> {
         let resolution_request =
             RouteResolutionRequest::new(method, path, authority, None, header_lookup);
-        let ResolvedBackend { route, backend } = match Self::resolve_backend_request(
+        let ResolvedBackend { route, backend } = match Self::resolve_backend_internal(
             &resolution_request,
             upstream_pools,
             upstream_policies,
             routing_index,
+            true,
         ) {
             Ok(resolved) => resolved,
             Err(err) => {
@@ -450,7 +451,7 @@ impl QUICListener {
         Ok(ResolvedBackend { route, backend })
     }
 
-    pub(super) fn resolve_backend_without_inflight_request(
+    fn resolve_backend_without_inflight_request(
         request: &RouteResolutionRequest<'_>,
         upstream_pools: &HashMap<String, Arc<RwLock<UpstreamPool>>>,
         upstream_policies: &HashMap<String, RuntimeUpstreamPolicy>,
@@ -465,8 +466,8 @@ impl QUICListener {
         )
     }
 
-    /// Resolve routing + LB for a request, returning `(backend_addr, backend_index, pool)`.
-    pub(in crate::quic_listener) fn resolve_backend_request(
+    #[cfg(test)]
+    pub(in crate::quic_listener) fn resolve_backend_request_for_test(
         request: &RouteResolutionRequest<'_>,
         upstream_pools: &HashMap<String, Arc<RwLock<UpstreamPool>>>,
         upstream_policies: &HashMap<String, RuntimeUpstreamPolicy>,

--- a/crates/edge/src/quic_listener/forwarding/resolve.rs
+++ b/crates/edge/src/quic_listener/forwarding/resolve.rs
@@ -47,6 +47,18 @@ pub(crate) struct ResolvedBackend {
     pub(crate) backend: SelectedBackend,
 }
 
+pub(super) struct ForwardingResolvedTarget {
+    pub(super) upstream_name: String,
+    pub(super) upstream_pool: Arc<RwLock<UpstreamPool>>,
+    pub(super) upstream_policy: RuntimeUpstreamPolicy,
+    pub(super) route_path_len: usize,
+    pub(super) route_host_specific: bool,
+    pub(super) route_reason: String,
+    pub(super) backend_addr: String,
+    pub(super) backend_index: usize,
+    pub(super) backend_lb: String,
+}
+
 struct BackendSelectionPlan {
     lb_type: String,
     lb_key: String,
@@ -144,6 +156,77 @@ impl QUICListener {
                 b"route/backend resolution failed\n",
             ),
         }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn resolve_forwarding_target(
+        method: &str,
+        path: &str,
+        authority: Option<&str>,
+        tunnel_mode: TunnelMode,
+        sticky_cid_key: &str,
+        header_lookup: Option<&LbHeaderLookup<'_>>,
+        routing_index: &RouteIndex,
+        upstream_pools: &HashMap<String, Arc<RwLock<UpstreamPool>>>,
+        upstream_policies: &HashMap<String, RuntimeUpstreamPolicy>,
+        metrics: &Metrics,
+        elapsed: Duration,
+    ) -> Result<ForwardingResolvedTarget, ProxyError> {
+        let route_method = if matches!(tunnel_mode, TunnelMode::Websocket) {
+            "GET"
+        } else {
+            method
+        };
+        let resolution_request = RouteResolutionRequest::new(
+            route_method,
+            path,
+            authority,
+            Some(sticky_cid_key),
+            header_lookup,
+        );
+        let ResolvedBackend { route, backend } =
+            match Self::resolve_backend_without_inflight_request(
+                &resolution_request,
+                upstream_pools,
+                upstream_policies,
+                routing_index,
+            ) {
+                Ok(resolved) => resolved,
+                Err(err) => {
+                    Self::observe_route_resolution_failure(
+                        &resolution_request,
+                        &err,
+                        metrics,
+                        elapsed,
+                    );
+                    return Err(err);
+                }
+            };
+        let ResolvedRoute {
+            upstream_name,
+            upstream_pool,
+            upstream_policy,
+            route_path_len,
+            route_host_specific,
+            route_reason,
+        } = route;
+        let SelectedBackend {
+            backend_addr,
+            backend_index,
+            backend_lb,
+        } = backend;
+
+        Ok(ForwardingResolvedTarget {
+            upstream_name,
+            upstream_pool,
+            upstream_policy,
+            route_path_len,
+            route_host_specific,
+            route_reason: format!("{route_reason:?}"),
+            backend_addr,
+            backend_index,
+            backend_lb,
+        })
     }
 
     #[allow(clippy::type_complexity)]

--- a/crates/edge/src/quic_listener/forwarding/resolve.rs
+++ b/crates/edge/src/quic_listener/forwarding/resolve.rs
@@ -1,4 +1,5 @@
 use super::*;
+use spooky_config::runtime::RuntimeUpstreamPolicy;
 
 pub(in crate::quic_listener) struct RouteResolutionRequest<'a> {
     pub(in crate::quic_listener) method: &'a str,
@@ -29,6 +30,7 @@ impl<'a> RouteResolutionRequest<'a> {
 pub(crate) struct ResolvedRoute {
     pub(crate) upstream_name: String,
     pub(crate) upstream_pool: Arc<RwLock<UpstreamPool>>,
+    pub(crate) upstream_policy: RuntimeUpstreamPolicy,
     pub(crate) route_path_len: usize,
     pub(crate) route_host_specific: bool,
     pub(crate) route_reason: RouteDecisionReason,
@@ -50,6 +52,7 @@ impl QUICListener {
     fn resolve_route_target(
         request: &RouteResolutionRequest<'_>,
         upstream_pools: &HashMap<String, Arc<RwLock<UpstreamPool>>>,
+        upstream_policies: &HashMap<String, RuntimeUpstreamPolicy>,
         routing_index: &RouteIndex,
     ) -> Result<ResolvedRoute, ProxyError> {
         if request.method.is_empty() || request.path.is_empty() {
@@ -64,10 +67,15 @@ impl QUICListener {
             .get(route_decision.upstream)
             .ok_or_else(|| ProxyError::Transport(format!("pool not found: {upstream_name}")))?
             .clone();
+        let upstream_policy = upstream_policies
+            .get(route_decision.upstream)
+            .cloned()
+            .unwrap_or_default();
 
         Ok(ResolvedRoute {
             upstream_name,
             upstream_pool,
+            upstream_policy,
             route_path_len: route_decision.matched_path_len,
             route_host_specific: route_decision.host_specific,
             route_reason: route_decision.reason,
@@ -176,10 +184,12 @@ impl QUICListener {
     fn resolve_backend_internal(
         request: &RouteResolutionRequest<'_>,
         upstream_pools: &HashMap<String, Arc<RwLock<UpstreamPool>>>,
+        upstream_policies: &HashMap<String, RuntimeUpstreamPolicy>,
         routing_index: &RouteIndex,
         begin_request: bool,
     ) -> Result<ResolvedBackend, ProxyError> {
-        let route = Self::resolve_route_target(request, upstream_pools, routing_index)?;
+        let route =
+            Self::resolve_route_target(request, upstream_pools, upstream_policies, routing_index)?;
         let backend = Self::select_backend_from_pool(request, &route.upstream_pool, begin_request)?;
 
         Self::log_backend_selection(
@@ -196,17 +206,31 @@ impl QUICListener {
     pub(super) fn resolve_backend_without_inflight_request(
         request: &RouteResolutionRequest<'_>,
         upstream_pools: &HashMap<String, Arc<RwLock<UpstreamPool>>>,
+        upstream_policies: &HashMap<String, RuntimeUpstreamPolicy>,
         routing_index: &RouteIndex,
     ) -> Result<ResolvedBackend, ProxyError> {
-        Self::resolve_backend_internal(request, upstream_pools, routing_index, false)
+        Self::resolve_backend_internal(
+            request,
+            upstream_pools,
+            upstream_policies,
+            routing_index,
+            false,
+        )
     }
 
     /// Resolve routing + LB for a request, returning `(backend_addr, backend_index, pool)`.
     pub(in crate::quic_listener) fn resolve_backend_request(
         request: &RouteResolutionRequest<'_>,
         upstream_pools: &HashMap<String, Arc<RwLock<UpstreamPool>>>,
+        upstream_policies: &HashMap<String, RuntimeUpstreamPolicy>,
         routing_index: &RouteIndex,
     ) -> Result<ResolvedBackend, ProxyError> {
-        Self::resolve_backend_internal(request, upstream_pools, routing_index, true)
+        Self::resolve_backend_internal(
+            request,
+            upstream_pools,
+            upstream_policies,
+            routing_index,
+            true,
+        )
     }
 }

--- a/crates/edge/src/quic_listener/forwarding/resolve.rs
+++ b/crates/edge/src/quic_listener/forwarding/resolve.rs
@@ -1,5 +1,6 @@
-use super::*;
 use spooky_config::runtime::RuntimeUpstreamPolicy;
+
+use super::*;
 
 pub(in crate::quic_listener) struct RouteResolutionRequest<'a> {
     pub(in crate::quic_listener) method: &'a str,

--- a/crates/edge/src/quic_listener/forwarding/resolve.rs
+++ b/crates/edge/src/quic_listener/forwarding/resolve.rs
@@ -59,6 +59,12 @@ pub(super) struct ForwardingResolvedTarget {
     pub(super) backend_lb: String,
 }
 
+pub(in crate::quic_listener) struct BootstrapResolvedTarget {
+    pub(in crate::quic_listener) upstream_name: String,
+    pub(in crate::quic_listener) upstream_policy: RuntimeUpstreamPolicy,
+    pub(in crate::quic_listener) backend_addr: String,
+}
+
 struct BackendSelectionPlan {
     lb_type: String,
     lb_key: String,
@@ -226,6 +232,39 @@ impl QUICListener {
             backend_addr,
             backend_index,
             backend_lb,
+        })
+    }
+
+    pub(in crate::quic_listener) fn resolve_bootstrap_target(
+        method: &str,
+        path: &str,
+        authority: Option<&str>,
+        header_lookup: Option<&LbHeaderLookup<'_>>,
+        routing_index: &RouteIndex,
+        upstream_pools: &HashMap<String, Arc<RwLock<UpstreamPool>>>,
+        upstream_policies: &HashMap<String, RuntimeUpstreamPolicy>,
+        metrics: &Metrics,
+        elapsed: Duration,
+    ) -> Result<BootstrapResolvedTarget, ProxyError> {
+        let resolution_request =
+            RouteResolutionRequest::new(method, path, authority, None, header_lookup);
+        let ResolvedBackend { route, backend } = match Self::resolve_backend_request(
+            &resolution_request,
+            upstream_pools,
+            upstream_policies,
+            routing_index,
+        ) {
+            Ok(resolved) => resolved,
+            Err(err) => {
+                Self::observe_route_resolution_failure(&resolution_request, &err, metrics, elapsed);
+                return Err(err);
+            }
+        };
+
+        Ok(BootstrapResolvedTarget {
+            upstream_name: route.upstream_name,
+            upstream_policy: route.upstream_policy,
+            backend_addr: backend.backend_addr,
         })
     }
 

--- a/crates/edge/src/quic_listener/forwarding/resolve.rs
+++ b/crates/edge/src/quic_listener/forwarding/resolve.rs
@@ -47,6 +47,11 @@ pub(crate) struct ResolvedBackend {
     pub(crate) backend: SelectedBackend,
 }
 
+struct BackendSelectionPlan {
+    lb_type: String,
+    lb_key: String,
+}
+
 impl QUICListener {
     #[allow(clippy::type_complexity)]
     fn resolve_route_target(
@@ -82,89 +87,106 @@ impl QUICListener {
         })
     }
 
+    fn build_backend_selection_plan(
+        request: &RouteResolutionRequest<'_>,
+        pool: &UpstreamPool,
+    ) -> BackendSelectionPlan {
+        let lb_type = pool.lb_name().to_string();
+        let lb_key = Self::resolve_lb_request_key(
+            &lb_type,
+            pool.lb_key(),
+            request.method,
+            request.path,
+            request.authority,
+            request.cid_key,
+            request.header_lookup,
+        );
+        BackendSelectionPlan { lb_type, lb_key }
+    }
+
+    fn no_servers_in_upstream_error() -> ProxyError {
+        ProxyError::Transport("no servers in upstream".into())
+    }
+
+    fn no_healthy_servers_error(pool: &UpstreamPool) -> ProxyError {
+        let total = pool.pool.len();
+        let healthy = pool.pool.healthy_len();
+        error!(
+            "no healthy backends available: {}/{} backends healthy",
+            healthy, total
+        );
+        ProxyError::Transport("no healthy servers".into())
+    }
+
+    fn select_backend_readonly(
+        pool: &UpstreamPool,
+        plan: &BackendSelectionPlan,
+        begin_request: bool,
+    ) -> Option<SelectedBackend> {
+        if pool.pool.readmit_due() {
+            return None;
+        }
+
+        pool.pick_readonly(plan.lb_key.as_str())
+            .and_then(|idx| pool.pool.address(idx).map(|addr| (idx, addr.to_string())))
+            .and_then(|(idx, addr)| {
+                (!begin_request || pool.begin_request_if_healthy(idx)).then_some(SelectedBackend {
+                    backend_addr: addr,
+                    backend_index: idx,
+                    backend_lb: plan.lb_type.clone(),
+                })
+            })
+    }
+
+    fn select_backend_with_write_lock(
+        pool: &mut UpstreamPool,
+        plan: &BackendSelectionPlan,
+        begin_request: bool,
+    ) -> Result<SelectedBackend, ProxyError> {
+        let idx = if begin_request {
+            pool.pick(plan.lb_key.as_str())
+        } else {
+            pool.pick_without_begin(plan.lb_key.as_str())
+        }
+        .ok_or_else(|| Self::no_healthy_servers_error(pool))?;
+        let backend_addr = pool
+            .pool
+            .address(idx)
+            .map(str::to_string)
+            .ok_or_else(|| ProxyError::Transport("invalid server address".into()))?;
+        Ok(SelectedBackend {
+            backend_addr,
+            backend_index: idx,
+            backend_lb: plan.lb_type.clone(),
+        })
+    }
+
     fn select_backend_from_pool(
         request: &RouteResolutionRequest<'_>,
         upstream_pool: &Arc<RwLock<UpstreamPool>>,
         begin_request: bool,
     ) -> Result<SelectedBackend, ProxyError> {
-        let (backend_index, backend_lb, backend_addr) = {
-            let (read_lb_type, read_fast_selected) = {
-                let pool = upstream_pool
-                    .read()
-                    .map_err(|_| ProxyError::Transport("upstream pool lock poisoned".into()))?;
-                if pool.pool.is_empty() {
-                    return Err(ProxyError::Transport("no servers in upstream".into()));
-                }
-                let lb_type = pool.lb_name();
-                let key = Self::resolve_lb_request_key(
-                    lb_type,
-                    pool.lb_key(),
-                    request.method,
-                    request.path,
-                    request.authority,
-                    request.cid_key,
-                    request.header_lookup,
-                );
-                let fast_selected = if pool.pool.readmit_due() {
-                    None
-                } else {
-                    pool.pick_readonly(key.as_str())
-                        .and_then(|idx| pool.pool.address(idx).map(|addr| (idx, addr.to_string())))
-                        .and_then(|(idx, addr)| {
-                            (!begin_request || pool.begin_request_if_healthy(idx))
-                                .then_some((idx, addr))
-                        })
-                };
-                (lb_type, fast_selected)
-            };
-
-            if let Some((idx, addr)) = read_fast_selected {
-                (idx, read_lb_type, addr)
-            } else {
-                let mut pool = upstream_pool
-                    .write()
-                    .map_err(|_| ProxyError::Transport("upstream pool lock poisoned".into()))?;
-                if pool.pool.is_empty() {
-                    return Err(ProxyError::Transport("no servers in upstream".into()));
-                }
-                let lb_type = pool.lb_name();
-                let key = Self::resolve_lb_request_key(
-                    lb_type,
-                    pool.lb_key(),
-                    request.method,
-                    request.path,
-                    request.authority,
-                    request.cid_key,
-                    request.header_lookup,
-                );
-                let idx = if begin_request {
-                    pool.pick(key.as_str())
-                } else {
-                    pool.pick_without_begin(key.as_str())
-                }
-                .ok_or_else(|| {
-                    let total = pool.pool.len();
-                    let healthy = pool.pool.healthy_len();
-                    error!(
-                        "no healthy backends available: {}/{} backends healthy",
-                        healthy, total
-                    );
-                    ProxyError::Transport("no healthy servers".into())
-                })?;
-                let backend_addr = pool
-                    .pool
-                    .address(idx)
-                    .map(str::to_string)
-                    .ok_or_else(|| ProxyError::Transport("invalid server address".into()))?;
-                (idx, lb_type, backend_addr)
+        {
+            let pool = upstream_pool
+                .read()
+                .map_err(|_| ProxyError::Transport("upstream pool lock poisoned".into()))?;
+            if pool.pool.is_empty() {
+                return Err(Self::no_servers_in_upstream_error());
             }
-        };
+            let plan = Self::build_backend_selection_plan(request, &pool);
+            if let Some(selected) = Self::select_backend_readonly(&pool, &plan, begin_request) {
+                return Ok(selected);
+            }
+        }
 
-        Ok(SelectedBackend {
-            backend_addr,
-            backend_index,
-            backend_lb: backend_lb.to_string(),
-        })
+        let mut pool = upstream_pool
+            .write()
+            .map_err(|_| ProxyError::Transport("upstream pool lock poisoned".into()))?;
+        if pool.pool.is_empty() {
+            return Err(Self::no_servers_in_upstream_error());
+        }
+        let plan = Self::build_backend_selection_plan(request, &pool);
+        Self::select_backend_with_write_lock(&mut pool, &plan, begin_request)
     }
 
     fn log_backend_selection(

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -309,29 +309,6 @@ fn is_websocket_upgrade_request(req: &Request<Incoming>, use_h2: bool) -> bool {
         .unwrap_or(false)
 }
 
-fn bootstrap_resolution_error_response(reason: &str) -> (StatusCode, &'static [u8]) {
-    if reason.starts_with("no route for ") {
-        return (StatusCode::BAD_GATEWAY, b"no route\n");
-    }
-    if reason.starts_with("pool not found:") {
-        return (StatusCode::BAD_GATEWAY, b"no pool\n");
-    }
-    if reason == "upstream pool lock poisoned" {
-        return (StatusCode::BAD_GATEWAY, b"pool error\n");
-    }
-    if reason == "no servers in upstream" || reason == "invalid server address" {
-        return (StatusCode::SERVICE_UNAVAILABLE, b"no backends\n");
-    }
-    if reason == "no healthy servers" {
-        return (StatusCode::SERVICE_UNAVAILABLE, b"no healthy backends\n");
-    }
-
-    (
-        StatusCode::BAD_GATEWAY,
-        b"route/backend resolution failed\n",
-    )
-}
-
 type BootstrapServiceFuture = std::pin::Pin<
     Box<
         dyn std::future::Future<

--- a/crates/edge/src/quic_listener/tests.rs
+++ b/crates/edge/src/quic_listener/tests.rs
@@ -762,17 +762,17 @@ fn resolve_backend_round_robin_is_not_pinned_to_first_backend() {
 
     let mut picks = Vec::new();
     for _ in 0..4 {
-        let resolved = super::QUICListener::resolve_backend(
+        let request = super::forwarding::SharedRouteResolutionRequest::new(
             "GET",
             "/api/items",
             None,
             None,
-            &upstream_pools,
-            &routing_index,
             None,
-        )
-        .expect("resolve backend");
-        picks.push(resolved.backend_addr);
+        );
+        let resolved =
+            super::QUICListener::resolve_backend_request(&request, &upstream_pools, &routing_index)
+                .expect("resolve backend");
+        picks.push(resolved.backend.backend_addr);
     }
 
     assert!(
@@ -793,19 +793,14 @@ fn resolve_backend_skips_unhealthy_backends() {
         guard.pool.mark_failure(0);
     }
 
-    let resolved = super::QUICListener::resolve_backend(
-        "GET",
-        "/api/items",
-        None,
-        None,
-        &upstream_pools,
-        &routing_index,
-        None,
-    )
-    .expect("resolve backend");
+    let request =
+        super::forwarding::SharedRouteResolutionRequest::new("GET", "/api/items", None, None, None);
+    let resolved =
+        super::QUICListener::resolve_backend_request(&request, &upstream_pools, &routing_index)
+            .expect("resolve backend");
 
     assert_eq!(
-        resolved.backend_addr, "127.0.0.1:7002",
+        resolved.backend.backend_addr, "127.0.0.1:7002",
         "unhealthy backend must be excluded from bootstrap backend selection"
     );
 }
@@ -819,19 +814,14 @@ fn resolve_backend_respects_least_connections_strategy() {
         guard.pool.begin_request(0);
     }
 
-    let resolved = super::QUICListener::resolve_backend(
-        "GET",
-        "/api/items",
-        None,
-        None,
-        &upstream_pools,
-        &routing_index,
-        None,
-    )
-    .expect("resolve backend");
+    let request =
+        super::forwarding::SharedRouteResolutionRequest::new("GET", "/api/items", None, None, None);
+    let resolved =
+        super::QUICListener::resolve_backend_request(&request, &upstream_pools, &routing_index)
+            .expect("resolve backend");
 
     assert_eq!(
-        resolved.backend_addr, "127.0.0.1:7002",
+        resolved.backend.backend_addr, "127.0.0.1:7002",
         "least-connections should prefer lower in-flight backend in bootstrap selection"
     );
 }
@@ -859,30 +849,25 @@ fn resolve_backend_prefers_method_specific_route() {
         upstream_pools.insert(name.clone(), Arc::new(RwLock::new(pool)));
     }
 
-    let resolved = super::QUICListener::resolve_backend(
-        "GET",
-        "/api/items",
-        None,
-        None,
-        &upstream_pools,
-        &routing_index,
-        None,
-    )
-    .expect("GET resolve");
-    assert_eq!(resolved.upstream_name, "all_methods");
+    let request =
+        super::forwarding::SharedRouteResolutionRequest::new("GET", "/api/items", None, None, None);
+    let resolved =
+        super::QUICListener::resolve_backend_request(&request, &upstream_pools, &routing_index)
+            .expect("GET resolve");
+    assert_eq!(resolved.route.upstream_name, "all_methods");
 
-    let resolved = super::QUICListener::resolve_backend(
+    let request = super::forwarding::SharedRouteResolutionRequest::new(
         "POST",
         "/api/items",
         None,
         None,
-        &upstream_pools,
-        &routing_index,
         None,
-    )
-    .expect("POST resolve");
-    assert_eq!(resolved.upstream_name, "post_only");
-    assert_eq!(resolved.backend_addr, "127.0.0.1:7010");
+    );
+    let resolved =
+        super::QUICListener::resolve_backend_request(&request, &upstream_pools, &routing_index)
+            .expect("POST resolve");
+    assert_eq!(resolved.route.upstream_name, "post_only");
+    assert_eq!(resolved.backend.backend_addr, "127.0.0.1:7010");
 }
 
 #[test]
@@ -910,29 +895,35 @@ fn resolve_backend_uses_configured_header_lb_key() {
         }
     };
 
-    let first = super::QUICListener::resolve_backend(
+    let first_request = super::forwarding::SharedRouteResolutionRequest::new(
         "GET",
         "/api/items",
         None,
         None,
+        Some(&header_lookup),
+    );
+    let first = super::QUICListener::resolve_backend_request(
+        &first_request,
         &upstream_pools,
         &routing_index,
-        Some(&header_lookup),
     )
     .expect("first resolve");
-    let second = super::QUICListener::resolve_backend(
+    let second_request = super::forwarding::SharedRouteResolutionRequest::new(
         "GET",
         "/api/items",
         None,
         None,
+        Some(&header_lookup),
+    );
+    let second = super::QUICListener::resolve_backend_request(
+        &second_request,
         &upstream_pools,
         &routing_index,
-        Some(&header_lookup),
     )
     .expect("second resolve");
 
     assert_eq!(
-        first.backend_addr, second.backend_addr,
+        first.backend.backend_addr, second.backend.backend_addr,
         "consistent-hash should remain stable when configured header key is constant"
     );
 }

--- a/crates/edge/src/quic_listener/tests.rs
+++ b/crates/edge/src/quic_listener/tests.rs
@@ -740,6 +740,7 @@ fn build_shared_state_separates_backend_identity_from_resolution_state() {
 
 type TestRoutingContext = (
     HashMap<String, Arc<RwLock<super::UpstreamPool>>>,
+    HashMap<String, spooky_config::runtime::RuntimeUpstreamPolicy>,
     super::RouteIndex,
     Arc<RwLock<super::UpstreamPool>>,
 );
@@ -753,12 +754,18 @@ fn test_routing_context(lb_type: &str) -> TestRoutingContext {
     let pool = Arc::new(RwLock::new(pool));
     let mut upstream_pools = HashMap::new();
     upstream_pools.insert("api_pool".to_string(), Arc::clone(&pool));
-    (upstream_pools, routing_index, pool)
+    let mut upstream_policies = HashMap::new();
+    upstream_policies.insert(
+        "api_pool".to_string(),
+        spooky_config::runtime::RuntimeUpstreamPolicy::default(),
+    );
+    (upstream_pools, upstream_policies, routing_index, pool)
 }
 
 #[test]
 fn resolve_backend_round_robin_is_not_pinned_to_first_backend() {
-    let (upstream_pools, routing_index, _pool) = test_routing_context("round-robin");
+    let (upstream_pools, upstream_policies, routing_index, _pool) =
+        test_routing_context("round-robin");
 
     let mut picks = Vec::new();
     for _ in 0..4 {
@@ -769,9 +776,13 @@ fn resolve_backend_round_robin_is_not_pinned_to_first_backend() {
             None,
             None,
         );
-        let resolved =
-            super::QUICListener::resolve_backend_request(&request, &upstream_pools, &routing_index)
-                .expect("resolve backend");
+        let resolved = super::QUICListener::resolve_backend_request(
+            &request,
+            &upstream_pools,
+            &upstream_policies,
+            &routing_index,
+        )
+        .expect("resolve backend");
         picks.push(resolved.backend.backend_addr);
     }
 
@@ -785,7 +796,8 @@ fn resolve_backend_round_robin_is_not_pinned_to_first_backend() {
 
 #[test]
 fn resolve_backend_skips_unhealthy_backends() {
-    let (upstream_pools, routing_index, pool) = test_routing_context("round-robin");
+    let (upstream_pools, upstream_policies, routing_index, pool) =
+        test_routing_context("round-robin");
     {
         let mut guard = pool.write().expect("pool write");
         guard.pool.mark_failure(0);
@@ -795,9 +807,13 @@ fn resolve_backend_skips_unhealthy_backends() {
 
     let request =
         super::forwarding::SharedRouteResolutionRequest::new("GET", "/api/items", None, None, None);
-    let resolved =
-        super::QUICListener::resolve_backend_request(&request, &upstream_pools, &routing_index)
-            .expect("resolve backend");
+    let resolved = super::QUICListener::resolve_backend_request(
+        &request,
+        &upstream_pools,
+        &upstream_policies,
+        &routing_index,
+    )
+    .expect("resolve backend");
 
     assert_eq!(
         resolved.backend.backend_addr, "127.0.0.1:7002",
@@ -807,7 +823,8 @@ fn resolve_backend_skips_unhealthy_backends() {
 
 #[test]
 fn resolve_backend_respects_least_connections_strategy() {
-    let (upstream_pools, routing_index, pool) = test_routing_context("least-connections");
+    let (upstream_pools, upstream_policies, routing_index, pool) =
+        test_routing_context("least-connections");
     {
         let guard = pool.read().expect("pool read");
         guard.pool.begin_request(0);
@@ -816,9 +833,13 @@ fn resolve_backend_respects_least_connections_strategy() {
 
     let request =
         super::forwarding::SharedRouteResolutionRequest::new("GET", "/api/items", None, None, None);
-    let resolved =
-        super::QUICListener::resolve_backend_request(&request, &upstream_pools, &routing_index)
-            .expect("resolve backend");
+    let resolved = super::QUICListener::resolve_backend_request(
+        &request,
+        &upstream_pools,
+        &upstream_policies,
+        &routing_index,
+    )
+    .expect("resolve backend");
 
     assert_eq!(
         resolved.backend.backend_addr, "127.0.0.1:7002",
@@ -844,16 +865,25 @@ fn resolve_backend_prefers_method_specific_route() {
 
     let routing_index = super::RouteIndex::from_upstreams(&upstreams);
     let mut upstream_pools = HashMap::new();
+    let mut upstream_policies = HashMap::new();
     for (name, upstream) in &upstreams {
         let pool = super::UpstreamPool::from_upstream(upstream).expect("pool");
         upstream_pools.insert(name.clone(), Arc::new(RwLock::new(pool)));
+        upstream_policies.insert(
+            name.clone(),
+            spooky_config::runtime::RuntimeUpstreamPolicy::default(),
+        );
     }
 
     let request =
         super::forwarding::SharedRouteResolutionRequest::new("GET", "/api/items", None, None, None);
-    let resolved =
-        super::QUICListener::resolve_backend_request(&request, &upstream_pools, &routing_index)
-            .expect("GET resolve");
+    let resolved = super::QUICListener::resolve_backend_request(
+        &request,
+        &upstream_pools,
+        &upstream_policies,
+        &routing_index,
+    )
+    .expect("GET resolve");
     assert_eq!(resolved.route.upstream_name, "all_methods");
 
     let request = super::forwarding::SharedRouteResolutionRequest::new(
@@ -863,16 +893,20 @@ fn resolve_backend_prefers_method_specific_route() {
         None,
         None,
     );
-    let resolved =
-        super::QUICListener::resolve_backend_request(&request, &upstream_pools, &routing_index)
-            .expect("POST resolve");
+    let resolved = super::QUICListener::resolve_backend_request(
+        &request,
+        &upstream_pools,
+        &upstream_policies,
+        &routing_index,
+    )
+    .expect("POST resolve");
     assert_eq!(resolved.route.upstream_name, "post_only");
     assert_eq!(resolved.backend.backend_addr, "127.0.0.1:7010");
 }
 
 #[test]
 fn resolve_backend_uses_configured_header_lb_key() {
-    let (upstream_pools, routing_index, _pool) = {
+    let (upstream_pools, upstream_policies, routing_index, _pool) = {
         let mut upstreams = HashMap::new();
         upstreams.insert(
             "api_pool".to_string(),
@@ -884,7 +918,12 @@ fn resolve_backend_uses_configured_header_lb_key() {
         let pool = Arc::new(RwLock::new(pool));
         let mut upstream_pools = HashMap::new();
         upstream_pools.insert("api_pool".to_string(), Arc::clone(&pool));
-        (upstream_pools, routing_index, pool)
+        let mut upstream_policies = HashMap::new();
+        upstream_policies.insert(
+            "api_pool".to_string(),
+            spooky_config::runtime::RuntimeUpstreamPolicy::default(),
+        );
+        (upstream_pools, upstream_policies, routing_index, pool)
     };
 
     let header_lookup = |name: &str| {
@@ -905,6 +944,7 @@ fn resolve_backend_uses_configured_header_lb_key() {
     let first = super::QUICListener::resolve_backend_request(
         &first_request,
         &upstream_pools,
+        &upstream_policies,
         &routing_index,
     )
     .expect("first resolve");
@@ -918,6 +958,7 @@ fn resolve_backend_uses_configured_header_lb_key() {
     let second = super::QUICListener::resolve_backend_request(
         &second_request,
         &upstream_pools,
+        &upstream_policies,
         &routing_index,
     )
     .expect("second resolve");

--- a/crates/edge/src/quic_listener/tests.rs
+++ b/crates/edge/src/quic_listener/tests.rs
@@ -769,14 +769,14 @@ fn resolve_backend_round_robin_is_not_pinned_to_first_backend() {
 
     let mut picks = Vec::new();
     for _ in 0..4 {
-        let request = super::forwarding::SharedRouteResolutionRequest::new(
+        let request = super::forwarding::TestRouteResolutionRequest::new(
             "GET",
             "/api/items",
             None,
             None,
             None,
         );
-        let resolved = super::QUICListener::resolve_backend_request(
+        let resolved = super::QUICListener::resolve_backend_request_for_test(
             &request,
             &upstream_pools,
             &upstream_policies,
@@ -806,8 +806,8 @@ fn resolve_backend_skips_unhealthy_backends() {
     }
 
     let request =
-        super::forwarding::SharedRouteResolutionRequest::new("GET", "/api/items", None, None, None);
-    let resolved = super::QUICListener::resolve_backend_request(
+        super::forwarding::TestRouteResolutionRequest::new("GET", "/api/items", None, None, None);
+    let resolved = super::QUICListener::resolve_backend_request_for_test(
         &request,
         &upstream_pools,
         &upstream_policies,
@@ -832,8 +832,8 @@ fn resolve_backend_respects_least_connections_strategy() {
     }
 
     let request =
-        super::forwarding::SharedRouteResolutionRequest::new("GET", "/api/items", None, None, None);
-    let resolved = super::QUICListener::resolve_backend_request(
+        super::forwarding::TestRouteResolutionRequest::new("GET", "/api/items", None, None, None);
+    let resolved = super::QUICListener::resolve_backend_request_for_test(
         &request,
         &upstream_pools,
         &upstream_policies,
@@ -876,8 +876,8 @@ fn resolve_backend_prefers_method_specific_route() {
     }
 
     let request =
-        super::forwarding::SharedRouteResolutionRequest::new("GET", "/api/items", None, None, None);
-    let resolved = super::QUICListener::resolve_backend_request(
+        super::forwarding::TestRouteResolutionRequest::new("GET", "/api/items", None, None, None);
+    let resolved = super::QUICListener::resolve_backend_request_for_test(
         &request,
         &upstream_pools,
         &upstream_policies,
@@ -886,14 +886,9 @@ fn resolve_backend_prefers_method_specific_route() {
     .expect("GET resolve");
     assert_eq!(resolved.route.upstream_name, "all_methods");
 
-    let request = super::forwarding::SharedRouteResolutionRequest::new(
-        "POST",
-        "/api/items",
-        None,
-        None,
-        None,
-    );
-    let resolved = super::QUICListener::resolve_backend_request(
+    let request =
+        super::forwarding::TestRouteResolutionRequest::new("POST", "/api/items", None, None, None);
+    let resolved = super::QUICListener::resolve_backend_request_for_test(
         &request,
         &upstream_pools,
         &upstream_policies,
@@ -934,28 +929,28 @@ fn resolve_backend_uses_configured_header_lb_key() {
         }
     };
 
-    let first_request = super::forwarding::SharedRouteResolutionRequest::new(
+    let first_request = super::forwarding::TestRouteResolutionRequest::new(
         "GET",
         "/api/items",
         None,
         None,
         Some(&header_lookup),
     );
-    let first = super::QUICListener::resolve_backend_request(
+    let first = super::QUICListener::resolve_backend_request_for_test(
         &first_request,
         &upstream_pools,
         &upstream_policies,
         &routing_index,
     )
     .expect("first resolve");
-    let second_request = super::forwarding::SharedRouteResolutionRequest::new(
+    let second_request = super::forwarding::TestRouteResolutionRequest::new(
         "GET",
         "/api/items",
         None,
         None,
         Some(&header_lookup),
     );
-    let second = super::QUICListener::resolve_backend_request(
+    let second = super::QUICListener::resolve_backend_request_for_test(
         &second_request,
         &upstream_pools,
         &upstream_policies,


### PR DESCRIPTION
## Summary

This PR consolidates route resolution and backend selection into a shared pipeline used by both QUIC forwarding and bootstrap TLS.

## What Changed

- extracted shared route resolution flow for:
  - route match
  - upstream lookup
  - load-balancing key resolution
  - backend selection
- centralized backend selection behavior:
  - LB strategy planning
  - healthy-backend gating
  - no-backend / no-healthy-backend handling
- centralized resolution logging and telemetry so QUIC and bootstrap emit the same decision metadata
- routed QUIC forwarding through the shared pre-auth resolution helper
- routed bootstrap TLS through the same shared resolution pipeline while preserving bootstrap-specific error response mapping
- cleaned up module boundaries and visibility:
  - removed stale compatibility paths
  - narrowed test-only exposure for low-level resolution APIs
  - reduced bootstrap resolution argument sprawl with a typed input struct

## Why

Before this change, `edge` still owned too much duplicated orchestration around route resolution and backend selection. That made the flow harder to reason about, harder to test, and easier to drift between QUIC and bootstrap paths.

This refactor makes resolution behavior more reusable, consistent, and maintainable without changing intended runtime behavior.

## Notes

This is a refactor-only PR focused on structure, shared logic, and boundary cleanup.