### PR TITLE
refactor(edge): centralize upstream error classification and policy interpretation

### DIFF
--- a/crates/edge/src/quic_listener/bootstrap_tls.rs
+++ b/crates/edge/src/quic_listener/bootstrap_tls.rs
@@ -30,7 +30,7 @@ use spooky_config::{
     backend_endpoint::{BackendEndpoint, BackendScheme},
     runtime::{ListenerRuntimeConfig, RuntimeUpstreamPolicy},
 };
-use spooky_errors::ProxyError;
+use spooky_errors::{ProxyError, classify_upstream_proxy_error};
 use spooky_lb::upstream_pool::UpstreamPool;
 use spooky_transport::transport_pool::UpstreamTransportPool;
 
@@ -388,33 +388,38 @@ impl QUICListener {
                                         .and_then(|value| value.to_str().ok())
                                         .map(str::to_string)
                                 };
-                                let (backend_addr, upstream_name, upstream_policy) =
-                                    match Self::resolve_bootstrap_target(
-                                        super::forwarding::BootstrapResolutionInput {
-                                            method: &method,
-                                            path: &path,
-                                            authority: authority.as_deref(),
-                                            header_lookup: Some(&lb_header_lookup),
-                                            routing_index: &routing_index,
-                                            upstream_pools: &upstream_pools,
-                                            upstream_policies: &upstream_policies,
-                                            metrics: &metrics,
-                                            elapsed: Duration::from_millis(0),
-                                        },
-                                    ) {
-                                        Ok(value) => (
-                                            value.backend_addr,
-                                            value.upstream_name,
-                                            value.upstream_policy,
-                                        ),
-                                        Err(err) => {
-                                            let (status, body) =
-                                                Self::bootstrap_route_resolution_error_response(
-                                                    &err,
-                                                );
-                                            return bootstrap_error(status, body);
-                                        }
-                                    };
+                                let (
+                                    backend_addr,
+                                    backend_index,
+                                    upstream_name,
+                                    upstream_policy,
+                                    upstream_pool,
+                                ) = match Self::resolve_bootstrap_target(
+                                    super::forwarding::BootstrapResolutionInput {
+                                        method: &method,
+                                        path: &path,
+                                        authority: authority.as_deref(),
+                                        header_lookup: Some(&lb_header_lookup),
+                                        routing_index: &routing_index,
+                                        upstream_pools: &upstream_pools,
+                                        upstream_policies: &upstream_policies,
+                                        metrics: &metrics,
+                                        elapsed: Duration::from_millis(0),
+                                    },
+                                ) {
+                                    Ok(value) => (
+                                        value.backend_addr,
+                                        value.backend_index,
+                                        value.upstream_name,
+                                        value.upstream_policy,
+                                        value.upstream_pool,
+                                    ),
+                                    Err(err) => {
+                                        let (status, body) =
+                                            Self::bootstrap_route_resolution_error_response(&err);
+                                        return bootstrap_error(status, body);
+                                    }
+                                };
 
                                 let admission = evaluate_forwarding_pre_admission_policy(
                                     &upstream_policy,
@@ -994,7 +999,55 @@ impl QUICListener {
                                     {
                                         Ok(Ok(resp)) => resp,
                                         Ok(Err(err)) => {
-                                            warn!("Bootstrap WebSocket upstream error: {}", err);
+                                            let proxy_err = ProxyError::Transport(err.to_string());
+                                            if let Some(classified) =
+                                                classify_upstream_proxy_error(&proxy_err)
+                                            {
+                                                if let Some(health_mapping) =
+                                                    classified.health_failure
+                                                {
+                                                    metrics.inc_health_failure(
+                                                        health_mapping.failure_reason,
+                                                    );
+                                                    if health_mapping.failure_reason
+                                                        == spooky_lb::health::HealthFailureReason::Tls
+                                                    {
+                                                        metrics.record_upstream_tls_failure(
+                                                            &backend_addr,
+                                                            "bootstrap",
+                                                            health_mapping.metrics_reason,
+                                                        );
+                                                    }
+                                                    if let Some(transition) = upstream_pool
+                                                        .write()
+                                                        .ok()
+                                                        .and_then(|mut pool| {
+                                                            pool.pool.mark_request_failure(
+                                                                backend_index,
+                                                                health_mapping.failure_reason,
+                                                            )
+                                                        })
+                                                    {
+                                                        Self::log_health_transition(
+                                                            &backend_addr,
+                                                            transition,
+                                                        );
+                                                    }
+                                                }
+                                                warn!(
+                                                    "Bootstrap WebSocket upstream failure route={} backend={} kind={:?} retryability={:?} detail={}",
+                                                    upstream_name,
+                                                    backend_addr,
+                                                    classified.kind,
+                                                    classified.retryability,
+                                                    classified.detail
+                                                );
+                                            } else {
+                                                warn!(
+                                                    "Bootstrap WebSocket upstream error route={} backend={}: {}",
+                                                    upstream_name, backend_addr, err
+                                                );
+                                            }
                                             return Ok(Response::builder()
                                                 .status(StatusCode::BAD_GATEWAY)
                                                 .header("alt-svc", &alt)
@@ -1008,6 +1061,38 @@ impl QUICListener {
                                                 }));
                                         }
                                         Err(_) => {
+                                            if let Some(classified) =
+                                                classify_upstream_proxy_error(&ProxyError::Timeout)
+                                                && let Some(health_mapping) =
+                                                    classified.health_failure
+                                            {
+                                                metrics.inc_health_failure(
+                                                    health_mapping.failure_reason,
+                                                );
+                                                if let Some(transition) = upstream_pool
+                                                    .write()
+                                                    .ok()
+                                                    .and_then(|mut pool| {
+                                                        pool.pool.mark_request_failure(
+                                                            backend_index,
+                                                            health_mapping.failure_reason,
+                                                        )
+                                                    })
+                                                {
+                                                    Self::log_health_transition(
+                                                        &backend_addr,
+                                                        transition,
+                                                    );
+                                                }
+                                                warn!(
+                                                    "Bootstrap WebSocket upstream failure route={} backend={} kind={:?} retryability={:?} detail={}",
+                                                    upstream_name,
+                                                    backend_addr,
+                                                    classified.kind,
+                                                    classified.retryability,
+                                                    classified.detail
+                                                );
+                                            }
                                             return Ok(Response::builder()
                                                 .status(StatusCode::GATEWAY_TIMEOUT)
                                                 .header("alt-svc", &alt)
@@ -1030,7 +1115,55 @@ impl QUICListener {
                                     {
                                         Ok(Ok(resp)) => resp,
                                         Ok(Err(err)) => {
-                                            warn!("Bootstrap proxy upstream error: {}", err);
+                                            let proxy_err = ProxyError::Pool(err);
+                                            if let Some(classified) =
+                                                classify_upstream_proxy_error(&proxy_err)
+                                            {
+                                                if let Some(health_mapping) =
+                                                    classified.health_failure
+                                                {
+                                                    metrics.inc_health_failure(
+                                                        health_mapping.failure_reason,
+                                                    );
+                                                    if health_mapping.failure_reason
+                                                        == spooky_lb::health::HealthFailureReason::Tls
+                                                    {
+                                                        metrics.record_upstream_tls_failure(
+                                                            &backend_addr,
+                                                            "bootstrap",
+                                                            health_mapping.metrics_reason,
+                                                        );
+                                                    }
+                                                    if let Some(transition) = upstream_pool
+                                                        .write()
+                                                        .ok()
+                                                        .and_then(|mut pool| {
+                                                            pool.pool.mark_request_failure(
+                                                                backend_index,
+                                                                health_mapping.failure_reason,
+                                                            )
+                                                        })
+                                                    {
+                                                        Self::log_health_transition(
+                                                            &backend_addr,
+                                                            transition,
+                                                        );
+                                                    }
+                                                }
+                                                warn!(
+                                                    "Bootstrap proxy upstream failure route={} backend={} kind={:?} retryability={:?} detail={}",
+                                                    upstream_name,
+                                                    backend_addr,
+                                                    classified.kind,
+                                                    classified.retryability,
+                                                    classified.detail
+                                                );
+                                            } else {
+                                                warn!(
+                                                    "Bootstrap proxy upstream error route={} backend={}: {}",
+                                                    upstream_name, backend_addr, proxy_err
+                                                );
+                                            }
                                             return Ok(Response::builder()
                                                 .status(StatusCode::BAD_GATEWAY)
                                                 .header("alt-svc", &alt)
@@ -1044,6 +1177,38 @@ impl QUICListener {
                                                 }));
                                         }
                                         Err(_) => {
+                                            if let Some(classified) =
+                                                classify_upstream_proxy_error(&ProxyError::Timeout)
+                                                && let Some(health_mapping) =
+                                                    classified.health_failure
+                                            {
+                                                metrics.inc_health_failure(
+                                                    health_mapping.failure_reason,
+                                                );
+                                                if let Some(transition) = upstream_pool
+                                                    .write()
+                                                    .ok()
+                                                    .and_then(|mut pool| {
+                                                        pool.pool.mark_request_failure(
+                                                            backend_index,
+                                                            health_mapping.failure_reason,
+                                                        )
+                                                    })
+                                                {
+                                                    Self::log_health_transition(
+                                                        &backend_addr,
+                                                        transition,
+                                                    );
+                                                }
+                                                warn!(
+                                                    "Bootstrap proxy upstream failure route={} backend={} kind={:?} retryability={:?} detail={}",
+                                                    upstream_name,
+                                                    backend_addr,
+                                                    classified.kind,
+                                                    classified.retryability,
+                                                    classified.detail
+                                                );
+                                            }
                                             return Ok(Response::builder()
                                                 .status(StatusCode::GATEWAY_TIMEOUT)
                                                 .header("alt-svc", &alt)

--- a/crates/edge/src/quic_listener/bootstrap_tls.rs
+++ b/crates/edge/src/quic_listener/bootstrap_tls.rs
@@ -1003,44 +1003,20 @@ impl QUICListener {
                                             if let Some(classified) =
                                                 classify_upstream_proxy_error(&proxy_err)
                                             {
-                                                if let Some(health_mapping) =
-                                                    classified.health_failure
-                                                {
-                                                    metrics.inc_health_failure(
-                                                        health_mapping.failure_reason,
-                                                    );
-                                                    if health_mapping.failure_reason
-                                                        == spooky_lb::health::HealthFailureReason::Tls
-                                                    {
-                                                        metrics.record_upstream_tls_failure(
-                                                            &backend_addr,
-                                                            "bootstrap",
-                                                            health_mapping.metrics_reason,
-                                                        );
-                                                    }
-                                                    if let Some(transition) = upstream_pool
-                                                        .write()
-                                                        .ok()
-                                                        .and_then(|mut pool| {
-                                                            pool.pool.mark_request_failure(
-                                                                backend_index,
-                                                                health_mapping.failure_reason,
-                                                            )
-                                                        })
-                                                    {
-                                                        Self::log_health_transition(
-                                                            &backend_addr,
-                                                            transition,
-                                                        );
-                                                    }
-                                                }
-                                                warn!(
-                                                    "Bootstrap WebSocket upstream failure route={} backend={} kind={:?} retryability={:?} detail={}",
-                                                    upstream_name,
-                                                    backend_addr,
-                                                    classified.kind,
-                                                    classified.retryability,
-                                                    classified.detail
+                                                Self::log_classified_upstream_failure(
+                                                    "bootstrap",
+                                                    Some(request_id),
+                                                    Some(&upstream_name),
+                                                    &backend_addr,
+                                                    &classified,
+                                                );
+                                                Self::mark_classified_upstream_health_failure(
+                                                    "bootstrap",
+                                                    &backend_addr,
+                                                    backend_index,
+                                                    Some(&upstream_pool),
+                                                    metrics.as_ref(),
+                                                    &classified,
                                                 );
                                             } else {
                                                 warn!(
@@ -1063,34 +1039,21 @@ impl QUICListener {
                                         Err(_) => {
                                             if let Some(classified) =
                                                 classify_upstream_proxy_error(&ProxyError::Timeout)
-                                                && let Some(health_mapping) =
-                                                    classified.health_failure
                                             {
-                                                metrics.inc_health_failure(
-                                                    health_mapping.failure_reason,
+                                                Self::log_classified_upstream_failure(
+                                                    "bootstrap",
+                                                    Some(request_id),
+                                                    Some(&upstream_name),
+                                                    &backend_addr,
+                                                    &classified,
                                                 );
-                                                if let Some(transition) = upstream_pool
-                                                    .write()
-                                                    .ok()
-                                                    .and_then(|mut pool| {
-                                                        pool.pool.mark_request_failure(
-                                                            backend_index,
-                                                            health_mapping.failure_reason,
-                                                        )
-                                                    })
-                                                {
-                                                    Self::log_health_transition(
-                                                        &backend_addr,
-                                                        transition,
-                                                    );
-                                                }
-                                                warn!(
-                                                    "Bootstrap WebSocket upstream failure route={} backend={} kind={:?} retryability={:?} detail={}",
-                                                    upstream_name,
-                                                    backend_addr,
-                                                    classified.kind,
-                                                    classified.retryability,
-                                                    classified.detail
+                                                Self::mark_classified_upstream_health_failure(
+                                                    "bootstrap",
+                                                    &backend_addr,
+                                                    backend_index,
+                                                    Some(&upstream_pool),
+                                                    metrics.as_ref(),
+                                                    &classified,
                                                 );
                                             }
                                             return Ok(Response::builder()
@@ -1119,44 +1082,20 @@ impl QUICListener {
                                             if let Some(classified) =
                                                 classify_upstream_proxy_error(&proxy_err)
                                             {
-                                                if let Some(health_mapping) =
-                                                    classified.health_failure
-                                                {
-                                                    metrics.inc_health_failure(
-                                                        health_mapping.failure_reason,
-                                                    );
-                                                    if health_mapping.failure_reason
-                                                        == spooky_lb::health::HealthFailureReason::Tls
-                                                    {
-                                                        metrics.record_upstream_tls_failure(
-                                                            &backend_addr,
-                                                            "bootstrap",
-                                                            health_mapping.metrics_reason,
-                                                        );
-                                                    }
-                                                    if let Some(transition) = upstream_pool
-                                                        .write()
-                                                        .ok()
-                                                        .and_then(|mut pool| {
-                                                            pool.pool.mark_request_failure(
-                                                                backend_index,
-                                                                health_mapping.failure_reason,
-                                                            )
-                                                        })
-                                                    {
-                                                        Self::log_health_transition(
-                                                            &backend_addr,
-                                                            transition,
-                                                        );
-                                                    }
-                                                }
-                                                warn!(
-                                                    "Bootstrap proxy upstream failure route={} backend={} kind={:?} retryability={:?} detail={}",
-                                                    upstream_name,
-                                                    backend_addr,
-                                                    classified.kind,
-                                                    classified.retryability,
-                                                    classified.detail
+                                                Self::log_classified_upstream_failure(
+                                                    "bootstrap",
+                                                    Some(request_id),
+                                                    Some(&upstream_name),
+                                                    &backend_addr,
+                                                    &classified,
+                                                );
+                                                Self::mark_classified_upstream_health_failure(
+                                                    "bootstrap",
+                                                    &backend_addr,
+                                                    backend_index,
+                                                    Some(&upstream_pool),
+                                                    metrics.as_ref(),
+                                                    &classified,
                                                 );
                                             } else {
                                                 warn!(
@@ -1179,34 +1118,21 @@ impl QUICListener {
                                         Err(_) => {
                                             if let Some(classified) =
                                                 classify_upstream_proxy_error(&ProxyError::Timeout)
-                                                && let Some(health_mapping) =
-                                                    classified.health_failure
                                             {
-                                                metrics.inc_health_failure(
-                                                    health_mapping.failure_reason,
+                                                Self::log_classified_upstream_failure(
+                                                    "bootstrap",
+                                                    Some(request_id),
+                                                    Some(&upstream_name),
+                                                    &backend_addr,
+                                                    &classified,
                                                 );
-                                                if let Some(transition) = upstream_pool
-                                                    .write()
-                                                    .ok()
-                                                    .and_then(|mut pool| {
-                                                        pool.pool.mark_request_failure(
-                                                            backend_index,
-                                                            health_mapping.failure_reason,
-                                                        )
-                                                    })
-                                                {
-                                                    Self::log_health_transition(
-                                                        &backend_addr,
-                                                        transition,
-                                                    );
-                                                }
-                                                warn!(
-                                                    "Bootstrap proxy upstream failure route={} backend={} kind={:?} retryability={:?} detail={}",
-                                                    upstream_name,
-                                                    backend_addr,
-                                                    classified.kind,
-                                                    classified.retryability,
-                                                    classified.detail
+                                                Self::mark_classified_upstream_health_failure(
+                                                    "bootstrap",
+                                                    &backend_addr,
+                                                    backend_index,
+                                                    Some(&upstream_pool),
+                                                    metrics.as_ref(),
+                                                    &classified,
                                                 );
                                             }
                                             return Ok(Response::builder()

--- a/crates/edge/src/quic_listener/forwarding/dispatch.rs
+++ b/crates/edge/src/quic_listener/forwarding/dispatch.rs
@@ -1,8 +1,9 @@
-use super::*;
 use spooky_errors::{
     RetryPolicyDecision, RetryPolicyDenial, RetryPolicyInput, UpstreamRetryReason,
     evaluate_retry_policy,
 };
+
+use super::*;
 
 fn metrics_retry_reason(reason: UpstreamRetryReason) -> RetryReason {
     match reason {

--- a/crates/edge/src/quic_listener/forwarding/dispatch.rs
+++ b/crates/edge/src/quic_listener/forwarding/dispatch.rs
@@ -1,4 +1,24 @@
 use super::*;
+use spooky_errors::{
+    RetryPolicyDecision, RetryPolicyDenial, RetryPolicyInput, UpstreamRetryReason,
+    evaluate_retry_policy,
+};
+
+fn metrics_retry_reason(reason: UpstreamRetryReason) -> RetryReason {
+    match reason {
+        UpstreamRetryReason::Timeout => RetryReason::BackendTimeout,
+        UpstreamRetryReason::Transport => RetryReason::BackendTransport,
+        UpstreamRetryReason::Pool => RetryReason::BackendPool,
+    }
+}
+
+fn metrics_retry_denial(reason: RetryPolicyDenial) -> RetryReason {
+    match reason {
+        RetryPolicyDenial::NotBodylessMode => RetryReason::NotBodylessMode,
+        RetryPolicyDenial::BudgetDenied => RetryReason::BudgetDenied,
+        RetryPolicyDenial::NoAlternateBackend => RetryReason::NoAlternateBackend,
+    }
+}
 
 impl QUICListener {
     #[allow(clippy::too_many_arguments)]
@@ -279,25 +299,21 @@ impl QUICListener {
                         {
                             Ok(response) => response,
                             Err(primary_err) => {
-                                let retry_reason = classify_retry_reason(&primary_err);
-                                let is_retryable_err = is_retryable(&primary_err);
-                                let budget_ok = retry_budget.allow_retry(&route_name).is_ok();
-                                let can_retry = bodyless_mode
-                                    && is_retryable_err
-                                    && budget_ok
-                                    && alternate_backend.is_some();
-                                if !can_retry {
-                                    if !bodyless_mode {
-                                        retry_denial_reason = Some(RetryReason::NotBodylessMode);
-                                    } else if !is_retryable_err {
-                                        retry_denial_reason = None;
-                                    } else if !budget_ok {
-                                        retry_denial_reason = Some(RetryReason::BudgetDenied);
-                                    } else {
-                                        retry_denial_reason = Some(RetryReason::NoAlternateBackend);
+                                let retry_decision = evaluate_retry_policy(RetryPolicyInput {
+                                    retryability: spooky_errors::classify_retryability(&primary_err),
+                                    bodyless_mode,
+                                    budget_available: retry_budget.allow_retry(&route_name).is_ok(),
+                                    alternate_backend_available: alternate_backend.is_some(),
+                                });
+                                let retry_reason = match retry_decision {
+                                    RetryPolicyDecision::Retry { reason } => {
+                                        metrics_retry_reason(reason)
                                     }
-                                    return Err(primary_err);
-                                }
+                                    RetryPolicyDecision::DoNotRetry { denial } => {
+                                        retry_denial_reason = denial.map(metrics_retry_denial);
+                                        return Err(primary_err);
+                                    }
+                                };
                                 if let Some((retry_backend, _)) = alternate_backend.clone()
                                     && let Some(endpoint) = backend_endpoints.get(&retry_backend)
                                     && let Ok(retry_request) =

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -9,7 +9,6 @@ mod stream_progress;
 use std::convert::Infallible;
 
 use spooky_config::config::ScopedRateLimitScope;
-use spooky_errors::{UpstreamErrorClassification, UpstreamErrorDetails};
 
 use self::prepare::{PreparedRequest, StartedAuthRequest};
 pub(in crate::quic_listener) use self::resolve::BootstrapResolutionInput;
@@ -84,21 +83,6 @@ pub(crate) struct StreamProgressConfig {
 }
 
 impl QUICListener {
-    pub fn classify_upstream_failure_reason(
-        is_connect: bool,
-        detail: &str,
-    ) -> UpstreamErrorClassification {
-        UpstreamErrorDetails::new(detail.to_string(), is_connect).classify()
-    }
-
-    pub(crate) fn classify_send_error(
-        err: &hyper_util::client::legacy::Error,
-    ) -> (UpstreamErrorDetails, UpstreamErrorClassification) {
-        let details = UpstreamErrorDetails::from_error_chain(err, err.is_connect());
-        let classification = details.classify();
-        (details, classification)
-    }
-
     fn is_internal_pool_control_error(error: &PoolError) -> bool {
         matches!(
             error,
@@ -1157,9 +1141,9 @@ mod tests {
     #[test]
     fn send_connect_error_with_tls_details_maps_to_tls_health_failure() {
         assert_eq!(
-            QUICListener::classify_upstream_failure_reason(
+            spooky_errors::classify_upstream_error_detail(
+                "client error (Connect): tls handshake failed: invalid certificate",
                 true,
-                "client error (Connect): tls handshake failed: invalid certificate"
             ),
             spooky_errors::UpstreamErrorClassification::tls(
                 spooky_errors::UpstreamTlsReason::Handshake,
@@ -1170,9 +1154,9 @@ mod tests {
     #[test]
     fn send_connect_error_without_tls_details_maps_to_transport_health_failure() {
         assert_eq!(
-            QUICListener::classify_upstream_failure_reason(
+            spooky_errors::classify_upstream_error_detail(
+                "client error (Connect): connection refused",
                 true,
-                "client error (Connect): connection refused"
             ),
             spooky_errors::UpstreamErrorClassification::transport()
         );
@@ -1181,7 +1165,7 @@ mod tests {
     #[test]
     fn send_error_with_timeout_detail_maps_to_timeout_health_failure() {
         assert_eq!(
-            QUICListener::classify_upstream_failure_reason(false, "request timed out"),
+            spooky_errors::classify_upstream_error_detail("request timed out", false),
             spooky_errors::UpstreamErrorClassification::timeout()
         );
     }

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -6,7 +6,7 @@ mod resolve;
 mod response;
 mod stream_progress;
 
-use std::{convert::Infallible, error::Error as StdError};
+use std::convert::Infallible;
 
 use spooky_config::config::ScopedRateLimitScope;
 use spooky_errors::{
@@ -19,6 +19,8 @@ pub(in crate::quic_listener) use self::resolve::BootstrapResolutionInput;
 pub(in crate::quic_listener) use self::resolve::RouteResolutionRequest as TestRouteResolutionRequest;
 use super::*;
 use crate::runtime::connection::{request::PendingForward, stream::StreamAdmissionState};
+#[cfg(test)]
+use std::error::Error as StdError;
 
 pub(super) fn abort_stream(req: &mut RequestEnvelope, metrics: &Metrics) -> StreamPhase {
     let phase = req.phase.clone();
@@ -88,51 +90,14 @@ impl QUICListener {
         is_connect: bool,
         detail: &str,
     ) -> UpstreamErrorClassification {
-        let normalized = detail.to_ascii_lowercase();
-        if normalized.contains("timeout") || normalized.contains("timed out") {
-            return UpstreamErrorClassification::timeout();
-        }
-
-        if is_connect {
-            if normalized.contains("unknownissuer") || normalized.contains("unknown issuer") {
-                return UpstreamErrorClassification::tls(UpstreamTlsReason::UnknownIssuer);
-            }
-            if normalized.contains("expired")
-                || normalized.contains("not yet valid")
-                || normalized.contains("validity")
-            {
-                return UpstreamErrorClassification::tls(UpstreamTlsReason::ExpiredCertificate);
-            }
-            if normalized.contains("hostname")
-                || normalized.contains("dns name")
-                || normalized.contains("subjectaltname")
-                || normalized.contains("not valid for")
-            {
-                return UpstreamErrorClassification::tls(UpstreamTlsReason::HostnameMismatch);
-            }
-            if normalized.contains("alpn") {
-                return UpstreamErrorClassification::tls(UpstreamTlsReason::Alpn);
-            }
-            if normalized.contains("invalidcertificate")
-                || normalized.contains("certificate")
-                || normalized.contains("x509")
-                || normalized.contains("rustls")
-                || normalized.contains("webpki")
-                || normalized.contains("tls")
-            {
-                return UpstreamErrorClassification::tls(UpstreamTlsReason::Handshake);
-            }
-        }
-
-        UpstreamErrorClassification::transport()
+        UpstreamErrorDetails::new(detail.to_string(), is_connect).classify()
     }
 
     pub(crate) fn classify_send_error(
         err: &hyper_util::client::legacy::Error,
     ) -> (UpstreamErrorDetails, UpstreamErrorClassification) {
-        let details = UpstreamErrorDetails::new(Self::format_error_chain(err), err.is_connect());
-        let classification =
-            Self::classify_upstream_failure_reason(details.is_connect, &details.detail);
+        let details = UpstreamErrorDetails::from_error_chain(err, err.is_connect());
+        let classification = details.classify();
         (details, classification)
     }
 
@@ -159,17 +124,6 @@ impl QUICListener {
                 (HealthFailureReason::Transport, "transport")
             }
         }
-    }
-
-    pub(crate) fn format_error_chain(err: &(dyn StdError + 'static)) -> String {
-        let mut detail = err.to_string();
-        let mut source = err.source();
-        while let Some(cause) = source {
-            detail.push_str(": ");
-            detail.push_str(&cause.to_string());
-            source = cause.source();
-        }
-        detail
     }
 
     fn is_internal_pool_control_error(error: &PoolError) -> bool {
@@ -1309,7 +1263,7 @@ mod tests {
 
     #[test]
     fn format_error_chain_includes_nested_causes() {
-        let msg = QUICListener::format_error_chain(&OuterErr(InnerErr));
+        let msg = spooky_errors::format_error_chain(&OuterErr(InnerErr));
         assert_eq!(msg, "outer: inner");
     }
 

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -9,6 +9,9 @@ mod stream_progress;
 use std::{convert::Infallible, error::Error as StdError};
 
 use spooky_config::config::ScopedRateLimitScope;
+use spooky_errors::{
+    UpstreamErrorCategory, UpstreamErrorClassification, UpstreamErrorDetails, UpstreamTlsReason,
+};
 
 use self::prepare::{PreparedRequest, StartedAuthRequest};
 pub(in crate::quic_listener) use self::resolve::BootstrapResolutionInput;
@@ -84,31 +87,31 @@ impl QUICListener {
     pub fn classify_upstream_failure_reason(
         is_connect: bool,
         detail: &str,
-    ) -> (HealthFailureReason, &'static str) {
+    ) -> UpstreamErrorClassification {
         let normalized = detail.to_ascii_lowercase();
         if normalized.contains("timeout") || normalized.contains("timed out") {
-            return (HealthFailureReason::Timeout, "timeout");
+            return UpstreamErrorClassification::timeout();
         }
 
         if is_connect {
             if normalized.contains("unknownissuer") || normalized.contains("unknown issuer") {
-                return (HealthFailureReason::Tls, "unknown_issuer");
+                return UpstreamErrorClassification::tls(UpstreamTlsReason::UnknownIssuer);
             }
             if normalized.contains("expired")
                 || normalized.contains("not yet valid")
                 || normalized.contains("validity")
             {
-                return (HealthFailureReason::Tls, "expired_certificate");
+                return UpstreamErrorClassification::tls(UpstreamTlsReason::ExpiredCertificate);
             }
             if normalized.contains("hostname")
                 || normalized.contains("dns name")
                 || normalized.contains("subjectaltname")
                 || normalized.contains("not valid for")
             {
-                return (HealthFailureReason::Tls, "hostname_mismatch");
+                return UpstreamErrorClassification::tls(UpstreamTlsReason::HostnameMismatch);
             }
             if normalized.contains("alpn") {
-                return (HealthFailureReason::Tls, "alpn");
+                return UpstreamErrorClassification::tls(UpstreamTlsReason::Alpn);
             }
             if normalized.contains("invalidcertificate")
                 || normalized.contains("certificate")
@@ -117,18 +120,45 @@ impl QUICListener {
                 || normalized.contains("webpki")
                 || normalized.contains("tls")
             {
-                return (HealthFailureReason::Tls, "handshake");
+                return UpstreamErrorClassification::tls(UpstreamTlsReason::Handshake);
             }
         }
 
-        (HealthFailureReason::Transport, "transport")
+        UpstreamErrorClassification::transport()
     }
 
-    pub(crate) fn send_error_health_failure_reason(
+    pub(crate) fn classify_send_error(
         err: &hyper_util::client::legacy::Error,
+    ) -> (UpstreamErrorDetails, UpstreamErrorClassification) {
+        let details = UpstreamErrorDetails::new(Self::format_error_chain(err), err.is_connect());
+        let classification =
+            Self::classify_upstream_failure_reason(details.is_connect, &details.detail);
+        (details, classification)
+    }
+
+    pub(crate) fn upstream_error_health_failure_reason(
+        classification: UpstreamErrorClassification,
     ) -> (HealthFailureReason, &'static str) {
-        let detail = Self::format_error_chain(err);
-        Self::classify_upstream_failure_reason(err.is_connect(), &detail)
+        match classification.category {
+            UpstreamErrorCategory::Timeout => (HealthFailureReason::Timeout, "timeout"),
+            UpstreamErrorCategory::Transport => (HealthFailureReason::Transport, "transport"),
+            UpstreamErrorCategory::Tls => (
+                HealthFailureReason::Tls,
+                match classification
+                    .tls_reason
+                    .unwrap_or(UpstreamTlsReason::Handshake)
+                {
+                    UpstreamTlsReason::UnknownIssuer => "unknown_issuer",
+                    UpstreamTlsReason::ExpiredCertificate => "expired_certificate",
+                    UpstreamTlsReason::HostnameMismatch => "hostname_mismatch",
+                    UpstreamTlsReason::Alpn => "alpn",
+                    UpstreamTlsReason::Handshake => "handshake",
+                },
+            ),
+            UpstreamErrorCategory::Protocol | UpstreamErrorCategory::Internal => {
+                (HealthFailureReason::Transport, "transport")
+            }
+        }
     }
 
     pub(crate) fn format_error_chain(err: &(dyn StdError + 'static)) -> String {
@@ -1204,7 +1234,9 @@ mod tests {
                 true,
                 "client error (Connect): tls handshake failed: invalid certificate"
             ),
-            (HealthFailureReason::Tls, "handshake")
+            spooky_errors::UpstreamErrorClassification::tls(
+                spooky_errors::UpstreamTlsReason::Handshake,
+            )
         );
     }
 
@@ -1215,7 +1247,7 @@ mod tests {
                 true,
                 "client error (Connect): connection refused"
             ),
-            (HealthFailureReason::Transport, "transport")
+            spooky_errors::UpstreamErrorClassification::transport()
         );
     }
 
@@ -1223,7 +1255,7 @@ mod tests {
     fn send_error_with_timeout_detail_maps_to_timeout_health_failure() {
         assert_eq!(
             QUICListener::classify_upstream_failure_reason(false, "request timed out"),
-            (HealthFailureReason::Timeout, "timeout")
+            spooky_errors::UpstreamErrorClassification::timeout()
         );
     }
 

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -9,9 +9,7 @@ mod stream_progress;
 use std::convert::Infallible;
 
 use spooky_config::config::ScopedRateLimitScope;
-use spooky_errors::{
-    UpstreamErrorCategory, UpstreamErrorClassification, UpstreamErrorDetails, UpstreamTlsReason,
-};
+use spooky_errors::{UpstreamErrorClassification, UpstreamErrorDetails};
 
 use self::prepare::{PreparedRequest, StartedAuthRequest};
 pub(in crate::quic_listener) use self::resolve::BootstrapResolutionInput;
@@ -99,31 +97,6 @@ impl QUICListener {
         let details = UpstreamErrorDetails::from_error_chain(err, err.is_connect());
         let classification = details.classify();
         (details, classification)
-    }
-
-    pub(crate) fn upstream_error_health_failure_reason(
-        classification: UpstreamErrorClassification,
-    ) -> (HealthFailureReason, &'static str) {
-        match classification.category {
-            UpstreamErrorCategory::Timeout => (HealthFailureReason::Timeout, "timeout"),
-            UpstreamErrorCategory::Transport => (HealthFailureReason::Transport, "transport"),
-            UpstreamErrorCategory::Tls => (
-                HealthFailureReason::Tls,
-                match classification
-                    .tls_reason
-                    .unwrap_or(UpstreamTlsReason::Handshake)
-                {
-                    UpstreamTlsReason::UnknownIssuer => "unknown_issuer",
-                    UpstreamTlsReason::ExpiredCertificate => "expired_certificate",
-                    UpstreamTlsReason::HostnameMismatch => "hostname_mismatch",
-                    UpstreamTlsReason::Alpn => "alpn",
-                    UpstreamTlsReason::Handshake => "handshake",
-                },
-            ),
-            UpstreamErrorCategory::Protocol | UpstreamErrorCategory::Internal => {
-                (HealthFailureReason::Transport, "transport")
-            }
-        }
     }
 
     fn is_internal_pool_control_error(error: &PoolError) -> bool {

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -9,6 +9,7 @@ mod stream_progress;
 use std::convert::Infallible;
 
 use spooky_config::config::ScopedRateLimitScope;
+use spooky_errors::ClassifiedUpstreamProxyError;
 
 use self::prepare::{PreparedRequest, StartedAuthRequest};
 pub(in crate::quic_listener) use self::resolve::BootstrapResolutionInput;
@@ -16,8 +17,6 @@ pub(in crate::quic_listener) use self::resolve::BootstrapResolutionInput;
 pub(in crate::quic_listener) use self::resolve::RouteResolutionRequest as TestRouteResolutionRequest;
 use super::*;
 use crate::runtime::connection::{request::PendingForward, stream::StreamAdmissionState};
-#[cfg(test)]
-use std::error::Error as StdError;
 
 pub(super) fn abort_stream(req: &mut RequestEnvelope, metrics: &Metrics) -> StreamPhase {
     let phase = req.phase.clone();
@@ -83,6 +82,73 @@ pub(crate) struct StreamProgressConfig {
 }
 
 impl QUICListener {
+    pub(super) fn log_classified_upstream_failure(
+        phase: &str,
+        request_id: Option<u64>,
+        upstream_name: Option<&str>,
+        backend_addr: &str,
+        classified: &ClassifiedUpstreamProxyError,
+    ) {
+        let request_id = request_id
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let upstream_name = upstream_name.unwrap_or("-");
+        match classified.health_failure {
+            Some(health_mapping) => error!(
+                "phase={} request_id={} upstream={} backend={} upstream failure kind={:?} retryability={:?} health_reason={:?} metrics_reason={} detail={}",
+                phase,
+                request_id,
+                upstream_name,
+                backend_addr,
+                classified.kind,
+                classified.retryability,
+                health_mapping.failure_reason,
+                health_mapping.metrics_reason,
+                classified.detail
+            ),
+            None => error!(
+                "phase={} request_id={} upstream={} backend={} upstream failure kind={:?} retryability={:?} detail={}",
+                phase,
+                request_id,
+                upstream_name,
+                backend_addr,
+                classified.kind,
+                classified.retryability,
+                classified.detail
+            ),
+        }
+    }
+
+    pub(super) fn mark_classified_upstream_health_failure(
+        metrics_phase: &str,
+        backend_addr: &str,
+        backend_index: usize,
+        upstream_pool: Option<&Arc<RwLock<UpstreamPool>>>,
+        metrics: &Metrics,
+        classified: &ClassifiedUpstreamProxyError,
+    ) {
+        let Some(health_mapping) = classified.health_failure else {
+            return;
+        };
+
+        metrics.inc_health_failure(health_mapping.failure_reason);
+        if health_mapping.failure_reason == HealthFailureReason::Tls {
+            metrics.record_upstream_tls_failure(
+                backend_addr,
+                metrics_phase,
+                health_mapping.metrics_reason,
+            );
+        }
+        if let Some(pool) = upstream_pool
+            && let Some(transition) = pool.write().ok().and_then(|mut p| {
+                p.pool
+                    .mark_request_failure(backend_index, health_mapping.failure_reason)
+            })
+        {
+            Self::log_health_transition(backend_addr, transition);
+        }
+    }
+
     fn is_internal_pool_control_error(error: &PoolError) -> bool {
         matches!(
             error,
@@ -1190,38 +1256,6 @@ mod tests {
             RouteOutcome::Success => {}
             _ => panic!("unexpected route outcome"),
         }
-    }
-
-    #[derive(Debug)]
-    struct OuterErr(InnerErr);
-
-    #[derive(Debug)]
-    struct InnerErr;
-
-    impl std::fmt::Display for OuterErr {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "outer")
-        }
-    }
-
-    impl std::fmt::Display for InnerErr {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "inner")
-        }
-    }
-
-    impl StdError for OuterErr {
-        fn source(&self) -> Option<&(dyn StdError + 'static)> {
-            Some(&self.0)
-        }
-    }
-
-    impl StdError for InnerErr {}
-
-    #[test]
-    fn format_error_chain_includes_nested_causes() {
-        let msg = spooky_errors::format_error_chain(&OuterErr(InnerErr));
-        assert_eq!(msg, "outer: inner");
     }
 
     #[test]

--- a/crates/edge/src/quic_listener/forwarding/resolve.rs
+++ b/crates/edge/src/quic_listener/forwarding/resolve.rs
@@ -62,8 +62,10 @@ pub(super) struct ForwardingResolvedTarget {
 
 pub(in crate::quic_listener) struct BootstrapResolvedTarget {
     pub(in crate::quic_listener) upstream_name: String,
+    pub(in crate::quic_listener) upstream_pool: Arc<RwLock<UpstreamPool>>,
     pub(in crate::quic_listener) upstream_policy: RuntimeUpstreamPolicy,
     pub(in crate::quic_listener) backend_addr: String,
+    pub(in crate::quic_listener) backend_index: usize,
 }
 
 pub(in crate::quic_listener) struct BootstrapResolutionInput<'a> {
@@ -280,8 +282,10 @@ impl QUICListener {
 
         Ok(BootstrapResolvedTarget {
             upstream_name: route.upstream_name,
+            upstream_pool: route.upstream_pool,
             upstream_policy: route.upstream_policy,
             backend_addr: backend.backend_addr,
+            backend_index: backend.backend_index,
         })
     }
 

--- a/crates/edge/src/quic_listener/forwarding/response.rs
+++ b/crates/edge/src/quic_listener/forwarding/response.rs
@@ -1,8 +1,8 @@
+use spooky_errors::{UpstreamProxyErrorKind, classify_upstream_proxy_error};
 use tokio::sync::mpsc::error::TryRecvError;
 
 use super::*;
 use crate::runtime::connection::auth::ExternalAuthDecision;
-use spooky_errors::{UpstreamProxyErrorKind, classify_upstream_proxy_error};
 
 impl QUICListener {
     /// Handle an already-resolved `ForwardResult`, applying health transitions

--- a/crates/edge/src/quic_listener/forwarding/response.rs
+++ b/crates/edge/src/quic_listener/forwarding/response.rs
@@ -2,8 +2,70 @@ use tokio::sync::mpsc::error::TryRecvError;
 
 use super::*;
 use crate::runtime::connection::auth::ExternalAuthDecision;
+use spooky_errors::{
+    ClassifiedUpstreamProxyError, UpstreamProxyErrorKind, classify_upstream_proxy_error,
+};
 
 impl QUICListener {
+    fn log_classified_upstream_error(
+        req: &RequestEnvelope,
+        backend_addr: &str,
+        classified: &ClassifiedUpstreamProxyError,
+    ) {
+        let upstream_name = req.upstream_name.as_deref().unwrap_or("-");
+        match classified.health_failure {
+            Some(health_mapping) => error!(
+                "request_id={} upstream={} backend={} upstream failure kind={:?} retryability={:?} health_reason={:?} metrics_reason={} detail={}",
+                req.request_id,
+                upstream_name,
+                backend_addr,
+                classified.kind,
+                classified.retryability,
+                health_mapping.failure_reason,
+                health_mapping.metrics_reason,
+                classified.detail
+            ),
+            None => error!(
+                "request_id={} upstream={} backend={} upstream failure kind={:?} retryability={:?} detail={}",
+                req.request_id,
+                upstream_name,
+                backend_addr,
+                classified.kind,
+                classified.retryability,
+                classified.detail
+            ),
+        }
+    }
+
+    fn mark_classified_upstream_health_failure(
+        backend_addr: &str,
+        backend_index: usize,
+        upstream_pool: Option<&Arc<RwLock<UpstreamPool>>>,
+        metrics: &Metrics,
+        classified: &ClassifiedUpstreamProxyError,
+    ) {
+        let Some(health_mapping) = classified.health_failure else {
+            return;
+        };
+
+        metrics.inc_health_failure(health_mapping.failure_reason);
+        if health_mapping.failure_reason == HealthFailureReason::Tls {
+            metrics.record_upstream_tls_failure(
+                backend_addr,
+                "data_plane",
+                health_mapping.metrics_reason,
+            );
+        }
+        if let Some(pool) = upstream_pool
+            && let Some(transition) = pool.write().ok().and_then(|mut p| {
+                p.pool
+                    .mark_request_failure(backend_index, health_mapping.failure_reason)
+            })
+        {
+            Self::log_health_transition(backend_addr, transition);
+        }
+    }
+
     /// Handle an already-resolved `ForwardResult`, applying health transitions
     /// and sending the H3 response.
     pub(super) fn handle_forward_result(
@@ -140,85 +202,6 @@ impl QUICListener {
                     overload_retry_after_seconds,
                 )
             }
-            Err(ProxyError::Pool(PoolError::Send(ref send_err))) => {
-                let (send_err_details, classification) = Self::classify_send_error(send_err);
-                let health_mapping = classification.health_failure_mapping();
-                error!(
-                    "Upstream send failed for {} (health_reason={:?}, tls_reason={}): {}",
-                    backend_addr,
-                    health_mapping.failure_reason,
-                    health_mapping.metrics_reason,
-                    send_err_details.detail
-                );
-                metrics.inc_health_failure(health_mapping.failure_reason);
-                if health_mapping.failure_reason == HealthFailureReason::Tls {
-                    metrics.record_upstream_tls_failure(
-                        backend_addr,
-                        "data_plane",
-                        health_mapping.metrics_reason,
-                    );
-                }
-                if let Some(pool) = &upstream_pool
-                    && let Some(t) = pool.write().ok().and_then(|mut p| {
-                        p.pool
-                            .mark_request_failure(backend_index, health_mapping.failure_reason)
-                    })
-                {
-                    Self::log_health_transition(backend_addr, t);
-                }
-                metrics.inc_failure();
-                metrics.inc_backend_error();
-                metrics.record_route(route_label, start.elapsed(), RouteOutcome::BackendError);
-                Self::record_request_observation(
-                    metrics,
-                    req,
-                    Some(http::StatusCode::BAD_GATEWAY.as_u16()),
-                    RouteOutcome::BackendError,
-                );
-                Self::log_access(req, 502);
-                Self::send_simple_response(
-                    h3,
-                    quic,
-                    stream_id,
-                    http::StatusCode::BAD_GATEWAY,
-                    b"upstream error\n",
-                )
-            }
-            Err(ProxyError::Transport(err)) => {
-                error!(
-                    "request_id={} upstream={} backend={} Upstream transport error: {}",
-                    req.request_id,
-                    req.upstream_name.as_deref().unwrap_or("-"),
-                    backend_addr,
-                    err
-                );
-                metrics.inc_health_failure(HealthFailureReason::Transport);
-                if let Some(pool) = &upstream_pool
-                    && let Some(t) = pool.write().ok().and_then(|mut p| {
-                        p.pool
-                            .mark_request_failure(backend_index, HealthFailureReason::Transport)
-                    })
-                {
-                    Self::log_health_transition(backend_addr, t);
-                }
-                metrics.inc_failure();
-                metrics.inc_backend_error();
-                metrics.record_route(route_label, start.elapsed(), RouteOutcome::BackendError);
-                Self::record_request_observation(
-                    metrics,
-                    req,
-                    Some(http::StatusCode::BAD_GATEWAY.as_u16()),
-                    RouteOutcome::BackendError,
-                );
-                Self::log_access(req, 502);
-                Self::send_simple_response(
-                    h3,
-                    quic,
-                    stream_id,
-                    http::StatusCode::BAD_GATEWAY,
-                    b"upstream error\n",
-                )
-            }
             Err(ProxyError::Pool(pool_err @ PoolError::InflightLimiterClosed))
             | Err(ProxyError::Pool(pool_err @ PoolError::UnknownBackend(_))) => {
                 debug_assert!(Self::is_internal_pool_control_error(&pool_err));
@@ -249,74 +232,127 @@ impl QUICListener {
                     b"upstream error\n",
                 )
             }
-            Err(ProxyError::Protocol(err)) => {
-                error!("request_id={} Protocol error: {}", req.request_id, err);
-                metrics.inc_failure();
-                metrics.inc_backend_error();
-                metrics.record_route(route_label, start.elapsed(), RouteOutcome::BackendError);
-                Self::record_request_observation(
+            Err(err) => {
+                let Some(classified) = classify_upstream_proxy_error(&err) else {
+                    error!(
+                        "request_id={} upstream={} backend={} unclassified forward error: {:?}",
+                        req.request_id,
+                        req.upstream_name.as_deref().unwrap_or("-"),
+                        backend_addr,
+                        err
+                    );
+                    metrics.inc_failure();
+                    metrics.inc_backend_error();
+                    metrics.record_route(route_label, start.elapsed(), RouteOutcome::BackendError);
+                    Self::record_request_observation(
+                        metrics,
+                        req,
+                        Some(http::StatusCode::BAD_GATEWAY.as_u16()),
+                        RouteOutcome::BackendError,
+                    );
+                    Self::log_access(req, 502);
+                    return Self::send_simple_response(
+                        h3,
+                        quic,
+                        stream_id,
+                        http::StatusCode::BAD_GATEWAY,
+                        b"upstream error\n",
+                    );
+                };
+                Self::log_classified_upstream_error(req, backend_addr, &classified);
+                Self::mark_classified_upstream_health_failure(
+                    backend_addr,
+                    backend_index,
+                    upstream_pool.as_ref(),
                     metrics,
-                    req,
-                    Some(http::StatusCode::BAD_GATEWAY.as_u16()),
-                    RouteOutcome::BackendError,
+                    &classified,
                 );
-                Self::log_access(req, 502);
-                Self::send_simple_response(
-                    h3,
-                    quic,
-                    stream_id,
-                    http::StatusCode::BAD_GATEWAY,
-                    b"upstream protocol error\n",
-                )
-            }
-            Err(ProxyError::Timeout) => {
-                error!("request_id={} Upstream request timed out", req.request_id);
-                metrics.inc_health_failure(HealthFailureReason::Timeout);
-                if let Some(pool) = &upstream_pool
-                    && let Some(t) = pool.write().ok().and_then(|mut p| {
-                        p.pool
-                            .mark_request_failure(backend_index, HealthFailureReason::Timeout)
-                    })
-                {
-                    Self::log_health_transition(backend_addr, t);
+
+                match classified.kind {
+                    UpstreamProxyErrorKind::Timeout => {
+                        metrics.inc_failure();
+                        metrics.inc_timeout();
+                        metrics.record_route(route_label, start.elapsed(), RouteOutcome::Timeout);
+                        Self::record_request_observation(
+                            metrics,
+                            req,
+                            Some(http::StatusCode::SERVICE_UNAVAILABLE.as_u16()),
+                            RouteOutcome::Timeout,
+                        );
+                        Self::log_access(req, 503);
+                        Self::send_simple_response(
+                            h3,
+                            quic,
+                            stream_id,
+                            http::StatusCode::SERVICE_UNAVAILABLE,
+                            b"upstream timeout\n",
+                        )
+                    }
+                    UpstreamProxyErrorKind::Tls => {
+                        metrics.inc_failure();
+                        metrics.record_route(route_label, start.elapsed(), RouteOutcome::Failure);
+                        Self::record_request_observation(
+                            metrics,
+                            req,
+                            Some(http::StatusCode::INTERNAL_SERVER_ERROR.as_u16()),
+                            RouteOutcome::Failure,
+                        );
+                        Self::log_access(req, 500);
+                        Self::send_simple_response(
+                            h3,
+                            quic,
+                            stream_id,
+                            http::StatusCode::INTERNAL_SERVER_ERROR,
+                            b"internal server error\n",
+                        )
+                    }
+                    UpstreamProxyErrorKind::Protocol => {
+                        metrics.inc_failure();
+                        metrics.inc_backend_error();
+                        metrics.record_route(
+                            route_label,
+                            start.elapsed(),
+                            RouteOutcome::BackendError,
+                        );
+                        Self::record_request_observation(
+                            metrics,
+                            req,
+                            Some(http::StatusCode::BAD_GATEWAY.as_u16()),
+                            RouteOutcome::BackendError,
+                        );
+                        Self::log_access(req, 502);
+                        Self::send_simple_response(
+                            h3,
+                            quic,
+                            stream_id,
+                            http::StatusCode::BAD_GATEWAY,
+                            b"upstream protocol error\n",
+                        )
+                    }
+                    UpstreamProxyErrorKind::Send | UpstreamProxyErrorKind::Transport => {
+                        metrics.inc_failure();
+                        metrics.inc_backend_error();
+                        metrics.record_route(
+                            route_label,
+                            start.elapsed(),
+                            RouteOutcome::BackendError,
+                        );
+                        Self::record_request_observation(
+                            metrics,
+                            req,
+                            Some(http::StatusCode::BAD_GATEWAY.as_u16()),
+                            RouteOutcome::BackendError,
+                        );
+                        Self::log_access(req, 502);
+                        Self::send_simple_response(
+                            h3,
+                            quic,
+                            stream_id,
+                            http::StatusCode::BAD_GATEWAY,
+                            b"upstream error\n",
+                        )
+                    }
                 }
-                metrics.inc_failure();
-                metrics.inc_timeout();
-                metrics.record_route(route_label, start.elapsed(), RouteOutcome::Timeout);
-                Self::record_request_observation(
-                    metrics,
-                    req,
-                    Some(http::StatusCode::SERVICE_UNAVAILABLE.as_u16()),
-                    RouteOutcome::Timeout,
-                );
-                Self::log_access(req, 503);
-                Self::send_simple_response(
-                    h3,
-                    quic,
-                    stream_id,
-                    http::StatusCode::SERVICE_UNAVAILABLE,
-                    b"upstream timeout\n",
-                )
-            }
-            Err(ProxyError::Tls(err)) => {
-                error!("TLS error: {}", err);
-                metrics.inc_health_failure(HealthFailureReason::Tls);
-                metrics.inc_failure();
-                metrics.record_route(route_label, start.elapsed(), RouteOutcome::Failure);
-                Self::record_request_observation(
-                    metrics,
-                    req,
-                    Some(http::StatusCode::INTERNAL_SERVER_ERROR.as_u16()),
-                    RouteOutcome::Failure,
-                );
-                Self::log_access(req, 500);
-                Self::send_simple_response(
-                    h3,
-                    quic,
-                    stream_id,
-                    http::StatusCode::INTERNAL_SERVER_ERROR,
-                    b"internal server error\n",
-                )
             }
         }
     }
@@ -666,30 +702,46 @@ impl QUICListener {
                     }
                 },
                 ResponseChunk::Error(err) => {
+                    let classified = classify_upstream_proxy_error(&err);
                     if !req.response_headers_sent {
-                        let (status, body): (http::StatusCode, &[u8]) = match &err {
-                            ProxyError::Timeout => {
-                                (http::StatusCode::SERVICE_UNAVAILABLE, b"upstream timeout\n")
-                            }
-                            ProxyError::Pool(PoolError::BackendOverloaded(_)) => (
-                                http::StatusCode::SERVICE_UNAVAILABLE,
-                                b"upstream response body too large\n",
-                            ),
-                            _ => (http::StatusCode::BAD_GATEWAY, b"upstream error\n"),
-                        };
+                        let (status, body): (http::StatusCode, &[u8]) =
+                            match (&err, classified.as_ref()) {
+                                (ProxyError::Pool(PoolError::BackendOverloaded(_)), _) => (
+                                    http::StatusCode::SERVICE_UNAVAILABLE,
+                                    b"upstream response body too large\n",
+                                ),
+                                (_, Some(classified))
+                                    if classified.kind == UpstreamProxyErrorKind::Timeout =>
+                                {
+                                    (http::StatusCode::SERVICE_UNAVAILABLE, b"upstream timeout\n")
+                                }
+                                _ => (http::StatusCode::BAD_GATEWAY, b"upstream error\n"),
+                            };
                         let _ = Self::send_simple_response(h3, quic, stream_id, status, body);
                     } else {
                         let _ = h3.send_body(quic, stream_id, b"", true);
                     }
                     req.phase = StreamPhase::Failed;
                     let upstream_name = routing_index.lookup(&req.path, req.authority.as_deref());
-                    if let (Some(idx), Some(pool)) = (
+                    let upstream_pool = upstream_name.and_then(|n| upstream_pools.get(n));
+                    if let (Some(addr), Some(idx), Some(classified)) = (
+                        req.backend_addr.as_deref(),
                         req.backend_index,
-                        upstream_name.and_then(|n| upstream_pools.get(n)),
-                    ) && let Some(t) = pool.write().ok().and_then(|mut p| {
-                        p.pool
-                            .mark_request_failure(idx, HealthFailureReason::HttpStatus5xx)
-                    }) && let Some(addr) = &req.backend_addr
+                        classified.as_ref(),
+                    ) {
+                        Self::mark_classified_upstream_health_failure(
+                            addr,
+                            idx,
+                            upstream_pool,
+                            metrics,
+                            classified,
+                        );
+                    } else if let (Some(idx), Some(pool)) = (req.backend_index, upstream_pool)
+                        && let Some(t) = pool.write().ok().and_then(|mut p| {
+                            p.pool
+                                .mark_request_failure(idx, HealthFailureReason::HttpStatus5xx)
+                        })
+                        && let Some(addr) = &req.backend_addr
                     {
                         Self::log_health_transition(addr, t);
                     }
@@ -771,11 +823,17 @@ impl QUICListener {
                             resilience
                                 .adaptive_admission
                                 .observe(req.start.elapsed(), true);
-                            error!(
-                                "Upstream {} body error: {:?}",
-                                req.backend_addr.as_deref().unwrap_or("?"),
-                                err
-                            );
+                            if let (Some(addr), Some(classified)) =
+                                (req.backend_addr.as_deref(), classified.as_ref())
+                            {
+                                Self::log_classified_upstream_error(req, addr, classified);
+                            } else {
+                                error!(
+                                    "Upstream {} body error: {:?}",
+                                    req.backend_addr.as_deref().unwrap_or("?"),
+                                    err
+                                );
+                            }
                         }
                     }
                     terminal = true;

--- a/crates/edge/src/quic_listener/forwarding/response.rs
+++ b/crates/edge/src/quic_listener/forwarding/response.rs
@@ -7,7 +7,7 @@ use spooky_errors::{
 };
 
 impl QUICListener {
-    fn log_classified_upstream_error(
+    pub(in crate::quic_listener) fn log_classified_upstream_error(
         req: &RequestEnvelope,
         backend_addr: &str,
         classified: &ClassifiedUpstreamProxyError,
@@ -37,7 +37,7 @@ impl QUICListener {
         }
     }
 
-    fn mark_classified_upstream_health_failure(
+    pub(in crate::quic_listener) fn mark_classified_upstream_health_failure(
         backend_addr: &str,
         backend_index: usize,
         upstream_pool: Option<&Arc<RwLock<UpstreamPool>>>,

--- a/crates/edge/src/quic_listener/forwarding/response.rs
+++ b/crates/edge/src/quic_listener/forwarding/response.rs
@@ -141,11 +141,12 @@ impl QUICListener {
                 )
             }
             Err(ProxyError::Pool(PoolError::Send(ref send_err))) => {
-                let send_err_detail = Self::format_error_chain(send_err);
-                let (failure_reason, tls_reason) = Self::send_error_health_failure_reason(send_err);
+                let (send_err_details, classification) = Self::classify_send_error(send_err);
+                let (failure_reason, tls_reason) =
+                    Self::upstream_error_health_failure_reason(classification);
                 error!(
                     "Upstream send failed for {} (health_reason={:?}, tls_reason={}): {}",
-                    backend_addr, failure_reason, tls_reason, send_err_detail
+                    backend_addr, failure_reason, tls_reason, send_err_details.detail
                 );
                 metrics.inc_health_failure(failure_reason);
                 if failure_reason == HealthFailureReason::Tls {

--- a/crates/edge/src/quic_listener/forwarding/response.rs
+++ b/crates/edge/src/quic_listener/forwarding/response.rs
@@ -2,70 +2,9 @@ use tokio::sync::mpsc::error::TryRecvError;
 
 use super::*;
 use crate::runtime::connection::auth::ExternalAuthDecision;
-use spooky_errors::{
-    ClassifiedUpstreamProxyError, UpstreamProxyErrorKind, classify_upstream_proxy_error,
-};
+use spooky_errors::{UpstreamProxyErrorKind, classify_upstream_proxy_error};
 
 impl QUICListener {
-    pub(in crate::quic_listener) fn log_classified_upstream_error(
-        req: &RequestEnvelope,
-        backend_addr: &str,
-        classified: &ClassifiedUpstreamProxyError,
-    ) {
-        let upstream_name = req.upstream_name.as_deref().unwrap_or("-");
-        match classified.health_failure {
-            Some(health_mapping) => error!(
-                "request_id={} upstream={} backend={} upstream failure kind={:?} retryability={:?} health_reason={:?} metrics_reason={} detail={}",
-                req.request_id,
-                upstream_name,
-                backend_addr,
-                classified.kind,
-                classified.retryability,
-                health_mapping.failure_reason,
-                health_mapping.metrics_reason,
-                classified.detail
-            ),
-            None => error!(
-                "request_id={} upstream={} backend={} upstream failure kind={:?} retryability={:?} detail={}",
-                req.request_id,
-                upstream_name,
-                backend_addr,
-                classified.kind,
-                classified.retryability,
-                classified.detail
-            ),
-        }
-    }
-
-    pub(in crate::quic_listener) fn mark_classified_upstream_health_failure(
-        backend_addr: &str,
-        backend_index: usize,
-        upstream_pool: Option<&Arc<RwLock<UpstreamPool>>>,
-        metrics: &Metrics,
-        classified: &ClassifiedUpstreamProxyError,
-    ) {
-        let Some(health_mapping) = classified.health_failure else {
-            return;
-        };
-
-        metrics.inc_health_failure(health_mapping.failure_reason);
-        if health_mapping.failure_reason == HealthFailureReason::Tls {
-            metrics.record_upstream_tls_failure(
-                backend_addr,
-                "data_plane",
-                health_mapping.metrics_reason,
-            );
-        }
-        if let Some(pool) = upstream_pool
-            && let Some(transition) = pool.write().ok().and_then(|mut p| {
-                p.pool
-                    .mark_request_failure(backend_index, health_mapping.failure_reason)
-            })
-        {
-            Self::log_health_transition(backend_addr, transition);
-        }
-    }
-
     /// Handle an already-resolved `ForwardResult`, applying health transitions
     /// and sending the H3 response.
     pub(super) fn handle_forward_result(
@@ -259,8 +198,15 @@ impl QUICListener {
                         b"upstream error\n",
                     );
                 };
-                Self::log_classified_upstream_error(req, backend_addr, &classified);
+                Self::log_classified_upstream_failure(
+                    "data_plane",
+                    Some(req.request_id),
+                    req.upstream_name.as_deref(),
+                    backend_addr,
+                    &classified,
+                );
                 Self::mark_classified_upstream_health_failure(
+                    "data_plane",
                     backend_addr,
                     backend_index,
                     upstream_pool.as_ref(),
@@ -730,6 +676,7 @@ impl QUICListener {
                         classified.as_ref(),
                     ) {
                         Self::mark_classified_upstream_health_failure(
+                            "data_plane",
                             addr,
                             idx,
                             upstream_pool,
@@ -826,7 +773,13 @@ impl QUICListener {
                             if let (Some(addr), Some(classified)) =
                                 (req.backend_addr.as_deref(), classified.as_ref())
                             {
-                                Self::log_classified_upstream_error(req, addr, classified);
+                                Self::log_classified_upstream_failure(
+                                    "data_plane",
+                                    Some(req.request_id),
+                                    req.upstream_name.as_deref(),
+                                    addr,
+                                    classified,
+                                );
                             } else {
                                 error!(
                                     "Upstream {} body error: {:?}",

--- a/crates/edge/src/quic_listener/forwarding/response.rs
+++ b/crates/edge/src/quic_listener/forwarding/response.rs
@@ -142,19 +142,26 @@ impl QUICListener {
             }
             Err(ProxyError::Pool(PoolError::Send(ref send_err))) => {
                 let (send_err_details, classification) = Self::classify_send_error(send_err);
-                let (failure_reason, tls_reason) =
-                    Self::upstream_error_health_failure_reason(classification);
+                let health_mapping = classification.health_failure_mapping();
                 error!(
                     "Upstream send failed for {} (health_reason={:?}, tls_reason={}): {}",
-                    backend_addr, failure_reason, tls_reason, send_err_details.detail
+                    backend_addr,
+                    health_mapping.failure_reason,
+                    health_mapping.metrics_reason,
+                    send_err_details.detail
                 );
-                metrics.inc_health_failure(failure_reason);
-                if failure_reason == HealthFailureReason::Tls {
-                    metrics.record_upstream_tls_failure(backend_addr, "data_plane", tls_reason);
+                metrics.inc_health_failure(health_mapping.failure_reason);
+                if health_mapping.failure_reason == HealthFailureReason::Tls {
+                    metrics.record_upstream_tls_failure(
+                        backend_addr,
+                        "data_plane",
+                        health_mapping.metrics_reason,
+                    );
                 }
                 if let Some(pool) = &upstream_pool
                     && let Some(t) = pool.write().ok().and_then(|mut p| {
-                        p.pool.mark_request_failure(backend_index, failure_reason)
+                        p.pool
+                            .mark_request_failure(backend_index, health_mapping.failure_reason)
                     })
                 {
                     Self::log_health_transition(backend_addr, t);

--- a/crates/edge/src/quic_listener/health_check.rs
+++ b/crates/edge/src/quic_listener/health_check.rs
@@ -1,4 +1,5 @@
 use super::*;
+use spooky_errors::{classify_upstream_proxy_error, classify_upstream_send_error};
 
 impl QUICListener {
     pub(super) fn spawn_health_checks(
@@ -127,9 +128,10 @@ impl QUICListener {
                                     classify_active_health_check_response(response.status())
                                 }
                                 Ok(Err(PoolError::Send(send_err))) => {
-                                    let (send_err_details, classification) =
-                                        Self::classify_send_error(&send_err);
-                                    let health_mapping = classification.health_failure_mapping();
+                                    let classified = classify_upstream_send_error(&send_err);
+                                    let health_mapping = classified
+                                        .health_failure
+                                        .expect("send errors must include health mapping");
                                     if health_mapping.failure_reason == HealthFailureReason::Tls {
                                         task_metrics.record_upstream_tls_failure(
                                             &job.backend_identity,
@@ -140,18 +142,34 @@ impl QUICListener {
                                             "Health check upstream TLS failure for {} (tls_reason={}): {}",
                                             job.backend_identity,
                                             health_mapping.metrics_reason,
-                                            send_err_details.detail
+                                            classified.detail
                                         );
                                     }
                                     task_metrics.inc_health_failure(health_mapping.failure_reason);
                                     HealthClassification::Failure
                                 }
-                                Ok(Err(_)) => {
-                                    task_metrics.inc_health_failure(HealthFailureReason::Transport);
+                                Ok(Err(pool_err)) => {
+                                    let proxy_err = ProxyError::Pool(pool_err);
+                                    if let Some(classified) =
+                                        classify_upstream_proxy_error(&proxy_err)
+                                        && let Some(health_mapping) = classified.health_failure
+                                    {
+                                        task_metrics
+                                            .inc_health_failure(health_mapping.failure_reason);
+                                    } else {
+                                        task_metrics
+                                            .inc_health_failure(HealthFailureReason::Transport);
+                                    }
                                     HealthClassification::Failure
                                 }
                                 Err(_) => {
-                                    task_metrics.inc_health_failure(HealthFailureReason::Timeout);
+                                    let classified =
+                                        classify_upstream_proxy_error(&ProxyError::Timeout)
+                                            .expect("timeout must classify");
+                                    let health_mapping = classified
+                                        .health_failure
+                                        .expect("timeout must include health mapping");
+                                    task_metrics.inc_health_failure(health_mapping.failure_reason);
                                     HealthClassification::Failure
                                 }
                             };

--- a/crates/edge/src/quic_listener/health_check.rs
+++ b/crates/edge/src/quic_listener/health_check.rs
@@ -1,5 +1,6 @@
-use super::*;
 use spooky_errors::{classify_upstream_proxy_error, classify_upstream_send_error};
+
+use super::*;
 
 impl QUICListener {
     pub(super) fn spawn_health_checks(

--- a/crates/edge/src/quic_listener/health_check.rs
+++ b/crates/edge/src/quic_listener/health_check.rs
@@ -174,24 +174,28 @@ impl QUICListener {
                                     HealthClassification::Failure
                                 }
                                 Err(_) => {
-                                    let classified =
+                                    if let Some(classified) =
                                         classify_upstream_proxy_error(&ProxyError::Timeout)
-                                            .expect("timeout must classify");
-                                    Self::log_classified_upstream_failure(
-                                        "health_check",
-                                        None,
-                                        None,
-                                        &job.backend_identity,
-                                        &classified,
-                                    );
-                                    Self::mark_classified_upstream_health_failure(
-                                        "health_check",
-                                        &job.backend_identity,
-                                        job.index,
-                                        Some(&job.upstream_pool),
-                                        task_metrics.as_ref(),
-                                        &classified,
-                                    );
+                                    {
+                                        Self::log_classified_upstream_failure(
+                                            "health_check",
+                                            None,
+                                            None,
+                                            &job.backend_identity,
+                                            &classified,
+                                        );
+                                        Self::mark_classified_upstream_health_failure(
+                                            "health_check",
+                                            &job.backend_identity,
+                                            job.index,
+                                            Some(&job.upstream_pool),
+                                            task_metrics.as_ref(),
+                                            &classified,
+                                        );
+                                    } else {
+                                        task_metrics
+                                            .inc_health_failure(HealthFailureReason::Timeout);
+                                    }
                                     HealthClassification::Failure
                                 }
                             };

--- a/crates/edge/src/quic_listener/health_check.rs
+++ b/crates/edge/src/quic_listener/health_check.rs
@@ -127,9 +127,10 @@ impl QUICListener {
                                     classify_active_health_check_response(response.status())
                                 }
                                 Ok(Err(PoolError::Send(send_err))) => {
-                                    let send_err_detail = Self::format_error_chain(&send_err);
+                                    let (send_err_details, classification) =
+                                        Self::classify_send_error(&send_err);
                                     let (failure_reason, tls_reason) =
-                                        Self::send_error_health_failure_reason(&send_err);
+                                        Self::upstream_error_health_failure_reason(classification);
                                     if failure_reason == HealthFailureReason::Tls {
                                         task_metrics.record_upstream_tls_failure(
                                             &job.backend_identity,
@@ -138,7 +139,9 @@ impl QUICListener {
                                         );
                                         error!(
                                             "Health check upstream TLS failure for {} (tls_reason={}): {}",
-                                            job.backend_identity, tls_reason, send_err_detail
+                                            job.backend_identity,
+                                            tls_reason,
+                                            send_err_details.detail
                                         );
                                     }
                                     task_metrics.inc_health_failure(failure_reason);

--- a/crates/edge/src/quic_listener/health_check.rs
+++ b/crates/edge/src/quic_listener/health_check.rs
@@ -129,33 +129,43 @@ impl QUICListener {
                                 }
                                 Ok(Err(PoolError::Send(send_err))) => {
                                     let classified = classify_upstream_send_error(&send_err);
-                                    let health_mapping = classified
-                                        .health_failure
-                                        .expect("send errors must include health mapping");
-                                    if health_mapping.failure_reason == HealthFailureReason::Tls {
-                                        task_metrics.record_upstream_tls_failure(
-                                            &job.backend_identity,
-                                            "health_check",
-                                            health_mapping.metrics_reason,
-                                        );
-                                        error!(
-                                            "Health check upstream TLS failure for {} (tls_reason={}): {}",
-                                            job.backend_identity,
-                                            health_mapping.metrics_reason,
-                                            classified.detail
-                                        );
-                                    }
-                                    task_metrics.inc_health_failure(health_mapping.failure_reason);
+                                    Self::log_classified_upstream_failure(
+                                        "health_check",
+                                        None,
+                                        None,
+                                        &job.backend_identity,
+                                        &classified,
+                                    );
+                                    Self::mark_classified_upstream_health_failure(
+                                        "health_check",
+                                        &job.backend_identity,
+                                        job.index,
+                                        Some(&job.upstream_pool),
+                                        task_metrics.as_ref(),
+                                        &classified,
+                                    );
                                     HealthClassification::Failure
                                 }
                                 Ok(Err(pool_err)) => {
                                     let proxy_err = ProxyError::Pool(pool_err);
                                     if let Some(classified) =
                                         classify_upstream_proxy_error(&proxy_err)
-                                        && let Some(health_mapping) = classified.health_failure
                                     {
-                                        task_metrics
-                                            .inc_health_failure(health_mapping.failure_reason);
+                                        Self::log_classified_upstream_failure(
+                                            "health_check",
+                                            None,
+                                            None,
+                                            &job.backend_identity,
+                                            &classified,
+                                        );
+                                        Self::mark_classified_upstream_health_failure(
+                                            "health_check",
+                                            &job.backend_identity,
+                                            job.index,
+                                            Some(&job.upstream_pool),
+                                            task_metrics.as_ref(),
+                                            &classified,
+                                        );
                                     } else {
                                         task_metrics
                                             .inc_health_failure(HealthFailureReason::Transport);
@@ -166,10 +176,21 @@ impl QUICListener {
                                     let classified =
                                         classify_upstream_proxy_error(&ProxyError::Timeout)
                                             .expect("timeout must classify");
-                                    let health_mapping = classified
-                                        .health_failure
-                                        .expect("timeout must include health mapping");
-                                    task_metrics.inc_health_failure(health_mapping.failure_reason);
+                                    Self::log_classified_upstream_failure(
+                                        "health_check",
+                                        None,
+                                        None,
+                                        &job.backend_identity,
+                                        &classified,
+                                    );
+                                    Self::mark_classified_upstream_health_failure(
+                                        "health_check",
+                                        &job.backend_identity,
+                                        job.index,
+                                        Some(&job.upstream_pool),
+                                        task_metrics.as_ref(),
+                                        &classified,
+                                    );
                                     HealthClassification::Failure
                                 }
                             };

--- a/crates/edge/src/quic_listener/health_check.rs
+++ b/crates/edge/src/quic_listener/health_check.rs
@@ -129,22 +129,21 @@ impl QUICListener {
                                 Ok(Err(PoolError::Send(send_err))) => {
                                     let (send_err_details, classification) =
                                         Self::classify_send_error(&send_err);
-                                    let (failure_reason, tls_reason) =
-                                        Self::upstream_error_health_failure_reason(classification);
-                                    if failure_reason == HealthFailureReason::Tls {
+                                    let health_mapping = classification.health_failure_mapping();
+                                    if health_mapping.failure_reason == HealthFailureReason::Tls {
                                         task_metrics.record_upstream_tls_failure(
                                             &job.backend_identity,
                                             "health_check",
-                                            tls_reason,
+                                            health_mapping.metrics_reason,
                                         );
                                         error!(
                                             "Health check upstream TLS failure for {} (tls_reason={}): {}",
                                             job.backend_identity,
-                                            tls_reason,
+                                            health_mapping.metrics_reason,
                                             send_err_details.detail
                                         );
                                     }
-                                    task_metrics.inc_health_failure(failure_reason);
+                                    task_metrics.inc_health_failure(health_mapping.failure_reason);
                                     HealthClassification::Failure
                                 }
                                 Ok(Err(_)) => {

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -51,7 +51,7 @@ use spooky_config::{
         RuntimeUpstreamPolicy,
     },
 };
-use spooky_errors::{PoolError, ProxyError, is_retryable};
+use spooky_errors::{PoolError, ProxyError};
 use spooky_lb::{
     backend::HealthTransition, health::HealthFailureReason, upstream_pool::UpstreamPool,
 };
@@ -1906,15 +1906,6 @@ impl QUICListener {
             Ok(resp) => resp,
             Err(_) => Response::new(Full::new(Bytes::from_static(b"failed to render metrics\n"))),
         }
-    }
-}
-
-fn classify_retry_reason(err: &ProxyError) -> RetryReason {
-    match err {
-        ProxyError::Timeout => RetryReason::BackendTimeout,
-        ProxyError::Transport(_) => RetryReason::BackendTransport,
-        ProxyError::Pool(_) => RetryReason::BackendPool,
-        _ => RetryReason::BackendTransport,
     }
 }
 

--- a/crates/edge/src/quic_listener/tests.rs
+++ b/crates/edge/src/quic_listener/tests.rs
@@ -16,7 +16,10 @@ use spooky_config::{
     },
     runtime::{ListenerRuntimeConfig, RuntimeConfig},
 };
-use spooky_errors::{UpstreamErrorCategory, UpstreamErrorClassification, UpstreamTlsReason};
+use spooky_errors::{
+    UpstreamErrorCategory, UpstreamErrorClassification, UpstreamTlsReason,
+    classify_upstream_error_detail,
+};
 use tempfile::tempdir;
 
 use super::{
@@ -657,36 +660,27 @@ fn certificate_name_matches_single_label_wildcards_only() {
 #[test]
 fn classify_upstream_failure_reason_distinguishes_tls_causes() {
     assert_eq!(
-        super::QUICListener::classify_upstream_failure_reason(
-            true,
-            "tls handshake failed: UnknownIssuer"
-        ),
+        classify_upstream_error_detail("tls handshake failed: UnknownIssuer", true),
         UpstreamErrorClassification::tls(UpstreamTlsReason::UnknownIssuer)
     );
     assert_eq!(
-        super::QUICListener::classify_upstream_failure_reason(
-            true,
-            "certificate expired while verifying backend"
-        ),
+        classify_upstream_error_detail("certificate expired while verifying backend", true),
         UpstreamErrorClassification::tls(UpstreamTlsReason::ExpiredCertificate)
     );
     assert_eq!(
-        super::QUICListener::classify_upstream_failure_reason(
-            true,
-            "certificate not valid for dns name api.example.com"
-        ),
+        classify_upstream_error_detail("certificate not valid for dns name api.example.com", true,),
         UpstreamErrorClassification::tls(UpstreamTlsReason::HostnameMismatch)
     );
     assert_eq!(
-        super::QUICListener::classify_upstream_failure_reason(true, "ALPN negotiation failed"),
+        classify_upstream_error_detail("ALPN negotiation failed", true),
         UpstreamErrorClassification::tls(UpstreamTlsReason::Alpn)
     );
     assert_eq!(
-        super::QUICListener::classify_upstream_failure_reason(false, "backend timed out"),
+        classify_upstream_error_detail("backend timed out", false),
         UpstreamErrorClassification::timeout()
     );
     assert_eq!(
-        super::QUICListener::classify_upstream_failure_reason(false, "connection reset"),
+        classify_upstream_error_detail("connection reset", false),
         UpstreamErrorClassification {
             category: UpstreamErrorCategory::Transport,
             tls_reason: None,

--- a/crates/edge/src/quic_listener/tests.rs
+++ b/crates/edge/src/quic_listener/tests.rs
@@ -16,7 +16,7 @@ use spooky_config::{
     },
     runtime::{ListenerRuntimeConfig, RuntimeConfig},
 };
-use spooky_lb::health::HealthFailureReason;
+use spooky_errors::{UpstreamErrorCategory, UpstreamErrorClassification, UpstreamTlsReason};
 use tempfile::tempdir;
 
 use super::{
@@ -661,29 +661,36 @@ fn classify_upstream_failure_reason_distinguishes_tls_causes() {
             true,
             "tls handshake failed: UnknownIssuer"
         ),
-        (HealthFailureReason::Tls, "unknown_issuer")
+        UpstreamErrorClassification::tls(UpstreamTlsReason::UnknownIssuer)
     );
     assert_eq!(
         super::QUICListener::classify_upstream_failure_reason(
             true,
             "certificate expired while verifying backend"
         ),
-        (HealthFailureReason::Tls, "expired_certificate")
+        UpstreamErrorClassification::tls(UpstreamTlsReason::ExpiredCertificate)
     );
     assert_eq!(
         super::QUICListener::classify_upstream_failure_reason(
             true,
             "certificate not valid for dns name api.example.com"
         ),
-        (HealthFailureReason::Tls, "hostname_mismatch")
+        UpstreamErrorClassification::tls(UpstreamTlsReason::HostnameMismatch)
     );
     assert_eq!(
         super::QUICListener::classify_upstream_failure_reason(true, "ALPN negotiation failed"),
-        (HealthFailureReason::Tls, "alpn")
+        UpstreamErrorClassification::tls(UpstreamTlsReason::Alpn)
     );
     assert_eq!(
         super::QUICListener::classify_upstream_failure_reason(false, "backend timed out"),
-        (HealthFailureReason::Timeout, "timeout")
+        UpstreamErrorClassification::timeout()
+    );
+    assert_eq!(
+        super::QUICListener::classify_upstream_failure_reason(false, "connection reset"),
+        UpstreamErrorClassification {
+            category: UpstreamErrorCategory::Transport,
+            tls_reason: None,
+        }
     );
 }
 

--- a/crates/errors/Cargo.toml
+++ b/crates/errors/Cargo.toml
@@ -9,3 +9,4 @@ thiserror = { workspace = true }
 http = { workspace = true }
 hyper-util = { workspace = true }
 quiche = { workspace = true }
+spooky-lb = { path = "../lb" }

--- a/crates/errors/src/lib.rs
+++ b/crates/errors/src/lib.rs
@@ -10,4 +10,5 @@ pub use proxy::ProxyError;
 pub use retry::is_retryable;
 pub use upstream::{
     UpstreamErrorCategory, UpstreamErrorClassification, UpstreamErrorDetails, UpstreamTlsReason,
+    format_error_chain,
 };

--- a/crates/errors/src/lib.rs
+++ b/crates/errors/src/lib.rs
@@ -7,7 +7,8 @@ pub mod upstream;
 pub use bridge::BridgeError;
 pub use pool::PoolError;
 pub use proxy::{
-    ClassifiedUpstreamProxyError, ProxyError, UpstreamProxyErrorKind, classify_upstream_proxy_error,
+    ClassifiedUpstreamProxyError, ProxyError, UpstreamProxyErrorKind,
+    classify_upstream_proxy_error, classify_upstream_send_error,
 };
 pub use retry::{
     RetryPolicyDecision, RetryPolicyDenial, RetryPolicyInput, UpstreamRetryReason,
@@ -16,5 +17,6 @@ pub use retry::{
 };
 pub use upstream::{
     UpstreamErrorCategory, UpstreamErrorClassification, UpstreamErrorDetails,
-    UpstreamHealthFailureMapping, UpstreamTlsReason, format_error_chain,
+    UpstreamHealthFailureMapping, UpstreamTlsReason, classify_upstream_error_detail,
+    format_error_chain,
 };

--- a/crates/errors/src/lib.rs
+++ b/crates/errors/src/lib.rs
@@ -6,7 +6,9 @@ pub mod upstream;
 
 pub use bridge::BridgeError;
 pub use pool::PoolError;
-pub use proxy::ProxyError;
+pub use proxy::{
+    ClassifiedUpstreamProxyError, ProxyError, UpstreamProxyErrorKind, classify_upstream_proxy_error,
+};
 pub use retry::{
     RetryPolicyDecision, RetryPolicyDenial, RetryPolicyInput, UpstreamRetryReason,
     UpstreamRetryability, UpstreamTerminalErrorKind, classify_retryability, evaluate_retry_policy,

--- a/crates/errors/src/lib.rs
+++ b/crates/errors/src/lib.rs
@@ -7,7 +7,11 @@ pub mod upstream;
 pub use bridge::BridgeError;
 pub use pool::PoolError;
 pub use proxy::ProxyError;
-pub use retry::is_retryable;
+pub use retry::{
+    RetryPolicyDecision, RetryPolicyDenial, RetryPolicyInput, UpstreamRetryReason,
+    UpstreamRetryability, UpstreamTerminalErrorKind, classify_retryability, evaluate_retry_policy,
+    is_retryable,
+};
 pub use upstream::{
     UpstreamErrorCategory, UpstreamErrorClassification, UpstreamErrorDetails,
     UpstreamHealthFailureMapping, UpstreamTlsReason, format_error_chain,

--- a/crates/errors/src/lib.rs
+++ b/crates/errors/src/lib.rs
@@ -9,6 +9,6 @@ pub use pool::PoolError;
 pub use proxy::ProxyError;
 pub use retry::is_retryable;
 pub use upstream::{
-    UpstreamErrorCategory, UpstreamErrorClassification, UpstreamErrorDetails, UpstreamTlsReason,
-    format_error_chain,
+    UpstreamErrorCategory, UpstreamErrorClassification, UpstreamErrorDetails,
+    UpstreamHealthFailureMapping, UpstreamTlsReason, format_error_chain,
 };

--- a/crates/errors/src/lib.rs
+++ b/crates/errors/src/lib.rs
@@ -2,8 +2,12 @@ pub mod bridge;
 pub mod pool;
 pub mod proxy;
 pub mod retry;
+pub mod upstream;
 
 pub use bridge::BridgeError;
 pub use pool::PoolError;
 pub use proxy::ProxyError;
 pub use retry::is_retryable;
+pub use upstream::{
+    UpstreamErrorCategory, UpstreamErrorClassification, UpstreamErrorDetails, UpstreamTlsReason,
+};

--- a/crates/errors/src/lib.rs
+++ b/crates/errors/src/lib.rs
@@ -16,7 +16,6 @@ pub use retry::{
     is_retryable,
 };
 pub use upstream::{
-    UpstreamErrorCategory, UpstreamErrorClassification, UpstreamErrorDetails,
-    UpstreamHealthFailureMapping, UpstreamTlsReason, classify_upstream_error_detail,
-    format_error_chain,
+    UpstreamErrorCategory, UpstreamErrorClassification, UpstreamHealthFailureMapping,
+    UpstreamTlsReason, classify_upstream_error_detail,
 };

--- a/crates/errors/src/proxy.rs
+++ b/crates/errors/src/proxy.rs
@@ -2,8 +2,8 @@ use thiserror::Error;
 
 use crate::{
     BridgeError, PoolError, UpstreamErrorCategory, UpstreamErrorClassification,
-    UpstreamErrorDetails, UpstreamHealthFailureMapping, UpstreamRetryability, UpstreamTlsReason,
-    classify_retryability,
+    UpstreamErrorDetails, UpstreamHealthFailureMapping, UpstreamRetryability,
+    UpstreamTerminalErrorKind, UpstreamTlsReason, classify_retryability,
 };
 
 #[derive(Debug, Error)]
@@ -46,7 +46,7 @@ pub struct ClassifiedUpstreamProxyError {
 }
 
 fn classify_tls_detail(detail: &str) -> UpstreamErrorClassification {
-    let classification = UpstreamErrorDetails::new(detail.to_string(), true).classify();
+    let classification = crate::classify_upstream_error_detail(detail, true);
     if matches!(classification.category, UpstreamErrorCategory::Transport) {
         UpstreamErrorClassification::tls(UpstreamTlsReason::Handshake)
     } else {
@@ -54,19 +54,23 @@ fn classify_tls_detail(detail: &str) -> UpstreamErrorClassification {
     }
 }
 
+pub fn classify_upstream_send_error(
+    err: &hyper_util::client::legacy::Error,
+) -> ClassifiedUpstreamProxyError {
+    let details = UpstreamErrorDetails::from_error_chain(err, err.is_connect());
+    let classification = details.classify();
+    ClassifiedUpstreamProxyError {
+        kind: UpstreamProxyErrorKind::Send,
+        detail: details.detail,
+        classification,
+        health_failure: Some(classification.health_failure_mapping()),
+        retryability: UpstreamRetryability::Terminal(UpstreamTerminalErrorKind::PoolSend),
+    }
+}
+
 pub fn classify_upstream_proxy_error(err: &ProxyError) -> Option<ClassifiedUpstreamProxyError> {
     match err {
-        ProxyError::Pool(PoolError::Send(send_err)) => {
-            let details = UpstreamErrorDetails::from_error_chain(send_err, send_err.is_connect());
-            let classification = details.classify();
-            Some(ClassifiedUpstreamProxyError {
-                kind: UpstreamProxyErrorKind::Send,
-                detail: details.detail,
-                classification,
-                health_failure: Some(classification.health_failure_mapping()),
-                retryability: classify_retryability(err),
-            })
-        }
+        ProxyError::Pool(PoolError::Send(send_err)) => Some(classify_upstream_send_error(send_err)),
         ProxyError::Transport(detail) => {
             let classification = UpstreamErrorClassification::transport();
             Some(ClassifiedUpstreamProxyError {

--- a/crates/errors/src/proxy.rs
+++ b/crates/errors/src/proxy.rs
@@ -1,10 +1,9 @@
 use thiserror::Error;
 
-use crate::upstream::UpstreamErrorDetails;
 use crate::{
     BridgeError, PoolError, UpstreamErrorCategory, UpstreamErrorClassification,
     UpstreamHealthFailureMapping, UpstreamRetryability, UpstreamTerminalErrorKind,
-    UpstreamTlsReason, classify_retryability,
+    UpstreamTlsReason, classify_retryability, upstream::UpstreamErrorDetails,
 };
 
 #[derive(Debug, Error)]

--- a/crates/errors/src/proxy.rs
+++ b/crates/errors/src/proxy.rs
@@ -1,6 +1,10 @@
 use thiserror::Error;
 
-use crate::{BridgeError, PoolError};
+use crate::{
+    BridgeError, PoolError, UpstreamErrorCategory, UpstreamErrorClassification,
+    UpstreamErrorDetails, UpstreamHealthFailureMapping, UpstreamRetryability, UpstreamTlsReason,
+    classify_retryability,
+};
 
 #[derive(Debug, Error)]
 pub enum ProxyError {
@@ -21,4 +25,86 @@ pub enum ProxyError {
 
     #[error("TLS error: {0}")]
     Tls(String),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum UpstreamProxyErrorKind {
+    Send,
+    Transport,
+    Timeout,
+    Protocol,
+    Tls,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ClassifiedUpstreamProxyError {
+    pub kind: UpstreamProxyErrorKind,
+    pub detail: String,
+    pub classification: UpstreamErrorClassification,
+    pub health_failure: Option<UpstreamHealthFailureMapping>,
+    pub retryability: UpstreamRetryability,
+}
+
+fn classify_tls_detail(detail: &str) -> UpstreamErrorClassification {
+    let classification = UpstreamErrorDetails::new(detail.to_string(), true).classify();
+    if matches!(classification.category, UpstreamErrorCategory::Transport) {
+        UpstreamErrorClassification::tls(UpstreamTlsReason::Handshake)
+    } else {
+        classification
+    }
+}
+
+pub fn classify_upstream_proxy_error(err: &ProxyError) -> Option<ClassifiedUpstreamProxyError> {
+    match err {
+        ProxyError::Pool(PoolError::Send(send_err)) => {
+            let details = UpstreamErrorDetails::from_error_chain(send_err, send_err.is_connect());
+            let classification = details.classify();
+            Some(ClassifiedUpstreamProxyError {
+                kind: UpstreamProxyErrorKind::Send,
+                detail: details.detail,
+                classification,
+                health_failure: Some(classification.health_failure_mapping()),
+                retryability: classify_retryability(err),
+            })
+        }
+        ProxyError::Transport(detail) => {
+            let classification = UpstreamErrorClassification::transport();
+            Some(ClassifiedUpstreamProxyError {
+                kind: UpstreamProxyErrorKind::Transport,
+                detail: detail.clone(),
+                classification,
+                health_failure: Some(classification.health_failure_mapping()),
+                retryability: classify_retryability(err),
+            })
+        }
+        ProxyError::Timeout => {
+            let classification = UpstreamErrorClassification::timeout();
+            Some(ClassifiedUpstreamProxyError {
+                kind: UpstreamProxyErrorKind::Timeout,
+                detail: err.to_string(),
+                classification,
+                health_failure: Some(classification.health_failure_mapping()),
+                retryability: classify_retryability(err),
+            })
+        }
+        ProxyError::Protocol(detail) => Some(ClassifiedUpstreamProxyError {
+            kind: UpstreamProxyErrorKind::Protocol,
+            detail: detail.clone(),
+            classification: UpstreamErrorClassification::protocol(),
+            health_failure: None,
+            retryability: classify_retryability(err),
+        }),
+        ProxyError::Tls(detail) => Some(ClassifiedUpstreamProxyError {
+            kind: UpstreamProxyErrorKind::Tls,
+            detail: detail.clone(),
+            classification: classify_tls_detail(detail),
+            health_failure: None,
+            retryability: classify_retryability(err),
+        }),
+        ProxyError::Bridge(_)
+        | ProxyError::Pool(PoolError::UnknownBackend(_))
+        | ProxyError::Pool(PoolError::BackendOverloaded(_))
+        | ProxyError::Pool(PoolError::CircuitOpen(_))
+        | ProxyError::Pool(PoolError::InflightLimiterClosed) => None,
+    }
 }

--- a/crates/errors/src/proxy.rs
+++ b/crates/errors/src/proxy.rs
@@ -1,9 +1,10 @@
 use thiserror::Error;
 
+use crate::upstream::UpstreamErrorDetails;
 use crate::{
     BridgeError, PoolError, UpstreamErrorCategory, UpstreamErrorClassification,
-    UpstreamErrorDetails, UpstreamHealthFailureMapping, UpstreamRetryability,
-    UpstreamTerminalErrorKind, UpstreamTlsReason, classify_retryability,
+    UpstreamHealthFailureMapping, UpstreamRetryability, UpstreamTerminalErrorKind,
+    UpstreamTlsReason, classify_retryability,
 };
 
 #[derive(Debug, Error)]

--- a/crates/errors/src/retry.rs
+++ b/crates/errors/src/retry.rs
@@ -1,11 +1,89 @@
 use crate::{PoolError, ProxyError};
 
-pub fn is_retryable(err: &ProxyError) -> bool {
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum UpstreamRetryReason {
+    Timeout,
+    Transport,
+    Pool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum UpstreamTerminalErrorKind {
+    PoolSend,
+    Tls,
+    Protocol,
+    Bridge,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum UpstreamRetryability {
+    Retryable(UpstreamRetryReason),
+    Terminal(UpstreamTerminalErrorKind),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RetryPolicyDenial {
+    NotBodylessMode,
+    BudgetDenied,
+    NoAlternateBackend,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RetryPolicyInput {
+    pub retryability: UpstreamRetryability,
+    pub bodyless_mode: bool,
+    pub budget_available: bool,
+    pub alternate_backend_available: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RetryPolicyDecision {
+    Retry { reason: UpstreamRetryReason },
+    DoNotRetry { denial: Option<RetryPolicyDenial> },
+}
+
+pub fn classify_retryability(err: &ProxyError) -> UpstreamRetryability {
     match err {
-        ProxyError::Transport(_) | ProxyError::Timeout => true,
-        // Pool send failures are connection-level (TLS/cert/SNI) — not transient
-        ProxyError::Pool(PoolError::Send(_)) => false,
-        ProxyError::Pool(_) => true,
-        _ => false,
+        ProxyError::Transport(_) => UpstreamRetryability::Retryable(UpstreamRetryReason::Transport),
+        ProxyError::Timeout => UpstreamRetryability::Retryable(UpstreamRetryReason::Timeout),
+        ProxyError::Pool(PoolError::Send(_)) => {
+            UpstreamRetryability::Terminal(UpstreamTerminalErrorKind::PoolSend)
+        }
+        ProxyError::Pool(_) => UpstreamRetryability::Retryable(UpstreamRetryReason::Pool),
+        ProxyError::Tls(_) => UpstreamRetryability::Terminal(UpstreamTerminalErrorKind::Tls),
+        ProxyError::Protocol(_) => {
+            UpstreamRetryability::Terminal(UpstreamTerminalErrorKind::Protocol)
+        }
+        ProxyError::Bridge(_) => UpstreamRetryability::Terminal(UpstreamTerminalErrorKind::Bridge),
     }
+}
+
+pub fn evaluate_retry_policy(input: RetryPolicyInput) -> RetryPolicyDecision {
+    match input.retryability {
+        UpstreamRetryability::Terminal(_) => RetryPolicyDecision::DoNotRetry { denial: None },
+        UpstreamRetryability::Retryable(reason) => {
+            if !input.bodyless_mode {
+                RetryPolicyDecision::DoNotRetry {
+                    denial: Some(RetryPolicyDenial::NotBodylessMode),
+                }
+            } else if !input.budget_available {
+                RetryPolicyDecision::DoNotRetry {
+                    denial: Some(RetryPolicyDenial::BudgetDenied),
+                }
+            } else if !input.alternate_backend_available {
+                RetryPolicyDecision::DoNotRetry {
+                    denial: Some(RetryPolicyDenial::NoAlternateBackend),
+                }
+            } else {
+                RetryPolicyDecision::Retry { reason }
+            }
+        }
+    }
+}
+
+pub fn is_retryable(err: &ProxyError) -> bool {
+    matches!(
+        classify_retryability(err),
+        UpstreamRetryability::Retryable(_)
+    )
 }

--- a/crates/errors/src/upstream.rs
+++ b/crates/errors/src/upstream.rs
@@ -18,44 +18,51 @@ impl UpstreamErrorDetails {
     }
 
     pub fn classify(&self) -> UpstreamErrorClassification {
-        let normalized = self.detail.to_ascii_lowercase();
-        if normalized.contains("timeout") || normalized.contains("timed out") {
-            return UpstreamErrorClassification::timeout();
-        }
-
-        if self.is_connect {
-            if normalized.contains("unknownissuer") || normalized.contains("unknown issuer") {
-                return UpstreamErrorClassification::tls(UpstreamTlsReason::UnknownIssuer);
-            }
-            if normalized.contains("expired")
-                || normalized.contains("not yet valid")
-                || normalized.contains("validity")
-            {
-                return UpstreamErrorClassification::tls(UpstreamTlsReason::ExpiredCertificate);
-            }
-            if normalized.contains("hostname")
-                || normalized.contains("dns name")
-                || normalized.contains("subjectaltname")
-                || normalized.contains("not valid for")
-            {
-                return UpstreamErrorClassification::tls(UpstreamTlsReason::HostnameMismatch);
-            }
-            if normalized.contains("alpn") {
-                return UpstreamErrorClassification::tls(UpstreamTlsReason::Alpn);
-            }
-            if normalized.contains("invalidcertificate")
-                || normalized.contains("certificate")
-                || normalized.contains("x509")
-                || normalized.contains("rustls")
-                || normalized.contains("webpki")
-                || normalized.contains("tls")
-            {
-                return UpstreamErrorClassification::tls(UpstreamTlsReason::Handshake);
-            }
-        }
-
-        UpstreamErrorClassification::transport()
+        classify_upstream_error_detail(&self.detail, self.is_connect)
     }
+}
+
+pub fn classify_upstream_error_detail(
+    detail: &str,
+    is_connect: bool,
+) -> UpstreamErrorClassification {
+    let normalized = detail.to_ascii_lowercase();
+    if normalized.contains("timeout") || normalized.contains("timed out") {
+        return UpstreamErrorClassification::timeout();
+    }
+
+    if is_connect {
+        if normalized.contains("unknownissuer") || normalized.contains("unknown issuer") {
+            return UpstreamErrorClassification::tls(UpstreamTlsReason::UnknownIssuer);
+        }
+        if normalized.contains("expired")
+            || normalized.contains("not yet valid")
+            || normalized.contains("validity")
+        {
+            return UpstreamErrorClassification::tls(UpstreamTlsReason::ExpiredCertificate);
+        }
+        if normalized.contains("hostname")
+            || normalized.contains("dns name")
+            || normalized.contains("subjectaltname")
+            || normalized.contains("not valid for")
+        {
+            return UpstreamErrorClassification::tls(UpstreamTlsReason::HostnameMismatch);
+        }
+        if normalized.contains("alpn") {
+            return UpstreamErrorClassification::tls(UpstreamTlsReason::Alpn);
+        }
+        if normalized.contains("invalidcertificate")
+            || normalized.contains("certificate")
+            || normalized.contains("x509")
+            || normalized.contains("rustls")
+            || normalized.contains("webpki")
+            || normalized.contains("tls")
+        {
+            return UpstreamErrorClassification::tls(UpstreamTlsReason::Handshake);
+        }
+    }
+
+    UpstreamErrorClassification::transport()
 }
 
 pub fn format_error_chain(err: &(dyn StdError + 'static)) -> String {

--- a/crates/errors/src/upstream.rs
+++ b/crates/errors/src/upstream.rs
@@ -1,3 +1,5 @@
+use std::error::Error as StdError;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UpstreamErrorDetails {
     pub detail: String,
@@ -8,6 +10,61 @@ impl UpstreamErrorDetails {
     pub fn new(detail: String, is_connect: bool) -> Self {
         Self { detail, is_connect }
     }
+
+    pub fn from_error_chain(err: &(dyn StdError + 'static), is_connect: bool) -> Self {
+        Self::new(format_error_chain(err), is_connect)
+    }
+
+    pub fn classify(&self) -> UpstreamErrorClassification {
+        let normalized = self.detail.to_ascii_lowercase();
+        if normalized.contains("timeout") || normalized.contains("timed out") {
+            return UpstreamErrorClassification::timeout();
+        }
+
+        if self.is_connect {
+            if normalized.contains("unknownissuer") || normalized.contains("unknown issuer") {
+                return UpstreamErrorClassification::tls(UpstreamTlsReason::UnknownIssuer);
+            }
+            if normalized.contains("expired")
+                || normalized.contains("not yet valid")
+                || normalized.contains("validity")
+            {
+                return UpstreamErrorClassification::tls(UpstreamTlsReason::ExpiredCertificate);
+            }
+            if normalized.contains("hostname")
+                || normalized.contains("dns name")
+                || normalized.contains("subjectaltname")
+                || normalized.contains("not valid for")
+            {
+                return UpstreamErrorClassification::tls(UpstreamTlsReason::HostnameMismatch);
+            }
+            if normalized.contains("alpn") {
+                return UpstreamErrorClassification::tls(UpstreamTlsReason::Alpn);
+            }
+            if normalized.contains("invalidcertificate")
+                || normalized.contains("certificate")
+                || normalized.contains("x509")
+                || normalized.contains("rustls")
+                || normalized.contains("webpki")
+                || normalized.contains("tls")
+            {
+                return UpstreamErrorClassification::tls(UpstreamTlsReason::Handshake);
+            }
+        }
+
+        UpstreamErrorClassification::transport()
+    }
+}
+
+pub fn format_error_chain(err: &(dyn StdError + 'static)) -> String {
+    let mut detail = err.to_string();
+    let mut source = err.source();
+    while let Some(cause) = source {
+        detail.push_str(": ");
+        detail.push_str(&cause.to_string());
+        source = cause.source();
+    }
+    detail
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/errors/src/upstream.rs
+++ b/crates/errors/src/upstream.rs
@@ -174,9 +174,92 @@ impl UpstreamErrorClassification {
 
 #[cfg(test)]
 mod tests {
+    use std::{error::Error as StdError, fmt};
+
     use spooky_lb::health::HealthFailureReason;
 
-    use super::{UpstreamErrorClassification, UpstreamHealthFailureMapping, UpstreamTlsReason};
+    use super::{
+        UpstreamErrorCategory, UpstreamErrorClassification, UpstreamErrorDetails,
+        UpstreamHealthFailureMapping, UpstreamTlsReason, classify_upstream_error_detail,
+        format_error_chain,
+    };
+
+    #[derive(Debug)]
+    struct ErrorChainOuter(ErrorChainInner);
+
+    #[derive(Debug)]
+    struct ErrorChainInner;
+
+    impl fmt::Display for ErrorChainOuter {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "outer error")
+        }
+    }
+
+    impl fmt::Display for ErrorChainInner {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "inner error")
+        }
+    }
+
+    impl StdError for ErrorChainOuter {
+        fn source(&self) -> Option<&(dyn StdError + 'static)> {
+            Some(&self.0)
+        }
+    }
+
+    impl StdError for ErrorChainInner {}
+
+    #[test]
+    fn classify_upstream_error_detail_covers_canonical_tls_and_transport_cases() {
+        assert_eq!(
+            classify_upstream_error_detail("request timed out", false),
+            UpstreamErrorClassification::timeout()
+        );
+        assert_eq!(
+            classify_upstream_error_detail("tls handshake failed: UnknownIssuer", true),
+            UpstreamErrorClassification::tls(UpstreamTlsReason::UnknownIssuer)
+        );
+        assert_eq!(
+            classify_upstream_error_detail("certificate expired while verifying backend", true),
+            UpstreamErrorClassification::tls(UpstreamTlsReason::ExpiredCertificate)
+        );
+        assert_eq!(
+            classify_upstream_error_detail(
+                "certificate not valid for dns name api.example.com",
+                true,
+            ),
+            UpstreamErrorClassification::tls(UpstreamTlsReason::HostnameMismatch)
+        );
+        assert_eq!(
+            classify_upstream_error_detail("ALPN negotiation failed", true),
+            UpstreamErrorClassification::tls(UpstreamTlsReason::Alpn)
+        );
+        assert_eq!(
+            classify_upstream_error_detail("connection reset by peer", false),
+            UpstreamErrorClassification::transport()
+        );
+    }
+
+    #[test]
+    fn upstream_error_details_classify_matches_shared_detail_classifier() {
+        let details = UpstreamErrorDetails::new(
+            "certificate not valid for dns name api.example.com".to_string(),
+            true,
+        );
+
+        assert_eq!(
+            details.classify(),
+            classify_upstream_error_detail(&details.detail, details.is_connect)
+        );
+    }
+
+    #[test]
+    fn format_error_chain_flattens_all_sources() {
+        let formatted = format_error_chain(&ErrorChainOuter(ErrorChainInner));
+
+        assert_eq!(formatted, "outer error: inner error");
+    }
 
     #[test]
     fn health_failure_mapping_preserves_tls_and_transport_reasoning() {
@@ -196,10 +279,51 @@ mod tests {
             }
         );
         assert_eq!(
+            UpstreamErrorClassification::tls(UpstreamTlsReason::ExpiredCertificate)
+                .health_failure_mapping(),
+            UpstreamHealthFailureMapping {
+                failure_reason: HealthFailureReason::Tls,
+                metrics_reason: "expired_certificate",
+            }
+        );
+        assert_eq!(
+            UpstreamErrorClassification::tls(UpstreamTlsReason::HostnameMismatch)
+                .health_failure_mapping(),
+            UpstreamHealthFailureMapping {
+                failure_reason: HealthFailureReason::Tls,
+                metrics_reason: "hostname_mismatch",
+            }
+        );
+        assert_eq!(
+            UpstreamErrorClassification::tls(UpstreamTlsReason::Alpn).health_failure_mapping(),
+            UpstreamHealthFailureMapping {
+                failure_reason: HealthFailureReason::Tls,
+                metrics_reason: "alpn",
+            }
+        );
+        assert_eq!(
+            UpstreamErrorClassification::transport().health_failure_mapping(),
+            UpstreamHealthFailureMapping {
+                failure_reason: HealthFailureReason::Transport,
+                metrics_reason: "transport",
+            }
+        );
+        assert_eq!(
             UpstreamErrorClassification::protocol().health_failure_mapping(),
             UpstreamHealthFailureMapping {
                 failure_reason: HealthFailureReason::Transport,
                 metrics_reason: "transport",
+            }
+        );
+        assert_eq!(
+            UpstreamErrorClassification {
+                category: UpstreamErrorCategory::Tls,
+                tls_reason: None,
+            }
+            .health_failure_mapping(),
+            UpstreamHealthFailureMapping {
+                failure_reason: HealthFailureReason::Tls,
+                metrics_reason: "handshake",
             }
         );
     }

--- a/crates/errors/src/upstream.rs
+++ b/crates/errors/src/upstream.rs
@@ -1,0 +1,72 @@
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UpstreamErrorDetails {
+    pub detail: String,
+    pub is_connect: bool,
+}
+
+impl UpstreamErrorDetails {
+    pub fn new(detail: String, is_connect: bool) -> Self {
+        Self { detail, is_connect }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum UpstreamErrorCategory {
+    Timeout,
+    Transport,
+    Tls,
+    Protocol,
+    Internal,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum UpstreamTlsReason {
+    UnknownIssuer,
+    ExpiredCertificate,
+    HostnameMismatch,
+    Alpn,
+    Handshake,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct UpstreamErrorClassification {
+    pub category: UpstreamErrorCategory,
+    pub tls_reason: Option<UpstreamTlsReason>,
+}
+
+impl UpstreamErrorClassification {
+    pub const fn timeout() -> Self {
+        Self {
+            category: UpstreamErrorCategory::Timeout,
+            tls_reason: None,
+        }
+    }
+
+    pub const fn transport() -> Self {
+        Self {
+            category: UpstreamErrorCategory::Transport,
+            tls_reason: None,
+        }
+    }
+
+    pub const fn tls(reason: UpstreamTlsReason) -> Self {
+        Self {
+            category: UpstreamErrorCategory::Tls,
+            tls_reason: Some(reason),
+        }
+    }
+
+    pub const fn protocol() -> Self {
+        Self {
+            category: UpstreamErrorCategory::Protocol,
+            tls_reason: None,
+        }
+    }
+
+    pub const fn internal() -> Self {
+        Self {
+            category: UpstreamErrorCategory::Internal,
+            tls_reason: None,
+        }
+    }
+}

--- a/crates/errors/src/upstream.rs
+++ b/crates/errors/src/upstream.rs
@@ -1,5 +1,7 @@
 use std::error::Error as StdError;
 
+use spooky_lb::health::HealthFailureReason;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UpstreamErrorDetails {
     pub detail: String,
@@ -91,6 +93,12 @@ pub struct UpstreamErrorClassification {
     pub tls_reason: Option<UpstreamTlsReason>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct UpstreamHealthFailureMapping {
+    pub failure_reason: HealthFailureReason,
+    pub metrics_reason: &'static str,
+}
+
 impl UpstreamErrorClassification {
     pub const fn timeout() -> Self {
         Self {
@@ -125,5 +133,67 @@ impl UpstreamErrorClassification {
             category: UpstreamErrorCategory::Internal,
             tls_reason: None,
         }
+    }
+
+    pub fn health_failure_mapping(self) -> UpstreamHealthFailureMapping {
+        match self.category {
+            UpstreamErrorCategory::Timeout => UpstreamHealthFailureMapping {
+                failure_reason: HealthFailureReason::Timeout,
+                metrics_reason: "timeout",
+            },
+            UpstreamErrorCategory::Transport => UpstreamHealthFailureMapping {
+                failure_reason: HealthFailureReason::Transport,
+                metrics_reason: "transport",
+            },
+            UpstreamErrorCategory::Tls => UpstreamHealthFailureMapping {
+                failure_reason: HealthFailureReason::Tls,
+                metrics_reason: match self.tls_reason.unwrap_or(UpstreamTlsReason::Handshake) {
+                    UpstreamTlsReason::UnknownIssuer => "unknown_issuer",
+                    UpstreamTlsReason::ExpiredCertificate => "expired_certificate",
+                    UpstreamTlsReason::HostnameMismatch => "hostname_mismatch",
+                    UpstreamTlsReason::Alpn => "alpn",
+                    UpstreamTlsReason::Handshake => "handshake",
+                },
+            },
+            UpstreamErrorCategory::Protocol | UpstreamErrorCategory::Internal => {
+                UpstreamHealthFailureMapping {
+                    failure_reason: HealthFailureReason::Transport,
+                    metrics_reason: "transport",
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use spooky_lb::health::HealthFailureReason;
+
+    use super::{UpstreamErrorClassification, UpstreamHealthFailureMapping, UpstreamTlsReason};
+
+    #[test]
+    fn health_failure_mapping_preserves_tls_and_transport_reasoning() {
+        assert_eq!(
+            UpstreamErrorClassification::timeout().health_failure_mapping(),
+            UpstreamHealthFailureMapping {
+                failure_reason: HealthFailureReason::Timeout,
+                metrics_reason: "timeout",
+            }
+        );
+        assert_eq!(
+            UpstreamErrorClassification::tls(UpstreamTlsReason::UnknownIssuer)
+                .health_failure_mapping(),
+            UpstreamHealthFailureMapping {
+                failure_reason: HealthFailureReason::Tls,
+                metrics_reason: "unknown_issuer",
+            }
+        );
+        assert_eq!(
+            UpstreamErrorClassification::protocol().health_failure_mapping(),
+            UpstreamHealthFailureMapping {
+                failure_reason: HealthFailureReason::Transport,
+                metrics_reason: "transport",
+            }
+        );
     }
 }

--- a/crates/errors/src/upstream.rs
+++ b/crates/errors/src/upstream.rs
@@ -3,7 +3,7 @@ use std::error::Error as StdError;
 use spooky_lb::health::HealthFailureReason;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct UpstreamErrorDetails {
+pub(crate) struct UpstreamErrorDetails {
     pub detail: String,
     pub is_connect: bool,
 }
@@ -65,7 +65,7 @@ pub fn classify_upstream_error_detail(
     UpstreamErrorClassification::transport()
 }
 
-pub fn format_error_chain(err: &(dyn StdError + 'static)) -> String {
+pub(crate) fn format_error_chain(err: &(dyn StdError + 'static)) -> String {
     let mut detail = err.to_string();
     let mut source = err.source();
     while let Some(cause) = source {

--- a/crates/errors/tests/proxy.rs
+++ b/crates/errors/tests/proxy.rs
@@ -1,4 +1,8 @@
-use spooky_errors::{PoolError, ProxyError};
+use spooky_errors::{
+    PoolError, ProxyError, RetryPolicyDecision, RetryPolicyDenial, RetryPolicyInput,
+    UpstreamRetryReason, UpstreamRetryability, UpstreamTerminalErrorKind, classify_retryability,
+    evaluate_retry_policy,
+};
 
 #[test]
 fn pool_and_transport_errors_have_distinct_display_text() {
@@ -14,4 +18,72 @@ fn overloaded_pool_error_keeps_pool_specific_prefix() {
     let err = ProxyError::Pool(PoolError::BackendOverloaded("api-b".to_string()));
 
     assert_eq!(err.to_string(), "pool error: backend overloaded: api-b");
+}
+
+#[test]
+fn retryability_classification_distinguishes_retryable_and_terminal_errors() {
+    assert_eq!(
+        classify_retryability(&ProxyError::Timeout),
+        UpstreamRetryability::Retryable(UpstreamRetryReason::Timeout)
+    );
+    assert_eq!(
+        classify_retryability(&ProxyError::Transport("reset".to_string())),
+        UpstreamRetryability::Retryable(UpstreamRetryReason::Transport)
+    );
+    assert_eq!(
+        classify_retryability(&ProxyError::Pool(PoolError::UnknownBackend(
+            "api-a".to_string()
+        ))),
+        UpstreamRetryability::Retryable(UpstreamRetryReason::Pool)
+    );
+    assert_eq!(
+        classify_retryability(&ProxyError::Tls("bad cert".to_string())),
+        UpstreamRetryability::Terminal(UpstreamTerminalErrorKind::Tls)
+    );
+}
+
+#[test]
+fn retry_policy_evaluation_preserves_existing_denial_behavior() {
+    assert_eq!(
+        evaluate_retry_policy(RetryPolicyInput {
+            retryability: UpstreamRetryability::Terminal(UpstreamTerminalErrorKind::Protocol),
+            bodyless_mode: true,
+            budget_available: true,
+            alternate_backend_available: true,
+        }),
+        RetryPolicyDecision::DoNotRetry { denial: None }
+    );
+    assert_eq!(
+        evaluate_retry_policy(RetryPolicyInput {
+            retryability: UpstreamRetryability::Retryable(UpstreamRetryReason::Transport),
+            bodyless_mode: false,
+            budget_available: true,
+            alternate_backend_available: true,
+        }),
+        RetryPolicyDecision::DoNotRetry {
+            denial: Some(RetryPolicyDenial::NotBodylessMode),
+        }
+    );
+    assert_eq!(
+        evaluate_retry_policy(RetryPolicyInput {
+            retryability: UpstreamRetryability::Retryable(UpstreamRetryReason::Pool),
+            bodyless_mode: true,
+            budget_available: false,
+            alternate_backend_available: true,
+        }),
+        RetryPolicyDecision::DoNotRetry {
+            denial: Some(RetryPolicyDenial::BudgetDenied),
+        }
+    );
+    assert_eq!(
+        evaluate_retry_policy(RetryPolicyInput {
+            retryability: UpstreamRetryability::Retryable(UpstreamRetryReason::Timeout),
+            bodyless_mode: true,
+            budget_available: true,
+            alternate_backend_available: true,
+        }),
+        RetryPolicyDecision::Retry {
+            reason: UpstreamRetryReason::Timeout,
+        }
+    );
 }

--- a/crates/errors/tests/proxy.rs
+++ b/crates/errors/tests/proxy.rs
@@ -1,7 +1,8 @@
 use spooky_errors::{
     PoolError, ProxyError, RetryPolicyDecision, RetryPolicyDenial, RetryPolicyInput,
-    UpstreamRetryReason, UpstreamRetryability, UpstreamTerminalErrorKind, classify_retryability,
-    evaluate_retry_policy,
+    UpstreamErrorClassification, UpstreamHealthFailureMapping, UpstreamProxyErrorKind,
+    UpstreamRetryReason, UpstreamRetryability, UpstreamTerminalErrorKind, UpstreamTlsReason,
+    classify_retryability, classify_upstream_proxy_error, evaluate_retry_policy,
 };
 
 #[test]
@@ -85,5 +86,45 @@ fn retry_policy_evaluation_preserves_existing_denial_behavior() {
         RetryPolicyDecision::Retry {
             reason: UpstreamRetryReason::Timeout,
         }
+    );
+}
+
+#[test]
+fn upstream_proxy_error_classification_preserves_tls_error_details() {
+    let err = ProxyError::Tls("tls handshake failed: unknown issuer".to_string());
+    let classified = classify_upstream_proxy_error(&err).expect("classified upstream error");
+
+    assert_eq!(classified.kind, UpstreamProxyErrorKind::Tls);
+    assert_eq!(
+        classified.classification,
+        UpstreamErrorClassification::tls(UpstreamTlsReason::UnknownIssuer)
+    );
+    assert!(classified.health_failure.is_none());
+    assert_eq!(
+        classified.retryability,
+        UpstreamRetryability::Terminal(UpstreamTerminalErrorKind::Tls)
+    );
+}
+
+#[test]
+fn upstream_proxy_error_classification_marks_timeout_as_retryable_health_failure() {
+    let classified =
+        classify_upstream_proxy_error(&ProxyError::Timeout).expect("classified timeout");
+
+    assert_eq!(classified.kind, UpstreamProxyErrorKind::Timeout);
+    assert_eq!(
+        classified.classification,
+        UpstreamErrorClassification::timeout()
+    );
+    assert_eq!(
+        classified.health_failure,
+        Some(UpstreamHealthFailureMapping {
+            failure_reason: spooky_lb::health::HealthFailureReason::Timeout,
+            metrics_reason: "timeout",
+        })
+    );
+    assert_eq!(
+        classified.retryability,
+        UpstreamRetryability::Retryable(UpstreamRetryReason::Timeout)
     );
 }

--- a/crates/errors/tests/proxy.rs
+++ b/crates/errors/tests/proxy.rs
@@ -2,7 +2,7 @@ use spooky_errors::{
     PoolError, ProxyError, RetryPolicyDecision, RetryPolicyDenial, RetryPolicyInput,
     UpstreamErrorClassification, UpstreamHealthFailureMapping, UpstreamProxyErrorKind,
     UpstreamRetryReason, UpstreamRetryability, UpstreamTerminalErrorKind, UpstreamTlsReason,
-    classify_retryability, classify_upstream_proxy_error, evaluate_retry_policy,
+    classify_retryability, classify_upstream_proxy_error, evaluate_retry_policy, is_retryable,
 };
 
 #[test]
@@ -40,6 +40,10 @@ fn retryability_classification_distinguishes_retryable_and_terminal_errors() {
     assert_eq!(
         classify_retryability(&ProxyError::Tls("bad cert".to_string())),
         UpstreamRetryability::Terminal(UpstreamTerminalErrorKind::Tls)
+    );
+    assert_eq!(
+        classify_retryability(&ProxyError::Protocol("bad frame".to_string())),
+        UpstreamRetryability::Terminal(UpstreamTerminalErrorKind::Protocol)
     );
 }
 
@@ -127,4 +131,68 @@ fn upstream_proxy_error_classification_marks_timeout_as_retryable_health_failure
         classified.retryability,
         UpstreamRetryability::Retryable(UpstreamRetryReason::Timeout)
     );
+}
+
+#[test]
+fn upstream_proxy_error_classification_covers_protocol_and_transport_cases() {
+    let transport =
+        classify_upstream_proxy_error(&ProxyError::Transport("connection reset".into()))
+            .expect("classified transport");
+    assert_eq!(transport.kind, UpstreamProxyErrorKind::Transport);
+    assert_eq!(
+        transport.classification,
+        UpstreamErrorClassification::transport()
+    );
+    assert_eq!(
+        transport.health_failure,
+        Some(UpstreamHealthFailureMapping {
+            failure_reason: spooky_lb::health::HealthFailureReason::Transport,
+            metrics_reason: "transport",
+        })
+    );
+    assert_eq!(
+        transport.retryability,
+        UpstreamRetryability::Retryable(UpstreamRetryReason::Transport)
+    );
+
+    let protocol = classify_upstream_proxy_error(&ProxyError::Protocol("bad frame".into()))
+        .expect("classified protocol");
+    assert_eq!(protocol.kind, UpstreamProxyErrorKind::Protocol);
+    assert_eq!(
+        protocol.classification,
+        UpstreamErrorClassification::protocol()
+    );
+    assert!(protocol.health_failure.is_none());
+    assert_eq!(
+        protocol.retryability,
+        UpstreamRetryability::Terminal(UpstreamTerminalErrorKind::Protocol)
+    );
+}
+
+#[test]
+fn retryability_boolean_matches_typed_retryability_contract() {
+    let retryable_errors = [
+        ProxyError::Timeout,
+        ProxyError::Transport("reset".into()),
+        ProxyError::Pool(PoolError::UnknownBackend("api-a".into())),
+    ];
+    for err in retryable_errors {
+        assert!(is_retryable(&err));
+        assert!(matches!(
+            classify_retryability(&err),
+            UpstreamRetryability::Retryable(_)
+        ));
+    }
+
+    let terminal_errors = [
+        ProxyError::Tls("bad cert".into()),
+        ProxyError::Protocol("bad frame".into()),
+    ];
+    for err in terminal_errors {
+        assert!(!is_retryable(&err));
+        assert!(matches!(
+            classify_retryability(&err),
+            UpstreamRetryability::Terminal(_)
+        ));
+    }
 }


### PR DESCRIPTION
## Summary
This PR moves upstream error classification out of ad hoc `edge` handling and into a canonical shared layer in `spooky-errors`, then routes QUIC forwarding, bootstrap TLS, and health checks through that shared contract.

## What Changed
- added shared upstream error detail classification for timeout, transport, TLS, protocol, and internal cases
- centralized health-failure mapping and metrics reason derivation
- centralized retryability classification and retry policy interpretation
- added shared proxy-error classification entrypoints for send, timeout, transport, protocol, and TLS errors
- routed forwarding response handling through the shared classifier
- routed bootstrap TLS upstream failure handling through the same classifier
- routed health-check error handling through the same classifier
- removed stale edge-local classification helpers and duplicate logging/health-mapping branches
- tightened visibility so callers depend on canonical classification entrypoints only
- added focused tests for canonical upstream error behavior, retryability, and health mapping

## Why
Upstream error handling had drifted across forwarding, bootstrap, and health-check code paths. Classification, retry decisions, health transitions, and logging were partially duplicated and could diverge over time. This PR establishes one shared contract and makes `edge` consume it consistently.

## Outcome
- timeout vs transport vs TLS vs protocol interpretation now comes from one layer
- retryability and retry-policy decisions are typed and shared
- health-failure mapping is stable and reused across all edge paths
- bootstrap, forwarding, and health checks emit consistent upstream error behavior
- edge orchestration code is smaller and easier to maintain

## Validation
- `cargo fmt --all`
- `cargo check -p spooky-errors -p spooky-edge --tests`