### PR TITLE
refactor(bridge): centralize response normalization across bridge and edge

### DIFF
--- a/crates/bridge/src/lib.rs
+++ b/crates/bridge/src/lib.rs
@@ -4,6 +4,7 @@ pub mod h3_to_h2;
 mod headers;
 mod host;
 pub mod request;
+pub mod response;
 pub mod websocket;
 
 pub use spooky_errors::BridgeError;

--- a/crates/bridge/src/response.rs
+++ b/crates/bridge/src/response.rs
@@ -230,11 +230,12 @@ pub fn apply_response_header_defaults(
     if matches!(emission.content_length, ContentLengthPolicy::Strip) {
         headers.retain(|header| header.name != http::header::CONTENT_LENGTH);
     } else if !has_content_length {
-        headers.push(NormalizedHeader {
-            name: http::header::CONTENT_LENGTH,
-            value: HeaderValue::from_str(&body_len.to_string())
-                .expect("synthesized content-length must be valid"),
-        });
+        if let Ok(value) = HeaderValue::from_str(&body_len.to_string()) {
+            headers.push(NormalizedHeader {
+                name: http::header::CONTENT_LENGTH,
+                value,
+            });
+        }
     }
 
     if matches!(

--- a/crates/bridge/src/response.rs
+++ b/crates/bridge/src/response.rs
@@ -90,7 +90,9 @@ pub(crate) fn status_forbids_response_body(status: StatusCode) -> bool {
 }
 
 fn is_hop_by_hop_response_header(name: &HeaderName, preserve_upgrade: bool) -> bool {
-    if preserve_upgrade && name == http::header::UPGRADE {
+    if preserve_upgrade
+        && (name == http::header::CONNECTION || name == http::header::UPGRADE)
+    {
         return false;
     }
 
@@ -126,7 +128,10 @@ pub fn should_strip_response_header(
     connection_tokens: &HashSet<String>,
     constraints: ResponseProtocolConstraints,
 ) -> bool {
-    (constraints.strip_connection_headers && connection_tokens.contains(name.as_str()))
+    (constraints.strip_connection_headers
+        && !(constraints.preserve_upgrade
+            && (name == http::header::CONNECTION || name == http::header::UPGRADE))
+        && connection_tokens.contains(name.as_str()))
         || is_hop_by_hop_response_header(name, constraints.preserve_upgrade)
         || matches!(constraints.protocol, ResponseNormalizationProtocol::Http3)
             && name == http::header::CONTENT_LENGTH

--- a/crates/bridge/src/response.rs
+++ b/crates/bridge/src/response.rs
@@ -121,7 +121,7 @@ pub(crate) fn response_connection_tokens(headers: &HeaderMap) -> HashSet<String>
     tokens
 }
 
-pub(crate) fn should_strip_response_header(
+pub fn should_strip_response_header(
     name: &HeaderName,
     connection_tokens: &HashSet<String>,
     constraints: ResponseProtocolConstraints,

--- a/crates/bridge/src/response.rs
+++ b/crates/bridge/src/response.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use http::{HeaderMap, HeaderName, HeaderValue, StatusCode};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -79,4 +81,71 @@ pub struct NormalizedResponse {
     pub head: NormalizedResponseHead,
     pub trailers: Vec<NormalizedHeader>,
     pub emission: ResponseEmissionPolicy,
+}
+
+fn is_hop_by_hop_response_header(name: &HeaderName, preserve_upgrade: bool) -> bool {
+    if preserve_upgrade && name == http::header::UPGRADE {
+        return false;
+    }
+
+    name == http::header::CONNECTION
+        || name == http::header::PROXY_AUTHENTICATE
+        || name == http::header::PROXY_AUTHORIZATION
+        || name == http::header::TE
+        || name == http::header::TRAILER
+        || name == http::header::TRANSFER_ENCODING
+        || name == http::header::UPGRADE
+        || name.as_str().eq_ignore_ascii_case("keep-alive")
+        || name.as_str().eq_ignore_ascii_case("proxy-connection")
+}
+
+pub fn response_connection_tokens(headers: &HeaderMap) -> HashSet<String> {
+    let mut tokens = HashSet::new();
+    for value in headers.get_all(http::header::CONNECTION) {
+        let Ok(raw) = value.to_str() else {
+            continue;
+        };
+        for part in raw.split(',') {
+            let token = part.trim().to_ascii_lowercase();
+            if !token.is_empty() {
+                tokens.insert(token);
+            }
+        }
+    }
+    tokens
+}
+
+pub fn should_strip_response_header(
+    name: &HeaderName,
+    connection_tokens: &HashSet<String>,
+    constraints: ResponseProtocolConstraints,
+) -> bool {
+    (constraints.strip_connection_headers && connection_tokens.contains(name.as_str()))
+        || is_hop_by_hop_response_header(name, constraints.preserve_upgrade)
+        || matches!(constraints.protocol, ResponseNormalizationProtocol::Http3)
+            && name == http::header::CONTENT_LENGTH
+        || matches!(constraints.protocol, ResponseNormalizationProtocol::Http1)
+            && name.as_str().eq_ignore_ascii_case("alt-svc")
+}
+
+pub fn normalize_response_trailers(
+    trailers: &HeaderMap,
+    constraints: ResponseProtocolConstraints,
+) -> Vec<NormalizedHeader> {
+    if !constraints.allow_trailers {
+        return Vec::new();
+    }
+
+    let connection_tokens = response_connection_tokens(trailers);
+    let mut normalized = Vec::with_capacity(trailers.len());
+    for (name, value) in trailers {
+        if should_strip_response_header(name, &connection_tokens, constraints) {
+            continue;
+        }
+        normalized.push(NormalizedHeader {
+            name: name.clone(),
+            value: value.clone(),
+        });
+    }
+    normalized
 }

--- a/crates/bridge/src/response.rs
+++ b/crates/bridge/src/response.rs
@@ -1,0 +1,82 @@
+use http::{HeaderMap, HeaderName, HeaderValue, StatusCode};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ResponseNormalizationProtocol {
+    Http1,
+    Http3,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ResponseBodyMode {
+    Normal,
+    HeadRequest,
+    BodylessRequest,
+    TunnelSuccess,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ResponseBodyPolicy {
+    Forward,
+    Suppress,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ContentLengthPolicy {
+    Preserve,
+    Strip,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ContentTypePolicy {
+    Preserve,
+    SynthesizeTextPlain,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ResponseProtocolConstraints {
+    pub protocol: ResponseNormalizationProtocol,
+    pub strip_connection_headers: bool,
+    pub allow_trailers: bool,
+    pub preserve_upgrade: bool,
+}
+
+#[derive(Debug)]
+pub struct UpstreamResponseView<'a> {
+    pub status: StatusCode,
+    pub headers: &'a HeaderMap,
+    pub trailers: Option<&'a HeaderMap>,
+}
+
+#[derive(Debug)]
+pub struct ResponseNormalizationInput<'a> {
+    pub upstream: UpstreamResponseView<'a>,
+    pub body_mode: ResponseBodyMode,
+    pub constraints: ResponseProtocolConstraints,
+}
+
+#[derive(Debug)]
+pub struct NormalizedHeader {
+    pub name: HeaderName,
+    pub value: HeaderValue,
+}
+
+#[derive(Debug)]
+pub struct NormalizedResponseHead {
+    pub status: StatusCode,
+    pub headers: Vec<NormalizedHeader>,
+}
+
+#[derive(Debug)]
+pub struct ResponseEmissionPolicy {
+    pub body: ResponseBodyPolicy,
+    pub content_length: ContentLengthPolicy,
+    pub content_type: ContentTypePolicy,
+    pub emit_end_stream_on_headers: bool,
+}
+
+#[derive(Debug)]
+pub struct NormalizedResponse {
+    pub head: NormalizedResponseHead,
+    pub trailers: Vec<NormalizedHeader>,
+    pub emission: ResponseEmissionPolicy,
+}

--- a/crates/bridge/src/response.rs
+++ b/crates/bridge/src/response.rs
@@ -229,14 +229,13 @@ pub fn apply_response_header_defaults(
 
     if matches!(emission.content_length, ContentLengthPolicy::Strip) {
         headers.retain(|header| header.name != http::header::CONTENT_LENGTH);
-    } else if !has_content_length {
-        if let Ok(value) = HeaderValue::from_str(&body_len.to_string()) {
+    } else if !has_content_length
+        && let Ok(value) = HeaderValue::from_str(&body_len.to_string()) {
             headers.push(NormalizedHeader {
                 name: http::header::CONTENT_LENGTH,
                 value,
             });
         }
-    }
 
     if matches!(
         emission.content_type,

--- a/crates/bridge/src/response.rs
+++ b/crates/bridge/src/response.rs
@@ -83,7 +83,7 @@ pub struct NormalizedResponse {
     pub emission: ResponseEmissionPolicy,
 }
 
-pub fn status_forbids_response_body(status: StatusCode) -> bool {
+pub(crate) fn status_forbids_response_body(status: StatusCode) -> bool {
     status.is_informational()
         || status == StatusCode::NO_CONTENT
         || status == StatusCode::NOT_MODIFIED
@@ -105,7 +105,7 @@ fn is_hop_by_hop_response_header(name: &HeaderName, preserve_upgrade: bool) -> b
         || name.as_str().eq_ignore_ascii_case("proxy-connection")
 }
 
-pub fn response_connection_tokens(headers: &HeaderMap) -> HashSet<String> {
+pub(crate) fn response_connection_tokens(headers: &HeaderMap) -> HashSet<String> {
     let mut tokens = HashSet::new();
     for value in headers.get_all(http::header::CONNECTION) {
         let Ok(raw) = value.to_str() else {
@@ -121,7 +121,7 @@ pub fn response_connection_tokens(headers: &HeaderMap) -> HashSet<String> {
     tokens
 }
 
-pub fn should_strip_response_header(
+pub(crate) fn should_strip_response_header(
     name: &HeaderName,
     connection_tokens: &HashSet<String>,
     constraints: ResponseProtocolConstraints,

--- a/crates/bridge/src/response.rs
+++ b/crates/bridge/src/response.rs
@@ -251,13 +251,14 @@ pub fn apply_response_header_defaults(
 
 #[cfg(test)]
 mod tests {
-    use http::{HeaderMap, HeaderValue, StatusCode};
+    use http::{HeaderMap, HeaderName, HeaderValue, StatusCode};
 
     use super::{
         ContentLengthPolicy, ContentTypePolicy, NormalizedHeader, ResponseBodyMode,
         ResponseBodyPolicy, ResponseEmissionPolicy, ResponseNormalizationInput,
         ResponseNormalizationProtocol, ResponseProtocolConstraints, UpstreamResponseView,
-        apply_response_header_defaults, normalize_upstream_response, status_forbids_response_body,
+        apply_response_header_defaults, normalize_response_trailers, normalize_upstream_response,
+        response_connection_tokens, should_strip_response_header, status_forbids_response_body,
     };
 
     fn http3_constraints() -> ResponseProtocolConstraints {
@@ -278,12 +279,135 @@ mod tests {
         }
     }
 
+    fn header_value<'a>(headers: &'a [NormalizedHeader], name: &str) -> Option<&'a str> {
+        let name = HeaderName::from_bytes(name.as_bytes()).ok()?;
+        headers
+            .iter()
+            .find(|header| header.name == name)
+            .and_then(|header| header.value.to_str().ok())
+    }
+
     #[test]
     fn forbids_bodies_for_informational_and_empty_statuses() {
         assert!(status_forbids_response_body(StatusCode::CONTINUE));
         assert!(status_forbids_response_body(StatusCode::NO_CONTENT));
         assert!(status_forbids_response_body(StatusCode::NOT_MODIFIED));
         assert!(!status_forbids_response_body(StatusCode::OK));
+    }
+
+    #[test]
+    fn response_connection_tokens_normalize_multiple_values() {
+        let mut headers = HeaderMap::new();
+        headers.append(
+            http::header::CONNECTION,
+            HeaderValue::from_static(" keep-alive , x-hop "),
+        );
+        headers.append(
+            http::header::CONNECTION,
+            HeaderValue::from_static("Upgrade, x-extra"),
+        );
+
+        let tokens = response_connection_tokens(&headers);
+
+        assert!(tokens.contains("keep-alive"));
+        assert!(tokens.contains("x-hop"));
+        assert!(tokens.contains("upgrade"));
+        assert!(tokens.contains("x-extra"));
+    }
+
+    #[test]
+    fn http3_header_filter_strips_hop_headers_connection_tokens_and_content_length() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            http::header::CONNECTION,
+            HeaderValue::from_static("x-internal-hop"),
+        );
+        let tokens = response_connection_tokens(&headers);
+
+        assert!(should_strip_response_header(
+            &http::header::TE,
+            &tokens,
+            http3_constraints(),
+        ));
+        assert!(should_strip_response_header(
+            &http::header::TRAILER,
+            &tokens,
+            http3_constraints(),
+        ));
+        assert!(should_strip_response_header(
+            &http::header::CONTENT_LENGTH,
+            &tokens,
+            http3_constraints(),
+        ));
+        assert!(should_strip_response_header(
+            &HeaderName::from_static("x-internal-hop"),
+            &tokens,
+            http3_constraints(),
+        ));
+        assert!(!should_strip_response_header(
+            &http::header::CACHE_CONTROL,
+            &tokens,
+            http3_constraints(),
+        ));
+    }
+
+    #[test]
+    fn http1_header_filter_strips_alt_svc_and_can_preserve_upgrade() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            http::header::CONNECTION,
+            HeaderValue::from_static("x-hop-token"),
+        );
+        let tokens = response_connection_tokens(&headers);
+
+        assert!(should_strip_response_header(
+            &HeaderName::from_static("alt-svc"),
+            &tokens,
+            http1_constraints(),
+        ));
+        assert!(should_strip_response_header(
+            &HeaderName::from_static("x-hop-token"),
+            &tokens,
+            http1_constraints(),
+        ));
+        assert!(!should_strip_response_header(
+            &http::header::UPGRADE,
+            &tokens,
+            ResponseProtocolConstraints {
+                preserve_upgrade: true,
+                ..http1_constraints()
+            },
+        ));
+    }
+
+    #[test]
+    fn trailer_normalization_preserves_end_to_end_and_filters_hop_headers() {
+        let mut trailers = HeaderMap::new();
+        trailers.insert(
+            http::HeaderName::from_static("grpc-status"),
+            HeaderValue::from_static("0"),
+        );
+        trailers.insert(
+            http::HeaderName::from_static("grpc-message"),
+            HeaderValue::from_static("ok"),
+        );
+        trailers.insert(
+            http::header::CONNECTION,
+            HeaderValue::from_static("x-hop-token"),
+        );
+        trailers.insert(http::header::TE, HeaderValue::from_static("trailers"));
+        trailers.insert(
+            http::HeaderName::from_static("x-hop-token"),
+            HeaderValue::from_static("secret"),
+        );
+        trailers.insert(http::header::CONTENT_LENGTH, HeaderValue::from_static("12"));
+
+        let normalized = normalize_response_trailers(&trailers, http3_constraints());
+
+        assert_eq!(normalized.len(), 2);
+        assert_eq!(header_value(&normalized, "grpc-status"), Some("0"));
+        assert_eq!(header_value(&normalized, "grpc-message"), Some("ok"));
+        assert_eq!(header_value(&normalized, "x-hop-token"), None);
     }
 
     #[test]
@@ -333,6 +457,25 @@ mod tests {
                 .iter()
                 .any(|header| header.name == http::HeaderName::from_static("x-custom"))
         );
+    }
+
+    #[test]
+    fn normalizes_bodyless_request_mode_as_suppressed_and_terminal() {
+        let mut headers = HeaderMap::new();
+        headers.insert(http::header::CONTENT_LENGTH, HeaderValue::from_static("7"));
+
+        let normalized = normalize_upstream_response(ResponseNormalizationInput {
+            upstream: UpstreamResponseView {
+                status: StatusCode::OK,
+                headers: &headers,
+                trailers: None,
+            },
+            body_mode: ResponseBodyMode::BodylessRequest,
+            constraints: http3_constraints(),
+        });
+
+        assert_eq!(normalized.emission.body, ResponseBodyPolicy::Suppress);
+        assert!(normalized.emission.emit_end_stream_on_headers);
     }
 
     #[test]
@@ -449,6 +592,65 @@ mod tests {
             headers
                 .iter()
                 .all(|header| header.name != http::header::CONTENT_LENGTH)
+        );
+    }
+
+    #[test]
+    fn quic_and_bootstrap_normalizers_preserve_same_end_to_end_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            http::header::CONNECTION,
+            HeaderValue::from_static("x-hop-token"),
+        );
+        headers.insert(
+            HeaderName::from_static("x-hop-token"),
+            HeaderValue::from_static("secret"),
+        );
+        headers.insert(http::header::CONTENT_LENGTH, HeaderValue::from_static("9"));
+        headers.insert(
+            http::header::CACHE_CONTROL,
+            HeaderValue::from_static("max-age=60"),
+        );
+        headers.insert(http::header::ETAG, HeaderValue::from_static("\"etag-1\""));
+
+        let h3 = normalize_upstream_response(ResponseNormalizationInput {
+            upstream: UpstreamResponseView {
+                status: StatusCode::OK,
+                headers: &headers,
+                trailers: None,
+            },
+            body_mode: ResponseBodyMode::Normal,
+            constraints: http3_constraints(),
+        });
+        let http1 = normalize_upstream_response(ResponseNormalizationInput {
+            upstream: UpstreamResponseView {
+                status: StatusCode::OK,
+                headers: &headers,
+                trailers: None,
+            },
+            body_mode: ResponseBodyMode::Normal,
+            constraints: http1_constraints(),
+        });
+
+        assert_eq!(h3.head.status, http1.head.status);
+        assert_eq!(h3.emission.body, ResponseBodyPolicy::Forward);
+        assert_eq!(http1.emission.body, ResponseBodyPolicy::Forward);
+        assert!(!h3.emission.emit_end_stream_on_headers);
+        assert!(!http1.emission.emit_end_stream_on_headers);
+        assert_eq!(
+            header_value(&h3.head.headers, "cache-control"),
+            header_value(&http1.head.headers, "cache-control")
+        );
+        assert_eq!(
+            header_value(&h3.head.headers, "etag"),
+            header_value(&http1.head.headers, "etag")
+        );
+        assert_eq!(header_value(&h3.head.headers, "x-hop-token"), None);
+        assert_eq!(header_value(&http1.head.headers, "x-hop-token"), None);
+        assert_eq!(header_value(&h3.head.headers, "content-length"), None);
+        assert_eq!(
+            header_value(&http1.head.headers, "content-length"),
+            Some("9")
         );
     }
 }

--- a/crates/bridge/src/response.rs
+++ b/crates/bridge/src/response.rs
@@ -83,6 +83,12 @@ pub struct NormalizedResponse {
     pub emission: ResponseEmissionPolicy,
 }
 
+pub fn status_forbids_response_body(status: StatusCode) -> bool {
+    status.is_informational()
+        || status == StatusCode::NO_CONTENT
+        || status == StatusCode::NOT_MODIFIED
+}
+
 fn is_hop_by_hop_response_header(name: &HeaderName, preserve_upgrade: bool) -> bool {
     if preserve_upgrade && name == http::header::UPGRADE {
         return false;
@@ -148,4 +154,301 @@ pub fn normalize_response_trailers(
         });
     }
     normalized
+}
+
+pub fn normalize_upstream_response(input: ResponseNormalizationInput<'_>) -> NormalizedResponse {
+    let constraints = input.constraints;
+    let headers = input.upstream.headers;
+    let connection_tokens = response_connection_tokens(headers);
+    let mut normalized_headers = Vec::with_capacity(headers.len());
+    for (name, value) in headers {
+        if should_strip_response_header(name, &connection_tokens, constraints) {
+            continue;
+        }
+        normalized_headers.push(NormalizedHeader {
+            name: name.clone(),
+            value: value.clone(),
+        });
+    }
+
+    let declared_content_length = headers
+        .get(http::header::CONTENT_LENGTH)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<usize>().ok());
+    let body_forbidden = status_forbids_response_body(input.upstream.status);
+    let suppress_body = !matches!(input.body_mode, ResponseBodyMode::TunnelSuccess)
+        && (matches!(
+            input.body_mode,
+            ResponseBodyMode::HeadRequest | ResponseBodyMode::BodylessRequest
+        ) || body_forbidden);
+
+    let emission = ResponseEmissionPolicy {
+        body: if suppress_body {
+            ResponseBodyPolicy::Suppress
+        } else {
+            ResponseBodyPolicy::Forward
+        },
+        content_length: if matches!(constraints.protocol, ResponseNormalizationProtocol::Http3) {
+            ContentLengthPolicy::Strip
+        } else {
+            ContentLengthPolicy::Preserve
+        },
+        content_type: ContentTypePolicy::Preserve,
+        emit_end_stream_on_headers: suppress_body
+            || (!matches!(input.body_mode, ResponseBodyMode::TunnelSuccess)
+                && (body_forbidden || declared_content_length == Some(0))),
+    };
+
+    let trailers = input
+        .upstream
+        .trailers
+        .map(|trailers| normalize_response_trailers(trailers, constraints))
+        .unwrap_or_default();
+
+    NormalizedResponse {
+        head: NormalizedResponseHead {
+            status: input.upstream.status,
+            headers: normalized_headers,
+        },
+        trailers,
+        emission,
+    }
+}
+
+pub fn apply_response_header_defaults(
+    headers: &mut Vec<NormalizedHeader>,
+    emission: &ResponseEmissionPolicy,
+    body_len: usize,
+) {
+    let has_content_type = headers
+        .iter()
+        .any(|header| header.name == http::header::CONTENT_TYPE);
+    let has_content_length = headers
+        .iter()
+        .any(|header| header.name == http::header::CONTENT_LENGTH);
+
+    if matches!(emission.content_length, ContentLengthPolicy::Strip) {
+        headers.retain(|header| header.name != http::header::CONTENT_LENGTH);
+    } else if !has_content_length {
+        headers.push(NormalizedHeader {
+            name: http::header::CONTENT_LENGTH,
+            value: HeaderValue::from_str(&body_len.to_string())
+                .expect("synthesized content-length must be valid"),
+        });
+    }
+
+    if matches!(
+        emission.content_type,
+        ContentTypePolicy::SynthesizeTextPlain
+    ) && !has_content_type
+    {
+        headers.push(NormalizedHeader {
+            name: http::header::CONTENT_TYPE,
+            value: HeaderValue::from_static("text/plain"),
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use http::{HeaderMap, HeaderValue, StatusCode};
+
+    use super::{
+        ContentLengthPolicy, ContentTypePolicy, NormalizedHeader, ResponseBodyMode,
+        ResponseBodyPolicy, ResponseEmissionPolicy, ResponseNormalizationInput,
+        ResponseNormalizationProtocol, ResponseProtocolConstraints, UpstreamResponseView,
+        apply_response_header_defaults, normalize_upstream_response, status_forbids_response_body,
+    };
+
+    fn http3_constraints() -> ResponseProtocolConstraints {
+        ResponseProtocolConstraints {
+            protocol: ResponseNormalizationProtocol::Http3,
+            strip_connection_headers: true,
+            allow_trailers: true,
+            preserve_upgrade: false,
+        }
+    }
+
+    fn http1_constraints() -> ResponseProtocolConstraints {
+        ResponseProtocolConstraints {
+            protocol: ResponseNormalizationProtocol::Http1,
+            strip_connection_headers: true,
+            allow_trailers: false,
+            preserve_upgrade: false,
+        }
+    }
+
+    #[test]
+    fn forbids_bodies_for_informational_and_empty_statuses() {
+        assert!(status_forbids_response_body(StatusCode::CONTINUE));
+        assert!(status_forbids_response_body(StatusCode::NO_CONTENT));
+        assert!(status_forbids_response_body(StatusCode::NOT_MODIFIED));
+        assert!(!status_forbids_response_body(StatusCode::OK));
+    }
+
+    #[test]
+    fn normalizes_http3_head_response_as_bodyless_and_header_terminal() {
+        let mut headers = HeaderMap::new();
+        headers.insert(http::header::CONTENT_LENGTH, HeaderValue::from_static("12"));
+        headers.insert(
+            http::header::CONTENT_TYPE,
+            HeaderValue::from_static("text/plain"),
+        );
+        headers.insert(
+            http::HeaderName::from_static("x-custom"),
+            HeaderValue::from_static("ok"),
+        );
+
+        let normalized = normalize_upstream_response(ResponseNormalizationInput {
+            upstream: UpstreamResponseView {
+                status: StatusCode::OK,
+                headers: &headers,
+                trailers: None,
+            },
+            body_mode: ResponseBodyMode::HeadRequest,
+            constraints: http3_constraints(),
+        });
+
+        assert_eq!(normalized.emission.body, ResponseBodyPolicy::Suppress);
+        assert_eq!(
+            normalized.emission.content_length,
+            ContentLengthPolicy::Strip
+        );
+        assert_eq!(
+            normalized.emission.content_type,
+            ContentTypePolicy::Preserve
+        );
+        assert!(normalized.emission.emit_end_stream_on_headers);
+        assert!(
+            normalized
+                .head
+                .headers
+                .iter()
+                .all(|header| header.name != http::header::CONTENT_LENGTH)
+        );
+        assert!(
+            normalized
+                .head
+                .headers
+                .iter()
+                .any(|header| header.name == http::HeaderName::from_static("x-custom"))
+        );
+    }
+
+    #[test]
+    fn normalizes_http1_no_content_without_suppressing_surviving_metadata() {
+        let mut headers = HeaderMap::new();
+        headers.insert(http::header::CONTENT_LENGTH, HeaderValue::from_static("0"));
+        headers.insert(
+            http::HeaderName::from_static("etag"),
+            HeaderValue::from_static("\"abc\""),
+        );
+
+        let normalized = normalize_upstream_response(ResponseNormalizationInput {
+            upstream: UpstreamResponseView {
+                status: StatusCode::NO_CONTENT,
+                headers: &headers,
+                trailers: None,
+            },
+            body_mode: ResponseBodyMode::Normal,
+            constraints: http1_constraints(),
+        });
+
+        assert_eq!(normalized.emission.body, ResponseBodyPolicy::Suppress);
+        assert_eq!(
+            normalized.emission.content_length,
+            ContentLengthPolicy::Preserve
+        );
+        assert!(normalized.emission.emit_end_stream_on_headers);
+        assert!(
+            normalized
+                .head
+                .headers
+                .iter()
+                .any(|header| header.name == http::header::CONTENT_LENGTH)
+        );
+        assert!(
+            normalized
+                .head
+                .headers
+                .iter()
+                .any(|header| header.name == http::HeaderName::from_static("etag"))
+        );
+    }
+
+    #[test]
+    fn tunnel_success_does_not_force_body_suppression_or_terminal_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert(http::header::CONTENT_LENGTH, HeaderValue::from_static("0"));
+
+        let normalized = normalize_upstream_response(ResponseNormalizationInput {
+            upstream: UpstreamResponseView {
+                status: StatusCode::OK,
+                headers: &headers,
+                trailers: None,
+            },
+            body_mode: ResponseBodyMode::TunnelSuccess,
+            constraints: http3_constraints(),
+        });
+
+        assert_eq!(normalized.emission.body, ResponseBodyPolicy::Forward);
+        assert!(!normalized.emission.emit_end_stream_on_headers);
+    }
+
+    #[test]
+    fn response_defaults_add_text_plain_and_content_length_when_missing() {
+        let mut headers = vec![NormalizedHeader {
+            name: http::HeaderName::from_static("x-custom"),
+            value: HeaderValue::from_static("ok"),
+        }];
+
+        apply_response_header_defaults(
+            &mut headers,
+            &ResponseEmissionPolicy {
+                body: ResponseBodyPolicy::Forward,
+                content_length: ContentLengthPolicy::Preserve,
+                content_type: ContentTypePolicy::SynthesizeTextPlain,
+                emit_end_stream_on_headers: false,
+            },
+            5,
+        );
+
+        assert!(
+            headers
+                .iter()
+                .any(|header| header.name == http::header::CONTENT_TYPE
+                    && header.value == HeaderValue::from_static("text/plain"))
+        );
+        assert!(
+            headers
+                .iter()
+                .any(|header| header.name == http::header::CONTENT_LENGTH
+                    && header.value == HeaderValue::from_static("5"))
+        );
+    }
+
+    #[test]
+    fn response_defaults_strip_content_length_when_requested() {
+        let mut headers = vec![NormalizedHeader {
+            name: http::header::CONTENT_LENGTH,
+            value: HeaderValue::from_static("9"),
+        }];
+
+        apply_response_header_defaults(
+            &mut headers,
+            &ResponseEmissionPolicy {
+                body: ResponseBodyPolicy::Suppress,
+                content_length: ContentLengthPolicy::Strip,
+                content_type: ContentTypePolicy::Preserve,
+                emit_end_stream_on_headers: true,
+            },
+            0,
+        );
+
+        assert!(
+            headers
+                .iter()
+                .all(|header| header.name != http::header::CONTENT_LENGTH)
+        );
+    }
 }

--- a/crates/edge/src/quic_listener/bootstrap_tls.rs
+++ b/crates/edge/src/quic_listener/bootstrap_tls.rs
@@ -28,6 +28,10 @@ use spooky_bridge::{
         RequestBuildInput, RequestBuildPolicies, RequestBuildTarget, RequestForwardedContext,
         RequestTraceContext,
     },
+    response::{
+        ResponseBodyMode, ResponseBodyPolicy, ResponseNormalizationInput,
+        ResponseNormalizationProtocol, ResponseProtocolConstraints, normalize_upstream_response,
+    },
 };
 use spooky_config::{
     backend_endpoint::{BackendEndpoint, BackendScheme},
@@ -43,10 +47,9 @@ use super::{
         AdmissionPolicyDecision, admission_rejection_response,
         evaluate_forwarding_pre_admission_policy,
     },
-    boxed_full, connection_header_tokens, is_head_method, is_websocket_upgrade_request,
+    boxed_full, is_head_method, is_websocket_upgrade_request,
     runtime_endpoint::RuntimeConnectionSlotGuard,
-    runtime_handle, should_strip_bootstrap_response_header, spawn_supervised_async_task,
-    validate_http_request,
+    runtime_handle, spawn_supervised_async_task, validate_http_request,
 };
 use crate::{
     Metrics, REQUEST_ID_COUNTER, RouteOutcome,
@@ -1094,23 +1097,30 @@ impl QUICListener {
                                 }
 
                                 let status = upstream_resp.status();
-                                let mut resp_builder = Response::builder().status(status);
-                                let response_connection_tokens =
-                                    connection_header_tokens(upstream_resp.headers());
-                                let preserve_upgrade_response_headers = is_websocket_upgrade
-                                    && status == StatusCode::SWITCHING_PROTOCOLS;
-                                for (name, value) in upstream_resp.headers() {
-                                    let preserve_upgrade_header = preserve_upgrade_response_headers
-                                        && (*name == http::header::CONNECTION
-                                            || *name == http::header::UPGRADE);
-                                    if should_strip_bootstrap_response_header(
-                                        name,
-                                        &response_connection_tokens,
-                                    ) && !preserve_upgrade_header
-                                    {
-                                        continue;
-                                    }
-                                    resp_builder = resp_builder.header(name, value);
+                                let normalized_response =
+                                    normalize_upstream_response(ResponseNormalizationInput {
+                                        upstream: spooky_bridge::response::UpstreamResponseView {
+                                            status,
+                                            headers: upstream_resp.headers(),
+                                            trailers: None,
+                                        },
+                                        body_mode: if suppress_downstream_body {
+                                            ResponseBodyMode::HeadRequest
+                                        } else {
+                                            ResponseBodyMode::Normal
+                                        },
+                                        constraints: ResponseProtocolConstraints {
+                                            protocol: ResponseNormalizationProtocol::Http1,
+                                            strip_connection_headers: true,
+                                            allow_trailers: false,
+                                            preserve_upgrade: is_websocket_upgrade
+                                                && status == StatusCode::SWITCHING_PROTOCOLS,
+                                        },
+                                    });
+                                let mut resp_builder =
+                                    Response::builder().status(normalized_response.head.status);
+                                for header in &normalized_response.head.headers {
+                                    resp_builder = resp_builder.header(&header.name, &header.value);
                                 }
                                 resp_builder = resp_builder.header("alt-svc", &alt);
                                 if is_websocket_upgrade
@@ -1161,7 +1171,10 @@ impl QUICListener {
                                             Response::new(boxed_full(Bytes::new()))
                                         }));
                                 }
-                                let resp_body = if suppress_downstream_body {
+                                let resp_body = if matches!(
+                                    normalized_response.emission.body,
+                                    ResponseBodyPolicy::Suppress
+                                ) {
                                     boxed_full(Bytes::new())
                                 } else {
                                     BootstrapStreamingBody::with_max_bytes(

--- a/crates/edge/src/quic_listener/forwarding/stream_progress.rs
+++ b/crates/edge/src/quic_listener/forwarding/stream_progress.rs
@@ -225,6 +225,13 @@ impl QUICListener {
                         let tunnel_response = streams
                             .get(&stream_id)
                             .is_some_and(|req| is_tunnel_response(req.tunnel_mode, status));
+                        let response_body_mode = if tunnel_response {
+                            ResponseBodyMode::TunnelSuccess
+                        } else if suppress_downstream_body {
+                            ResponseBodyMode::HeadRequest
+                        } else {
+                            ResponseBodyMode::Normal
+                        };
                         let upstream_content_length = resp_headers
                             .get(http::header::CONTENT_LENGTH)
                             .and_then(|v| v.to_str().ok())
@@ -271,15 +278,26 @@ impl QUICListener {
                             continue;
                         }
 
+                        let normalized_response =
+                            normalize_upstream_response(ResponseNormalizationInput {
+                                upstream: spooky_bridge::response::UpstreamResponseView {
+                                    status,
+                                    headers: &resp_headers,
+                                    trailers: None,
+                                },
+                                body_mode: response_body_mode,
+                                constraints: ResponseProtocolConstraints {
+                                    protocol: ResponseNormalizationProtocol::Http3,
+                                    strip_connection_headers: true,
+                                    allow_trailers: true,
+                                    preserve_upgrade: false,
+                                },
+                            });
                         let mut owned_h3_headers: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
-                        let response_connection_tokens = connection_header_tokens(&resp_headers);
-                        for (name, value) in resp_headers.iter() {
-                            if should_strip_h3_response_header(name, &response_connection_tokens) {
-                                continue;
-                            }
+                        for header in &normalized_response.head.headers {
                             owned_h3_headers.push((
-                                name.as_str().as_bytes().to_vec(),
-                                value.as_bytes().to_vec(),
+                                header.name.as_str().as_bytes().to_vec(),
+                                header.value.as_bytes().to_vec(),
                             ));
                         }
                         owned_h3_headers.push((
@@ -290,19 +308,19 @@ impl QUICListener {
 
                         let defer_headers_until_body_validated = upstream_content_length.is_none()
                             && !tunnel_response
-                            && !suppress_downstream_body;
-                        let immediate_end = suppress_downstream_body
-                            || (!tunnel_response
-                                && (upstream_content_length == Some(0)
-                                    || status == http::StatusCode::NO_CONTENT
-                                    || status == http::StatusCode::NOT_MODIFIED));
+                            && matches!(
+                                normalized_response.emission.body,
+                                ResponseBodyPolicy::Forward
+                            )
+                            && !normalized_response.emission.emit_end_stream_on_headers;
+                        let immediate_end = normalized_response.emission.emit_end_stream_on_headers;
                         let mut immediate_terminal = false;
 
                         if !defer_headers_until_body_validated {
                             let mut h3_headers = Vec::with_capacity(owned_h3_headers.len() + 1);
                             h3_headers.push(quiche::h3::Header::new(
                                 b":status",
-                                status.as_str().as_bytes(),
+                                normalized_response.head.status.as_str().as_bytes(),
                             ));
                             for (name, value) in &owned_h3_headers {
                                 h3_headers.push(quiche::h3::Header::new(name, value));
@@ -345,7 +363,7 @@ impl QUICListener {
                                 let mut h3_headers = Vec::with_capacity(owned_h3_headers.len() + 1);
                                 h3_headers.push(quiche::h3::Header::new(
                                     b":status",
-                                    status.as_str().as_bytes(),
+                                    normalized_response.head.status.as_str().as_bytes(),
                                 ));
                                 for (name, value) in &owned_h3_headers {
                                     h3_headers.push(quiche::h3::Header::new(name, value));

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -42,8 +42,10 @@ use socket2::{Domain, Protocol, Socket, Type};
 use spooky_bridge::response::{
     ResponseBodyMode, ResponseBodyPolicy, ResponseNormalizationInput,
     ResponseNormalizationProtocol, ResponseProtocolConstraints, normalize_response_trailers,
-    normalize_upstream_response, should_strip_response_header,
+    normalize_upstream_response,
 };
+#[cfg(test)]
+use spooky_bridge::response::should_strip_response_header;
 use spooky_config::{
     backend_endpoint::{BackendEndpoint, BackendScheme},
     config::{ClientAuth, UpstreamTls},
@@ -131,6 +133,7 @@ use validation::{
 };
 use x509_parser::{extensions::GeneralName, parse_x509_certificate};
 
+#[cfg(test)]
 fn connection_header_tokens(headers: &http::HeaderMap) -> HashSet<String> {
     let mut tokens = HashSet::new();
     for value in headers.get_all(http::header::CONNECTION) {
@@ -218,6 +221,7 @@ fn collect_h3_trailers(trailers: &http::HeaderMap) -> Vec<(Vec<u8>, Vec<u8>)> {
     .collect()
 }
 
+#[cfg(test)]
 fn should_strip_bootstrap_response_header(
     name: &http::header::HeaderName,
     connection_tokens: &HashSet<String>,

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -40,8 +40,9 @@ use rustls_pki_types::pem::PemObject;
 use serde_json::json;
 use socket2::{Domain, Protocol, Socket, Type};
 use spooky_bridge::response::{
+    ResponseBodyMode, ResponseBodyPolicy, ResponseNormalizationInput,
     ResponseNormalizationProtocol, ResponseProtocolConstraints, normalize_response_trailers,
-    should_strip_response_header,
+    normalize_upstream_response, should_strip_response_header,
 };
 use spooky_config::{
     backend_endpoint::{BackendEndpoint, BackendScheme},
@@ -180,6 +181,7 @@ fn should_strip_bootstrap_request_header(
     false
 }
 
+#[cfg(test)]
 fn should_strip_h3_response_header(
     name: &http::header::HeaderName,
     connection_tokens: &HashSet<String>,

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -39,13 +39,13 @@ use rustls::{
 use rustls_pki_types::pem::PemObject;
 use serde_json::json;
 use socket2::{Domain, Protocol, Socket, Type};
+#[cfg(test)]
+use spooky_bridge::response::should_strip_response_header;
 use spooky_bridge::response::{
     ResponseBodyMode, ResponseBodyPolicy, ResponseNormalizationInput,
     ResponseNormalizationProtocol, ResponseProtocolConstraints, normalize_response_trailers,
     normalize_upstream_response,
 };
-#[cfg(test)]
-use spooky_bridge::response::should_strip_response_header;
 use spooky_config::{
     backend_endpoint::{BackendEndpoint, BackendScheme},
     config::{ClientAuth, UpstreamTls},

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -39,6 +39,10 @@ use rustls::{
 use rustls_pki_types::pem::PemObject;
 use serde_json::json;
 use socket2::{Domain, Protocol, Socket, Type};
+use spooky_bridge::response::{
+    ResponseNormalizationProtocol, ResponseProtocolConstraints, normalize_response_trailers,
+    should_strip_response_header,
+};
 use spooky_config::{
     backend_endpoint::{BackendEndpoint, BackendScheme},
     config::{ClientAuth, UpstreamTls},
@@ -126,21 +130,6 @@ use validation::{
 };
 use x509_parser::{extensions::GeneralName, parse_x509_certificate};
 
-fn is_hop_header(name: &str) -> bool {
-    matches!(
-        name,
-        "connection"
-            | "keep-alive"
-            | "proxy-authenticate"
-            | "proxy-authorization"
-            | "proxy-connection"
-            | "transfer-encoding"
-            | "upgrade"
-            | "te"
-            | "trailer"
-    )
-}
-
 fn connection_header_tokens(headers: &http::HeaderMap) -> HashSet<String> {
     let mut tokens = HashSet::new();
     for value in headers.get_all(http::header::CONNECTION) {
@@ -195,30 +184,52 @@ fn should_strip_h3_response_header(
     name: &http::header::HeaderName,
     connection_tokens: &HashSet<String>,
 ) -> bool {
-    connection_tokens.contains(name.as_str())
-        || is_hop_header(name.as_str())
-        || name == http::header::CONTENT_LENGTH
+    should_strip_response_header(
+        name,
+        connection_tokens,
+        ResponseProtocolConstraints {
+            protocol: ResponseNormalizationProtocol::Http3,
+            strip_connection_headers: true,
+            allow_trailers: true,
+            preserve_upgrade: false,
+        },
+    )
 }
 
 fn collect_h3_trailers(trailers: &http::HeaderMap) -> Vec<(Vec<u8>, Vec<u8>)> {
-    let connection_tokens = connection_header_tokens(trailers);
-    let mut out = Vec::with_capacity(trailers.len());
-    for (name, value) in trailers.iter() {
-        if should_strip_h3_response_header(name, &connection_tokens) {
-            continue;
-        }
-        out.push((name.as_str().as_bytes().to_vec(), value.as_bytes().to_vec()));
-    }
-    out
+    normalize_response_trailers(
+        trailers,
+        ResponseProtocolConstraints {
+            protocol: ResponseNormalizationProtocol::Http3,
+            strip_connection_headers: true,
+            allow_trailers: true,
+            preserve_upgrade: false,
+        },
+    )
+    .into_iter()
+    .map(|header| {
+        (
+            header.name.as_str().as_bytes().to_vec(),
+            header.value.as_bytes().to_vec(),
+        )
+    })
+    .collect()
 }
 
 fn should_strip_bootstrap_response_header(
     name: &http::header::HeaderName,
     connection_tokens: &HashSet<String>,
 ) -> bool {
-    connection_tokens.contains(name.as_str())
-        || is_hop_header(name.as_str())
-        || name.as_str().eq_ignore_ascii_case("alt-svc")
+    should_strip_response_header(
+        name,
+        connection_tokens,
+        ResponseProtocolConstraints {
+            protocol: ResponseNormalizationProtocol::Http1,
+            strip_connection_headers: true,
+            allow_trailers: false,
+            preserve_upgrade: false,
+        },
+    )
 }
 
 fn response_size_exceeded_after_chunk(


### PR DESCRIPTION
## Summary

This PR introduces a canonical response-normalization layer shared by `bridge` and `edge`, removing path-specific response shaping differences between QUIC forwarding and bootstrap HTTP/TLS flows.

## What Changed

- added typed response-normalization inputs and protocol/body policy structs
- centralized hop-by-hop header stripping and `Connection` token filtering
- unified trailer normalization and conversion behavior
- centralized bodyless and no-content response shaping rules
- routed QUIC forwarding response emission through the canonical normalizer
- routed bootstrap response shaping through the same normalization layer
- added focused tests covering normalization parity and edge cases
- cleaned up old edge-local normalization helpers and tightened boundaries

## Why

Response handling had started to diverge across forwarding paths. This change makes header filtering, trailer handling, and bodyless/no-content behavior consistent, easier to reason about, and safer to evolve.

## Validation

- focused bridge normalization tests added and updated
- QUIC/bootstrap parity behavior covered in tests
- websocket upgrade header preservation regression addressed as part of follow-up fixes