### PR TITLE
refactor(edge): centralize streaming and body transfer guardrails

### DIFF
--- a/crates/edge/src/quic_listener/bootstrap_tls.rs
+++ b/crates/edge/src/quic_listener/bootstrap_tls.rs
@@ -1233,9 +1233,10 @@ impl QUICListener {
                                 ) {
                                     boxed_full(Bytes::new())
                                 } else {
-                                    BootstrapStreamingBody::with_max_bytes(
+                                    BootstrapStreamingBody::with_response_guardrails(
                                         upstream_resp.into_body(),
                                         max_response_body_bytes,
+                                        upstream_content_length,
                                     )
                                     .map_err(|never| match never {})
                                     .boxed()

--- a/crates/edge/src/quic_listener/bootstrap_tls.rs
+++ b/crates/edge/src/quic_listener/bootstrap_tls.rs
@@ -56,8 +56,16 @@ use crate::{
     resilience::runtime::RuntimeResilience,
     routing::index::RouteIndex,
     runtime::{
-        backend::store::RuntimeBackendResolutionStore, bundle::RuntimeBundleHandle,
-        shared_state::SharedRuntimeState, tls::store::ListenerTlsReloadStore,
+        backend::store::RuntimeBackendResolutionStore,
+        bundle::RuntimeBundleHandle,
+        connection::guardrails::{
+            BodyLimitKind, REQUEST_BODY_TOO_LARGE_BODY, RESPONSE_BODY_TOO_LARGE_BODY,
+            RequestBodyGuardrailConfig, RequestBodyGuardrailDecision, RequestBodyGuardrailInput,
+            ResponseBodyGuardrailConfig, ResponseBodyGuardrailDecision, ResponseBodyGuardrailInput,
+            evaluate_request_body_ingress, evaluate_response_body_guardrails,
+        },
+        shared_state::SharedRuntimeState,
+        tls::store::ListenerTlsReloadStore,
     },
 };
 
@@ -695,15 +703,34 @@ impl QUICListener {
                                 };
 
                                 let request_path = if path.is_empty() { "/" } else { &path };
-                                if !is_websocket_upgrade
-                                    && content_length
-                                        .is_some_and(|value| value > max_request_body_bytes)
-                                {
+                                let request_size_decision = evaluate_request_body_ingress(
+                                    RequestBodyGuardrailConfig {
+                                        idle_timeout: Duration::ZERO,
+                                        total_timeout: Duration::ZERO,
+                                        max_body_bytes: max_request_body_bytes,
+                                        max_buffered_bytes: usize::MAX,
+                                    },
+                                    RequestBodyGuardrailInput {
+                                        elapsed: Duration::ZERO,
+                                        idle_for: Duration::ZERO,
+                                        bytes_received: 0,
+                                        buffered_bytes: 0,
+                                        next_chunk_bytes: 0,
+                                        declared_content_length: content_length,
+                                        exempt_from_body_size_cap: is_websocket_upgrade,
+                                    },
+                                );
+                                if matches!(
+                                    request_size_decision,
+                                    RequestBodyGuardrailDecision::Reject {
+                                        kind: BodyLimitKind::BodySizeCap,
+                                    }
+                                ) {
                                     return Ok(Response::builder()
                                         .status(StatusCode::PAYLOAD_TOO_LARGE)
                                         .header("alt-svc", &alt)
                                         .body(boxed_full(Bytes::from_static(
-                                            b"request body too large\n",
+                                            REQUEST_BODY_TOO_LARGE_BODY,
                                         )))
                                         .unwrap_or_else(|_| {
                                             Response::new(boxed_full(Bytes::from_static(
@@ -1075,27 +1102,6 @@ impl QUICListener {
                                     }
                                 };
 
-                                if !suppress_downstream_body
-                                    && let Some(content_length) = upstream_resp
-                                        .headers()
-                                        .get(http::header::CONTENT_LENGTH)
-                                        .and_then(|v| v.to_str().ok())
-                                        .and_then(|s| s.parse::<usize>().ok())
-                                    && content_length > max_response_body_bytes
-                                {
-                                    return Ok(Response::builder()
-                                        .status(StatusCode::SERVICE_UNAVAILABLE)
-                                        .header("alt-svc", &alt)
-                                        .body(boxed_full(Bytes::from_static(
-                                            b"upstream response body too large\n",
-                                        )))
-                                        .unwrap_or_else(|_| {
-                                            Response::new(boxed_full(Bytes::from_static(
-                                                b"error\n",
-                                            )))
-                                        }));
-                                }
-
                                 let status = upstream_resp.status();
                                 let normalized_response =
                                     normalize_upstream_response(ResponseNormalizationInput {
@@ -1117,6 +1123,56 @@ impl QUICListener {
                                                 && status == StatusCode::SWITCHING_PROTOCOLS,
                                         },
                                     });
+                                let upstream_content_length = upstream_resp
+                                    .headers()
+                                    .get(http::header::CONTENT_LENGTH)
+                                    .and_then(|v| v.to_str().ok())
+                                    .and_then(|s| s.parse::<usize>().ok());
+                                let response_size_decision = evaluate_response_body_guardrails(
+                                    ResponseBodyGuardrailConfig {
+                                        idle_timeout: Duration::ZERO,
+                                        total_timeout: Duration::MAX,
+                                        max_body_bytes: max_response_body_bytes,
+                                        unknown_length_prebuffer_bytes: max_response_body_bytes,
+                                        chunk_bytes: 1,
+                                    },
+                                    ResponseBodyGuardrailInput {
+                                        elapsed: Duration::ZERO,
+                                        idle_for: Duration::ZERO,
+                                        bytes_received: 0,
+                                        prebuffered_bytes: 0,
+                                        next_chunk_bytes: 0,
+                                        declared_content_length: upstream_content_length,
+                                        headers_emitted: false,
+                                        progressive_emission_allowed: !normalized_response
+                                            .emission
+                                            .emit_end_stream_on_headers,
+                                        body_forwarding_enabled: matches!(
+                                            normalized_response.emission.body,
+                                            ResponseBodyPolicy::Forward
+                                        ),
+                                        exempt_from_body_size_cap: is_websocket_upgrade
+                                            && status == StatusCode::SWITCHING_PROTOCOLS,
+                                    },
+                                );
+                                if matches!(
+                                    response_size_decision,
+                                    ResponseBodyGuardrailDecision::Reject {
+                                        kind: BodyLimitKind::BodySizeCap,
+                                    }
+                                ) {
+                                    return Ok(Response::builder()
+                                        .status(StatusCode::SERVICE_UNAVAILABLE)
+                                        .header("alt-svc", &alt)
+                                        .body(boxed_full(Bytes::from_static(
+                                            RESPONSE_BODY_TOO_LARGE_BODY,
+                                        )))
+                                        .unwrap_or_else(|_| {
+                                            Response::new(boxed_full(Bytes::from_static(
+                                                b"error\n",
+                                            )))
+                                        }));
+                                }
                                 let mut resp_builder =
                                     Response::builder().status(normalized_response.head.status);
                                 for header in &normalized_response.head.headers {

--- a/crates/edge/src/quic_listener/bootstrap_tls.rs
+++ b/crates/edge/src/quic_listener/bootstrap_tls.rs
@@ -723,7 +723,7 @@ impl QUICListener {
                                 if matches!(
                                     request_size_decision,
                                     Err(RequestBodyGuardrailDecision::Reject {
-                                        kind: BodyLimitKind::BodySizeCap,
+                                        kind: BodyLimitKind::BodySize,
                                     })
                                 ) {
                                     return Ok(Response::builder()
@@ -1158,7 +1158,7 @@ impl QUICListener {
                                 if matches!(
                                     response_size_decision,
                                     Err(ResponseBodyGuardrailDecision::Reject {
-                                        kind: BodyLimitKind::BodySizeCap,
+                                        kind: BodyLimitKind::BodySize,
                                     })
                                 ) {
                                     return Ok(Response::builder()

--- a/crates/edge/src/quic_listener/bootstrap_tls.rs
+++ b/crates/edge/src/quic_listener/bootstrap_tls.rs
@@ -62,7 +62,7 @@ use crate::{
             BodyLimitKind, REQUEST_BODY_TOO_LARGE_BODY, RESPONSE_BODY_TOO_LARGE_BODY,
             RequestBodyGuardrailConfig, RequestBodyGuardrailDecision, RequestBodyGuardrailInput,
             ResponseBodyGuardrailConfig, ResponseBodyGuardrailDecision, ResponseBodyGuardrailInput,
-            evaluate_request_body_ingress, evaluate_response_body_guardrails,
+            checked_request_body_ingress, checked_response_body_guardrails,
         },
         shared_state::SharedRuntimeState,
         tls::store::ListenerTlsReloadStore,
@@ -703,7 +703,7 @@ impl QUICListener {
                                 };
 
                                 let request_path = if path.is_empty() { "/" } else { &path };
-                                let request_size_decision = evaluate_request_body_ingress(
+                                let request_size_decision = checked_request_body_ingress(
                                     RequestBodyGuardrailConfig {
                                         idle_timeout: Duration::ZERO,
                                         total_timeout: Duration::ZERO,
@@ -722,9 +722,9 @@ impl QUICListener {
                                 );
                                 if matches!(
                                     request_size_decision,
-                                    RequestBodyGuardrailDecision::Reject {
+                                    Err(RequestBodyGuardrailDecision::Reject {
                                         kind: BodyLimitKind::BodySizeCap,
-                                    }
+                                    })
                                 ) {
                                     return Ok(Response::builder()
                                         .status(StatusCode::PAYLOAD_TOO_LARGE)
@@ -1128,7 +1128,7 @@ impl QUICListener {
                                     .get(http::header::CONTENT_LENGTH)
                                     .and_then(|v| v.to_str().ok())
                                     .and_then(|s| s.parse::<usize>().ok());
-                                let response_size_decision = evaluate_response_body_guardrails(
+                                let response_size_decision = checked_response_body_guardrails(
                                     ResponseBodyGuardrailConfig {
                                         idle_timeout: Duration::ZERO,
                                         total_timeout: Duration::MAX,
@@ -1157,9 +1157,9 @@ impl QUICListener {
                                 );
                                 if matches!(
                                     response_size_decision,
-                                    ResponseBodyGuardrailDecision::Reject {
+                                    Err(ResponseBodyGuardrailDecision::Reject {
                                         kind: BodyLimitKind::BodySizeCap,
-                                    }
+                                    })
                                 ) {
                                     return Ok(Response::builder()
                                         .status(StatusCode::SERVICE_UNAVAILABLE)

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -923,10 +923,23 @@ impl QUICListener {
                                                     max_request_body_bytes,
                                                     request_buffer_global_cap_bytes,
                                                 ) {
-                                                    shed_due_to_buffer_pressure = true;
-                                                    metrics.inc_request_buffer_limit_reject();
-                                                    if err == RequestBufferError::GlobalCap {
-                                                        debug!("global request buffer cap reached");
+                                                    if err == RequestBufferError::BodySizeCap {
+                                                        payload_too_large = Some((
+                                                            req.upstream_name
+                                                                .clone()
+                                                                .unwrap_or_else(|| {
+                                                                    "unrouted".to_string()
+                                                                }),
+                                                            req.start.elapsed(),
+                                                        ));
+                                                    } else {
+                                                        shed_due_to_buffer_pressure = true;
+                                                        metrics.inc_request_buffer_limit_reject();
+                                                        if err == RequestBufferError::GlobalCap {
+                                                            debug!(
+                                                                "global request buffer cap reached"
+                                                            );
+                                                        }
                                                     }
                                                     break;
                                                 }

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -878,7 +878,7 @@ impl QUICListener {
                                     ));
                                 }
                                 if reject_body_for_bodyless.is_none() {
-                                    let decision = evaluate_request_body_ingress(
+                                    let next_state = checked_request_body_ingress(
                                         RequestBodyGuardrailConfig {
                                             idle_timeout: Duration::ZERO,
                                             total_timeout: Duration::ZERO,
@@ -898,40 +898,53 @@ impl QUICListener {
                                             ),
                                         },
                                     );
-                                    if matches!(
-                                        decision,
-                                        RequestBodyGuardrailDecision::Reject {
+                                    match next_state {
+                                        Err(RequestBodyGuardrailDecision::Reject {
                                             kind: BodyLimitKind::BodySizeCap,
+                                        }) => {
+                                            payload_too_large = Some((
+                                                req.upstream_name
+                                                    .clone()
+                                                    .unwrap_or_else(|| "unrouted".to_string()),
+                                                req.start.elapsed(),
+                                            ));
                                         }
-                                    ) {
-                                        payload_too_large = Some((
-                                            req.upstream_name
-                                                .clone()
-                                                .unwrap_or_else(|| "unrouted".to_string()),
-                                            req.start.elapsed(),
-                                        ));
-                                    } else {
-                                        req.body_bytes_received =
-                                            req.body_bytes_received.saturating_add(read);
+                                        Ok(next_state) => {
+                                            req.body_bytes_received = next_state.bytes_received;
 
-                                        for chunk_slice in
-                                            body_buf[..read].chunks(REQUEST_CHUNK_BYTES_LIMIT)
-                                        {
-                                            let chunk = Bytes::copy_from_slice(chunk_slice);
-                                            if let Err(err) = Self::enqueue_request_chunk(
-                                                req,
-                                                chunk,
-                                                &metrics,
-                                                max_request_body_bytes,
-                                                request_buffer_global_cap_bytes,
-                                            ) {
-                                                shed_due_to_buffer_pressure = true;
-                                                metrics.inc_request_buffer_limit_reject();
-                                                if err == RequestBufferError::GlobalCap {
-                                                    debug!("global request buffer cap reached");
+                                            for chunk_slice in
+                                                body_buf[..read].chunks(REQUEST_CHUNK_BYTES_LIMIT)
+                                            {
+                                                let chunk = Bytes::copy_from_slice(chunk_slice);
+                                                if let Err(err) = Self::enqueue_request_chunk(
+                                                    req,
+                                                    chunk,
+                                                    &metrics,
+                                                    max_request_body_bytes,
+                                                    request_buffer_global_cap_bytes,
+                                                ) {
+                                                    shed_due_to_buffer_pressure = true;
+                                                    metrics.inc_request_buffer_limit_reject();
+                                                    if err == RequestBufferError::GlobalCap {
+                                                        debug!("global request buffer cap reached");
+                                                    }
+                                                    break;
                                                 }
-                                                break;
                                             }
+                                        }
+                                        Err(RequestBodyGuardrailDecision::Reject {
+                                            kind:
+                                                BodyLimitKind::UnknownLengthPrebufferCap
+                                                | BodyLimitKind::BufferedBodyCap,
+                                        }) => {
+                                            shed_due_to_buffer_pressure = true;
+                                            metrics.inc_request_buffer_limit_reject();
+                                        }
+                                        Err(other) => {
+                                            unreachable!(
+                                                "request ingress should not timeout in data path: {:?}",
+                                                other
+                                            );
                                         }
                                     }
                                 }

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -878,11 +878,32 @@ impl QUICListener {
                                     ));
                                 }
                                 if reject_body_for_bodyless.is_none() {
-                                    // Enforce cap on total bytes received for the stream,
-                                    // including chunks already forwarded to the H2 body channel.
-                                    let next_total = req.body_bytes_received.saturating_add(read);
-                                    let request_is_connect = is_connect_method(&req.method);
-                                    if !request_is_connect && next_total > max_request_body_bytes {
+                                    let decision = evaluate_request_body_ingress(
+                                        RequestBodyGuardrailConfig {
+                                            idle_timeout: Duration::ZERO,
+                                            total_timeout: Duration::ZERO,
+                                            max_body_bytes: max_request_body_bytes,
+                                            max_buffered_bytes: usize::MAX,
+                                        },
+                                        RequestBodyGuardrailInput {
+                                            elapsed: req.start.elapsed(),
+                                            idle_for: Instant::now()
+                                                .saturating_duration_since(req.last_body_activity),
+                                            bytes_received: req.body_bytes_received,
+                                            buffered_bytes: 0,
+                                            next_chunk_bytes: read,
+                                            declared_content_length: None,
+                                            exempt_from_body_size_cap: is_connect_method(
+                                                &req.method,
+                                            ),
+                                        },
+                                    );
+                                    if matches!(
+                                        decision,
+                                        RequestBodyGuardrailDecision::Reject {
+                                            kind: BodyLimitKind::BodySizeCap,
+                                        }
+                                    ) {
                                         payload_too_large = Some((
                                             req.upstream_name
                                                 .clone()
@@ -890,7 +911,8 @@ impl QUICListener {
                                             req.start.elapsed(),
                                         ));
                                     } else {
-                                        req.body_bytes_received = next_total;
+                                        req.body_bytes_received =
+                                            req.body_bytes_received.saturating_add(read);
 
                                         for chunk_slice in
                                             body_buf[..read].chunks(REQUEST_CHUNK_BYTES_LIMIT)

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -961,7 +961,7 @@ impl QUICListener {
                                     &mut connection.quic,
                                     stream_id,
                                     http::StatusCode::PAYLOAD_TOO_LARGE,
-                                    b"request body too large\n",
+                                    REQUEST_BODY_TOO_LARGE_BODY,
                                 )?;
                                 if let Some(req) = connection.streams.get_mut(&stream_id) {
                                     abort_stream(req, &metrics);

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -900,7 +900,7 @@ impl QUICListener {
                                     );
                                     match next_state {
                                         Err(RequestBodyGuardrailDecision::Reject {
-                                            kind: BodyLimitKind::BodySizeCap,
+                                            kind: BodyLimitKind::BodySize,
                                         }) => {
                                             payload_too_large = Some((
                                                 req.upstream_name
@@ -923,7 +923,7 @@ impl QUICListener {
                                                     max_request_body_bytes,
                                                     request_buffer_global_cap_bytes,
                                                 ) {
-                                                    if err == RequestBufferError::BodySizeCap {
+                                                    if err == RequestBufferError::BodySize {
                                                         payload_too_large = Some((
                                                             req.upstream_name
                                                                 .clone()
@@ -935,7 +935,7 @@ impl QUICListener {
                                                     } else {
                                                         shed_due_to_buffer_pressure = true;
                                                         metrics.inc_request_buffer_limit_reject();
-                                                        if err == RequestBufferError::GlobalCap {
+                                                        if err == RequestBufferError::Global {
                                                             debug!(
                                                                 "global request buffer cap reached"
                                                             );
@@ -947,8 +947,8 @@ impl QUICListener {
                                         }
                                         Err(RequestBodyGuardrailDecision::Reject {
                                             kind:
-                                                BodyLimitKind::UnknownLengthPrebufferCap
-                                                | BodyLimitKind::BufferedBodyCap,
+                                                BodyLimitKind::UnknownLengthPrebuffer
+                                                | BodyLimitKind::BufferedBody,
                                         }) => {
                                             shed_due_to_buffer_pressure = true;
                                             metrics.inc_request_buffer_limit_reject();

--- a/crates/edge/src/quic_listener/forwarding/response.rs
+++ b/crates/edge/src/quic_listener/forwarding/response.rs
@@ -2,7 +2,9 @@ use spooky_errors::{UpstreamProxyErrorKind, classify_upstream_proxy_error};
 use tokio::sync::mpsc::error::TryRecvError;
 
 use super::*;
-use crate::runtime::connection::auth::ExternalAuthDecision;
+use crate::runtime::connection::{
+    auth::ExternalAuthDecision, guardrails::is_unknown_length_response_prebuffer_reason,
+};
 
 impl QUICListener {
     /// Handle an already-resolved `ForwardResult`, applying health transitions
@@ -99,7 +101,7 @@ impl QUICListener {
             }
             Err(ProxyError::Pool(PoolError::BackendOverloaded(reason))) => {
                 metrics.inc_failure();
-                if reason.contains("unknown-length response prebuffer limit exceeded") {
+                if is_unknown_length_response_prebuffer_reason(&reason) {
                     metrics.inc_response_prebuffer_limit_reject();
                     metrics.inc_overload_shed_reason(OverloadShedReason::ResponsePrebufferCap);
                 } else {
@@ -720,7 +722,7 @@ impl QUICListener {
                         }
                         ProxyError::Pool(PoolError::BackendOverloaded(reason)) => {
                             metrics.inc_failure();
-                            if reason.contains("unknown-length response prebuffer limit exceeded") {
+                            if is_unknown_length_response_prebuffer_reason(&reason) {
                                 metrics.inc_response_prebuffer_limit_reject();
                                 metrics.inc_overload_shed_reason(
                                     OverloadShedReason::ResponsePrebufferCap,

--- a/crates/edge/src/quic_listener/forwarding/stream_progress.rs
+++ b/crates/edge/src/quic_listener/forwarding/stream_progress.rs
@@ -2,10 +2,32 @@ use super::*;
 use crate::runtime::connection::{
     auth::ExternalAuthResult,
     guardrails::{
-        BodyTimeoutKind, RequestBodyGuardrailConfig, RequestBodyGuardrailDecision,
-        RequestBodyGuardrailInput, evaluate_request_body_timeouts,
+        BodyLimitKind, BodyTimeoutKind, ProgressiveEmissionPolicy, RequestBodyGuardrailConfig,
+        RequestBodyGuardrailDecision, RequestBodyGuardrailInput, ResponseBodyGuardrailConfig,
+        ResponseBodyGuardrailDecision, ResponseBodyGuardrailInput, evaluate_request_body_timeouts,
+        evaluate_response_body_guardrails, response_chunk_ranges,
     },
 };
+
+fn response_body_guardrail_error(decision: ResponseBodyGuardrailDecision) -> Option<ProxyError> {
+    match decision {
+        ResponseBodyGuardrailDecision::Continue { .. } => None,
+        ResponseBodyGuardrailDecision::Timeout { .. } => Some(ProxyError::Timeout),
+        ResponseBodyGuardrailDecision::Reject {
+            kind: BodyLimitKind::BodySizeCap,
+        } => Some(ProxyError::Pool(PoolError::BackendOverloaded(
+            "upstream response body too large".into(),
+        ))),
+        ResponseBodyGuardrailDecision::Reject {
+            kind: BodyLimitKind::UnknownLengthPrebufferCap,
+        } => Some(ProxyError::Pool(PoolError::BackendOverloaded(
+            "unknown-length response prebuffer limit exceeded".into(),
+        ))),
+        ResponseBodyGuardrailDecision::Reject { .. } => Some(ProxyError::Pool(
+            PoolError::BackendOverloaded("upstream response rejected".into()),
+        )),
+    }
+}
 
 impl QUICListener {
     /// Advance all in-flight streams without blocking.
@@ -298,11 +320,56 @@ impl QUICListener {
                             .get(http::header::CONTENT_LENGTH)
                             .and_then(|v| v.to_str().ok())
                             .and_then(|v| v.parse::<usize>().ok());
-                        if !tunnel_response
-                            && !suppress_downstream_body
-                            && upstream_content_length
-                                .is_some_and(|len| len > progress_config.max_response_body_bytes)
-                        {
+                        let normalized_response =
+                            normalize_upstream_response(ResponseNormalizationInput {
+                                upstream: spooky_bridge::response::UpstreamResponseView {
+                                    status,
+                                    headers: &resp_headers,
+                                    trailers: None,
+                                },
+                                body_mode: response_body_mode,
+                                constraints: ResponseProtocolConstraints {
+                                    protocol: ResponseNormalizationProtocol::Http3,
+                                    strip_connection_headers: true,
+                                    allow_trailers: true,
+                                    preserve_upgrade: false,
+                                },
+                            });
+                        let body_forwarding_enabled = matches!(
+                            normalized_response.emission.body,
+                            ResponseBodyPolicy::Forward
+                        );
+                        let progressive_body_emission_allowed =
+                            !normalized_response.emission.emit_end_stream_on_headers;
+                        let response_guardrails = ResponseBodyGuardrailConfig {
+                            idle_timeout: progress_config.backend_body_idle_timeout,
+                            total_timeout: progress_config.backend_body_total_timeout,
+                            max_body_bytes: progress_config.max_response_body_bytes,
+                            unknown_length_prebuffer_bytes: progress_config
+                                .unknown_length_response_prebuffer_bytes,
+                            chunk_bytes: RESPONSE_CHUNK_BYTES_LIMIT,
+                        };
+                        let preflight_guardrail = evaluate_response_body_guardrails(
+                            response_guardrails,
+                            ResponseBodyGuardrailInput {
+                                elapsed: Duration::ZERO,
+                                idle_for: Duration::ZERO,
+                                bytes_received: 0,
+                                prebuffered_bytes: 0,
+                                next_chunk_bytes: 0,
+                                declared_content_length: upstream_content_length,
+                                headers_emitted: false,
+                                progressive_emission_allowed: progressive_body_emission_allowed,
+                                body_forwarding_enabled,
+                                exempt_from_body_size_cap: tunnel_response,
+                            },
+                        );
+                        if matches!(
+                            preflight_guardrail,
+                            ResponseBodyGuardrailDecision::Reject {
+                                kind: BodyLimitKind::BodySizeCap,
+                            }
+                        ) {
                             if let Some(req) = streams.get(&stream_id) {
                                 metrics.inc_failure();
                                 metrics.inc_overload_shed_reason(
@@ -339,22 +406,6 @@ impl QUICListener {
                             streams.remove(&stream_id);
                             continue;
                         }
-
-                        let normalized_response =
-                            normalize_upstream_response(ResponseNormalizationInput {
-                                upstream: spooky_bridge::response::UpstreamResponseView {
-                                    status,
-                                    headers: &resp_headers,
-                                    trailers: None,
-                                },
-                                body_mode: response_body_mode,
-                                constraints: ResponseProtocolConstraints {
-                                    protocol: ResponseNormalizationProtocol::Http3,
-                                    strip_connection_headers: true,
-                                    allow_trailers: true,
-                                    preserve_upgrade: false,
-                                },
-                            });
                         let mut owned_h3_headers: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
                         for header in &normalized_response.head.headers {
                             owned_h3_headers.push((
@@ -368,13 +419,14 @@ impl QUICListener {
                                 .into_bytes(),
                         ));
 
-                        let defer_headers_until_body_validated = upstream_content_length.is_none()
-                            && !tunnel_response
-                            && matches!(
-                                normalized_response.emission.body,
-                                ResponseBodyPolicy::Forward
-                            )
-                            && !normalized_response.emission.emit_end_stream_on_headers;
+                        let defer_headers_until_body_validated = matches!(
+                            preflight_guardrail,
+                            ResponseBodyGuardrailDecision::Continue { streaming }
+                                if matches!(
+                                    streaming.emission,
+                                    ProgressiveEmissionPolicy::PrebufferUntilValidated
+                                )
+                        );
                         let immediate_end = normalized_response.emission.emit_end_stream_on_headers;
                         let mut immediate_terminal = false;
 
@@ -481,16 +533,13 @@ impl QUICListener {
                                 let (chunk_tx, chunk_rx) =
                                     mpsc::channel::<ResponseChunk>(RESPONSE_CHUNK_CHANNEL_CAPACITY);
                                 let fail_tx = chunk_tx.clone();
-                                let body_idle_timeout = progress_config.backend_body_idle_timeout;
-                                let max_response_body_bytes =
-                                    progress_config.max_response_body_bytes;
-                                let unknown_length_response_prebuffer_bytes =
-                                    progress_config.unknown_length_response_prebuffer_bytes;
-                                let first_byte_deadline = tokio::time::Instant::now()
-                                    + progress_config.backend_body_total_timeout;
                                 let deferred_status = status;
                                 let deferred_headers = owned_h3_headers.clone();
                                 let tunnel_mode = tunnel_response;
+                                let response_guardrails = response_guardrails;
+                                let progressive_emission_allowed =
+                                    progressive_body_emission_allowed;
+                                let body_forwarding_enabled = body_forwarding_enabled;
                                 let fut = async move {
                                     use http_body_util::BodyExt;
                                     let Some(mut body) = response_body else {
@@ -502,29 +551,49 @@ impl QUICListener {
                                             .await;
                                         return;
                                     };
+                                    let body_started_at = tokio::time::Instant::now();
+                                    let mut last_body_progress_at = body_started_at;
                                     let mut response_bytes_received: usize = 0;
+                                    let mut prebuffered_bytes: usize = 0;
                                     let mut buffered_chunks: Vec<Bytes> = Vec::new();
                                     let mut buffered_trailers: Option<Vec<(Vec<u8>, Vec<u8>)>> =
                                         None;
-                                    let mut saw_body_progress = false;
                                     loop {
-                                        let frame_fut = BodyExt::frame(&mut body);
-                                        let now = tokio::time::Instant::now();
-                                        if !saw_body_progress && now >= first_byte_deadline {
-                                            let _ = chunk_tx
-                                                .send(ResponseChunk::Error(ProxyError::Timeout))
-                                                .await;
-                                            return;
-                                        }
-                                        let wait_timeout = if saw_body_progress {
-                                            body_idle_timeout
-                                        } else {
-                                            first_byte_deadline
-                                                .saturating_duration_since(now)
-                                                .min(body_idle_timeout)
+                                        let wait_decision = evaluate_response_body_guardrails(
+                                            response_guardrails,
+                                            ResponseBodyGuardrailInput {
+                                                elapsed: body_started_at.elapsed(),
+                                                idle_for: last_body_progress_at.elapsed(),
+                                                bytes_received: response_bytes_received,
+                                                prebuffered_bytes,
+                                                next_chunk_bytes: 0,
+                                                declared_content_length: upstream_content_length,
+                                                headers_emitted:
+                                                    !defer_headers_until_body_validated,
+                                                progressive_emission_allowed,
+                                                body_forwarding_enabled,
+                                                exempt_from_body_size_cap: tunnel_mode,
+                                            },
+                                        );
+                                        let streaming = match wait_decision {
+                                            ResponseBodyGuardrailDecision::Continue {
+                                                streaming,
+                                            } => streaming,
+                                            other => {
+                                                if let Some(err) =
+                                                    response_body_guardrail_error(other)
+                                                {
+                                                    let _ = chunk_tx
+                                                        .send(ResponseChunk::Error(err))
+                                                        .await;
+                                                }
+                                                return;
+                                            }
                                         };
+                                        let frame_fut = BodyExt::frame(&mut body);
                                         let result =
-                                            tokio::time::timeout(wait_timeout, frame_fut).await;
+                                            tokio::time::timeout(streaming.wait_timeout, frame_fut)
+                                                .await;
                                         match result {
                                             Err(_elapsed) => {
                                                 let _ = chunk_tx
@@ -535,68 +604,72 @@ impl QUICListener {
                                             Ok(Some(Ok(f))) => match f.into_data() {
                                                 Ok(data) => {
                                                     if !data.is_empty() {
-                                                        saw_body_progress = true;
+                                                        last_body_progress_at =
+                                                            tokio::time::Instant::now();
                                                     }
-                                                    if !tunnel_mode
-                                                        && response_size_exceeded_after_chunk(
-                                                            &mut response_bytes_received,
-                                                            data.len(),
-                                                            max_response_body_bytes,
-                                                        )
-                                                    {
-                                                        let _ = chunk_tx
-                                                            .send(ResponseChunk::Error(
-                                                                ProxyError::Pool(
-                                                                    PoolError::BackendOverloaded(
-                                                                        "upstream response body too large"
-                                                                            .into(),
-                                                                    ),
-                                                                ),
-                                                            ))
-                                                            .await;
-                                                        return;
-                                                    }
-                                                    if defer_headers_until_body_validated {
-                                                        if response_bytes_received
-                                                            > unknown_length_response_prebuffer_bytes
-                                                        {
-                                                            let _ = chunk_tx
-                                                                .send(ResponseChunk::Error(
-                                                                    ProxyError::Pool(
-                                                                        PoolError::BackendOverloaded(
-                                                                            "unknown-length response prebuffer limit exceeded"
-                                                                                .into(),
-                                                                        ),
-                                                                    ),
-                                                                ))
-                                                                .await;
+                                                    let data_decision =
+                                                        evaluate_response_body_guardrails(
+                                                            response_guardrails,
+                                                            ResponseBodyGuardrailInput {
+                                                                elapsed: body_started_at.elapsed(),
+                                                                idle_for: last_body_progress_at
+                                                                    .elapsed(),
+                                                                bytes_received: response_bytes_received,
+                                                                prebuffered_bytes,
+                                                                next_chunk_bytes: data.len(),
+                                                                declared_content_length: upstream_content_length,
+                                                                headers_emitted: !defer_headers_until_body_validated,
+                                                                progressive_emission_allowed,
+                                                                body_forwarding_enabled,
+                                                                exempt_from_body_size_cap: tunnel_mode,
+                                                            },
+                                                        );
+                                                    let streaming = match data_decision {
+                                                        ResponseBodyGuardrailDecision::Continue {
+                                                            streaming,
+                                                        } => streaming,
+                                                        other => {
+                                                            if let Some(err) =
+                                                                response_body_guardrail_error(other)
+                                                            {
+                                                                let _ = chunk_tx
+                                                                    .send(ResponseChunk::Error(err))
+                                                                    .await;
+                                                            }
                                                             return;
                                                         }
-                                                        for start in (0..data.len())
-                                                            .step_by(RESPONSE_CHUNK_BYTES_LIMIT)
-                                                        {
-                                                            let end = (start
-                                                                + RESPONSE_CHUNK_BYTES_LIMIT)
-                                                                .min(data.len());
-                                                            buffered_chunks
-                                                                .push(data.slice(start..end));
-                                                        }
+                                                    };
+                                                    response_bytes_received =
+                                                        response_bytes_received
+                                                            .saturating_add(data.len());
+                                                    if matches!(
+                                                        streaming.emission,
+                                                        ProgressiveEmissionPolicy::PrebufferUntilValidated
+                                                    ) {
+                                                        prebuffered_bytes = prebuffered_bytes
+                                                            .saturating_add(data.len());
                                                     } else {
-                                                        for start in (0..data.len())
-                                                            .step_by(RESPONSE_CHUNK_BYTES_LIMIT)
-                                                        {
-                                                            let end = (start
-                                                                + RESPONSE_CHUNK_BYTES_LIMIT)
-                                                                .min(data.len());
-                                                            if chunk_tx
-                                                                .send(ResponseChunk::Data(
-                                                                    data.slice(start..end),
-                                                                ))
-                                                                .await
-                                                                .is_err()
-                                                            {
-                                                                return;
+                                                        prebuffered_bytes = 0;
+                                                    }
+                                                    for (start, end) in response_chunk_ranges(
+                                                        data.len(),
+                                                        streaming.chunk_emission,
+                                                    ) {
+                                                        let chunk = data.slice(start..end);
+                                                        match streaming.emission {
+                                                            ProgressiveEmissionPolicy::PrebufferUntilValidated => {
+                                                                buffered_chunks.push(chunk);
                                                             }
+                                                            ProgressiveEmissionPolicy::StreamProgressively => {
+                                                                if chunk_tx
+                                                                    .send(ResponseChunk::Data(chunk))
+                                                                    .await
+                                                                    .is_err()
+                                                                {
+                                                                    return;
+                                                                }
+                                                            }
+                                                            ProgressiveEmissionPolicy::SuppressBody => {}
                                                         }
                                                     }
                                                 }

--- a/crates/edge/src/quic_listener/forwarding/stream_progress.rs
+++ b/crates/edge/src/quic_listener/forwarding/stream_progress.rs
@@ -1,5 +1,11 @@
 use super::*;
-use crate::runtime::connection::auth::ExternalAuthResult;
+use crate::runtime::connection::{
+    auth::ExternalAuthResult,
+    guardrails::{
+        BodyTimeoutKind, RequestBodyGuardrailConfig, RequestBodyGuardrailDecision,
+        RequestBodyGuardrailInput, evaluate_request_body_timeouts,
+    },
+};
 
 impl QUICListener {
     /// Advance all in-flight streams without blocking.
@@ -34,8 +40,92 @@ impl QUICListener {
         let stream_ids: Vec<u64> = streams.keys().copied().collect();
 
         for stream_id in stream_ids {
+            let now = Instant::now();
             if let Some(req) = streams.get(&stream_id)
-                && Instant::now() >= req.total_request_deadline
+                && req.phase == StreamPhase::ReceivingRequest
+                && !req.request_fin_received
+                && !req.bodyless_mode
+            {
+                let timeout_decision = evaluate_request_body_timeouts(
+                    RequestBodyGuardrailConfig {
+                        idle_timeout: progress_config.client_body_idle_timeout,
+                        total_timeout: req
+                            .total_request_deadline
+                            .checked_duration_since(req.start)
+                            .unwrap_or_default(),
+                        max_body_bytes: usize::MAX,
+                        max_buffered_bytes: usize::MAX,
+                    },
+                    RequestBodyGuardrailInput {
+                        elapsed: req.start.elapsed(),
+                        idle_for: now.saturating_duration_since(req.last_body_activity),
+                        bytes_received: req.body_bytes_received,
+                        buffered_bytes: req.body_buf_bytes,
+                        next_chunk_bytes: 0,
+                        declared_content_length: None,
+                        exempt_from_body_size_cap: false,
+                    },
+                );
+
+                if matches!(
+                    timeout_decision,
+                    RequestBodyGuardrailDecision::Timeout {
+                        kind: BodyTimeoutKind::Total,
+                    }
+                ) {
+                    if let Err(protocol_err) = Self::handle_forward_result(
+                        h3,
+                        quic,
+                        stream_id,
+                        req,
+                        Err(ProxyError::Timeout),
+                        shared_ctx,
+                    ) {
+                        error!(
+                            "failed to emit timeout response for stream {}: {:?}",
+                            stream_id, protocol_err
+                        );
+                    }
+                    resilience
+                        .adaptive_admission
+                        .observe(req.start.elapsed(), true);
+                    if let Some(req) = streams.get_mut(&stream_id) {
+                        abort_stream(req, metrics);
+                    }
+                    streams.remove(&stream_id);
+                    continue;
+                }
+
+                if matches!(
+                    timeout_decision,
+                    RequestBodyGuardrailDecision::Timeout {
+                        kind: BodyTimeoutKind::Idle,
+                    }
+                ) {
+                    metrics.inc_failure();
+                    metrics.inc_timeout();
+                    let route_label = req.upstream_name.as_deref().unwrap_or("unrouted");
+                    metrics.record_route(route_label, req.start.elapsed(), RouteOutcome::Timeout);
+                    let _ = Self::send_simple_response(
+                        h3,
+                        quic,
+                        stream_id,
+                        http::StatusCode::REQUEST_TIMEOUT,
+                        b"request body idle timeout\n",
+                    );
+                    resilience
+                        .adaptive_admission
+                        .observe(req.start.elapsed(), true);
+                    if let Some(req) = streams.get_mut(&stream_id) {
+                        abort_stream(req, metrics);
+                    }
+                    streams.remove(&stream_id);
+                    continue;
+                }
+            }
+
+            if let Some(req) = streams.get(&stream_id)
+                && now >= req.total_request_deadline
             {
                 if let Err(protocol_err) = Self::handle_forward_result(
                     h3,
@@ -50,34 +140,6 @@ impl QUICListener {
                         stream_id, protocol_err
                     );
                 }
-                resilience
-                    .adaptive_admission
-                    .observe(req.start.elapsed(), true);
-                if let Some(req) = streams.get_mut(&stream_id) {
-                    abort_stream(req, metrics);
-                }
-                streams.remove(&stream_id);
-                continue;
-            }
-
-            if let Some(req) = streams.get(&stream_id)
-                && req.phase == StreamPhase::ReceivingRequest
-                && !req.request_fin_received
-                && !req.bodyless_mode
-                && Instant::now().saturating_duration_since(req.last_body_activity)
-                    >= progress_config.client_body_idle_timeout
-            {
-                metrics.inc_failure();
-                metrics.inc_timeout();
-                let route_label = req.upstream_name.as_deref().unwrap_or("unrouted");
-                metrics.record_route(route_label, req.start.elapsed(), RouteOutcome::Timeout);
-                let _ = Self::send_simple_response(
-                    h3,
-                    quic,
-                    stream_id,
-                    http::StatusCode::REQUEST_TIMEOUT,
-                    b"request body idle timeout\n",
-                );
                 resilience
                     .adaptive_admission
                     .observe(req.start.elapsed(), true);

--- a/crates/edge/src/quic_listener/forwarding/stream_progress.rs
+++ b/crates/edge/src/quic_listener/forwarding/stream_progress.rs
@@ -5,8 +5,8 @@ use crate::runtime::connection::{
         BodyLimitKind, BodyTimeoutKind, ProgressiveEmissionPolicy, RESPONSE_BODY_TOO_LARGE_BODY,
         RequestBodyGuardrailConfig, RequestBodyGuardrailDecision, RequestBodyGuardrailInput,
         ResponseBodyGuardrailConfig, ResponseBodyGuardrailDecision, ResponseBodyGuardrailInput,
-        evaluate_request_body_timeouts, evaluate_response_body_guardrails,
-        response_body_limit_reason, response_chunk_ranges,
+        checked_response_body_guardrails, evaluate_request_body_timeouts,
+        evaluate_response_body_guardrails, response_body_limit_reason, response_chunk_ranges,
     },
 };
 
@@ -562,7 +562,7 @@ impl QUICListener {
                                     let mut buffered_trailers: Option<Vec<(Vec<u8>, Vec<u8>)>> =
                                         None;
                                     loop {
-                                        let wait_decision = evaluate_response_body_guardrails(
+                                        let wait_decision = checked_response_body_guardrails(
                                             response_guardrails,
                                             ResponseBodyGuardrailInput {
                                                 elapsed: body_started_at.elapsed(),
@@ -579,12 +579,11 @@ impl QUICListener {
                                             },
                                         );
                                         let streaming = match wait_decision {
-                                            ResponseBodyGuardrailDecision::Continue {
-                                                streaming,
-                                            } => streaming,
+                                            Ok(evaluated) => evaluated.streaming,
                                             other => {
-                                                if let Some(err) =
-                                                    response_body_guardrail_error(other)
+                                                if let Err(other) = other
+                                                    && let Some(err) =
+                                                        response_body_guardrail_error(other)
                                                 {
                                                     let _ = chunk_tx
                                                         .send(ResponseChunk::Error(err))
@@ -611,7 +610,7 @@ impl QUICListener {
                                                             tokio::time::Instant::now();
                                                     }
                                                     let data_decision =
-                                                        evaluate_response_body_guardrails(
+                                                        checked_response_body_guardrails(
                                                             response_guardrails,
                                                             ResponseBodyGuardrailInput {
                                                                 elapsed: body_started_at.elapsed(),
@@ -627,33 +626,26 @@ impl QUICListener {
                                                                 exempt_from_body_size_cap: tunnel_mode,
                                                             },
                                                         );
-                                                    let streaming = match data_decision {
-                                                        ResponseBodyGuardrailDecision::Continue {
-                                                            streaming,
-                                                        } => streaming,
-                                                        other => {
-                                                            if let Some(err) =
+                                                    let evaluated =
+                                                        match data_decision {
+                                                            Ok(evaluated) => evaluated,
+                                                            other => {
+                                                                if let Err(other) = other
+                                                                && let Some(err) =
                                                                 response_body_guardrail_error(other)
                                                             {
                                                                 let _ = chunk_tx
                                                                     .send(ResponseChunk::Error(err))
                                                                     .await;
                                                             }
-                                                            return;
-                                                        }
-                                                    };
+                                                                return;
+                                                            }
+                                                        };
+                                                    let streaming = evaluated.streaming;
                                                     response_bytes_received =
-                                                        response_bytes_received
-                                                            .saturating_add(data.len());
-                                                    if matches!(
-                                                        streaming.emission,
-                                                        ProgressiveEmissionPolicy::PrebufferUntilValidated
-                                                    ) {
-                                                        prebuffered_bytes = prebuffered_bytes
-                                                            .saturating_add(data.len());
-                                                    } else {
-                                                        prebuffered_bytes = 0;
-                                                    }
+                                                        evaluated.next_state.bytes_received;
+                                                    prebuffered_bytes =
+                                                        evaluated.next_state.prebuffered_bytes;
                                                     for (start, end) in response_chunk_ranges(
                                                         data.len(),
                                                         streaming.chunk_emission,

--- a/crates/edge/src/quic_listener/forwarding/stream_progress.rs
+++ b/crates/edge/src/quic_listener/forwarding/stream_progress.rs
@@ -6,7 +6,7 @@ use crate::runtime::connection::{
         RequestBodyGuardrailConfig, RequestBodyGuardrailDecision, RequestBodyGuardrailInput,
         ResponseBodyGuardrailConfig, ResponseBodyGuardrailDecision, ResponseBodyGuardrailInput,
         checked_response_body_guardrails, evaluate_request_body_timeouts,
-        evaluate_response_body_guardrails, response_body_limit_reason, response_chunk_ranges,
+        response_body_limit_reason, response_chunk_ranges,
     },
 };
 
@@ -352,7 +352,7 @@ impl QUICListener {
                                 .unknown_length_response_prebuffer_bytes,
                             chunk_bytes: RESPONSE_CHUNK_BYTES_LIMIT,
                         };
-                        let preflight_guardrail = evaluate_response_body_guardrails(
+                        let preflight_guardrail = checked_response_body_guardrails(
                             response_guardrails,
                             ResponseBodyGuardrailInput {
                                 elapsed: Duration::ZERO,
@@ -369,9 +369,9 @@ impl QUICListener {
                         );
                         if matches!(
                             preflight_guardrail,
-                            ResponseBodyGuardrailDecision::Reject {
+                            Err(ResponseBodyGuardrailDecision::Reject {
                                 kind: BodyLimitKind::BodySizeCap,
-                            }
+                            })
                         ) {
                             if let Some(req) = streams.get(&stream_id) {
                                 metrics.inc_failure();
@@ -424,7 +424,10 @@ impl QUICListener {
 
                         let defer_headers_until_body_validated = matches!(
                             preflight_guardrail,
-                            ResponseBodyGuardrailDecision::Continue { streaming }
+                            Ok(crate::runtime::connection::guardrails::EvaluatedResponseBodyGuardrail {
+                                streaming,
+                                ..
+                            })
                                 if matches!(
                                     streaming.emission,
                                     ProgressiveEmissionPolicy::PrebufferUntilValidated

--- a/crates/edge/src/quic_listener/forwarding/stream_progress.rs
+++ b/crates/edge/src/quic_listener/forwarding/stream_progress.rs
@@ -15,18 +15,18 @@ fn response_body_guardrail_error(decision: ResponseBodyGuardrailDecision) -> Opt
         ResponseBodyGuardrailDecision::Continue { .. } => None,
         ResponseBodyGuardrailDecision::Timeout { .. } => Some(ProxyError::Timeout),
         ResponseBodyGuardrailDecision::Reject {
-            kind: BodyLimitKind::BodySizeCap,
+            kind: BodyLimitKind::BodySize,
         } => Some(ProxyError::Pool(PoolError::BackendOverloaded(
-            response_body_limit_reason(BodyLimitKind::BodySizeCap).into(),
+            response_body_limit_reason(BodyLimitKind::BodySize).into(),
         ))),
         ResponseBodyGuardrailDecision::Reject {
-            kind: BodyLimitKind::UnknownLengthPrebufferCap,
+            kind: BodyLimitKind::UnknownLengthPrebuffer,
         } => Some(ProxyError::Pool(PoolError::BackendOverloaded(
-            response_body_limit_reason(BodyLimitKind::UnknownLengthPrebufferCap).into(),
+            response_body_limit_reason(BodyLimitKind::UnknownLengthPrebuffer).into(),
         ))),
         ResponseBodyGuardrailDecision::Reject { .. } => {
             Some(ProxyError::Pool(PoolError::BackendOverloaded(
-                response_body_limit_reason(BodyLimitKind::BufferedBodyCap).into(),
+                response_body_limit_reason(BodyLimitKind::BufferedBody).into(),
             )))
         }
     }
@@ -370,7 +370,7 @@ impl QUICListener {
                         if matches!(
                             preflight_guardrail,
                             Err(ResponseBodyGuardrailDecision::Reject {
-                                kind: BodyLimitKind::BodySizeCap,
+                                kind: BodyLimitKind::BodySize,
                             })
                         ) {
                             if let Some(req) = streams.get(&stream_id) {
@@ -542,10 +542,8 @@ impl QUICListener {
                                 let deferred_status = status;
                                 let deferred_headers = owned_h3_headers.clone();
                                 let tunnel_mode = tunnel_response;
-                                let response_guardrails = response_guardrails;
                                 let progressive_emission_allowed =
                                     progressive_body_emission_allowed;
-                                let body_forwarding_enabled = body_forwarding_enabled;
                                 let fut = async move {
                                     use http_body_util::BodyExt;
                                     let Some(mut body) = response_body else {

--- a/crates/edge/src/quic_listener/forwarding/stream_progress.rs
+++ b/crates/edge/src/quic_listener/forwarding/stream_progress.rs
@@ -2,10 +2,11 @@ use super::*;
 use crate::runtime::connection::{
     auth::ExternalAuthResult,
     guardrails::{
-        BodyLimitKind, BodyTimeoutKind, ProgressiveEmissionPolicy, RequestBodyGuardrailConfig,
-        RequestBodyGuardrailDecision, RequestBodyGuardrailInput, ResponseBodyGuardrailConfig,
-        ResponseBodyGuardrailDecision, ResponseBodyGuardrailInput, evaluate_request_body_timeouts,
-        evaluate_response_body_guardrails, response_chunk_ranges,
+        BodyLimitKind, BodyTimeoutKind, ProgressiveEmissionPolicy, RESPONSE_BODY_TOO_LARGE_BODY,
+        RequestBodyGuardrailConfig, RequestBodyGuardrailDecision, RequestBodyGuardrailInput,
+        ResponseBodyGuardrailConfig, ResponseBodyGuardrailDecision, ResponseBodyGuardrailInput,
+        evaluate_request_body_timeouts, evaluate_response_body_guardrails,
+        response_body_limit_reason, response_chunk_ranges,
     },
 };
 
@@ -16,16 +17,18 @@ fn response_body_guardrail_error(decision: ResponseBodyGuardrailDecision) -> Opt
         ResponseBodyGuardrailDecision::Reject {
             kind: BodyLimitKind::BodySizeCap,
         } => Some(ProxyError::Pool(PoolError::BackendOverloaded(
-            "upstream response body too large".into(),
+            response_body_limit_reason(BodyLimitKind::BodySizeCap).into(),
         ))),
         ResponseBodyGuardrailDecision::Reject {
             kind: BodyLimitKind::UnknownLengthPrebufferCap,
         } => Some(ProxyError::Pool(PoolError::BackendOverloaded(
-            "unknown-length response prebuffer limit exceeded".into(),
+            response_body_limit_reason(BodyLimitKind::UnknownLengthPrebufferCap).into(),
         ))),
-        ResponseBodyGuardrailDecision::Reject { .. } => Some(ProxyError::Pool(
-            PoolError::BackendOverloaded("upstream response rejected".into()),
-        )),
+        ResponseBodyGuardrailDecision::Reject { .. } => {
+            Some(ProxyError::Pool(PoolError::BackendOverloaded(
+                response_body_limit_reason(BodyLimitKind::BufferedBodyCap).into(),
+            )))
+        }
     }
 }
 
@@ -397,7 +400,7 @@ impl QUICListener {
                                     quic,
                                     stream_id,
                                     http::StatusCode::SERVICE_UNAVAILABLE,
-                                    b"upstream response body too large\n",
+                                    RESPONSE_BODY_TOO_LARGE_BODY,
                                 );
                             }
                             if let Some(req) = streams.get_mut(&stream_id) {

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -1862,7 +1862,17 @@ impl QUICListener {
         );
         let Ok(next_state) = next_state else {
             metrics.release_request_buffer(chunk_len);
-            return Err(RequestBufferError::StreamCap);
+            return Err(match next_state {
+                Err(RequestBodyGuardrailDecision::Reject {
+                    kind: BodyLimitKind::BodySizeCap,
+                }) => RequestBufferError::BodySizeCap,
+                Err(RequestBodyGuardrailDecision::Reject { .. }) => RequestBufferError::StreamCap,
+                Err(other) => unreachable!(
+                    "request ingress should not timeout in enqueue path: {:?}",
+                    other
+                ),
+                Ok(_) => unreachable!("handled Ok state before request buffer error mapping"),
+            });
         };
         req.body_buf_bytes = next_state.buffered_bytes;
         req.body_buf.push_back(chunk);

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -1840,7 +1840,7 @@ impl QUICListener {
     ) -> Result<(), RequestBufferError> {
         let chunk_len = chunk.len();
         if !metrics.try_reserve_request_buffer(chunk_len, request_buffer_global_cap_bytes) {
-            return Err(RequestBufferError::GlobalCap);
+            return Err(RequestBufferError::Global);
         }
 
         let next_state = checked_request_body_ingress(
@@ -1864,9 +1864,9 @@ impl QUICListener {
             metrics.release_request_buffer(chunk_len);
             return Err(match next_state {
                 Err(RequestBodyGuardrailDecision::Reject {
-                    kind: BodyLimitKind::BodySizeCap,
-                }) => RequestBufferError::BodySizeCap,
-                Err(RequestBodyGuardrailDecision::Reject { .. }) => RequestBufferError::StreamCap,
+                    kind: BodyLimitKind::BodySize,
+                }) => RequestBufferError::BodySize,
+                Err(RequestBodyGuardrailDecision::Reject { .. }) => RequestBufferError::Stream,
                 Err(other) => unreachable!(
                     "request ingress should not timeout in enqueue path: {:?}",
                     other

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -89,7 +89,7 @@ use crate::{
             guardrails::{
                 BodyLimitKind, REQUEST_BODY_TOO_LARGE_BODY, RequestBodyGuardrailConfig,
                 RequestBodyGuardrailDecision, RequestBodyGuardrailInput,
-                evaluate_request_body_ingress,
+                checked_request_body_ingress,
             },
             quic::{QuicConnection, QuicConnectionErrorSnapshot},
             request::RequestEnvelope,
@@ -1810,7 +1810,7 @@ impl QUICListener {
             return Err(RequestBufferError::GlobalCap);
         }
 
-        let decision = evaluate_request_body_ingress(
+        let next_state = checked_request_body_ingress(
             RequestBodyGuardrailConfig {
                 idle_timeout: Duration::ZERO,
                 total_timeout: Duration::ZERO,
@@ -1827,11 +1827,11 @@ impl QUICListener {
                 exempt_from_body_size_cap: false,
             },
         );
-        if !matches!(decision, RequestBodyGuardrailDecision::Continue) {
+        let Ok(next_state) = next_state else {
             metrics.release_request_buffer(chunk_len);
             return Err(RequestBufferError::StreamCap);
-        }
-        req.body_buf_bytes = req.body_buf_bytes.saturating_add(chunk_len);
+        };
+        req.body_buf_bytes = next_state.buffered_bytes;
         req.body_buf.push_back(chunk);
         Ok(())
     }

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -89,7 +89,8 @@ use crate::{
             guardrails::{
                 BodyLimitKind, REQUEST_BODY_TOO_LARGE_BODY, RequestBodyGuardrailConfig,
                 RequestBodyGuardrailDecision, RequestBodyGuardrailInput,
-                checked_request_body_ingress,
+                ResponseBodyGuardrailConfig, ResponseBodyGuardrailInput,
+                checked_request_body_ingress, checked_response_body_guardrails,
             },
             quic::{QuicConnection, QuicConnectionErrorSnapshot},
             request::RequestEnvelope,
@@ -335,8 +336,10 @@ type LbHeaderLookup<'a> = dyn Fn(&str) -> Option<String> + 'a;
 
 struct BootstrapStreamingBody {
     inner: Incoming,
-    max_bytes: Option<usize>,
+    guardrails: Option<ResponseBodyGuardrailConfig>,
+    declared_content_length: Option<usize>,
     bytes_seen: usize,
+    prebuffered_bytes: usize,
     capped: bool,
 }
 
@@ -344,17 +347,31 @@ impl BootstrapStreamingBody {
     fn new(inner: Incoming) -> Self {
         Self {
             inner,
-            max_bytes: None,
+            guardrails: None,
+            declared_content_length: None,
             bytes_seen: 0,
+            prebuffered_bytes: 0,
             capped: false,
         }
     }
 
-    fn with_max_bytes(inner: Incoming, max_bytes: usize) -> Self {
+    fn with_response_guardrails(
+        inner: Incoming,
+        max_body_bytes: usize,
+        declared_content_length: Option<usize>,
+    ) -> Self {
         Self {
             inner,
-            max_bytes: Some(max_bytes),
+            guardrails: Some(ResponseBodyGuardrailConfig {
+                idle_timeout: Duration::MAX,
+                total_timeout: Duration::MAX,
+                max_body_bytes,
+                unknown_length_prebuffer_bytes: max_body_bytes,
+                chunk_bytes: usize::MAX,
+            }),
+            declared_content_length,
             bytes_seen: 0,
+            prebuffered_bytes: 0,
             capped: false,
         }
     }
@@ -374,11 +391,27 @@ impl Body for BootstrapStreamingBody {
 
         match Pin::new(&mut self.inner).poll_frame(cx) {
             Poll::Ready(Some(Ok(frame))) => {
-                if let Some(limit) = self.max_bytes
+                if let Some(guardrails) = self.guardrails
                     && let Some(data) = frame.data_ref()
                 {
-                    self.bytes_seen = self.bytes_seen.saturating_add(data.len());
-                    if self.bytes_seen > limit {
+                    if let Ok(next_state) = checked_response_body_guardrails(
+                        guardrails,
+                        ResponseBodyGuardrailInput {
+                            elapsed: Duration::ZERO,
+                            idle_for: Duration::ZERO,
+                            bytes_received: self.bytes_seen,
+                            prebuffered_bytes: self.prebuffered_bytes,
+                            next_chunk_bytes: data.len(),
+                            declared_content_length: self.declared_content_length,
+                            headers_emitted: true,
+                            progressive_emission_allowed: true,
+                            body_forwarding_enabled: true,
+                            exempt_from_body_size_cap: false,
+                        },
+                    ) {
+                        self.bytes_seen = next_state.next_state.bytes_received;
+                        self.prebuffered_bytes = next_state.next_state.prebuffered_bytes;
+                    } else {
                         self.capped = true;
                         return Poll::Ready(None);
                     }

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -86,6 +86,10 @@ use crate::{
         backend::{resolution::RuntimeBackendResolution, store::RuntimeBackendResolutionStore},
         bundle::{RuntimeBundle, RuntimeBundleHandle},
         connection::{
+            guardrails::{
+                BodyLimitKind, RequestBodyGuardrailConfig, RequestBodyGuardrailDecision,
+                RequestBodyGuardrailInput, evaluate_request_body_ingress,
+            },
             quic::{QuicConnection, QuicConnectionErrorSnapshot},
             request::RequestEnvelope,
             response::{ForwardResult, ForwardSuccess, ResponseChunk, UpstreamResult},
@@ -1814,12 +1818,28 @@ impl QUICListener {
             return Err(RequestBufferError::GlobalCap);
         }
 
-        let next = req.body_buf_bytes.saturating_add(chunk.len());
-        if next > max_request_body_bytes {
+        let decision = evaluate_request_body_ingress(
+            RequestBodyGuardrailConfig {
+                idle_timeout: Duration::ZERO,
+                total_timeout: Duration::ZERO,
+                max_body_bytes: max_request_body_bytes,
+                max_buffered_bytes: max_request_body_bytes,
+            },
+            RequestBodyGuardrailInput {
+                elapsed: Duration::ZERO,
+                idle_for: Duration::ZERO,
+                bytes_received: req.body_bytes_received,
+                buffered_bytes: req.body_buf_bytes,
+                next_chunk_bytes: chunk_len,
+                declared_content_length: None,
+                exempt_from_body_size_cap: false,
+            },
+        );
+        if !matches!(decision, RequestBodyGuardrailDecision::Continue) {
             metrics.release_request_buffer(chunk_len);
             return Err(RequestBufferError::StreamCap);
         }
-        req.body_buf_bytes = next;
+        req.body_buf_bytes = req.body_buf_bytes.saturating_add(chunk_len);
         req.body_buf.push_back(chunk);
         Ok(())
     }

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -87,8 +87,9 @@ use crate::{
         bundle::{RuntimeBundle, RuntimeBundleHandle},
         connection::{
             guardrails::{
-                BodyLimitKind, RequestBodyGuardrailConfig, RequestBodyGuardrailDecision,
-                RequestBodyGuardrailInput, evaluate_request_body_ingress,
+                BodyLimitKind, REQUEST_BODY_TOO_LARGE_BODY, RequestBodyGuardrailConfig,
+                RequestBodyGuardrailDecision, RequestBodyGuardrailInput,
+                evaluate_request_body_ingress,
             },
             quic::{QuicConnection, QuicConnectionErrorSnapshot},
             request::RequestEnvelope,
@@ -240,16 +241,6 @@ fn should_strip_bootstrap_response_header(
             preserve_upgrade: false,
         },
     )
-}
-
-#[cfg(test)]
-fn response_size_exceeded_after_chunk(
-    response_bytes_received: &mut usize,
-    chunk_len: usize,
-    max_response_body_bytes: usize,
-) -> bool {
-    *response_bytes_received = response_bytes_received.saturating_add(chunk_len);
-    *response_bytes_received > max_response_body_bytes
 }
 
 fn is_connect_method(method: &str) -> bool {

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -242,6 +242,7 @@ fn should_strip_bootstrap_response_header(
     )
 }
 
+#[cfg(test)]
 fn response_size_exceeded_after_chunk(
     response_bytes_received: &mut usize,
     chunk_len: usize,

--- a/crates/edge/src/quic_listener/tests.rs
+++ b/crates/edge/src/quic_listener/tests.rs
@@ -1174,7 +1174,7 @@ fn response_size_cap_enforced_as_running_total() {
         unknown_length_prebuffer_bytes: 10,
         chunk_bytes: 4,
     };
-    assert!(matches!(
+    assert!(
         checked_response_body_guardrails(
             config,
             ResponseBodyGuardrailInput {
@@ -1189,10 +1189,10 @@ fn response_size_cap_enforced_as_running_total() {
                 body_forwarding_enabled: true,
                 exempt_from_body_size_cap: false,
             },
-        ),
-        Ok(_)
-    ));
-    assert!(matches!(
+        )
+        .is_ok()
+    );
+    assert!(
         checked_response_body_guardrails(
             config,
             ResponseBodyGuardrailInput {
@@ -1207,9 +1207,9 @@ fn response_size_cap_enforced_as_running_total() {
                 body_forwarding_enabled: true,
                 exempt_from_body_size_cap: false,
             },
-        ),
-        Ok(_)
-    ));
+        )
+        .is_ok()
+    );
     assert_eq!(
         checked_response_body_guardrails(
             config,

--- a/crates/edge/src/quic_listener/tests.rs
+++ b/crates/edge/src/quic_listener/tests.rs
@@ -36,7 +36,7 @@ use crate::{
     runtime::connection::{
         guardrails::{
             BodyLimitKind, ResponseBodyGuardrailConfig, ResponseBodyGuardrailDecision,
-            ResponseBodyGuardrailInput, evaluate_response_body_guardrails,
+            ResponseBodyGuardrailInput, checked_response_body_guardrails,
         },
         stream::StreamAdmissionState,
     },
@@ -1175,7 +1175,7 @@ fn response_size_cap_enforced_as_running_total() {
         chunk_bytes: 4,
     };
     assert!(matches!(
-        evaluate_response_body_guardrails(
+        checked_response_body_guardrails(
             config,
             ResponseBodyGuardrailInput {
                 elapsed: Duration::ZERO,
@@ -1190,10 +1190,10 @@ fn response_size_cap_enforced_as_running_total() {
                 exempt_from_body_size_cap: false,
             },
         ),
-        ResponseBodyGuardrailDecision::Continue { .. }
+        Ok(_)
     ));
     assert!(matches!(
-        evaluate_response_body_guardrails(
+        checked_response_body_guardrails(
             config,
             ResponseBodyGuardrailInput {
                 elapsed: Duration::ZERO,
@@ -1208,10 +1208,10 @@ fn response_size_cap_enforced_as_running_total() {
                 exempt_from_body_size_cap: false,
             },
         ),
-        ResponseBodyGuardrailDecision::Continue { .. }
+        Ok(_)
     ));
     assert_eq!(
-        evaluate_response_body_guardrails(
+        checked_response_body_guardrails(
             config,
             ResponseBodyGuardrailInput {
                 elapsed: Duration::ZERO,
@@ -1226,9 +1226,9 @@ fn response_size_cap_enforced_as_running_total() {
                 exempt_from_body_size_cap: false,
             },
         ),
-        ResponseBodyGuardrailDecision::Reject {
+        Err(ResponseBodyGuardrailDecision::Reject {
             kind: BodyLimitKind::BodySizeCap,
-        }
+        })
     );
 }
 

--- a/crates/edge/src/quic_listener/tests.rs
+++ b/crates/edge/src/quic_listener/tests.rs
@@ -26,12 +26,20 @@ use super::{
     ConnectionRoutes, TokenBucket, abort_stream, can_poll_upstream_result,
     classify_active_health_check_response, collect_h3_trailers, connection_header_tokens,
     is_bodyless_request_mode, is_connect_tunnel_response, purge_connection_routes,
-    resolve_primary_from_radix_prefix, response_size_exceeded_after_chunk,
-    should_strip_bootstrap_request_header, should_strip_bootstrap_response_header,
-    should_strip_h3_response_header, sweep_closed_connections,
+    resolve_primary_from_radix_prefix, should_strip_bootstrap_request_header,
+    should_strip_bootstrap_response_header, should_strip_h3_response_header,
+    sweep_closed_connections,
 };
 use crate::{
-    REQUEST_ID_COUNTER, cid_radix::CidRadix, runtime::connection::stream::StreamAdmissionState,
+    REQUEST_ID_COUNTER,
+    cid_radix::CidRadix,
+    runtime::connection::{
+        guardrails::{
+            BodyLimitKind, ResponseBodyGuardrailConfig, ResponseBodyGuardrailDecision,
+            ResponseBodyGuardrailInput, evaluate_response_body_guardrails,
+        },
+        stream::StreamAdmissionState,
+    },
 };
 type RoutingMaps = (
     HashMap<Arc<[u8]>, Arc<[u8]>>,
@@ -1159,13 +1167,69 @@ fn bootstrap_response_filter_keeps_end_to_end_headers() {
 
 #[test]
 fn response_size_cap_enforced_as_running_total() {
-    let mut received = 0usize;
-    assert!(!response_size_exceeded_after_chunk(&mut received, 4, 10));
-    assert_eq!(received, 4);
-    assert!(!response_size_exceeded_after_chunk(&mut received, 6, 10));
-    assert_eq!(received, 10);
-    assert!(response_size_exceeded_after_chunk(&mut received, 1, 10));
-    assert_eq!(received, 11);
+    let config = ResponseBodyGuardrailConfig {
+        idle_timeout: Duration::from_secs(5),
+        total_timeout: Duration::from_secs(30),
+        max_body_bytes: 10,
+        unknown_length_prebuffer_bytes: 10,
+        chunk_bytes: 4,
+    };
+    assert!(matches!(
+        evaluate_response_body_guardrails(
+            config,
+            ResponseBodyGuardrailInput {
+                elapsed: Duration::ZERO,
+                idle_for: Duration::ZERO,
+                bytes_received: 0,
+                prebuffered_bytes: 0,
+                next_chunk_bytes: 4,
+                declared_content_length: None,
+                headers_emitted: true,
+                progressive_emission_allowed: true,
+                body_forwarding_enabled: true,
+                exempt_from_body_size_cap: false,
+            },
+        ),
+        ResponseBodyGuardrailDecision::Continue { .. }
+    ));
+    assert!(matches!(
+        evaluate_response_body_guardrails(
+            config,
+            ResponseBodyGuardrailInput {
+                elapsed: Duration::ZERO,
+                idle_for: Duration::ZERO,
+                bytes_received: 4,
+                prebuffered_bytes: 0,
+                next_chunk_bytes: 6,
+                declared_content_length: None,
+                headers_emitted: true,
+                progressive_emission_allowed: true,
+                body_forwarding_enabled: true,
+                exempt_from_body_size_cap: false,
+            },
+        ),
+        ResponseBodyGuardrailDecision::Continue { .. }
+    ));
+    assert_eq!(
+        evaluate_response_body_guardrails(
+            config,
+            ResponseBodyGuardrailInput {
+                elapsed: Duration::ZERO,
+                idle_for: Duration::ZERO,
+                bytes_received: 10,
+                prebuffered_bytes: 0,
+                next_chunk_bytes: 1,
+                declared_content_length: None,
+                headers_emitted: true,
+                progressive_emission_allowed: true,
+                body_forwarding_enabled: true,
+                exempt_from_body_size_cap: false,
+            },
+        ),
+        ResponseBodyGuardrailDecision::Reject {
+            kind: BodyLimitKind::BodySizeCap,
+        }
+    );
 }
 
 #[test]

--- a/crates/edge/src/quic_listener/tests.rs
+++ b/crates/edge/src/quic_listener/tests.rs
@@ -1227,7 +1227,7 @@ fn response_size_cap_enforced_as_running_total() {
             },
         ),
         Err(ResponseBodyGuardrailDecision::Reject {
-            kind: BodyLimitKind::BodySizeCap,
+            kind: BodyLimitKind::BodySize,
         })
     );
 }

--- a/crates/edge/src/quic_listener/validation.rs
+++ b/crates/edge/src/quic_listener/validation.rs
@@ -11,6 +11,7 @@ pub(super) struct RequestValidationResult {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum RequestBufferError {
+    BodySizeCap,
     StreamCap,
     GlobalCap,
 }

--- a/crates/edge/src/quic_listener/validation.rs
+++ b/crates/edge/src/quic_listener/validation.rs
@@ -11,9 +11,9 @@ pub(super) struct RequestValidationResult {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum RequestBufferError {
-    BodySizeCap,
-    StreamCap,
-    GlobalCap,
+    BodySize,
+    Stream,
+    Global,
 }
 
 pub(super) fn validate_request_headers(

--- a/crates/edge/src/runtime/connection/guardrails.rs
+++ b/crates/edge/src/runtime/connection/guardrails.rs
@@ -49,6 +49,10 @@ pub(crate) struct ResponseBodyGuardrailInput {
     pub exempt_from_body_size_cap: bool,
 }
 
+fn response_body_progress_observed(input: ResponseBodyGuardrailInput) -> bool {
+    input.bytes_received > 0 || input.next_chunk_bytes > 0
+}
+
 /// Canonical timeout reasons shared by request and response body handling.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum BodyTimeoutKind {
@@ -209,10 +213,12 @@ fn response_wait_timeout(
     config: ResponseBodyGuardrailConfig,
     input: ResponseBodyGuardrailInput,
 ) -> Duration {
-    config
-        .idle_timeout
-        .saturating_sub(input.idle_for)
-        .min(config.total_timeout.saturating_sub(input.elapsed))
+    let idle_remaining = config.idle_timeout.saturating_sub(input.idle_for);
+    if response_body_progress_observed(input) {
+        idle_remaining
+    } else {
+        idle_remaining.min(config.total_timeout.saturating_sub(input.elapsed))
+    }
 }
 
 fn resolve_progressive_emission_policy(
@@ -237,7 +243,7 @@ fn evaluate_response_body_guardrails(
     config: ResponseBodyGuardrailConfig,
     input: ResponseBodyGuardrailInput,
 ) -> ResponseBodyGuardrailDecision {
-    if input.elapsed >= config.total_timeout {
+    if !response_body_progress_observed(input) && input.elapsed >= config.total_timeout {
         return ResponseBodyGuardrailDecision::Timeout {
             kind: BodyTimeoutKind::Total,
         };
@@ -664,6 +670,42 @@ mod tests {
             decision,
             ResponseBodyGuardrailDecision::Timeout {
                 kind: BodyTimeoutKind::Total,
+            }
+        );
+    }
+
+    #[test]
+    fn response_body_total_timeout_is_ignored_after_progress() {
+        let decision = evaluate_response_body_guardrails(
+            ResponseBodyGuardrailConfig {
+                idle_timeout: Duration::from_secs(5),
+                total_timeout: Duration::from_secs(30),
+                max_body_bytes: 64,
+                unknown_length_prebuffer_bytes: 16,
+                chunk_bytes: 8,
+            },
+            ResponseBodyGuardrailInput {
+                elapsed: Duration::from_secs(30),
+                idle_for: Duration::from_secs(1),
+                bytes_received: 1,
+                prebuffered_bytes: 0,
+                next_chunk_bytes: 0,
+                declared_content_length: None,
+                headers_emitted: false,
+                progressive_emission_allowed: true,
+                body_forwarding_enabled: true,
+                exempt_from_body_size_cap: false,
+            },
+        );
+
+        assert_eq!(
+            decision,
+            ResponseBodyGuardrailDecision::Continue {
+                streaming: ResponseStreamingPolicy {
+                    emission: ProgressiveEmissionPolicy::PrebufferUntilValidated,
+                    chunk_emission: ResponseChunkEmissionPolicy::FixedSize { max_chunk_bytes: 8 },
+                    wait_timeout: Duration::from_secs(4),
+                },
             }
         );
     }

--- a/crates/edge/src/runtime/connection/guardrails.rs
+++ b/crates/edge/src/runtime/connection/guardrails.rs
@@ -199,9 +199,7 @@ pub(crate) fn response_body_limit_reason(kind: BodyLimitKind) -> &'static str {
     match kind {
         BodyLimitKind::BodySize => "upstream response body too large",
         BodyLimitKind::BufferedBody => "upstream response buffered body limit exceeded",
-        BodyLimitKind::UnknownLengthPrebuffer => {
-            "unknown-length response prebuffer limit exceeded"
-        }
+        BodyLimitKind::UnknownLengthPrebuffer => "unknown-length response prebuffer limit exceeded",
     }
 }
 

--- a/crates/edge/src/runtime/connection/guardrails.rs
+++ b/crates/edge/src/runtime/connection/guardrails.rs
@@ -1,0 +1,91 @@
+use std::time::Duration;
+
+/// Shared limits for request-body ingress handling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RequestBodyGuardrailConfig {
+    pub idle_timeout: Duration,
+    pub total_timeout: Duration,
+    pub max_body_bytes: usize,
+    pub max_buffered_bytes: usize,
+}
+
+/// Point-in-time request-body state evaluated against ingress guardrails.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RequestBodyGuardrailInput {
+    pub elapsed: Duration,
+    pub idle_for: Duration,
+    pub bytes_received: usize,
+    pub buffered_bytes: usize,
+    pub next_chunk_bytes: usize,
+    pub declared_content_length: Option<usize>,
+    pub exempt_from_body_size_cap: bool,
+}
+
+/// Shared limits for response-body egress handling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResponseBodyGuardrailConfig {
+    pub idle_timeout: Duration,
+    pub total_timeout: Duration,
+    pub max_body_bytes: usize,
+    pub unknown_length_prebuffer_bytes: usize,
+    pub chunk_bytes: usize,
+}
+
+/// Point-in-time response-body state evaluated against egress guardrails.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResponseBodyGuardrailInput {
+    pub elapsed: Duration,
+    pub idle_for: Duration,
+    pub bytes_received: usize,
+    pub prebuffered_bytes: usize,
+    pub next_chunk_bytes: usize,
+    pub declared_content_length: Option<usize>,
+    pub headers_emitted: bool,
+    pub progressive_emission_allowed: bool,
+}
+
+/// Canonical timeout reasons shared by request and response body handling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BodyTimeoutKind {
+    Idle,
+    Total,
+}
+
+/// Canonical body-size and buffering rejection reasons.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BodyLimitKind {
+    BodySizeCap,
+    BufferedBodyCap,
+    UnknownLengthPrebufferCap,
+}
+
+/// Policy describing how response body bytes may be emitted downstream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProgressiveEmissionPolicy {
+    StreamProgressively,
+    PrebufferUntilValidated,
+    SuppressBody,
+}
+
+/// Canonical decision for request-body ingress guardrails.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequestBodyGuardrailDecision {
+    Continue,
+    Timeout { kind: BodyTimeoutKind },
+    Reject { kind: BodyLimitKind },
+}
+
+/// Canonical decision for response-body egress guardrails.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResponseBodyGuardrailDecision {
+    Continue { emission: ProgressiveEmissionPolicy },
+    Timeout { kind: BodyTimeoutKind },
+    Reject { kind: BodyLimitKind },
+}
+
+/// Explicit chunk-emission sizing policy for progressive downstream writes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResponseChunkEmissionPolicy {
+    Passthrough,
+    FixedSize { max_chunk_bytes: usize },
+}

--- a/crates/edge/src/runtime/connection/guardrails.rs
+++ b/crates/edge/src/runtime/connection/guardrails.rs
@@ -1,5 +1,8 @@
 use std::time::Duration;
 
+pub(crate) const REQUEST_BODY_TOO_LARGE_BODY: &[u8] = b"request body too large\n";
+pub(crate) const RESPONSE_BODY_TOO_LARGE_BODY: &[u8] = b"upstream response body too large\n";
+
 /// Shared limits for request-body ingress handling.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RequestBodyGuardrailConfig {
@@ -123,6 +126,15 @@ pub(crate) fn evaluate_request_body_ingress(
     config: RequestBodyGuardrailConfig,
     input: RequestBodyGuardrailInput,
 ) -> RequestBodyGuardrailDecision {
+    if input
+        .declared_content_length
+        .is_some_and(|length| !input.exempt_from_body_size_cap && length > config.max_body_bytes)
+    {
+        return RequestBodyGuardrailDecision::Reject {
+            kind: BodyLimitKind::BodySizeCap,
+        };
+    }
+
     let next_total = input.bytes_received.saturating_add(input.next_chunk_bytes);
     if !input.exempt_from_body_size_cap && next_total > config.max_body_bytes {
         return RequestBodyGuardrailDecision::Reject {
@@ -141,6 +153,20 @@ pub(crate) fn evaluate_request_body_ingress(
     }
 
     RequestBodyGuardrailDecision::Continue
+}
+
+pub(crate) fn response_body_limit_reason(kind: BodyLimitKind) -> &'static str {
+    match kind {
+        BodyLimitKind::BodySizeCap => "upstream response body too large",
+        BodyLimitKind::BufferedBodyCap => "upstream response buffered body limit exceeded",
+        BodyLimitKind::UnknownLengthPrebufferCap => {
+            "unknown-length response prebuffer limit exceeded"
+        }
+    }
+}
+
+pub(crate) fn is_unknown_length_response_prebuffer_reason(reason: &str) -> bool {
+    reason == response_body_limit_reason(BodyLimitKind::UnknownLengthPrebufferCap)
 }
 
 fn response_wait_timeout(
@@ -357,6 +383,34 @@ mod tests {
             decision,
             RequestBodyGuardrailDecision::Reject {
                 kind: BodyLimitKind::UnknownLengthPrebufferCap,
+            }
+        );
+    }
+
+    #[test]
+    fn request_body_declared_length_cap_rejects() {
+        let decision = evaluate_request_body_ingress(
+            RequestBodyGuardrailConfig {
+                idle_timeout: Duration::from_secs(5),
+                total_timeout: Duration::from_secs(30),
+                max_body_bytes: 16,
+                max_buffered_bytes: usize::MAX,
+            },
+            RequestBodyGuardrailInput {
+                elapsed: Duration::ZERO,
+                idle_for: Duration::ZERO,
+                bytes_received: 0,
+                buffered_bytes: 0,
+                next_chunk_bytes: 0,
+                declared_content_length: Some(17),
+                exempt_from_body_size_cap: false,
+            },
+        );
+
+        assert_eq!(
+            decision,
+            RequestBodyGuardrailDecision::Reject {
+                kind: BodyLimitKind::BodySizeCap,
             }
         );
     }

--- a/crates/edge/src/runtime/connection/guardrails.rs
+++ b/crates/edge/src/runtime/connection/guardrails.rs
@@ -479,6 +479,64 @@ mod tests {
     }
 
     #[test]
+    fn request_body_running_total_cap_rejects() {
+        let decision = evaluate_request_body_ingress(
+            RequestBodyGuardrailConfig {
+                idle_timeout: Duration::from_secs(5),
+                total_timeout: Duration::from_secs(30),
+                max_body_bytes: 16,
+                max_buffered_bytes: usize::MAX,
+            },
+            RequestBodyGuardrailInput {
+                elapsed: Duration::ZERO,
+                idle_for: Duration::ZERO,
+                bytes_received: 12,
+                buffered_bytes: 0,
+                next_chunk_bytes: 5,
+                declared_content_length: None,
+                exempt_from_body_size_cap: false,
+            },
+        );
+
+        assert_eq!(
+            decision,
+            RequestBodyGuardrailDecision::Reject {
+                kind: BodyLimitKind::BodySizeCap,
+            }
+        );
+    }
+
+    #[test]
+    fn checked_request_body_ingress_returns_next_accounting_state() {
+        let next_state = checked_request_body_ingress(
+            RequestBodyGuardrailConfig {
+                idle_timeout: Duration::from_secs(5),
+                total_timeout: Duration::from_secs(30),
+                max_body_bytes: 64,
+                max_buffered_bytes: 32,
+            },
+            RequestBodyGuardrailInput {
+                elapsed: Duration::ZERO,
+                idle_for: Duration::ZERO,
+                bytes_received: 7,
+                buffered_bytes: 3,
+                next_chunk_bytes: 5,
+                declared_content_length: None,
+                exempt_from_body_size_cap: false,
+            },
+        )
+        .expect("request ingress should pass");
+
+        assert_eq!(
+            next_state,
+            RequestBodyIngressState {
+                bytes_received: 12,
+                buffered_bytes: 8,
+            }
+        );
+    }
+
+    #[test]
     fn response_body_prefers_prebuffer_for_unknown_length_before_headers() {
         let decision = evaluate_response_body_guardrails(
             ResponseBodyGuardrailConfig {
@@ -611,6 +669,151 @@ mod tests {
     }
 
     #[test]
+    fn response_body_idle_timeout_rejects() {
+        let decision = evaluate_response_body_guardrails(
+            ResponseBodyGuardrailConfig {
+                idle_timeout: Duration::from_secs(5),
+                total_timeout: Duration::from_secs(30),
+                max_body_bytes: 64,
+                unknown_length_prebuffer_bytes: 16,
+                chunk_bytes: 8,
+            },
+            ResponseBodyGuardrailInput {
+                elapsed: Duration::from_secs(4),
+                idle_for: Duration::from_secs(5),
+                bytes_received: 0,
+                prebuffered_bytes: 0,
+                next_chunk_bytes: 0,
+                declared_content_length: None,
+                headers_emitted: false,
+                progressive_emission_allowed: true,
+                body_forwarding_enabled: true,
+                exempt_from_body_size_cap: false,
+            },
+        );
+
+        assert_eq!(
+            decision,
+            ResponseBodyGuardrailDecision::Timeout {
+                kind: BodyTimeoutKind::Idle,
+            }
+        );
+    }
+
+    #[test]
+    fn response_body_known_length_streams_progressively() {
+        let decision = evaluate_response_body_guardrails(
+            ResponseBodyGuardrailConfig {
+                idle_timeout: Duration::from_secs(5),
+                total_timeout: Duration::from_secs(30),
+                max_body_bytes: 64,
+                unknown_length_prebuffer_bytes: 16,
+                chunk_bytes: 8,
+            },
+            ResponseBodyGuardrailInput {
+                elapsed: Duration::from_secs(1),
+                idle_for: Duration::from_secs(1),
+                bytes_received: 0,
+                prebuffered_bytes: 0,
+                next_chunk_bytes: 0,
+                declared_content_length: Some(12),
+                headers_emitted: false,
+                progressive_emission_allowed: true,
+                body_forwarding_enabled: true,
+                exempt_from_body_size_cap: false,
+            },
+        );
+
+        assert_eq!(
+            decision,
+            ResponseBodyGuardrailDecision::Continue {
+                streaming: ResponseStreamingPolicy {
+                    emission: ProgressiveEmissionPolicy::StreamProgressively,
+                    chunk_emission: ResponseChunkEmissionPolicy::FixedSize { max_chunk_bytes: 8 },
+                    wait_timeout: Duration::from_secs(4),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn response_body_suppresses_emission_when_body_is_disabled() {
+        let decision = evaluate_response_body_guardrails(
+            ResponseBodyGuardrailConfig {
+                idle_timeout: Duration::from_secs(5),
+                total_timeout: Duration::from_secs(30),
+                max_body_bytes: 64,
+                unknown_length_prebuffer_bytes: 16,
+                chunk_bytes: 8,
+            },
+            ResponseBodyGuardrailInput {
+                elapsed: Duration::from_secs(1),
+                idle_for: Duration::from_secs(1),
+                bytes_received: 0,
+                prebuffered_bytes: 0,
+                next_chunk_bytes: 0,
+                declared_content_length: None,
+                headers_emitted: false,
+                progressive_emission_allowed: true,
+                body_forwarding_enabled: false,
+                exempt_from_body_size_cap: false,
+            },
+        );
+
+        assert_eq!(
+            decision,
+            ResponseBodyGuardrailDecision::Continue {
+                streaming: ResponseStreamingPolicy {
+                    emission: ProgressiveEmissionPolicy::SuppressBody,
+                    chunk_emission: ResponseChunkEmissionPolicy::Passthrough,
+                    wait_timeout: Duration::from_secs(4),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn checked_response_body_guardrails_returns_next_streaming_state() {
+        let evaluated = checked_response_body_guardrails(
+            ResponseBodyGuardrailConfig {
+                idle_timeout: Duration::from_secs(5),
+                total_timeout: Duration::from_secs(30),
+                max_body_bytes: 64,
+                unknown_length_prebuffer_bytes: 16,
+                chunk_bytes: 4,
+            },
+            ResponseBodyGuardrailInput {
+                elapsed: Duration::from_secs(1),
+                idle_for: Duration::from_secs(1),
+                bytes_received: 5,
+                prebuffered_bytes: 5,
+                next_chunk_bytes: 3,
+                declared_content_length: None,
+                headers_emitted: false,
+                progressive_emission_allowed: true,
+                body_forwarding_enabled: true,
+                exempt_from_body_size_cap: false,
+            },
+        )
+        .expect("response egress should pass");
+
+        assert_eq!(
+            evaluated,
+            EvaluatedResponseBodyGuardrail {
+                streaming: ResponseStreamingPolicy {
+                    emission: ProgressiveEmissionPolicy::PrebufferUntilValidated,
+                    chunk_emission: ResponseChunkEmissionPolicy::FixedSize { max_chunk_bytes: 4 },
+                    wait_timeout: Duration::from_secs(4),
+                },
+                next_state: ResponseBodyEgressState {
+                    bytes_received: 8,
+                    prebuffered_bytes: 8,
+                },
+            }
+        );
+    }
+
+    #[test]
     fn response_chunk_ranges_follow_fixed_size_policy() {
         assert_eq!(
             response_chunk_ranges(
@@ -618,6 +821,14 @@ mod tests {
                 ResponseChunkEmissionPolicy::FixedSize { max_chunk_bytes: 4 }
             ),
             vec![(0, 4), (4, 8), (8, 10)]
+        );
+    }
+
+    #[test]
+    fn response_chunk_ranges_passthrough_policy_keeps_single_chunk() {
+        assert_eq!(
+            response_chunk_ranges(10, ResponseChunkEmissionPolicy::Passthrough),
+            vec![(0, 10)]
         );
     }
 }

--- a/crates/edge/src/runtime/connection/guardrails.rs
+++ b/crates/edge/src/runtime/connection/guardrails.rs
@@ -63,9 +63,9 @@ pub(crate) enum BodyTimeoutKind {
 /// Canonical body-size and buffering rejection reasons.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum BodyLimitKind {
-    BodySizeCap,
-    BufferedBodyCap,
-    UnknownLengthPrebufferCap,
+    BodySize,
+    BufferedBody,
+    UnknownLengthPrebuffer,
 }
 
 /// Policy describing how response body bytes may be emitted downstream.
@@ -156,23 +156,23 @@ fn evaluate_request_body_ingress(
         .is_some_and(|length| !input.exempt_from_body_size_cap && length > config.max_body_bytes)
     {
         return RequestBodyGuardrailDecision::Reject {
-            kind: BodyLimitKind::BodySizeCap,
+            kind: BodyLimitKind::BodySize,
         };
     }
 
     let next_total = input.bytes_received.saturating_add(input.next_chunk_bytes);
     if !input.exempt_from_body_size_cap && next_total > config.max_body_bytes {
         return RequestBodyGuardrailDecision::Reject {
-            kind: BodyLimitKind::BodySizeCap,
+            kind: BodyLimitKind::BodySize,
         };
     }
 
     let next_buffered = input.buffered_bytes.saturating_add(input.next_chunk_bytes);
     if next_buffered > config.max_buffered_bytes {
         let kind = if input.declared_content_length.is_some() {
-            BodyLimitKind::BufferedBodyCap
+            BodyLimitKind::BufferedBody
         } else {
-            BodyLimitKind::UnknownLengthPrebufferCap
+            BodyLimitKind::UnknownLengthPrebuffer
         };
         return RequestBodyGuardrailDecision::Reject { kind };
     }
@@ -197,16 +197,16 @@ pub(crate) fn checked_request_body_ingress(
 
 pub(crate) fn response_body_limit_reason(kind: BodyLimitKind) -> &'static str {
     match kind {
-        BodyLimitKind::BodySizeCap => "upstream response body too large",
-        BodyLimitKind::BufferedBodyCap => "upstream response buffered body limit exceeded",
-        BodyLimitKind::UnknownLengthPrebufferCap => {
+        BodyLimitKind::BodySize => "upstream response body too large",
+        BodyLimitKind::BufferedBody => "upstream response buffered body limit exceeded",
+        BodyLimitKind::UnknownLengthPrebuffer => {
             "unknown-length response prebuffer limit exceeded"
         }
     }
 }
 
 pub(crate) fn is_unknown_length_response_prebuffer_reason(reason: &str) -> bool {
-    reason == response_body_limit_reason(BodyLimitKind::UnknownLengthPrebufferCap)
+    reason == response_body_limit_reason(BodyLimitKind::UnknownLengthPrebuffer)
 }
 
 fn response_wait_timeout(
@@ -262,14 +262,14 @@ fn evaluate_response_body_guardrails(
             .is_some_and(|length| length > config.max_body_bytes)
         {
             return ResponseBodyGuardrailDecision::Reject {
-                kind: BodyLimitKind::BodySizeCap,
+                kind: BodyLimitKind::BodySize,
             };
         }
 
         let next_total = input.bytes_received.saturating_add(input.next_chunk_bytes);
         if next_total > config.max_body_bytes {
             return ResponseBodyGuardrailDecision::Reject {
-                kind: BodyLimitKind::BodySizeCap,
+                kind: BodyLimitKind::BodySize,
             };
         }
 
@@ -280,7 +280,7 @@ fn evaluate_response_body_guardrails(
                 > config.unknown_length_prebuffer_bytes
         {
             return ResponseBodyGuardrailDecision::Reject {
-                kind: BodyLimitKind::UnknownLengthPrebufferCap,
+                kind: BodyLimitKind::UnknownLengthPrebuffer,
             };
         }
     }
@@ -451,7 +451,7 @@ mod tests {
         assert_eq!(
             decision,
             RequestBodyGuardrailDecision::Reject {
-                kind: BodyLimitKind::UnknownLengthPrebufferCap,
+                kind: BodyLimitKind::UnknownLengthPrebuffer,
             }
         );
     }
@@ -479,7 +479,7 @@ mod tests {
         assert_eq!(
             decision,
             RequestBodyGuardrailDecision::Reject {
-                kind: BodyLimitKind::BodySizeCap,
+                kind: BodyLimitKind::BodySize,
             }
         );
     }
@@ -507,7 +507,7 @@ mod tests {
         assert_eq!(
             decision,
             RequestBodyGuardrailDecision::Reject {
-                kind: BodyLimitKind::BodySizeCap,
+                kind: BodyLimitKind::BodySize,
             }
         );
     }
@@ -605,7 +605,7 @@ mod tests {
         assert_eq!(
             decision,
             ResponseBodyGuardrailDecision::Reject {
-                kind: BodyLimitKind::BodySizeCap,
+                kind: BodyLimitKind::BodySize,
             }
         );
     }
@@ -637,7 +637,7 @@ mod tests {
         assert_eq!(
             decision,
             ResponseBodyGuardrailDecision::Reject {
-                kind: BodyLimitKind::UnknownLengthPrebufferCap,
+                kind: BodyLimitKind::UnknownLengthPrebuffer,
             }
         );
     }

--- a/crates/edge/src/runtime/connection/guardrails.rs
+++ b/crates/edge/src/runtime/connection/guardrails.rs
@@ -42,6 +42,8 @@ pub struct ResponseBodyGuardrailInput {
     pub declared_content_length: Option<usize>,
     pub headers_emitted: bool,
     pub progressive_emission_allowed: bool,
+    pub body_forwarding_enabled: bool,
+    pub exempt_from_body_size_cap: bool,
 }
 
 /// Canonical timeout reasons shared by request and response body handling.
@@ -78,7 +80,7 @@ pub enum RequestBodyGuardrailDecision {
 /// Canonical decision for response-body egress guardrails.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ResponseBodyGuardrailDecision {
-    Continue { emission: ProgressiveEmissionPolicy },
+    Continue { streaming: ResponseStreamingPolicy },
     Timeout { kind: BodyTimeoutKind },
     Reject { kind: BodyLimitKind },
 }
@@ -88,6 +90,14 @@ pub enum ResponseBodyGuardrailDecision {
 pub enum ResponseChunkEmissionPolicy {
     Passthrough,
     FixedSize { max_chunk_bytes: usize },
+}
+
+/// Canonical streaming policy for a response body once guardrails pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResponseStreamingPolicy {
+    pub emission: ProgressiveEmissionPolicy,
+    pub chunk_emission: ResponseChunkEmissionPolicy,
+    pub wait_timeout: Duration,
 }
 
 pub(crate) fn evaluate_request_body_timeouts(
@@ -131,6 +141,112 @@ pub(crate) fn evaluate_request_body_ingress(
     }
 
     RequestBodyGuardrailDecision::Continue
+}
+
+fn response_wait_timeout(
+    config: ResponseBodyGuardrailConfig,
+    input: ResponseBodyGuardrailInput,
+) -> Duration {
+    config
+        .idle_timeout
+        .saturating_sub(input.idle_for)
+        .min(config.total_timeout.saturating_sub(input.elapsed))
+}
+
+fn resolve_progressive_emission_policy(
+    input: ResponseBodyGuardrailInput,
+) -> ProgressiveEmissionPolicy {
+    if !input.body_forwarding_enabled {
+        return ProgressiveEmissionPolicy::SuppressBody;
+    }
+
+    if !input.progressive_emission_allowed
+        || input.headers_emitted
+        || input.declared_content_length.is_some()
+        || input.exempt_from_body_size_cap
+    {
+        return ProgressiveEmissionPolicy::StreamProgressively;
+    }
+
+    ProgressiveEmissionPolicy::PrebufferUntilValidated
+}
+
+pub(crate) fn evaluate_response_body_guardrails(
+    config: ResponseBodyGuardrailConfig,
+    input: ResponseBodyGuardrailInput,
+) -> ResponseBodyGuardrailDecision {
+    if input.elapsed >= config.total_timeout {
+        return ResponseBodyGuardrailDecision::Timeout {
+            kind: BodyTimeoutKind::Total,
+        };
+    }
+
+    if input.idle_for >= config.idle_timeout {
+        return ResponseBodyGuardrailDecision::Timeout {
+            kind: BodyTimeoutKind::Idle,
+        };
+    }
+
+    let emission = resolve_progressive_emission_policy(input);
+    if input.body_forwarding_enabled && !input.exempt_from_body_size_cap {
+        if input
+            .declared_content_length
+            .is_some_and(|length| length > config.max_body_bytes)
+        {
+            return ResponseBodyGuardrailDecision::Reject {
+                kind: BodyLimitKind::BodySizeCap,
+            };
+        }
+
+        let next_total = input.bytes_received.saturating_add(input.next_chunk_bytes);
+        if next_total > config.max_body_bytes {
+            return ResponseBodyGuardrailDecision::Reject {
+                kind: BodyLimitKind::BodySizeCap,
+            };
+        }
+
+        if matches!(emission, ProgressiveEmissionPolicy::PrebufferUntilValidated)
+            && input
+                .prebuffered_bytes
+                .saturating_add(input.next_chunk_bytes)
+                > config.unknown_length_prebuffer_bytes
+        {
+            return ResponseBodyGuardrailDecision::Reject {
+                kind: BodyLimitKind::UnknownLengthPrebufferCap,
+            };
+        }
+    }
+
+    let chunk_emission = match emission {
+        ProgressiveEmissionPolicy::SuppressBody => ResponseChunkEmissionPolicy::Passthrough,
+        ProgressiveEmissionPolicy::StreamProgressively
+        | ProgressiveEmissionPolicy::PrebufferUntilValidated => {
+            ResponseChunkEmissionPolicy::FixedSize {
+                max_chunk_bytes: config.chunk_bytes.max(1),
+            }
+        }
+    };
+
+    ResponseBodyGuardrailDecision::Continue {
+        streaming: ResponseStreamingPolicy {
+            emission,
+            chunk_emission,
+            wait_timeout: response_wait_timeout(config, input),
+        },
+    }
+}
+
+pub(crate) fn response_chunk_ranges(
+    data_len: usize,
+    policy: ResponseChunkEmissionPolicy,
+) -> Vec<(usize, usize)> {
+    match policy {
+        ResponseChunkEmissionPolicy::Passthrough => vec![(0, data_len)],
+        ResponseChunkEmissionPolicy::FixedSize { max_chunk_bytes } => (0..data_len)
+            .step_by(max_chunk_bytes.max(1))
+            .map(|start| (start, (start + max_chunk_bytes).min(data_len)))
+            .collect(),
+    }
 }
 
 #[cfg(test)]
@@ -242,6 +358,149 @@ mod tests {
             RequestBodyGuardrailDecision::Reject {
                 kind: BodyLimitKind::UnknownLengthPrebufferCap,
             }
+        );
+    }
+
+    #[test]
+    fn response_body_prefers_prebuffer_for_unknown_length_before_headers() {
+        let decision = evaluate_response_body_guardrails(
+            ResponseBodyGuardrailConfig {
+                idle_timeout: Duration::from_secs(5),
+                total_timeout: Duration::from_secs(30),
+                max_body_bytes: 64,
+                unknown_length_prebuffer_bytes: 16,
+                chunk_bytes: 8,
+            },
+            ResponseBodyGuardrailInput {
+                elapsed: Duration::from_secs(1),
+                idle_for: Duration::from_secs(1),
+                bytes_received: 0,
+                prebuffered_bytes: 0,
+                next_chunk_bytes: 0,
+                declared_content_length: None,
+                headers_emitted: false,
+                progressive_emission_allowed: true,
+                body_forwarding_enabled: true,
+                exempt_from_body_size_cap: false,
+            },
+        );
+
+        assert_eq!(
+            decision,
+            ResponseBodyGuardrailDecision::Continue {
+                streaming: ResponseStreamingPolicy {
+                    emission: ProgressiveEmissionPolicy::PrebufferUntilValidated,
+                    chunk_emission: ResponseChunkEmissionPolicy::FixedSize { max_chunk_bytes: 8 },
+                    wait_timeout: Duration::from_secs(4),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn response_body_declared_length_cap_rejects() {
+        let decision = evaluate_response_body_guardrails(
+            ResponseBodyGuardrailConfig {
+                idle_timeout: Duration::from_secs(5),
+                total_timeout: Duration::from_secs(30),
+                max_body_bytes: 16,
+                unknown_length_prebuffer_bytes: 8,
+                chunk_bytes: 8,
+            },
+            ResponseBodyGuardrailInput {
+                elapsed: Duration::ZERO,
+                idle_for: Duration::ZERO,
+                bytes_received: 0,
+                prebuffered_bytes: 0,
+                next_chunk_bytes: 0,
+                declared_content_length: Some(17),
+                headers_emitted: false,
+                progressive_emission_allowed: true,
+                body_forwarding_enabled: true,
+                exempt_from_body_size_cap: false,
+            },
+        );
+
+        assert_eq!(
+            decision,
+            ResponseBodyGuardrailDecision::Reject {
+                kind: BodyLimitKind::BodySizeCap,
+            }
+        );
+    }
+
+    #[test]
+    fn response_body_unknown_length_prebuffer_cap_rejects() {
+        let decision = evaluate_response_body_guardrails(
+            ResponseBodyGuardrailConfig {
+                idle_timeout: Duration::from_secs(5),
+                total_timeout: Duration::from_secs(30),
+                max_body_bytes: 64,
+                unknown_length_prebuffer_bytes: 10,
+                chunk_bytes: 4,
+            },
+            ResponseBodyGuardrailInput {
+                elapsed: Duration::from_secs(1),
+                idle_for: Duration::from_secs(1),
+                bytes_received: 6,
+                prebuffered_bytes: 6,
+                next_chunk_bytes: 5,
+                declared_content_length: None,
+                headers_emitted: false,
+                progressive_emission_allowed: true,
+                body_forwarding_enabled: true,
+                exempt_from_body_size_cap: false,
+            },
+        );
+
+        assert_eq!(
+            decision,
+            ResponseBodyGuardrailDecision::Reject {
+                kind: BodyLimitKind::UnknownLengthPrebufferCap,
+            }
+        );
+    }
+
+    #[test]
+    fn response_body_total_timeout_rejects() {
+        let decision = evaluate_response_body_guardrails(
+            ResponseBodyGuardrailConfig {
+                idle_timeout: Duration::from_secs(5),
+                total_timeout: Duration::from_secs(30),
+                max_body_bytes: 64,
+                unknown_length_prebuffer_bytes: 16,
+                chunk_bytes: 8,
+            },
+            ResponseBodyGuardrailInput {
+                elapsed: Duration::from_secs(30),
+                idle_for: Duration::from_secs(1),
+                bytes_received: 0,
+                prebuffered_bytes: 0,
+                next_chunk_bytes: 0,
+                declared_content_length: None,
+                headers_emitted: false,
+                progressive_emission_allowed: true,
+                body_forwarding_enabled: true,
+                exempt_from_body_size_cap: false,
+            },
+        );
+
+        assert_eq!(
+            decision,
+            ResponseBodyGuardrailDecision::Timeout {
+                kind: BodyTimeoutKind::Total,
+            }
+        );
+    }
+
+    #[test]
+    fn response_chunk_ranges_follow_fixed_size_policy() {
+        assert_eq!(
+            response_chunk_ranges(
+                10,
+                ResponseChunkEmissionPolicy::FixedSize { max_chunk_bytes: 4 }
+            ),
+            vec![(0, 4), (4, 8), (8, 10)]
         );
     }
 }

--- a/crates/edge/src/runtime/connection/guardrails.rs
+++ b/crates/edge/src/runtime/connection/guardrails.rs
@@ -103,6 +103,27 @@ pub struct ResponseStreamingPolicy {
     pub wait_timeout: Duration,
 }
 
+/// Canonical request-body accounting state after an ingress step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RequestBodyIngressState {
+    pub bytes_received: usize,
+    pub buffered_bytes: usize,
+}
+
+/// Canonical response-body accounting state after an egress step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResponseBodyEgressState {
+    pub bytes_received: usize,
+    pub prebuffered_bytes: usize,
+}
+
+/// Shared result for a validated response-body streaming step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EvaluatedResponseBodyGuardrail {
+    pub streaming: ResponseStreamingPolicy,
+    pub next_state: ResponseBodyEgressState,
+}
+
 pub(crate) fn evaluate_request_body_timeouts(
     config: RequestBodyGuardrailConfig,
     input: RequestBodyGuardrailInput,
@@ -153,6 +174,21 @@ pub(crate) fn evaluate_request_body_ingress(
     }
 
     RequestBodyGuardrailDecision::Continue
+}
+
+pub(crate) fn checked_request_body_ingress(
+    config: RequestBodyGuardrailConfig,
+    input: RequestBodyGuardrailInput,
+) -> Result<RequestBodyIngressState, RequestBodyGuardrailDecision> {
+    let decision = evaluate_request_body_ingress(config, input);
+    if !matches!(decision, RequestBodyGuardrailDecision::Continue) {
+        return Err(decision);
+    }
+
+    Ok(RequestBodyIngressState {
+        bytes_received: input.bytes_received.saturating_add(input.next_chunk_bytes),
+        buffered_bytes: input.buffered_bytes.saturating_add(input.next_chunk_bytes),
+    })
 }
 
 pub(crate) fn response_body_limit_reason(kind: BodyLimitKind) -> &'static str {
@@ -260,6 +296,33 @@ pub(crate) fn evaluate_response_body_guardrails(
             wait_timeout: response_wait_timeout(config, input),
         },
     }
+}
+
+pub(crate) fn checked_response_body_guardrails(
+    config: ResponseBodyGuardrailConfig,
+    input: ResponseBodyGuardrailInput,
+) -> Result<EvaluatedResponseBodyGuardrail, ResponseBodyGuardrailDecision> {
+    let decision = evaluate_response_body_guardrails(config, input);
+    let ResponseBodyGuardrailDecision::Continue { streaming } = decision else {
+        return Err(decision);
+    };
+
+    let next_bytes_received = input.bytes_received.saturating_add(input.next_chunk_bytes);
+    let next_prebuffered_bytes = match streaming.emission {
+        ProgressiveEmissionPolicy::PrebufferUntilValidated => input
+            .prebuffered_bytes
+            .saturating_add(input.next_chunk_bytes),
+        ProgressiveEmissionPolicy::StreamProgressively
+        | ProgressiveEmissionPolicy::SuppressBody => 0,
+    };
+
+    Ok(EvaluatedResponseBodyGuardrail {
+        streaming,
+        next_state: ResponseBodyEgressState {
+            bytes_received: next_bytes_received,
+            prebuffered_bytes: next_prebuffered_bytes,
+        },
+    })
 }
 
 pub(crate) fn response_chunk_ranges(

--- a/crates/edge/src/runtime/connection/guardrails.rs
+++ b/crates/edge/src/runtime/connection/guardrails.rs
@@ -89,3 +89,159 @@ pub enum ResponseChunkEmissionPolicy {
     Passthrough,
     FixedSize { max_chunk_bytes: usize },
 }
+
+pub(crate) fn evaluate_request_body_timeouts(
+    config: RequestBodyGuardrailConfig,
+    input: RequestBodyGuardrailInput,
+) -> RequestBodyGuardrailDecision {
+    if input.elapsed >= config.total_timeout {
+        return RequestBodyGuardrailDecision::Timeout {
+            kind: BodyTimeoutKind::Total,
+        };
+    }
+
+    if input.idle_for >= config.idle_timeout {
+        return RequestBodyGuardrailDecision::Timeout {
+            kind: BodyTimeoutKind::Idle,
+        };
+    }
+
+    RequestBodyGuardrailDecision::Continue
+}
+
+pub(crate) fn evaluate_request_body_ingress(
+    config: RequestBodyGuardrailConfig,
+    input: RequestBodyGuardrailInput,
+) -> RequestBodyGuardrailDecision {
+    let next_total = input.bytes_received.saturating_add(input.next_chunk_bytes);
+    if !input.exempt_from_body_size_cap && next_total > config.max_body_bytes {
+        return RequestBodyGuardrailDecision::Reject {
+            kind: BodyLimitKind::BodySizeCap,
+        };
+    }
+
+    let next_buffered = input.buffered_bytes.saturating_add(input.next_chunk_bytes);
+    if next_buffered > config.max_buffered_bytes {
+        let kind = if input.declared_content_length.is_some() {
+            BodyLimitKind::BufferedBodyCap
+        } else {
+            BodyLimitKind::UnknownLengthPrebufferCap
+        };
+        return RequestBodyGuardrailDecision::Reject { kind };
+    }
+
+    RequestBodyGuardrailDecision::Continue
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_body_idle_timeout_rejects() {
+        let decision = evaluate_request_body_timeouts(
+            RequestBodyGuardrailConfig {
+                idle_timeout: Duration::from_secs(5),
+                total_timeout: Duration::from_secs(30),
+                max_body_bytes: usize::MAX,
+                max_buffered_bytes: usize::MAX,
+            },
+            RequestBodyGuardrailInput {
+                elapsed: Duration::from_secs(4),
+                idle_for: Duration::from_secs(5),
+                bytes_received: 0,
+                buffered_bytes: 0,
+                next_chunk_bytes: 0,
+                declared_content_length: None,
+                exempt_from_body_size_cap: false,
+            },
+        );
+
+        assert_eq!(
+            decision,
+            RequestBodyGuardrailDecision::Timeout {
+                kind: BodyTimeoutKind::Idle,
+            }
+        );
+    }
+
+    #[test]
+    fn request_body_total_timeout_rejects() {
+        let decision = evaluate_request_body_timeouts(
+            RequestBodyGuardrailConfig {
+                idle_timeout: Duration::from_secs(5),
+                total_timeout: Duration::from_secs(30),
+                max_body_bytes: usize::MAX,
+                max_buffered_bytes: usize::MAX,
+            },
+            RequestBodyGuardrailInput {
+                elapsed: Duration::from_secs(30),
+                idle_for: Duration::from_secs(1),
+                bytes_received: 0,
+                buffered_bytes: 0,
+                next_chunk_bytes: 0,
+                declared_content_length: None,
+                exempt_from_body_size_cap: false,
+            },
+        );
+
+        assert_eq!(
+            decision,
+            RequestBodyGuardrailDecision::Timeout {
+                kind: BodyTimeoutKind::Total,
+            }
+        );
+    }
+
+    #[test]
+    fn request_body_size_cap_respects_connect_exemption() {
+        let config = RequestBodyGuardrailConfig {
+            idle_timeout: Duration::from_secs(5),
+            total_timeout: Duration::from_secs(30),
+            max_body_bytes: 16,
+            max_buffered_bytes: usize::MAX,
+        };
+        let input = RequestBodyGuardrailInput {
+            elapsed: Duration::ZERO,
+            idle_for: Duration::ZERO,
+            bytes_received: 12,
+            buffered_bytes: 0,
+            next_chunk_bytes: 8,
+            declared_content_length: None,
+            exempt_from_body_size_cap: true,
+        };
+
+        assert_eq!(
+            evaluate_request_body_ingress(config, input),
+            RequestBodyGuardrailDecision::Continue
+        );
+    }
+
+    #[test]
+    fn request_body_unknown_length_prebuffer_cap_rejects() {
+        let decision = evaluate_request_body_ingress(
+            RequestBodyGuardrailConfig {
+                idle_timeout: Duration::from_secs(5),
+                total_timeout: Duration::from_secs(30),
+                max_body_bytes: usize::MAX,
+                max_buffered_bytes: 10,
+            },
+            RequestBodyGuardrailInput {
+                elapsed: Duration::ZERO,
+                idle_for: Duration::ZERO,
+                bytes_received: 0,
+                buffered_bytes: 6,
+                next_chunk_bytes: 5,
+                declared_content_length: None,
+                exempt_from_body_size_cap: false,
+            },
+        );
+
+        assert_eq!(
+            decision,
+            RequestBodyGuardrailDecision::Reject {
+                kind: BodyLimitKind::UnknownLengthPrebufferCap,
+            }
+        );
+    }
+}

--- a/crates/edge/src/runtime/connection/guardrails.rs
+++ b/crates/edge/src/runtime/connection/guardrails.rs
@@ -5,7 +5,7 @@ pub(crate) const RESPONSE_BODY_TOO_LARGE_BODY: &[u8] = b"upstream response body 
 
 /// Shared limits for request-body ingress handling.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct RequestBodyGuardrailConfig {
+pub(crate) struct RequestBodyGuardrailConfig {
     pub idle_timeout: Duration,
     pub total_timeout: Duration,
     pub max_body_bytes: usize,
@@ -14,7 +14,7 @@ pub struct RequestBodyGuardrailConfig {
 
 /// Point-in-time request-body state evaluated against ingress guardrails.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct RequestBodyGuardrailInput {
+pub(crate) struct RequestBodyGuardrailInput {
     pub elapsed: Duration,
     pub idle_for: Duration,
     pub bytes_received: usize,
@@ -26,7 +26,7 @@ pub struct RequestBodyGuardrailInput {
 
 /// Shared limits for response-body egress handling.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ResponseBodyGuardrailConfig {
+pub(crate) struct ResponseBodyGuardrailConfig {
     pub idle_timeout: Duration,
     pub total_timeout: Duration,
     pub max_body_bytes: usize,
@@ -36,7 +36,7 @@ pub struct ResponseBodyGuardrailConfig {
 
 /// Point-in-time response-body state evaluated against egress guardrails.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ResponseBodyGuardrailInput {
+pub(crate) struct ResponseBodyGuardrailInput {
     pub elapsed: Duration,
     pub idle_for: Duration,
     pub bytes_received: usize,
@@ -51,14 +51,14 @@ pub struct ResponseBodyGuardrailInput {
 
 /// Canonical timeout reasons shared by request and response body handling.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BodyTimeoutKind {
+pub(crate) enum BodyTimeoutKind {
     Idle,
     Total,
 }
 
 /// Canonical body-size and buffering rejection reasons.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BodyLimitKind {
+pub(crate) enum BodyLimitKind {
     BodySizeCap,
     BufferedBodyCap,
     UnknownLengthPrebufferCap,
@@ -66,7 +66,7 @@ pub enum BodyLimitKind {
 
 /// Policy describing how response body bytes may be emitted downstream.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ProgressiveEmissionPolicy {
+pub(crate) enum ProgressiveEmissionPolicy {
     StreamProgressively,
     PrebufferUntilValidated,
     SuppressBody,
@@ -74,7 +74,7 @@ pub enum ProgressiveEmissionPolicy {
 
 /// Canonical decision for request-body ingress guardrails.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RequestBodyGuardrailDecision {
+pub(crate) enum RequestBodyGuardrailDecision {
     Continue,
     Timeout { kind: BodyTimeoutKind },
     Reject { kind: BodyLimitKind },
@@ -82,7 +82,7 @@ pub enum RequestBodyGuardrailDecision {
 
 /// Canonical decision for response-body egress guardrails.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ResponseBodyGuardrailDecision {
+pub(crate) enum ResponseBodyGuardrailDecision {
     Continue { streaming: ResponseStreamingPolicy },
     Timeout { kind: BodyTimeoutKind },
     Reject { kind: BodyLimitKind },
@@ -90,14 +90,14 @@ pub enum ResponseBodyGuardrailDecision {
 
 /// Explicit chunk-emission sizing policy for progressive downstream writes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ResponseChunkEmissionPolicy {
+pub(crate) enum ResponseChunkEmissionPolicy {
     Passthrough,
     FixedSize { max_chunk_bytes: usize },
 }
 
 /// Canonical streaming policy for a response body once guardrails pass.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ResponseStreamingPolicy {
+pub(crate) struct ResponseStreamingPolicy {
     pub emission: ProgressiveEmissionPolicy,
     pub chunk_emission: ResponseChunkEmissionPolicy,
     pub wait_timeout: Duration,
@@ -105,21 +105,21 @@ pub struct ResponseStreamingPolicy {
 
 /// Canonical request-body accounting state after an ingress step.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct RequestBodyIngressState {
+pub(crate) struct RequestBodyIngressState {
     pub bytes_received: usize,
     pub buffered_bytes: usize,
 }
 
 /// Canonical response-body accounting state after an egress step.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ResponseBodyEgressState {
+pub(crate) struct ResponseBodyEgressState {
     pub bytes_received: usize,
     pub prebuffered_bytes: usize,
 }
 
 /// Shared result for a validated response-body streaming step.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct EvaluatedResponseBodyGuardrail {
+pub(crate) struct EvaluatedResponseBodyGuardrail {
     pub streaming: ResponseStreamingPolicy,
     pub next_state: ResponseBodyEgressState,
 }
@@ -143,7 +143,7 @@ pub(crate) fn evaluate_request_body_timeouts(
     RequestBodyGuardrailDecision::Continue
 }
 
-pub(crate) fn evaluate_request_body_ingress(
+fn evaluate_request_body_ingress(
     config: RequestBodyGuardrailConfig,
     input: RequestBodyGuardrailInput,
 ) -> RequestBodyGuardrailDecision {
@@ -233,7 +233,7 @@ fn resolve_progressive_emission_policy(
     ProgressiveEmissionPolicy::PrebufferUntilValidated
 }
 
-pub(crate) fn evaluate_response_body_guardrails(
+fn evaluate_response_body_guardrails(
     config: ResponseBodyGuardrailConfig,
     input: ResponseBodyGuardrailInput,
 ) -> ResponseBodyGuardrailDecision {

--- a/crates/edge/src/runtime/connection/mod.rs
+++ b/crates/edge/src/runtime/connection/mod.rs
@@ -1,5 +1,5 @@
 pub mod auth;
-pub mod guardrails;
+pub(crate) mod guardrails;
 pub mod quic;
 pub mod request;
 pub mod response;

--- a/crates/edge/src/runtime/connection/mod.rs
+++ b/crates/edge/src/runtime/connection/mod.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+pub mod guardrails;
 pub mod quic;
 pub mod request;
 pub mod response;


### PR DESCRIPTION
## Summary
This PR introduces a canonical streaming/body guardrail layer for `spooky-edge` and routes the QUIC forwarding paths through it.

## What Changed
- added shared request/response body guardrail types and decision models
- centralized request-body ingress checks for:
  - idle timeout
  - total timeout
  - size-cap enforcement
  - unknown-length buffering limits
- centralized response-body egress checks for:
  - idle timeout
  - prebuffer gating
  - progressive emission policy
  - chunk sizing
  - response size-cap enforcement
- routed QUIC stream progression and request buffering through the shared guardrail evaluator
- aligned failure mapping so oversized request bodies return `413` and buffer-pressure overload remains `503`
- restored long-stream behavior so total body timeout only applies before response body progress begins
- cleaned up Clippy issues around redundant locals and enum variant naming

## Why
Streaming/body transfer policy had become spread across forwarding and buffering paths, which made behavior harder to reason about and introduced divergence during refactoring. This change gives the codebase one canonical place for body-transfer guardrails while keeping QUIC-specific polling and emission mechanics local.
