### PR TITLE
refactor(edge): extract canonical load-balancing key resolution layer

### DIFF
--- a/crates/edge/src/quic_listener/admission.rs
+++ b/crates/edge/src/quic_listener/admission.rs
@@ -14,7 +14,7 @@ use spooky_lb::upstream_pool::UpstreamPool;
 use subtle::ConstantTimeEq;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore, TryAcquireError};
 
-use super::LbHeaderLookup;
+use super::{LbHeaderLookup, QUICListener};
 use crate::{
     RouteOutcome,
     metrics::OverloadShedReason,
@@ -434,7 +434,7 @@ pub(super) fn jwt_is_authorized(
     else {
         return false;
     };
-    let Some(token) = bearer_token_from_authorization_value(&raw) else {
+    let Some(token) = QUICListener::bearer_token_from_authorization_value(&raw) else {
         return false;
     };
     let Some(claims) = validated_hs256_jwt_claims(token.as_str(), jwt, SystemTime::now()) else {
@@ -540,20 +540,6 @@ pub(super) fn jwt_claims_satisfy_rbac(policy: &RuntimeUpstreamPolicy, claims: &V
             .required_roles
             .iter()
             .all(|required| roles.contains(required))
-}
-
-fn bearer_token_from_authorization_value(raw: &str) -> Option<String> {
-    let raw = raw.trim();
-    let split = raw.find(char::is_whitespace)?;
-    let (scheme, rest) = raw.split_at(split);
-    if !scheme.eq_ignore_ascii_case("bearer") {
-        return None;
-    }
-    let token = rest.trim_start();
-    if token.is_empty() {
-        return None;
-    }
-    Some(token.to_string())
 }
 
 fn overloaded(reason: OverloadDecisionReason, retry_after_seconds: u32) -> OverloadDecision {

--- a/crates/edge/src/quic_listener/forwarding/lb_key.rs
+++ b/crates/edge/src/quic_listener/forwarding/lb_key.rs
@@ -1,5 +1,66 @@
 use super::*;
 
+pub(in crate::quic_listener) struct LbKeyRequestParts<'a> {
+    pub(in crate::quic_listener) method: &'a str,
+    pub(in crate::quic_listener) path: &'a str,
+    pub(in crate::quic_listener) authority: Option<&'a str>,
+    pub(in crate::quic_listener) cid_key: Option<&'a str>,
+    pub(in crate::quic_listener) client_addr: Option<SocketAddr>,
+    pub(in crate::quic_listener) header_lookup: Option<&'a LbHeaderLookup<'a>>,
+}
+
+impl<'a> LbKeyRequestParts<'a> {
+    pub(in crate::quic_listener) fn new(
+        method: &'a str,
+        path: &'a str,
+        authority: Option<&'a str>,
+        cid_key: Option<&'a str>,
+        client_addr: Option<SocketAddr>,
+        header_lookup: Option<&'a LbHeaderLookup<'a>>,
+    ) -> Self {
+        Self {
+            method,
+            path,
+            authority,
+            cid_key,
+            client_addr,
+            header_lookup,
+        }
+    }
+}
+
+pub(in crate::quic_listener) struct LbKeyResolutionInput<'a> {
+    pub(in crate::quic_listener) lb_type: &'a str,
+    pub(in crate::quic_listener) lb_key_spec: Option<&'a str>,
+    pub(in crate::quic_listener) request: LbKeyRequestParts<'a>,
+}
+
+impl<'a> LbKeyResolutionInput<'a> {
+    pub(in crate::quic_listener) fn new(
+        lb_type: &'a str,
+        lb_key_spec: Option<&'a str>,
+        request: LbKeyRequestParts<'a>,
+    ) -> Self {
+        Self {
+            lb_type,
+            lb_key_spec,
+            request,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::quic_listener) enum LbKeySource {
+    ConfiguredSpec,
+    StickyCidFallback,
+    DefaultFallback,
+}
+
+pub(in crate::quic_listener) struct ResolvedLbKey {
+    pub(in crate::quic_listener) value: String,
+    pub(in crate::quic_listener) source: LbKeySource,
+}
+
 fn extract_cookie_value(cookie_header: &str, cookie_name: &str) -> Option<String> {
     for pair in cookie_header.split(';') {
         let part = pair.trim();
@@ -34,14 +95,9 @@ fn extract_query_param(path: &str, param: &str) -> Option<String> {
 }
 
 impl QUICListener {
-    pub(super) fn resolve_lb_key_from_spec(
+    pub(in crate::quic_listener) fn resolve_lb_key_from_parts(
         lb_key_spec: &str,
-        method: &str,
-        path: &str,
-        authority: Option<&str>,
-        cid_key: Option<&str>,
-        client_addr: Option<SocketAddr>,
-        header_lookup: Option<&LbHeaderLookup<'_>>,
+        request: &LbKeyRequestParts<'_>,
     ) -> Option<String> {
         let spec = lb_key_spec.trim();
         if spec.is_empty() {
@@ -49,24 +105,29 @@ impl QUICListener {
         }
 
         if spec.eq_ignore_ascii_case("path") {
-            let path_only = path.split_once('?').map(|(p, _)| p).unwrap_or(path);
+            let path_only = request
+                .path
+                .split_once('?')
+                .map(|(p, _)| p)
+                .unwrap_or(request.path);
             return Some(path_only.to_string());
         }
         if spec.eq_ignore_ascii_case("authority") {
-            return authority.map(str::to_string);
+            return request.authority.map(str::to_string);
         }
         if spec.eq_ignore_ascii_case("method") {
-            return Some(method.to_string());
+            return Some(request.method.to_string());
         }
         if spec.eq_ignore_ascii_case("cid") || spec.eq_ignore_ascii_case("sticky-cid") {
-            return cid_key.map(str::to_string);
+            return request.cid_key.map(str::to_string);
         }
         if spec.eq_ignore_ascii_case("peer_ip") || spec.eq_ignore_ascii_case("client_ip") {
-            return client_addr.map(|addr| addr.ip().to_string());
+            return request.client_addr.map(|addr| addr.ip().to_string());
         }
         if spec.eq_ignore_ascii_case("bearer_token") {
-            let raw =
-                header_lookup.and_then(|lookup| lookup(http::header::AUTHORIZATION.as_str()))?;
+            let raw = request
+                .header_lookup
+                .and_then(|lookup| lookup(http::header::AUTHORIZATION.as_str()))?;
             return Self::bearer_token_from_authorization_value(&raw);
         }
 
@@ -77,65 +138,78 @@ impl QUICListener {
         }
 
         if source.eq_ignore_ascii_case("header") {
-            return header_lookup.and_then(|lookup| lookup(key_name));
+            return request.header_lookup.and_then(|lookup| lookup(key_name));
         }
 
         if source.eq_ignore_ascii_case("cookie") {
-            let cookie_header =
-                header_lookup.and_then(|lookup| lookup(http::header::COOKIE.as_str()))?;
+            let cookie_header = request
+                .header_lookup
+                .and_then(|lookup| lookup(http::header::COOKIE.as_str()))?;
             return extract_cookie_value(cookie_header.as_str(), key_name);
         }
 
         if source.eq_ignore_ascii_case("query") {
-            return extract_query_param(path, key_name);
+            return extract_query_param(request.path, key_name);
         }
 
         None
     }
 
-    pub(super) fn default_lb_request_key(
-        method: &str,
-        path: &str,
-        authority: Option<&str>,
-    ) -> String {
-        authority
-            .unwrap_or(if !path.is_empty() { path } else { method })
-            .to_string()
-    }
-
-    pub(super) fn resolve_lb_request_key(
-        lb_type: &str,
-        lb_key_spec: Option<&str>,
+    pub(super) fn resolve_lb_key_from_spec(
+        lb_key_spec: &str,
         method: &str,
         path: &str,
         authority: Option<&str>,
         cid_key: Option<&str>,
+        client_addr: Option<SocketAddr>,
         header_lookup: Option<&LbHeaderLookup<'_>>,
-    ) -> String {
-        let default_key = Self::default_lb_request_key(method, path, authority);
+    ) -> Option<String> {
+        let request =
+            LbKeyRequestParts::new(method, path, authority, cid_key, client_addr, header_lookup);
+        Self::resolve_lb_key_from_parts(lb_key_spec, &request)
+    }
 
-        if let Some(spec) = lb_key_spec
-            && let Some(value) = Self::resolve_lb_key_from_spec(
-                spec,
-                method,
-                path,
-                authority,
-                cid_key,
-                None,
-                header_lookup,
-            )
+    pub(in crate::quic_listener) fn default_lb_request_key_for_parts(
+        request: &LbKeyRequestParts<'_>,
+    ) -> String {
+        request
+            .authority
+            .unwrap_or(if !request.path.is_empty() {
+                request.path
+            } else {
+                request.method
+            })
+            .to_string()
+    }
+
+    pub(in crate::quic_listener) fn resolve_lb_key_for_input(
+        input: &LbKeyResolutionInput<'_>,
+    ) -> ResolvedLbKey {
+        let default_key = Self::default_lb_request_key_for_parts(&input.request);
+
+        if let Some(spec) = input.lb_key_spec
+            && let Some(value) = Self::resolve_lb_key_from_parts(spec, &input.request)
             && !value.is_empty()
         {
-            return value;
+            return ResolvedLbKey {
+                value,
+                source: LbKeySource::ConfiguredSpec,
+            };
         }
 
-        if lb_type == "sticky-cid"
-            && let Some(cid_key) = cid_key
+        if input.lb_type == "sticky-cid"
+            && let Some(cid_key) = input.request.cid_key
         {
-            return cid_key.to_string();
+            return ResolvedLbKey {
+                value: cid_key.to_string(),
+                source: LbKeySource::StickyCidFallback,
+            };
         }
 
-        default_key
+        ResolvedLbKey {
+            value: default_key,
+            source: LbKeySource::DefaultFallback,
+        }
     }
 
     pub(super) fn bearer_token_from_authorization_value(raw: &str) -> Option<String> {

--- a/crates/edge/src/quic_listener/forwarding/lb_key.rs
+++ b/crates/edge/src/quic_listener/forwarding/lb_key.rs
@@ -155,20 +155,6 @@ impl QUICListener {
         None
     }
 
-    pub(super) fn resolve_lb_key_from_spec(
-        lb_key_spec: &str,
-        method: &str,
-        path: &str,
-        authority: Option<&str>,
-        cid_key: Option<&str>,
-        client_addr: Option<SocketAddr>,
-        header_lookup: Option<&LbHeaderLookup<'_>>,
-    ) -> Option<String> {
-        let request =
-            LbKeyRequestParts::new(method, path, authority, cid_key, client_addr, header_lookup);
-        Self::resolve_lb_key_from_parts(lb_key_spec, &request)
-    }
-
     pub(in crate::quic_listener) fn default_lb_request_key_for_parts(
         request: &LbKeyRequestParts<'_>,
     ) -> String {
@@ -212,7 +198,9 @@ impl QUICListener {
         }
     }
 
-    pub(super) fn bearer_token_from_authorization_value(raw: &str) -> Option<String> {
+    pub(in crate::quic_listener) fn bearer_token_from_authorization_value(
+        raw: &str,
+    ) -> Option<String> {
         let raw = raw.trim();
         let split = raw.find(char::is_whitespace)?;
         let (scheme, rest) = raw.split_at(split);

--- a/crates/edge/src/quic_listener/forwarding/lb_key.rs
+++ b/crates/edge/src/quic_listener/forwarding/lb_key.rs
@@ -95,20 +95,37 @@ fn extract_query_param(path: &str, param: &str) -> Option<String> {
 }
 
 impl QUICListener {
+    #[allow(clippy::too_many_arguments)]
+    pub(in crate::quic_listener) fn resolve_lb_key(
+        lb_type: &str,
+        lb_key_spec: Option<&str>,
+        method: &str,
+        path: &str,
+        authority: Option<&str>,
+        cid_key: Option<&str>,
+        client_addr: Option<SocketAddr>,
+        header_lookup: Option<&LbHeaderLookup<'_>>,
+    ) -> ResolvedLbKey {
+        let request =
+            LbKeyRequestParts::new(method, path, authority, cid_key, client_addr, header_lookup);
+        Self::resolve_lb_key_for_input(&LbKeyResolutionInput::new(lb_type, lb_key_spec, request))
+    }
+
     pub(in crate::quic_listener) fn resolve_lb_key_for_route_request(
         lb_type: &str,
         lb_key_spec: Option<&str>,
         request: &super::resolve::RouteResolutionRequest<'_>,
     ) -> ResolvedLbKey {
-        let request = LbKeyRequestParts::new(
+        Self::resolve_lb_key(
+            lb_type,
+            lb_key_spec,
             request.method,
             request.path,
             request.authority,
             request.cid_key,
             None,
             request.header_lookup,
-        );
-        Self::resolve_lb_key_for_input(&LbKeyResolutionInput::new(lb_type, lb_key_spec, request))
+        )
     }
 
     pub(in crate::quic_listener) fn resolve_lb_key_from_parts(

--- a/crates/edge/src/quic_listener/forwarding/lb_key.rs
+++ b/crates/edge/src/quic_listener/forwarding/lb_key.rs
@@ -1,16 +1,16 @@
 use super::*;
 
-pub(in crate::quic_listener) struct LbKeyRequestParts<'a> {
-    pub(in crate::quic_listener) method: &'a str,
-    pub(in crate::quic_listener) path: &'a str,
-    pub(in crate::quic_listener) authority: Option<&'a str>,
-    pub(in crate::quic_listener) cid_key: Option<&'a str>,
-    pub(in crate::quic_listener) client_addr: Option<SocketAddr>,
-    pub(in crate::quic_listener) header_lookup: Option<&'a LbHeaderLookup<'a>>,
+struct LbKeyRequestParts<'a> {
+    method: &'a str,
+    path: &'a str,
+    authority: Option<&'a str>,
+    cid_key: Option<&'a str>,
+    client_addr: Option<SocketAddr>,
+    header_lookup: Option<&'a LbHeaderLookup<'a>>,
 }
 
 impl<'a> LbKeyRequestParts<'a> {
-    pub(in crate::quic_listener) fn new(
+    fn new(
         method: &'a str,
         path: &'a str,
         authority: Option<&'a str>,
@@ -29,18 +29,14 @@ impl<'a> LbKeyRequestParts<'a> {
     }
 }
 
-pub(in crate::quic_listener) struct LbKeyResolutionInput<'a> {
-    pub(in crate::quic_listener) lb_type: &'a str,
-    pub(in crate::quic_listener) lb_key_spec: Option<&'a str>,
-    pub(in crate::quic_listener) request: LbKeyRequestParts<'a>,
+struct LbKeyResolutionInput<'a> {
+    lb_type: &'a str,
+    lb_key_spec: Option<&'a str>,
+    request: LbKeyRequestParts<'a>,
 }
 
 impl<'a> LbKeyResolutionInput<'a> {
-    pub(in crate::quic_listener) fn new(
-        lb_type: &'a str,
-        lb_key_spec: Option<&'a str>,
-        request: LbKeyRequestParts<'a>,
-    ) -> Self {
+    fn new(lb_type: &'a str, lb_key_spec: Option<&'a str>, request: LbKeyRequestParts<'a>) -> Self {
         Self {
             lb_type,
             lb_key_spec,
@@ -50,15 +46,15 @@ impl<'a> LbKeyResolutionInput<'a> {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(in crate::quic_listener) enum LbKeySource {
+pub(super) enum LbKeySource {
     ConfiguredSpec,
     StickyCidFallback,
     DefaultFallback,
 }
 
-pub(in crate::quic_listener) struct ResolvedLbKey {
-    pub(in crate::quic_listener) value: String,
-    pub(in crate::quic_listener) source: LbKeySource,
+pub(super) struct ResolvedLbKey {
+    pub(super) value: String,
+    pub(super) source: LbKeySource,
 }
 
 fn extract_cookie_value(cookie_header: &str, cookie_name: &str) -> Option<String> {
@@ -96,7 +92,7 @@ fn extract_query_param(path: &str, param: &str) -> Option<String> {
 
 impl QUICListener {
     #[allow(clippy::too_many_arguments)]
-    pub(in crate::quic_listener) fn resolve_lb_key(
+    pub(in crate::quic_listener::forwarding) fn resolve_lb_key(
         lb_type: &str,
         lb_key_spec: Option<&str>,
         method: &str,
@@ -111,7 +107,7 @@ impl QUICListener {
         Self::resolve_lb_key_for_input(&LbKeyResolutionInput::new(lb_type, lb_key_spec, request))
     }
 
-    pub(in crate::quic_listener) fn resolve_lb_key_for_route_request(
+    pub(in crate::quic_listener::forwarding) fn resolve_lb_key_for_route_request(
         lb_type: &str,
         lb_key_spec: Option<&str>,
         request: &super::resolve::RouteResolutionRequest<'_>,
@@ -128,7 +124,7 @@ impl QUICListener {
         )
     }
 
-    pub(in crate::quic_listener) fn resolve_lb_key_from_parts(
+    fn resolve_lb_key_from_parts(
         lb_key_spec: &str,
         request: &LbKeyRequestParts<'_>,
     ) -> Option<String> {
@@ -188,9 +184,7 @@ impl QUICListener {
         None
     }
 
-    pub(in crate::quic_listener) fn default_lb_request_key_for_parts(
-        request: &LbKeyRequestParts<'_>,
-    ) -> String {
+    fn default_lb_request_key_for_parts(request: &LbKeyRequestParts<'_>) -> String {
         request
             .authority
             .unwrap_or(if !request.path.is_empty() {
@@ -201,9 +195,7 @@ impl QUICListener {
             .to_string()
     }
 
-    pub(in crate::quic_listener) fn resolve_lb_key_for_input(
-        input: &LbKeyResolutionInput<'_>,
-    ) -> ResolvedLbKey {
+    fn resolve_lb_key_for_input(input: &LbKeyResolutionInput<'_>) -> ResolvedLbKey {
         let default_key = Self::default_lb_request_key_for_parts(&input.request);
 
         if let Some(spec) = input.lb_key_spec

--- a/crates/edge/src/quic_listener/forwarding/lb_key.rs
+++ b/crates/edge/src/quic_listener/forwarding/lb_key.rs
@@ -95,6 +95,22 @@ fn extract_query_param(path: &str, param: &str) -> Option<String> {
 }
 
 impl QUICListener {
+    pub(in crate::quic_listener) fn resolve_lb_key_for_route_request(
+        lb_type: &str,
+        lb_key_spec: Option<&str>,
+        request: &super::resolve::RouteResolutionRequest<'_>,
+    ) -> ResolvedLbKey {
+        let request = LbKeyRequestParts::new(
+            request.method,
+            request.path,
+            request.authority,
+            request.cid_key,
+            None,
+            request.header_lookup,
+        );
+        Self::resolve_lb_key_for_input(&LbKeyResolutionInput::new(lb_type, lb_key_spec, request))
+    }
+
     pub(in crate::quic_listener) fn resolve_lb_key_from_parts(
         lb_key_spec: &str,
         request: &LbKeyRequestParts<'_>,

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -10,6 +10,9 @@ use std::{convert::Infallible, error::Error as StdError};
 
 use spooky_config::config::ScopedRateLimitScope;
 
+pub(in crate::quic_listener) use self::lb_key::{
+    LbKeyRequestParts, LbKeyResolutionInput, ResolvedLbKey,
+};
 use self::prepare::{PreparedRequest, StartedAuthRequest};
 pub(in crate::quic_listener) use self::resolve::BootstrapResolutionInput;
 #[cfg(test)]

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -10,9 +10,9 @@ use std::{convert::Infallible, error::Error as StdError};
 
 use spooky_config::config::ScopedRateLimitScope;
 
-pub(in crate::quic_listener) use self::lb_key::{
-    LbKeyRequestParts, LbKeyResolutionInput, ResolvedLbKey,
-};
+pub(in crate::quic_listener) use self::lb_key::ResolvedLbKey;
+#[cfg(test)]
+pub(in crate::quic_listener) use self::lb_key::{LbKeyRequestParts, LbKeyResolutionInput};
 use self::prepare::{PreparedRequest, StartedAuthRequest};
 pub(in crate::quic_listener) use self::resolve::BootstrapResolutionInput;
 #[cfg(test)]
@@ -1067,38 +1067,45 @@ impl QUICListener {
         client_addr: SocketAddr,
         header_lookup: Option<&LbHeaderLookup<'_>>,
     ) -> Option<String> {
-        let request = LbKeyRequestParts::new(
-            method,
-            path,
-            authority,
-            None,
-            Some(client_addr),
-            header_lookup,
-        );
         match rule.scope() {
             ScopedRateLimitScope::Route => Some(route.to_string()),
             ScopedRateLimitScope::Client => Some(
-                Self::resolve_lb_key_for_input(&LbKeyResolutionInput::new(
+                Self::resolve_lb_key(
                     "",
                     Some(rule.key_spec().unwrap_or("peer_ip")),
-                    request,
-                ))
+                    method,
+                    path,
+                    authority,
+                    None,
+                    Some(client_addr),
+                    header_lookup,
+                )
                 .value,
             ),
             ScopedRateLimitScope::Tenant => rule.key_spec().map(|key_spec| {
-                Self::resolve_lb_key_for_input(&LbKeyResolutionInput::new(
+                Self::resolve_lb_key(
                     "",
                     Some(key_spec),
-                    request,
-                ))
+                    method,
+                    path,
+                    authority,
+                    None,
+                    Some(client_addr),
+                    header_lookup,
+                )
                 .value
             }),
             ScopedRateLimitScope::Token => Some(
-                Self::resolve_lb_key_for_input(&LbKeyResolutionInput::new(
+                Self::resolve_lb_key(
                     "",
                     Some(rule.key_spec().unwrap_or("bearer_token")),
-                    request,
-                ))
+                    method,
+                    path,
+                    authority,
+                    None,
+                    Some(client_addr),
+                    header_lookup,
+                )
                 .value,
             ),
         }

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -10,9 +10,6 @@ use std::{convert::Infallible, error::Error as StdError};
 
 use spooky_config::config::ScopedRateLimitScope;
 
-pub(in crate::quic_listener) use self::lb_key::ResolvedLbKey;
-#[cfg(test)]
-pub(in crate::quic_listener) use self::lb_key::{LbKeyRequestParts, LbKeyResolutionInput};
 use self::prepare::{PreparedRequest, StartedAuthRequest};
 pub(in crate::quic_listener) use self::resolve::BootstrapResolutionInput;
 #[cfg(test)]
@@ -1434,28 +1431,40 @@ mod tests {
     }
 
     #[test]
-    fn resolve_lb_key_from_parts_supports_peer_ip_and_bearer_token() {
+    fn resolve_lb_key_supports_peer_ip_and_bearer_token() {
         let headers = [("authorization".to_string(), "Bearer token-1".to_string())]
             .into_iter()
             .collect::<std::collections::HashMap<_, _>>();
         let lookup = |name: &str| headers.get(&name.to_ascii_lowercase()).cloned();
         let client_addr = "203.0.113.9:443".parse().expect("client addr");
-        let request = LbKeyRequestParts::new(
-            "GET",
-            "/",
-            Some("api.example.com"),
-            None,
-            Some(client_addr),
-            Some(&lookup),
-        );
 
         assert_eq!(
-            QUICListener::resolve_lb_key_from_parts("peer_ip", &request).as_deref(),
-            Some("203.0.113.9")
+            QUICListener::resolve_lb_key(
+                "",
+                Some("peer_ip"),
+                "GET",
+                "/",
+                Some("api.example.com"),
+                None,
+                Some(client_addr),
+                Some(&lookup),
+            )
+            .value,
+            "203.0.113.9"
         );
         assert_eq!(
-            QUICListener::resolve_lb_key_from_parts("bearer_token", &request).as_deref(),
-            Some("token-1")
+            QUICListener::resolve_lb_key(
+                "",
+                Some("bearer_token"),
+                "GET",
+                "/",
+                Some("api.example.com"),
+                None,
+                Some(client_addr),
+                Some(&lookup),
+            )
+            .value,
+            "token-1"
         );
     }
 
@@ -1714,8 +1723,10 @@ mod tests {
     }
 
     #[test]
-    fn resolve_lb_key_for_input_uses_sticky_cid_before_default_fallback() {
-        let request = LbKeyRequestParts::new(
+    fn resolve_lb_key_uses_sticky_cid_before_default_fallback() {
+        let resolved = QUICListener::resolve_lb_key(
+            "sticky-cid",
+            Some("header:x-user-id"),
             "GET",
             "/resource",
             Some("api.example.com"),
@@ -1723,12 +1734,6 @@ mod tests {
             None,
             None,
         );
-
-        let resolved = QUICListener::resolve_lb_key_for_input(&LbKeyResolutionInput::new(
-            "sticky-cid",
-            Some("header:x-user-id"),
-            request,
-        ));
 
         assert_eq!(resolved.value, "cid-123");
         assert!(matches!(

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -1067,37 +1067,25 @@ impl QUICListener {
         client_addr: SocketAddr,
         header_lookup: Option<&LbHeaderLookup<'_>>,
     ) -> Option<String> {
+        let request = LbKeyRequestParts::new(
+            method,
+            path,
+            authority,
+            None,
+            Some(client_addr),
+            header_lookup,
+        );
         match rule.scope() {
             ScopedRateLimitScope::Route => Some(route.to_string()),
-            ScopedRateLimitScope::Client => Self::resolve_lb_key_from_spec(
-                rule.key_spec().unwrap_or("peer_ip"),
-                method,
-                path,
-                authority,
-                None,
-                Some(client_addr),
-                header_lookup,
-            ),
-            ScopedRateLimitScope::Tenant => rule.key_spec().and_then(|key_spec| {
-                Self::resolve_lb_key_from_spec(
-                    key_spec,
-                    method,
-                    path,
-                    authority,
-                    None,
-                    Some(client_addr),
-                    header_lookup,
-                )
-            }),
-            ScopedRateLimitScope::Token => Self::resolve_lb_key_from_spec(
-                rule.key_spec().unwrap_or("bearer_token"),
-                method,
-                path,
-                authority,
-                None,
-                Some(client_addr),
-                header_lookup,
-            ),
+            ScopedRateLimitScope::Client => {
+                Self::resolve_lb_key_from_parts(rule.key_spec().unwrap_or("peer_ip"), &request)
+            }
+            ScopedRateLimitScope::Tenant => rule
+                .key_spec()
+                .and_then(|key_spec| Self::resolve_lb_key_from_parts(key_spec, &request)),
+            ScopedRateLimitScope::Token => {
+                Self::resolve_lb_key_from_parts(rule.key_spec().unwrap_or("bearer_token"), &request)
+            }
         }
     }
 }
@@ -1424,37 +1412,27 @@ mod tests {
     }
 
     #[test]
-    fn resolve_lb_key_from_spec_supports_peer_ip_and_bearer_token() {
+    fn resolve_lb_key_from_parts_supports_peer_ip_and_bearer_token() {
         let headers = [("authorization".to_string(), "Bearer token-1".to_string())]
             .into_iter()
             .collect::<std::collections::HashMap<_, _>>();
         let lookup = |name: &str| headers.get(&name.to_ascii_lowercase()).cloned();
         let client_addr = "203.0.113.9:443".parse().expect("client addr");
+        let request = LbKeyRequestParts::new(
+            "GET",
+            "/",
+            Some("api.example.com"),
+            None,
+            Some(client_addr),
+            Some(&lookup),
+        );
 
         assert_eq!(
-            QUICListener::resolve_lb_key_from_spec(
-                "peer_ip",
-                "GET",
-                "/",
-                Some("api.example.com"),
-                None,
-                Some(client_addr),
-                Some(&lookup),
-            )
-            .as_deref(),
+            QUICListener::resolve_lb_key_from_parts("peer_ip", &request).as_deref(),
             Some("203.0.113.9")
         );
         assert_eq!(
-            QUICListener::resolve_lb_key_from_spec(
-                "bearer_token",
-                "GET",
-                "/",
-                Some("api.example.com"),
-                None,
-                Some(client_addr),
-                Some(&lookup),
-            )
-            .as_deref(),
+            QUICListener::resolve_lb_key_from_parts("bearer_token", &request).as_deref(),
             Some("token-1")
         );
     }

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -1460,6 +1460,170 @@ mod tests {
     }
 
     #[test]
+    fn canonical_lb_key_resolver_extracts_common_sources() {
+        let headers = [
+            ("authorization".to_string(), "Bearer token-3".to_string()),
+            ("cookie".to_string(), "session=s123; theme=dark".to_string()),
+            ("x-user-id".to_string(), "alice".to_string()),
+        ]
+        .into_iter()
+        .collect::<std::collections::HashMap<_, _>>();
+        let lookup = |name: &str| headers.get(&name.to_ascii_lowercase()).cloned();
+        let client_addr = "203.0.113.9:443".parse().expect("client addr");
+
+        let assert_key = |spec: &str, expected: &str| {
+            let resolved = QUICListener::resolve_lb_key(
+                "",
+                Some(spec),
+                "POST",
+                "/api/items?tenant=acme",
+                Some("api.example.com"),
+                Some("cid-123"),
+                Some(client_addr),
+                Some(&lookup),
+            );
+            assert_eq!(resolved.value, expected);
+            assert!(matches!(
+                resolved.source,
+                super::lb_key::LbKeySource::ConfiguredSpec
+            ));
+        };
+
+        assert_key("header:x-user-id", "alice");
+        assert_key("cookie:session", "s123");
+        assert_key("query:tenant", "acme");
+        assert_key("bearer_token", "token-3");
+        assert_key("cid", "cid-123");
+        assert_key("peer_ip", "203.0.113.9");
+        assert_key("path", "/api/items");
+        assert_key("authority", "api.example.com");
+        assert_key("method", "POST");
+    }
+
+    #[test]
+    fn canonical_lb_key_resolver_unifies_default_and_sticky_cid_fallbacks() {
+        let sticky = QUICListener::resolve_lb_key(
+            "sticky-cid",
+            Some("header:x-user-id"),
+            "GET",
+            "/resource",
+            Some("api.example.com"),
+            Some("cid-123"),
+            None,
+            None,
+        );
+        assert_eq!(sticky.value, "cid-123");
+        assert!(matches!(
+            sticky.source,
+            super::lb_key::LbKeySource::StickyCidFallback
+        ));
+
+        let authority_default = QUICListener::resolve_lb_key(
+            "",
+            Some("header:x-user-id"),
+            "GET",
+            "/resource",
+            Some("api.example.com"),
+            None,
+            None,
+            None,
+        );
+        assert_eq!(authority_default.value, "api.example.com");
+        assert!(matches!(
+            authority_default.source,
+            super::lb_key::LbKeySource::DefaultFallback
+        ));
+
+        let path_default = QUICListener::resolve_lb_key(
+            "",
+            Some("header:x-user-id"),
+            "GET",
+            "/resource",
+            None,
+            None,
+            None,
+            None,
+        );
+        assert_eq!(path_default.value, "/resource");
+
+        let method_default = QUICListener::resolve_lb_key(
+            "",
+            Some("header:x-user-id"),
+            "GET",
+            "",
+            None,
+            None,
+            None,
+            None,
+        );
+        assert_eq!(method_default.value, "GET");
+        assert!(matches!(
+            method_default.source,
+            super::lb_key::LbKeySource::DefaultFallback
+        ));
+    }
+
+    #[test]
+    fn canonical_lb_key_route_request_adapter_matches_direct_resolver() {
+        let headers = [
+            ("authorization".to_string(), "Bearer token-4".to_string()),
+            ("x-user-id".to_string(), "bob".to_string()),
+        ]
+        .into_iter()
+        .collect::<std::collections::HashMap<_, _>>();
+        let lookup = |name: &str| headers.get(&name.to_ascii_lowercase()).cloned();
+        let route_request = TestRouteResolutionRequest::new(
+            "GET",
+            "/api/items?tenant=acme",
+            Some("api.example.com"),
+            Some("cid-456"),
+            Some(&lookup),
+        );
+
+        let direct_header = QUICListener::resolve_lb_key(
+            "",
+            Some("header:x-user-id"),
+            "GET",
+            "/api/items?tenant=acme",
+            Some("api.example.com"),
+            Some("cid-456"),
+            None,
+            Some(&lookup),
+        );
+        let routed_header = QUICListener::resolve_lb_key_for_route_request(
+            "",
+            Some("header:x-user-id"),
+            &route_request,
+        );
+        assert_eq!(direct_header.value, routed_header.value);
+        assert!(matches!(
+            routed_header.source,
+            super::lb_key::LbKeySource::ConfiguredSpec
+        ));
+
+        let direct_sticky = QUICListener::resolve_lb_key(
+            "sticky-cid",
+            Some("header:x-missing"),
+            "GET",
+            "/api/items?tenant=acme",
+            Some("api.example.com"),
+            Some("cid-456"),
+            None,
+            Some(&lookup),
+        );
+        let routed_sticky = QUICListener::resolve_lb_key_for_route_request(
+            "sticky-cid",
+            Some("header:x-missing"),
+            &route_request,
+        );
+        assert_eq!(direct_sticky.value, routed_sticky.value);
+        assert!(matches!(
+            routed_sticky.source,
+            super::lb_key::LbKeySource::StickyCidFallback
+        ));
+    }
+
+    #[test]
     fn resolve_scoped_rate_limit_key_defaults_match_scope() {
         let client_rule = crate::resilience::scoped_rate_limit::ScopedRateLimitRule::from_config(
             &ScopedRateLimit {

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -1077,15 +1077,30 @@ impl QUICListener {
         );
         match rule.scope() {
             ScopedRateLimitScope::Route => Some(route.to_string()),
-            ScopedRateLimitScope::Client => {
-                Self::resolve_lb_key_from_parts(rule.key_spec().unwrap_or("peer_ip"), &request)
-            }
-            ScopedRateLimitScope::Tenant => rule
-                .key_spec()
-                .and_then(|key_spec| Self::resolve_lb_key_from_parts(key_spec, &request)),
-            ScopedRateLimitScope::Token => {
-                Self::resolve_lb_key_from_parts(rule.key_spec().unwrap_or("bearer_token"), &request)
-            }
+            ScopedRateLimitScope::Client => Some(
+                Self::resolve_lb_key_for_input(&LbKeyResolutionInput::new(
+                    "",
+                    Some(rule.key_spec().unwrap_or("peer_ip")),
+                    request,
+                ))
+                .value,
+            ),
+            ScopedRateLimitScope::Tenant => rule.key_spec().map(|key_spec| {
+                Self::resolve_lb_key_for_input(&LbKeyResolutionInput::new(
+                    "",
+                    Some(key_spec),
+                    request,
+                ))
+                .value
+            }),
+            ScopedRateLimitScope::Token => Some(
+                Self::resolve_lb_key_for_input(&LbKeyResolutionInput::new(
+                    "",
+                    Some(rule.key_spec().unwrap_or("bearer_token")),
+                    request,
+                ))
+                .value,
+            ),
         }
     }
 }
@@ -1493,6 +1508,62 @@ mod tests {
             .as_deref(),
             Some("token-2")
         );
+    }
+
+    #[test]
+    fn resolve_scoped_rate_limit_key_falls_back_to_default_request_key() {
+        let tenant_rule = crate::resilience::scoped_rate_limit::ScopedRateLimitRule::from_config(
+            &ScopedRateLimit {
+                name: "tenant".to_string(),
+                scope: ScopedRateLimitScope::Tenant,
+                requests_per_sec: 10,
+                burst: 10,
+                key: Some("header:x-tenant-id".to_string()),
+                route_allowlist: Vec::new(),
+                idle_ttl_secs: 300,
+            },
+        );
+        let headers = std::collections::HashMap::<String, String>::new();
+        let lookup = |name: &str| headers.get(&name.to_ascii_lowercase()).cloned();
+        let client_addr = "198.51.100.10:443".parse().expect("client addr");
+
+        assert_eq!(
+            QUICListener::resolve_scoped_rate_limit_key(
+                &tenant_rule,
+                "api",
+                "GET",
+                "/resource",
+                Some("api.example.com"),
+                client_addr,
+                Some(&lookup),
+            )
+            .as_deref(),
+            Some("api.example.com")
+        );
+    }
+
+    #[test]
+    fn resolve_lb_key_for_input_uses_sticky_cid_before_default_fallback() {
+        let request = LbKeyRequestParts::new(
+            "GET",
+            "/resource",
+            Some("api.example.com"),
+            Some("cid-123"),
+            None,
+            None,
+        );
+
+        let resolved = QUICListener::resolve_lb_key_for_input(&LbKeyResolutionInput::new(
+            "sticky-cid",
+            Some("header:x-user-id"),
+            request,
+        ));
+
+        assert_eq!(resolved.value, "cid-123");
+        assert!(matches!(
+            resolved.source,
+            super::lb_key::LbKeySource::StickyCidFallback
+        ));
     }
 
     #[test]

--- a/crates/edge/src/quic_listener/forwarding/resolve.rs
+++ b/crates/edge/src/quic_listener/forwarding/resolve.rs
@@ -1,3 +1,4 @@
+use super::lb_key::ResolvedLbKey;
 use spooky_config::runtime::RuntimeUpstreamPolicy;
 
 use super::*;

--- a/crates/edge/src/quic_listener/forwarding/resolve.rs
+++ b/crates/edge/src/quic_listener/forwarding/resolve.rs
@@ -1,7 +1,6 @@
-use super::lb_key::ResolvedLbKey;
 use spooky_config::runtime::RuntimeUpstreamPolicy;
 
-use super::*;
+use super::{lb_key::ResolvedLbKey, *};
 
 pub(in crate::quic_listener) struct RouteResolutionRequest<'a> {
     pub(in crate::quic_listener) method: &'a str,

--- a/crates/edge/src/quic_listener/forwarding/resolve.rs
+++ b/crates/edge/src/quic_listener/forwarding/resolve.rs
@@ -324,15 +324,22 @@ impl QUICListener {
         pool: &UpstreamPool,
     ) -> BackendSelectionPlan {
         let lb_type = pool.lb_name().to_string();
-        let lb_key = Self::resolve_lb_request_key(
-            &lb_type,
-            pool.lb_key(),
+        let lb_request = LbKeyRequestParts::new(
             request.method,
             request.path,
             request.authority,
             request.cid_key,
+            None,
             request.header_lookup,
         );
+        let ResolvedLbKey {
+            value: lb_key,
+            source: _lb_key_source,
+        } = Self::resolve_lb_key_for_input(&LbKeyResolutionInput::new(
+            &lb_type,
+            pool.lb_key(),
+            lb_request,
+        ));
         BackendSelectionPlan { lb_type, lb_key }
     }
 

--- a/crates/edge/src/quic_listener/forwarding/resolve.rs
+++ b/crates/edge/src/quic_listener/forwarding/resolve.rs
@@ -324,22 +324,10 @@ impl QUICListener {
         pool: &UpstreamPool,
     ) -> BackendSelectionPlan {
         let lb_type = pool.lb_name().to_string();
-        let lb_request = LbKeyRequestParts::new(
-            request.method,
-            request.path,
-            request.authority,
-            request.cid_key,
-            None,
-            request.header_lookup,
-        );
         let ResolvedLbKey {
             value: lb_key,
             source: _lb_key_source,
-        } = Self::resolve_lb_key_for_input(&LbKeyResolutionInput::new(
-            &lb_type,
-            pool.lb_key(),
-            lb_request,
-        ));
+        } = Self::resolve_lb_key_for_route_request(&lb_type, pool.lb_key(), request);
         BackendSelectionPlan { lb_type, lb_key }
     }
 


### PR DESCRIPTION
## Summary
This PR extracts load-balancing key resolution into a canonical shared layer and routes the edge resolution flow through it.

## What Changed
- introduced shared LB key resolution input/output types
- centralized key extraction for cookie, query, header, bearer token, CID, peer IP, path, authority, and method sources
- unified default fallback and sticky-CID fallback behavior
- routed QUIC forwarding backend selection through the canonical LB key resolver
- routed bootstrap and remaining resolution call sites through the same resolver
- added focused tests for canonical LB key behavior
- cleaned up stale helper paths and tightened module boundaries

## Why
LB key extraction had drifted into request-path-specific helpers inside `edge`. That made fallback behavior harder to reason about and increased the risk of different routing paths producing different stickiness behavior for the same request shape. This change makes key resolution a single contract with one implementation.

## Outcome
- all resolution paths now use the same LB key extraction semantics
- fallback behavior is consistent across QUIC forwarding and bootstrap paths
- backend selection logic in `resolve.rs` stays focused on selection rather than request parsing
- tests now pin the canonical behavior for future refactors

## Validation
- `cargo fmt --all`
- `cargo check -p spooky-edge --tests`