### PR TITLE
refactor(edge): extract shared retry and hedge policy layer

### DIFF
--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -13,13 +13,18 @@ pub mod watchdog;
 pub use body::ChannelBody;
 pub(crate) use hash::REQUEST_ID_COUNTER;
 pub use hash::{stable_hash_socket_addr, stable_hash64};
-pub use metrics::{HealthFailureReason, Metrics, OverloadShedReason, RetryReason, RouteOutcome};
+pub use metrics::{HealthFailureReason, Metrics, OverloadShedReason, RouteOutcome};
 pub use quic_listener::configure_async_runtime;
 
 #[cfg(test)]
 mod tests {
     use core::net::SocketAddr;
     use std::{sync::atomic::Ordering, time::Duration};
+
+    use spooky_errors::{
+        HedgeOutcomeTelemetryReason, HedgeTriggerTelemetryReason, RetryAttemptTelemetryReason,
+        RetryPolicyDenialReason,
+    };
 
     use super::*;
 
@@ -126,10 +131,9 @@ mod tests {
         metrics.inc_overload_shed_reason(OverloadShedReason::CircuitOpen);
         metrics.set_active_connections(7);
         metrics.inc_connection_cap_reject();
-        metrics.inc_hedge_triggered();
-        metrics.inc_hedge_won();
-        metrics.inc_hedge_wasted();
-        metrics.inc_hedge_primary_won_after_trigger();
+        metrics.inc_hedge_trigger(HedgeTriggerTelemetryReason::DelayElapsed);
+        metrics.inc_hedge_outcome(HedgeOutcomeTelemetryReason::HedgeWon);
+        metrics.inc_hedge_outcome(HedgeOutcomeTelemetryReason::PrimaryWonAfterTrigger);
         metrics.observe_hedge_primary_late_ms(42);
         metrics.inc_control_api_connection_limit_drop();
 
@@ -164,8 +168,8 @@ mod tests {
     #[test]
     fn resilience_metrics_increment_correctly() {
         let metrics = Metrics::default();
-        metrics.inc_retry_attempt(RetryReason::BackendTimeout);
-        metrics.inc_retry_denied(RetryReason::BudgetDenied);
+        metrics.inc_retry_attempt(RetryAttemptTelemetryReason::Timeout);
+        metrics.inc_retry_denied(RetryPolicyDenialReason::BudgetDenied);
         metrics.inc_circuit_breaker_rejected();
         metrics.inc_circuit_breaker_rejected();
         metrics.set_brownout_active(true);

--- a/crates/edge/src/metrics/mod.rs
+++ b/crates/edge/src/metrics/mod.rs
@@ -9,11 +9,11 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-pub use spooky_lb::health::HealthFailureReason;
 use spooky_errors::{
     HedgeOutcomeTelemetryReason, HedgeTriggerTelemetryReason, RetryAttemptTelemetryReason,
     RetryPolicyDenialReason,
 };
+pub use spooky_lb::health::HealthFailureReason;
 
 pub struct Metrics {
     pub requests_total: AtomicU64,

--- a/crates/edge/src/metrics/mod.rs
+++ b/crates/edge/src/metrics/mod.rs
@@ -10,6 +10,10 @@ use std::{
 };
 
 pub use spooky_lb::health::HealthFailureReason;
+use spooky_errors::{
+    HedgeOutcomeTelemetryReason, HedgeTriggerTelemetryReason, RetryAttemptTelemetryReason,
+    RetryPolicyDenialReason,
+};
 
 pub struct Metrics {
     pub requests_total: AtomicU64,
@@ -348,16 +352,6 @@ pub enum OverloadShedReason {
     ConnectionCap,
 }
 
-#[derive(Clone, Copy, Debug)]
-pub enum RetryReason {
-    BackendTimeout,
-    BackendTransport,
-    BackendPool,
-    BudgetDenied,
-    NotBodylessMode,
-    NoAlternateBackend,
-}
-
 impl Default for Metrics {
     fn default() -> Self {
         Self::new(1, [String::from("unrouted")])
@@ -654,21 +648,21 @@ impl Metrics {
             .fetch_add(1, Ordering::Relaxed);
     }
 
-    pub fn inc_hedge_triggered(&self) {
+    pub fn inc_hedge_trigger(&self, _reason: HedgeTriggerTelemetryReason) {
         self.hedge_triggered.fetch_add(1, Ordering::Relaxed);
     }
 
-    pub fn inc_hedge_won(&self) {
-        self.hedge_won.fetch_add(1, Ordering::Relaxed);
-    }
-
-    pub fn inc_hedge_wasted(&self) {
-        self.hedge_wasted.fetch_add(1, Ordering::Relaxed);
-    }
-
-    pub fn inc_hedge_primary_won_after_trigger(&self) {
-        self.hedge_primary_won_after_trigger
-            .fetch_add(1, Ordering::Relaxed);
+    pub fn inc_hedge_outcome(&self, reason: HedgeOutcomeTelemetryReason) {
+        match reason {
+            HedgeOutcomeTelemetryReason::PrimaryWonAfterTrigger => {
+                self.hedge_primary_won_after_trigger
+                    .fetch_add(1, Ordering::Relaxed);
+                self.hedge_wasted.fetch_add(1, Ordering::Relaxed);
+            }
+            HedgeOutcomeTelemetryReason::HedgeWon => {
+                self.hedge_won.fetch_add(1, Ordering::Relaxed);
+            }
+        }
     }
 
     pub fn observe_hedge_primary_late_ms(&self, late_ms: u64) {
@@ -1176,40 +1170,37 @@ impl Metrics {
         self.runtime_panics.fetch_add(1, Ordering::Relaxed);
     }
 
-    pub fn inc_retry_attempt(&self, reason: RetryReason) {
+    pub fn inc_retry_attempt(&self, reason: RetryAttemptTelemetryReason) {
         self.retries_total.fetch_add(1, Ordering::Relaxed);
         match reason {
-            RetryReason::BackendTimeout => {
+            RetryAttemptTelemetryReason::Timeout => {
                 self.retry_reason_timeout.fetch_add(1, Ordering::Relaxed);
             }
-            RetryReason::BackendTransport => {
+            RetryAttemptTelemetryReason::Transport => {
                 self.retry_reason_transport.fetch_add(1, Ordering::Relaxed);
             }
-            RetryReason::BackendPool => {
+            RetryAttemptTelemetryReason::Pool => {
                 self.retry_reason_pool.fetch_add(1, Ordering::Relaxed);
             }
-            RetryReason::BudgetDenied
-            | RetryReason::NotBodylessMode
-            | RetryReason::NoAlternateBackend => {}
         }
     }
 
-    pub fn inc_retry_denied(&self, reason: RetryReason) {
+    pub fn inc_retry_denied(&self, reason: RetryPolicyDenialReason) {
         match reason {
-            RetryReason::BudgetDenied => {
+            RetryPolicyDenialReason::BudgetDenied => {
                 self.retry_denied_budget.fetch_add(1, Ordering::Relaxed);
             }
-            RetryReason::NotBodylessMode => {
+            RetryPolicyDenialReason::MethodNotIdempotent
+            | RetryPolicyDenialReason::RequestBodyNotReplayable => {
                 self.retry_denied_no_bodyless
                     .fetch_add(1, Ordering::Relaxed);
             }
-            RetryReason::NoAlternateBackend => {
+            RetryPolicyDenialReason::AlternateBackendUnavailable(_) => {
                 self.retry_denied_no_alternate
                     .fetch_add(1, Ordering::Relaxed);
             }
-            RetryReason::BackendTimeout
-            | RetryReason::BackendTransport
-            | RetryReason::BackendPool => {}
+            RetryPolicyDenialReason::TerminalError(_)
+            | RetryPolicyDenialReason::AttemptLimitReached => {}
         }
     }
 

--- a/crates/edge/src/quic_listener/forwarding/dispatch.rs
+++ b/crates/edge/src/quic_listener/forwarding/dispatch.rs
@@ -1,5 +1,6 @@
 use spooky_errors::{
-    RetryPolicyDecision, RetryPolicyFacts, RetryPolicyDenialReason, RetryTelemetryReason,
+    HedgePolicyDecision, HedgePolicyFacts, HedgePrimaryState, RetryPolicyDecision,
+    RetryPolicyFacts, RetryPolicyDenialReason, RetryTelemetryReason, evaluate_hedge_policy,
     evaluate_retry_policy, is_idempotent_method,
 };
 
@@ -150,9 +151,6 @@ impl QUICListener {
         let backend_endpoints = Arc::clone(&exec_ctx.backend_endpoints);
         let _backend_resolutions = Arc::clone(&exec_ctx.backend_resolution_store);
         let transport = Arc::clone(&exec_ctx.transport_pool);
-        let allow_hedge = req.tunnel_mode == TunnelMode::None
-            && req.bodyless_mode
-            && resilience.hedging_allowed_for(&req.method, &route_name, true);
         let hedge_delay = resilience.hedging_delay;
         let alternate_backend = req.upstream_pool.as_ref().and_then(|upstream_pool| {
             Self::pick_alternate_backend(upstream_pool, pending_forward.backend_index)
@@ -164,6 +162,9 @@ impl QUICListener {
         let bodyless_mode = req.bodyless_mode;
         let request_id = req.request_id;
         let method_idempotent = is_idempotent_method(&req.method);
+        let hedge_method_allowed = resilience.hedging_method_allowed(&req.method);
+        let hedge_configured = resilience.hedging_route_enabled_for(&route_name);
+        let hedge_tunnel_request = req.tunnel_mode != TunnelMode::None;
         let fut = async move {
             let mut hedge_telemetry =
                 crate::runtime::connection::response::HedgeTelemetry::default();
@@ -214,7 +215,19 @@ impl QUICListener {
                             "missing upstream request for non-websocket forward".into(),
                         )
                     })?;
-                    let response: Response<Incoming> = if allow_hedge {
+                    let response: Response<Incoming> = if matches!(
+                        evaluate_hedge_policy(HedgePolicyFacts {
+                            hedging_configured: hedge_configured,
+                            method_allowed: hedge_method_allowed,
+                            request_body_replayable: bodyless_mode,
+                            tunnel_request: hedge_tunnel_request,
+                            alternate_backend_available: alternate_backend.is_some(),
+                            alternate_backend_healthy: alternate_backend.is_some(),
+                            budget_available: false,
+                            primary_state: HedgePrimaryState::InFlightBeforeDelay,
+                        }),
+                        HedgePolicyDecision::WaitForPrimary
+                    ) {
                         let hedge_candidate = alternate_backend.clone().and_then(|(backend, _idx)| {
                             let endpoint = backend_endpoints.get(&backend)?;
                             pending_forward_for_upstream
@@ -241,31 +254,44 @@ impl QUICListener {
                                 _ = &mut hedge_sleep => None,
                             } {
                                 result?
-                            } else if retry_budget.allow_retry(&route_name).is_ok() {
-                                hedge_telemetry.launched = true;
-                                let hedge_fut = send_once(
-                                    hedge_backend,
-                                    hedge_request,
-                                    Arc::clone(&cb),
-                                    Arc::clone(&transport),
-                                );
-                                tokio::pin!(hedge_fut);
-                                tokio::select! {
-                                    result = &mut primary_fut => {
-                                        hedge_telemetry.primary_won_after_trigger = true;
-                                        hedge_telemetry.hedge_wasted = true;
-                                        result?
-                                    },
-                                    result = &mut hedge_fut => {
-                                        hedge_telemetry.hedge_won = true;
-                                        let elapsed_ms = primary_started.elapsed().as_millis() as u64;
-                                        let delay_ms = hedge_delay.as_millis() as u64;
-                                        hedge_telemetry.primary_late_ms = elapsed_ms.saturating_sub(delay_ms);
-                                        result?
-                                    },
-                                }
                             } else {
-                                primary_fut.await?
+                                match evaluate_hedge_policy(HedgePolicyFacts {
+                                    hedging_configured: hedge_configured,
+                                    method_allowed: hedge_method_allowed,
+                                    request_body_replayable: bodyless_mode,
+                                    tunnel_request: hedge_tunnel_request,
+                                    alternate_backend_available: true,
+                                    alternate_backend_healthy: true,
+                                    budget_available: retry_budget.allow_retry(&route_name).is_ok(),
+                                    primary_state: HedgePrimaryState::InFlightAfterDelay,
+                                }) {
+                                    HedgePolicyDecision::Hedge { .. } => {
+                                        hedge_telemetry.launched = true;
+                                        let hedge_fut = send_once(
+                                            hedge_backend,
+                                            hedge_request,
+                                            Arc::clone(&cb),
+                                            Arc::clone(&transport),
+                                        );
+                                        tokio::pin!(hedge_fut);
+                                        tokio::select! {
+                                            result = &mut primary_fut => {
+                                                hedge_telemetry.primary_won_after_trigger = true;
+                                                hedge_telemetry.hedge_wasted = true;
+                                                result?
+                                            },
+                                            result = &mut hedge_fut => {
+                                                hedge_telemetry.hedge_won = true;
+                                                let elapsed_ms = primary_started.elapsed().as_millis() as u64;
+                                                let delay_ms = hedge_delay.as_millis() as u64;
+                                                hedge_telemetry.primary_late_ms = elapsed_ms.saturating_sub(delay_ms);
+                                                result?
+                                            },
+                                        }
+                                    }
+                                    HedgePolicyDecision::WaitForPrimary
+                                    | HedgePolicyDecision::DoNotHedge { .. } => primary_fut.await?,
+                                }
                             }
                         } else {
                             send_once(

--- a/crates/edge/src/quic_listener/forwarding/dispatch.rs
+++ b/crates/edge/src/quic_listener/forwarding/dispatch.rs
@@ -1,7 +1,7 @@
 use spooky_errors::{
     HedgeOutcomeTelemetryReason, HedgePolicyDecision, HedgePolicyFacts, HedgePrimaryState,
-    RetryAttemptTelemetryReason, RetryPolicyDecision, RetryPolicyDenialReason,
-    RetryPolicyFacts, evaluate_hedge_policy, evaluate_retry_policy, is_idempotent_method,
+    RetryAttemptTelemetryReason, RetryPolicyDecision, RetryPolicyDenialReason, RetryPolicyFacts,
+    evaluate_hedge_policy, evaluate_retry_policy, is_idempotent_method,
 };
 use spooky_lb::alternate_backend::{
     AlternateBackendDecision, AlternateBackendFailureReason, choose_alternate_backend,
@@ -10,11 +10,16 @@ use spooky_lb::alternate_backend::{
 use super::*;
 
 const MAX_UPSTREAM_RETRY_ATTEMPTS: u8 = 1;
+type UpstreamRequest = Request<BoxBody<Bytes, Infallible>>;
 
 #[derive(Clone, Debug)]
 enum ResolvedAlternateBackend {
-    Selected { address: String },
-    Unavailable { reason: AlternateBackendFailureReason },
+    Selected {
+        address: String,
+    },
+    Unavailable {
+        reason: AlternateBackendFailureReason,
+    },
 }
 
 impl ResolvedAlternateBackend {
@@ -28,6 +33,102 @@ impl ResolvedAlternateBackend {
             Self::Unavailable { reason } => Some(*reason),
         }
     }
+}
+
+struct AlternateBodylessCandidate {
+    backend: String,
+    request: UpstreamRequest,
+}
+
+#[derive(Clone, Copy)]
+struct ForwardingRetryHedgePolicy<'a> {
+    method_idempotent: bool,
+    bodyless_mode: bool,
+    hedge_method_allowed: bool,
+    hedge_configured: bool,
+    hedge_tunnel_request: bool,
+    _marker: std::marker::PhantomData<&'a ()>,
+}
+
+impl<'a> ForwardingRetryHedgePolicy<'a> {
+    fn new(
+        method_idempotent: bool,
+        bodyless_mode: bool,
+        hedge_method_allowed: bool,
+        hedge_configured: bool,
+        hedge_tunnel_request: bool,
+    ) -> Self {
+        Self {
+            method_idempotent,
+            bodyless_mode,
+            hedge_method_allowed,
+            hedge_configured,
+            hedge_tunnel_request,
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    fn hedge_before_delay(
+        self,
+        alternate_backend: Option<&ResolvedAlternateBackend>,
+    ) -> HedgePolicyDecision {
+        let (alternate_backend_available, alternate_backend_failure) =
+            alternate_backend_policy_state(alternate_backend);
+        evaluate_hedge_policy(HedgePolicyFacts {
+            hedging_configured: self.hedge_configured,
+            method_allowed: self.hedge_method_allowed,
+            request_body_replayable: self.bodyless_mode,
+            tunnel_request: self.hedge_tunnel_request,
+            alternate_backend_available,
+            alternate_backend_failure,
+            budget_available: false,
+            primary_state: HedgePrimaryState::InFlightBeforeDelay,
+        })
+    }
+
+    fn hedge_after_delay(self, budget_available: bool) -> HedgePolicyDecision {
+        evaluate_hedge_policy(HedgePolicyFacts {
+            hedging_configured: self.hedge_configured,
+            method_allowed: self.hedge_method_allowed,
+            request_body_replayable: self.bodyless_mode,
+            tunnel_request: self.hedge_tunnel_request,
+            alternate_backend_available: true,
+            alternate_backend_failure: None,
+            budget_available,
+            primary_state: HedgePrimaryState::InFlightAfterDelay,
+        })
+    }
+
+    fn retry_after_error(
+        self,
+        primary_err: &ProxyError,
+        retry_count: u8,
+        max_attempts: u8,
+        budget_available: bool,
+        alternate_backend: Option<&ResolvedAlternateBackend>,
+    ) -> RetryPolicyDecision {
+        let (alternate_backend_available, alternate_backend_failure) =
+            alternate_backend_policy_state(alternate_backend);
+        evaluate_retry_policy(RetryPolicyFacts {
+            retryability: spooky_errors::classify_retryability(primary_err),
+            method_idempotent: self.method_idempotent,
+            request_body_replayable: self.bodyless_mode,
+            attempt_count: retry_count,
+            max_attempts,
+            budget_available,
+            alternate_backend_available,
+            alternate_backend_failure,
+        })
+    }
+}
+
+fn alternate_backend_policy_state(
+    alternate_backend: Option<&ResolvedAlternateBackend>,
+) -> (bool, Option<AlternateBackendFailureReason>) {
+    (
+        alternate_backend.is_some_and(ResolvedAlternateBackend::is_available),
+        alternate_backend.and_then(ResolvedAlternateBackend::failure_reason),
+    )
 }
 
 impl QUICListener {
@@ -165,11 +266,29 @@ impl QUICListener {
         }
     }
 
+    fn build_alternate_bodyless_candidate(
+        alternate_backend: Option<&ResolvedAlternateBackend>,
+        backend_endpoints: &HashMap<String, BackendEndpoint>,
+        pending_forward: &PendingForward,
+    ) -> Option<AlternateBodylessCandidate> {
+        match alternate_backend? {
+            ResolvedAlternateBackend::Selected { address } => {
+                let endpoint = backend_endpoints.get(address)?;
+                let request = pending_forward.build_bodyless_request(endpoint).ok()?;
+                Some(AlternateBodylessCandidate {
+                    backend: address.clone(),
+                    request,
+                })
+            }
+            ResolvedAlternateBackend::Unavailable { .. } => None,
+        }
+    }
+
     pub(super) fn spawn_upstream_forward_task(
         req: &RequestEnvelope,
         pending_forward: Arc<PendingForward>,
         backend_endpoint: BackendEndpoint,
-        request: Option<Request<BoxBody<Bytes, Infallible>>>,
+        request: Option<UpstreamRequest>,
         websocket_tunnel_body_rx: Option<mpsc::Receiver<Bytes>>,
         exec_ctx: &ForwardingExecutionCtx<'_>,
         shared_ctx: &ForwardingSharedCtx<'_>,
@@ -185,12 +304,9 @@ impl QUICListener {
         let _backend_resolutions = Arc::clone(&exec_ctx.backend_resolution_store);
         let transport = Arc::clone(&exec_ctx.transport_pool);
         let hedge_delay = resilience.hedging_delay;
-        let alternate_backend = req
-            .upstream_pool
-            .as_ref()
-            .map(|upstream_pool| {
-                Self::resolve_alternate_backend(upstream_pool, pending_forward.backend_index)
-            });
+        let alternate_backend = req.upstream_pool.as_ref().map(|upstream_pool| {
+            Self::resolve_alternate_backend(upstream_pool, pending_forward.backend_index)
+        });
         let trace_span_for_upstream = req.trace_span.clone();
         let pending_forward_for_upstream = Arc::clone(&pending_forward);
         let (result_tx, result_rx) = oneshot::channel::<UpstreamResult>();
@@ -201,6 +317,13 @@ impl QUICListener {
         let hedge_method_allowed = resilience.hedging_method_allowed(&req.method);
         let hedge_configured = resilience.hedging_route_enabled_for(&route_name);
         let hedge_tunnel_request = req.tunnel_mode != TunnelMode::None;
+        let policy = ForwardingRetryHedgePolicy::new(
+            method_idempotent,
+            bodyless_mode,
+            hedge_method_allowed,
+            hedge_configured,
+            hedge_tunnel_request,
+        );
         let fut = async move {
             let mut hedge_telemetry =
                 crate::runtime::connection::response::HedgeTelemetry::default();
@@ -212,7 +335,7 @@ impl QUICListener {
 
                 let send_once =
                     |backend: String,
-                     req: http::Request<BoxBody<Bytes, std::convert::Infallible>>,
+                     req: UpstreamRequest,
                      cb: Arc<crate::resilience::circuit_breaker::CircuitBreakers>,
                      transport: Arc<UpstreamTransportPool>| async move {
                         if !cb.allow_request(&backend) {
@@ -251,38 +374,21 @@ impl QUICListener {
                             "missing upstream request for non-websocket forward".into(),
                         )
                     })?;
-                    let response: Response<Incoming> = if matches!(
-                        evaluate_hedge_policy(HedgePolicyFacts {
-                            hedging_configured: hedge_configured,
-                            method_allowed: hedge_method_allowed,
-                            request_body_replayable: bodyless_mode,
-                            tunnel_request: hedge_tunnel_request,
-                            alternate_backend_available: alternate_backend
-                                .as_ref()
-                                .is_some_and(ResolvedAlternateBackend::is_available),
-                            alternate_backend_failure: alternate_backend
-                                .as_ref()
-                                .and_then(ResolvedAlternateBackend::failure_reason),
-                            budget_available: false,
-                            primary_state: HedgePrimaryState::InFlightBeforeDelay,
-                        }),
-                        HedgePolicyDecision::WaitForPrimary
-                    ) {
-                        let hedge_candidate =
-                            alternate_backend
-                                .clone()
-                                .and_then(|alternate| match alternate {
-                                    ResolvedAlternateBackend::Selected { address, .. } => {
-                                        let endpoint = backend_endpoints.get(&address)?;
-                                        pending_forward_for_upstream
-                                            .build_bodyless_request(endpoint)
-                                            .ok()
-                                            .map(|req| (address, req))
-                                    }
-                                    ResolvedAlternateBackend::Unavailable { .. } => None,
-                                });
+                    let response: Response<Incoming> = match policy
+                        .hedge_before_delay(alternate_backend.as_ref())
+                    {
+                        HedgePolicyDecision::WaitForPrimary => {
+                            let hedge_candidate = Self::build_alternate_bodyless_candidate(
+                                alternate_backend.as_ref(),
+                                backend_endpoints.as_ref(),
+                                pending_forward_for_upstream.as_ref(),
+                            );
 
-                        if let Some((hedge_backend, hedge_request)) = hedge_candidate {
+                            if let Some(AlternateBodylessCandidate {
+                                backend: hedge_backend,
+                                request: hedge_request,
+                            }) = hedge_candidate
+                            {
                             let primary_started = Instant::now();
                             let primary_backend = fwd_addr.clone();
                             let primary_fut = send_once(
@@ -301,16 +407,9 @@ impl QUICListener {
                             } {
                                 result?
                             } else {
-                                match evaluate_hedge_policy(HedgePolicyFacts {
-                                    hedging_configured: hedge_configured,
-                                    method_allowed: hedge_method_allowed,
-                                    request_body_replayable: bodyless_mode,
-                                    tunnel_request: hedge_tunnel_request,
-                                    alternate_backend_available: true,
-                                    alternate_backend_failure: None,
-                                    budget_available: retry_budget.allow_retry(&route_name).is_ok(),
-                                    primary_state: HedgePrimaryState::InFlightAfterDelay,
-                                }) {
+                                match policy.hedge_after_delay(
+                                    retry_budget.allow_retry(&route_name).is_ok(),
+                                ) {
                                     HedgePolicyDecision::Hedge { reason } => {
                                         hedge_telemetry.trigger_reason = Some(reason);
                                         let hedge_fut = send_once(
@@ -336,60 +435,67 @@ impl QUICListener {
                                             },
                                         }
                                     }
-                                    HedgePolicyDecision::WaitForPrimary
-                                    | HedgePolicyDecision::DoNotHedge { .. } => primary_fut.await?,
+                                    HedgePolicyDecision::WaitForPrimary => primary_fut.await?,
+                                    HedgePolicyDecision::DoNotHedge { denial } => {
+                                        debug!(
+                                            "request_id={} hedge suppressed after delay: route={} reason={:?}",
+                                            request_id, route_name, denial
+                                        );
+                                        primary_fut.await?
+                                    }
                                 }
                             }
-                        } else {
-                            send_once(
+                            } else {
+                                send_once(
+                                    fwd_addr.clone(),
+                                    request,
+                                    Arc::clone(&cb),
+                                    Arc::clone(&transport),
+                                )
+                                .await?
+                            }
+                        }
+                        HedgePolicyDecision::DoNotHedge { denial } => {
+                            debug!(
+                                "request_id={} hedging disabled for request: route={} reason={:?}",
+                                request_id, route_name, denial
+                            );
+                            match send_once(
                                 fwd_addr.clone(),
                                 request,
                                 Arc::clone(&cb),
                                 Arc::clone(&transport),
                             )
-                            .await?
-                        }
-                    } else {
-                        match send_once(
-                            fwd_addr.clone(),
-                            request,
-                            Arc::clone(&cb),
-                            Arc::clone(&transport),
-                        )
-                        .await
-                        {
-                            Ok(response) => response,
-                            Err(primary_err) => {
-                                let retry_decision = evaluate_retry_policy(RetryPolicyFacts {
-                                    retryability: spooky_errors::classify_retryability(&primary_err),
-                                    method_idempotent,
-                                    request_body_replayable: bodyless_mode,
-                                    attempt_count: retry_count,
-                                    max_attempts: MAX_UPSTREAM_RETRY_ATTEMPTS,
-                                    budget_available: retry_budget.allow_retry(&route_name).is_ok(),
-                                    alternate_backend_available: alternate_backend
-                                        .as_ref()
-                                        .is_some_and(ResolvedAlternateBackend::is_available),
-                                    alternate_backend_failure: alternate_backend
-                                        .as_ref()
-                                        .and_then(ResolvedAlternateBackend::failure_reason),
-                                });
-                                let retry_reason = match retry_decision {
-                                    RetryPolicyDecision::Retry { reason } => reason.into(),
-                                    RetryPolicyDecision::DoNotRetry { denial } => {
-                                        retry_denial_reason = denial;
-                                        return Err(primary_err);
-                                    }
-                                };
-                                if let Some(alternate_backend) = alternate_backend.clone() {
-                                    if let ResolvedAlternateBackend::Selected {
-                                        address: retry_backend,
-                                        ..
-                                    } = alternate_backend
-                                        && let Some(endpoint) = backend_endpoints.get(&retry_backend)
-                                        && let Ok(retry_request) = pending_forward_for_upstream
-                                            .build_bodyless_request(endpoint)
-                                    {
+                            .await
+                            {
+                                Ok(response) => response,
+                                Err(primary_err) => {
+                                    let retry_decision = policy.retry_after_error(
+                                        &primary_err,
+                                        retry_count,
+                                        MAX_UPSTREAM_RETRY_ATTEMPTS,
+                                        retry_budget.allow_retry(&route_name).is_ok(),
+                                        alternate_backend.as_ref(),
+                                    );
+                                    let retry_reason = match retry_decision {
+                                        RetryPolicyDecision::Retry { reason } => reason.into(),
+                                        RetryPolicyDecision::DoNotRetry { denial } => {
+                                            retry_denial_reason = denial;
+                                            debug!(
+                                                "request_id={} retry denied: route={} reason={:?}",
+                                                request_id, route_name, denial
+                                            );
+                                            return Err(primary_err);
+                                        }
+                                    };
+                                    if let Some(AlternateBodylessCandidate {
+                                        backend: retry_backend,
+                                        request: retry_request,
+                                    }) = Self::build_alternate_bodyless_candidate(
+                                        alternate_backend.as_ref(),
+                                        backend_endpoints.as_ref(),
+                                        pending_forward_for_upstream.as_ref(),
+                                    ) {
                                         retry_count = retry_count.saturating_add(1);
                                         retry_attempt_reason = Some(retry_reason);
                                         info!(
@@ -406,8 +512,66 @@ impl QUICListener {
                                     } else {
                                         return Err(primary_err);
                                     }
-                                } else {
-                                    return Err(primary_err);
+                                }
+                            }
+                        }
+                        HedgePolicyDecision::Hedge { reason } => {
+                            debug!(
+                                "request_id={} shared hedge policy triggered early: route={} reason={:?}",
+                                request_id, route_name, reason
+                            );
+                            match send_once(
+                                fwd_addr.clone(),
+                                request,
+                                Arc::clone(&cb),
+                                Arc::clone(&transport),
+                            )
+                            .await
+                            {
+                                Ok(response) => response,
+                                Err(primary_err) => {
+                                    let retry_decision = policy.retry_after_error(
+                                        &primary_err,
+                                        retry_count,
+                                        MAX_UPSTREAM_RETRY_ATTEMPTS,
+                                        retry_budget.allow_retry(&route_name).is_ok(),
+                                        alternate_backend.as_ref(),
+                                    );
+                                let retry_reason = match retry_decision {
+                                    RetryPolicyDecision::Retry { reason } => reason.into(),
+                                    RetryPolicyDecision::DoNotRetry { denial } => {
+                                        retry_denial_reason = denial;
+                                        debug!(
+                                            "request_id={} retry denied: route={} reason={:?}",
+                                            request_id, route_name, denial
+                                        );
+                                        return Err(primary_err);
+                                    }
+                                };
+                                    if let Some(AlternateBodylessCandidate {
+                                        backend: retry_backend,
+                                        request: retry_request,
+                                    }) = Self::build_alternate_bodyless_candidate(
+                                        alternate_backend.as_ref(),
+                                        backend_endpoints.as_ref(),
+                                        pending_forward_for_upstream.as_ref(),
+                                    ) {
+                                        retry_count = retry_count.saturating_add(1);
+                                        retry_attempt_reason = Some(retry_reason);
+                                        info!(
+                                            "request_id={} retrying request on alternate backend: route={} reason={:?}",
+                                            request_id, route_name, retry_reason
+                                        );
+                                        send_once(
+                                            retry_backend,
+                                            retry_request,
+                                            Arc::clone(&cb),
+                                            Arc::clone(&transport),
+                                        )
+                                        .await?
+                                    } else {
+                                        return Err(primary_err);
+                                    }
                                 }
                             }
                         }

--- a/crates/edge/src/quic_listener/forwarding/dispatch.rs
+++ b/crates/edge/src/quic_listener/forwarding/dispatch.rs
@@ -130,6 +130,15 @@ fn alternate_backend_policy_state(
     )
 }
 
+fn retry_budget_available_for_error(
+    primary_err: &ProxyError,
+    route_name: &str,
+    retry_budget: &crate::resilience::retry_budget::RetryBudget,
+) -> bool {
+    matches!(primary_err, ProxyError::Pool(PoolError::CircuitOpen(_)))
+        || retry_budget.allow_retry(route_name).is_ok()
+}
+
 impl QUICListener {
     async fn send_upstream_request(
         backend: String,
@@ -322,7 +331,7 @@ impl QUICListener {
             &primary_err,
             policy_telemetry.retry.count,
             MAX_UPSTREAM_RETRY_ATTEMPTS,
-            retry_budget.allow_retry(route_name).is_ok(),
+            retry_budget_available_for_error(&primary_err, route_name, retry_budget),
             alternate_backend,
         );
         let retry_reason = match retry_decision {
@@ -465,7 +474,11 @@ impl QUICListener {
                                 result?
                             } else {
                                 match policy.hedge_after_delay(
-                                    retry_budget.allow_retry(&route_name).is_ok(),
+                                    retry_budget_available_for_error(
+                                        &ProxyError::Timeout,
+                                        &route_name,
+                                        retry_budget.as_ref(),
+                                    ),
                                 ) {
                                     HedgePolicyDecision::Hedge { reason } => {
                                         policy_telemetry.hedge.record_trigger(reason);
@@ -479,21 +492,46 @@ impl QUICListener {
                                         tokio::pin!(hedge_fut);
                                         tokio::select! {
                                             result = &mut primary_fut => {
-                                                policy_telemetry
-                                                    .hedge
-                                                    .record_outcome(HedgeOutcomeTelemetryReason::PrimaryWonAfterTrigger);
-                                                result?
+                                                match result {
+                                                    Ok(response) => {
+                                                        policy_telemetry
+                                                            .hedge
+                                                            .record_outcome(HedgeOutcomeTelemetryReason::PrimaryWonAfterTrigger);
+                                                        response
+                                                    }
+                                                    Err(_primary_err) => {
+                                                        policy_telemetry
+                                                            .hedge
+                                                            .record_outcome(HedgeOutcomeTelemetryReason::HedgeWon);
+                                                        let elapsed_ms = primary_started.elapsed().as_millis() as u64;
+                                                        let delay_ms = hedge_delay.as_millis() as u64;
+                                                        policy_telemetry
+                                                            .hedge
+                                                            .observe_primary_late_ms(elapsed_ms.saturating_sub(delay_ms));
+                                                        hedge_fut.await?
+                                                    }
+                                                }
                                             },
                                             result = &mut hedge_fut => {
-                                                policy_telemetry
-                                                    .hedge
-                                                    .record_outcome(HedgeOutcomeTelemetryReason::HedgeWon);
-                                                let elapsed_ms = primary_started.elapsed().as_millis() as u64;
-                                                let delay_ms = hedge_delay.as_millis() as u64;
-                                                policy_telemetry
-                                                    .hedge
-                                                    .observe_primary_late_ms(elapsed_ms.saturating_sub(delay_ms));
-                                                result?
+                                                match result {
+                                                    Ok(response) => {
+                                                        policy_telemetry
+                                                            .hedge
+                                                            .record_outcome(HedgeOutcomeTelemetryReason::HedgeWon);
+                                                        let elapsed_ms = primary_started.elapsed().as_millis() as u64;
+                                                        let delay_ms = hedge_delay.as_millis() as u64;
+                                                        policy_telemetry
+                                                            .hedge
+                                                            .observe_primary_late_ms(elapsed_ms.saturating_sub(delay_ms));
+                                                        response
+                                                    }
+                                                    Err(_hedge_err) => {
+                                                        policy_telemetry
+                                                            .hedge
+                                                            .record_outcome(HedgeOutcomeTelemetryReason::PrimaryWonAfterTrigger);
+                                                        primary_fut.await?
+                                                    }
+                                                }
                                             },
                                         }
                                     }

--- a/crates/edge/src/quic_listener/forwarding/dispatch.rs
+++ b/crates/edge/src/quic_listener/forwarding/dispatch.rs
@@ -1,15 +1,34 @@
 use spooky_errors::{
-    HedgePolicyDecision, HedgePolicyFacts, HedgePrimaryState, RetryPolicyDecision,
-    RetryPolicyFacts, RetryPolicyDenialReason, RetryTelemetryReason, evaluate_hedge_policy,
-    evaluate_retry_policy, is_idempotent_method,
+    HedgeOutcomeTelemetryReason, HedgePolicyDecision, HedgePolicyFacts, HedgePrimaryState,
+    RetryAttemptTelemetryReason, RetryPolicyDecision, RetryPolicyDenialReason,
+    RetryPolicyFacts, evaluate_hedge_policy, evaluate_retry_policy, is_idempotent_method,
 };
 use spooky_lb::alternate_backend::{
-    AlternateBackendDecision, choose_alternate_backend,
+    AlternateBackendDecision, AlternateBackendFailureReason, choose_alternate_backend,
 };
 
 use super::*;
 
 const MAX_UPSTREAM_RETRY_ATTEMPTS: u8 = 1;
+
+#[derive(Clone, Debug)]
+enum ResolvedAlternateBackend {
+    Selected { address: String },
+    Unavailable { reason: AlternateBackendFailureReason },
+}
+
+impl ResolvedAlternateBackend {
+    fn is_available(&self) -> bool {
+        matches!(self, Self::Selected { .. })
+    }
+
+    fn failure_reason(&self) -> Option<AlternateBackendFailureReason> {
+        match self {
+            Self::Selected { .. } => None,
+            Self::Unavailable { reason } => Some(*reason),
+        }
+    }
+}
 
 impl QUICListener {
     #[allow(clippy::too_many_arguments)]
@@ -122,14 +141,27 @@ impl QUICListener {
     fn resolve_alternate_backend(
         upstream_pool: &Arc<RwLock<UpstreamPool>>,
         primary_index: usize,
-    ) -> Option<(String, usize)> {
-        let pool = upstream_pool.read().ok()?;
+    ) -> ResolvedAlternateBackend {
+        let Ok(pool) = upstream_pool.read() else {
+            return ResolvedAlternateBackend::Unavailable {
+                reason: AlternateBackendFailureReason::PoolUnavailable,
+            };
+        };
         match choose_alternate_backend(&pool, &[primary_index], None) {
-            AlternateBackendDecision::Select(choice) => pool
-                .pool
-                .address(choice.index)
-                .map(|address| (address.to_string(), choice.index)),
-            AlternateBackendDecision::DoNotSelect { .. } => None,
+            AlternateBackendDecision::Select(choice) => {
+                if let Some(address) = pool.pool.address(choice.index) {
+                    ResolvedAlternateBackend::Selected {
+                        address: address.to_string(),
+                    }
+                } else {
+                    ResolvedAlternateBackend::Unavailable {
+                        reason: AlternateBackendFailureReason::BackendAddressMissing,
+                    }
+                }
+            }
+            AlternateBackendDecision::DoNotSelect { denial } => {
+                ResolvedAlternateBackend::Unavailable { reason: denial }
+            }
         }
     }
 
@@ -153,9 +185,12 @@ impl QUICListener {
         let _backend_resolutions = Arc::clone(&exec_ctx.backend_resolution_store);
         let transport = Arc::clone(&exec_ctx.transport_pool);
         let hedge_delay = resilience.hedging_delay;
-        let alternate_backend = req.upstream_pool.as_ref().and_then(|upstream_pool| {
-            Self::resolve_alternate_backend(upstream_pool, pending_forward.backend_index)
-        });
+        let alternate_backend = req
+            .upstream_pool
+            .as_ref()
+            .map(|upstream_pool| {
+                Self::resolve_alternate_backend(upstream_pool, pending_forward.backend_index)
+            });
         let trace_span_for_upstream = req.trace_span.clone();
         let pending_forward_for_upstream = Arc::clone(&pending_forward);
         let (result_tx, result_rx) = oneshot::channel::<UpstreamResult>();
@@ -170,7 +205,7 @@ impl QUICListener {
             let mut hedge_telemetry =
                 crate::runtime::connection::response::HedgeTelemetry::default();
             let mut retry_count: u8 = 0;
-            let mut retry_attempt_reason: Option<RetryTelemetryReason> = None;
+            let mut retry_attempt_reason: Option<RetryAttemptTelemetryReason> = None;
             let mut retry_denial_reason: Option<RetryPolicyDenialReason> = None;
             let result: ForwardResult = async {
                 retry_budget.mark_primary(&route_name);
@@ -222,20 +257,30 @@ impl QUICListener {
                             method_allowed: hedge_method_allowed,
                             request_body_replayable: bodyless_mode,
                             tunnel_request: hedge_tunnel_request,
-                            alternate_backend_available: alternate_backend.is_some(),
-                            alternate_backend_healthy: alternate_backend.is_some(),
+                            alternate_backend_available: alternate_backend
+                                .as_ref()
+                                .is_some_and(ResolvedAlternateBackend::is_available),
+                            alternate_backend_failure: alternate_backend
+                                .as_ref()
+                                .and_then(ResolvedAlternateBackend::failure_reason),
                             budget_available: false,
                             primary_state: HedgePrimaryState::InFlightBeforeDelay,
                         }),
                         HedgePolicyDecision::WaitForPrimary
                     ) {
-                        let hedge_candidate = alternate_backend.clone().and_then(|(backend, _idx)| {
-                            let endpoint = backend_endpoints.get(&backend)?;
-                            pending_forward_for_upstream
-                                .build_bodyless_request(endpoint)
-                                .ok()
-                                .map(|req| (backend, req))
-                        });
+                        let hedge_candidate =
+                            alternate_backend
+                                .clone()
+                                .and_then(|alternate| match alternate {
+                                    ResolvedAlternateBackend::Selected { address, .. } => {
+                                        let endpoint = backend_endpoints.get(&address)?;
+                                        pending_forward_for_upstream
+                                            .build_bodyless_request(endpoint)
+                                            .ok()
+                                            .map(|req| (address, req))
+                                    }
+                                    ResolvedAlternateBackend::Unavailable { .. } => None,
+                                });
 
                         if let Some((hedge_backend, hedge_request)) = hedge_candidate {
                             let primary_started = Instant::now();
@@ -262,12 +307,12 @@ impl QUICListener {
                                     request_body_replayable: bodyless_mode,
                                     tunnel_request: hedge_tunnel_request,
                                     alternate_backend_available: true,
-                                    alternate_backend_healthy: true,
+                                    alternate_backend_failure: None,
                                     budget_available: retry_budget.allow_retry(&route_name).is_ok(),
                                     primary_state: HedgePrimaryState::InFlightAfterDelay,
                                 }) {
-                                    HedgePolicyDecision::Hedge { .. } => {
-                                        hedge_telemetry.launched = true;
+                                    HedgePolicyDecision::Hedge { reason } => {
+                                        hedge_telemetry.trigger_reason = Some(reason);
                                         let hedge_fut = send_once(
                                             hedge_backend,
                                             hedge_request,
@@ -277,12 +322,13 @@ impl QUICListener {
                                         tokio::pin!(hedge_fut);
                                         tokio::select! {
                                             result = &mut primary_fut => {
-                                                hedge_telemetry.primary_won_after_trigger = true;
-                                                hedge_telemetry.hedge_wasted = true;
+                                                hedge_telemetry.outcome_reason =
+                                                    Some(HedgeOutcomeTelemetryReason::PrimaryWonAfterTrigger);
                                                 result?
                                             },
                                             result = &mut hedge_fut => {
-                                                hedge_telemetry.hedge_won = true;
+                                                hedge_telemetry.outcome_reason =
+                                                    Some(HedgeOutcomeTelemetryReason::HedgeWon);
                                                 let elapsed_ms = primary_started.elapsed().as_millis() as u64;
                                                 let delay_ms = hedge_delay.as_millis() as u64;
                                                 hedge_telemetry.primary_late_ms = elapsed_ms.saturating_sub(delay_ms);
@@ -321,8 +367,12 @@ impl QUICListener {
                                     attempt_count: retry_count,
                                     max_attempts: MAX_UPSTREAM_RETRY_ATTEMPTS,
                                     budget_available: retry_budget.allow_retry(&route_name).is_ok(),
-                                    alternate_backend_available: alternate_backend.is_some(),
-                                    alternate_backend_healthy: alternate_backend.is_some(),
+                                    alternate_backend_available: alternate_backend
+                                        .as_ref()
+                                        .is_some_and(ResolvedAlternateBackend::is_available),
+                                    alternate_backend_failure: alternate_backend
+                                        .as_ref()
+                                        .and_then(ResolvedAlternateBackend::failure_reason),
                                 });
                                 let retry_reason = match retry_decision {
                                     RetryPolicyDecision::Retry { reason } => reason.into(),
@@ -331,24 +381,31 @@ impl QUICListener {
                                         return Err(primary_err);
                                     }
                                 };
-                                if let Some((retry_backend, _)) = alternate_backend.clone()
-                                    && let Some(endpoint) = backend_endpoints.get(&retry_backend)
-                                    && let Ok(retry_request) =
-                                        pending_forward_for_upstream.build_bodyless_request(endpoint)
-                                {
-                                    retry_count = retry_count.saturating_add(1);
-                                    retry_attempt_reason = Some(retry_reason);
-                                    info!(
-                                        "request_id={} retrying request on alternate backend: route={} reason={:?}",
-                                        request_id, route_name, retry_reason
-                                    );
-                                    send_once(
-                                        retry_backend,
-                                        retry_request,
-                                        Arc::clone(&cb),
-                                        Arc::clone(&transport),
-                                    )
-                                    .await?
+                                if let Some(alternate_backend) = alternate_backend.clone() {
+                                    if let ResolvedAlternateBackend::Selected {
+                                        address: retry_backend,
+                                        ..
+                                    } = alternate_backend
+                                        && let Some(endpoint) = backend_endpoints.get(&retry_backend)
+                                        && let Ok(retry_request) = pending_forward_for_upstream
+                                            .build_bodyless_request(endpoint)
+                                    {
+                                        retry_count = retry_count.saturating_add(1);
+                                        retry_attempt_reason = Some(retry_reason);
+                                        info!(
+                                            "request_id={} retrying request on alternate backend: route={} reason={:?}",
+                                            request_id, route_name, retry_reason
+                                        );
+                                        send_once(
+                                            retry_backend,
+                                            retry_request,
+                                            Arc::clone(&cb),
+                                            Arc::clone(&transport),
+                                        )
+                                        .await?
+                                    } else {
+                                        return Err(primary_err);
+                                    }
                                 } else {
                                     return Err(primary_err);
                                 }

--- a/crates/edge/src/quic_listener/forwarding/dispatch.rs
+++ b/crates/edge/src/quic_listener/forwarding/dispatch.rs
@@ -370,7 +370,8 @@ impl QUICListener {
             alternate_backend,
             backend_endpoints,
             pending_forward,
-        ) else {
+        )
+        else {
             return Err(primary_err);
         };
 

--- a/crates/edge/src/quic_listener/forwarding/dispatch.rs
+++ b/crates/edge/src/quic_listener/forwarding/dispatch.rs
@@ -3,6 +3,9 @@ use spooky_errors::{
     RetryPolicyFacts, RetryPolicyDenialReason, RetryTelemetryReason, evaluate_hedge_policy,
     evaluate_retry_policy, is_idempotent_method,
 };
+use spooky_lb::alternate_backend::{
+    AlternateBackendDecision, choose_alternate_backend,
+};
 
 use super::*;
 
@@ -116,20 +119,18 @@ impl QUICListener {
         })
     }
 
-    fn pick_alternate_backend(
+    fn resolve_alternate_backend(
         upstream_pool: &Arc<RwLock<UpstreamPool>>,
         primary_index: usize,
     ) -> Option<(String, usize)> {
         let pool = upstream_pool.read().ok()?;
-        for index in pool.pool.healthy_indices_iter() {
-            if index == primary_index {
-                continue;
-            }
-            if let Some(address) = pool.pool.address(index) {
-                return Some((address.to_string(), index));
-            }
+        match choose_alternate_backend(&pool, &[primary_index], None) {
+            AlternateBackendDecision::Select(choice) => pool
+                .pool
+                .address(choice.index)
+                .map(|address| (address.to_string(), choice.index)),
+            AlternateBackendDecision::DoNotSelect { .. } => None,
         }
-        None
     }
 
     pub(super) fn spawn_upstream_forward_task(
@@ -153,7 +154,7 @@ impl QUICListener {
         let transport = Arc::clone(&exec_ctx.transport_pool);
         let hedge_delay = resilience.hedging_delay;
         let alternate_backend = req.upstream_pool.as_ref().and_then(|upstream_pool| {
-            Self::pick_alternate_backend(upstream_pool, pending_forward.backend_index)
+            Self::resolve_alternate_backend(upstream_pool, pending_forward.backend_index)
         });
         let trace_span_for_upstream = req.trace_span.clone();
         let pending_forward_for_upstream = Arc::clone(&pending_forward);

--- a/crates/edge/src/quic_listener/forwarding/dispatch.rs
+++ b/crates/edge/src/quic_listener/forwarding/dispatch.rs
@@ -1,13 +1,14 @@
 use spooky_errors::{
     HedgeOutcomeTelemetryReason, HedgePolicyDecision, HedgePolicyFacts, HedgePrimaryState,
-    RetryAttemptTelemetryReason, RetryPolicyDecision, RetryPolicyDenialReason, RetryPolicyFacts,
-    evaluate_hedge_policy, evaluate_retry_policy, is_idempotent_method,
+    RetryPolicyDecision, RetryPolicyFacts, evaluate_hedge_policy, evaluate_retry_policy,
+    is_idempotent_method,
 };
 use spooky_lb::alternate_backend::{
     AlternateBackendDecision, AlternateBackendFailureReason, choose_alternate_backend,
 };
 
 use super::*;
+use crate::runtime::connection::response::ForwardingPolicyTelemetry;
 
 const MAX_UPSTREAM_RETRY_ATTEMPTS: u8 = 1;
 type UpstreamRequest = Request<BoxBody<Bytes, Infallible>>;
@@ -325,11 +326,7 @@ impl QUICListener {
             hedge_tunnel_request,
         );
         let fut = async move {
-            let mut hedge_telemetry =
-                crate::runtime::connection::response::HedgeTelemetry::default();
-            let mut retry_count: u8 = 0;
-            let mut retry_attempt_reason: Option<RetryAttemptTelemetryReason> = None;
-            let mut retry_denial_reason: Option<RetryPolicyDenialReason> = None;
+            let mut policy_telemetry = ForwardingPolicyTelemetry::default();
             let result: ForwardResult = async {
                 retry_budget.mark_primary(&route_name);
 
@@ -411,7 +408,7 @@ impl QUICListener {
                                     retry_budget.allow_retry(&route_name).is_ok(),
                                 ) {
                                     HedgePolicyDecision::Hedge { reason } => {
-                                        hedge_telemetry.trigger_reason = Some(reason);
+                                        policy_telemetry.hedge.record_trigger(reason);
                                         let hedge_fut = send_once(
                                             hedge_backend,
                                             hedge_request,
@@ -421,16 +418,20 @@ impl QUICListener {
                                         tokio::pin!(hedge_fut);
                                         tokio::select! {
                                             result = &mut primary_fut => {
-                                                hedge_telemetry.outcome_reason =
-                                                    Some(HedgeOutcomeTelemetryReason::PrimaryWonAfterTrigger);
+                                                policy_telemetry
+                                                    .hedge
+                                                    .record_outcome(HedgeOutcomeTelemetryReason::PrimaryWonAfterTrigger);
                                                 result?
                                             },
                                             result = &mut hedge_fut => {
-                                                hedge_telemetry.outcome_reason =
-                                                    Some(HedgeOutcomeTelemetryReason::HedgeWon);
+                                                policy_telemetry
+                                                    .hedge
+                                                    .record_outcome(HedgeOutcomeTelemetryReason::HedgeWon);
                                                 let elapsed_ms = primary_started.elapsed().as_millis() as u64;
                                                 let delay_ms = hedge_delay.as_millis() as u64;
-                                                hedge_telemetry.primary_late_ms = elapsed_ms.saturating_sub(delay_ms);
+                                                policy_telemetry
+                                                    .hedge
+                                                    .observe_primary_late_ms(elapsed_ms.saturating_sub(delay_ms));
                                                 result?
                                             },
                                         }
@@ -472,7 +473,7 @@ impl QUICListener {
                                 Err(primary_err) => {
                                     let retry_decision = policy.retry_after_error(
                                         &primary_err,
-                                        retry_count,
+                                        policy_telemetry.retry.count,
                                         MAX_UPSTREAM_RETRY_ATTEMPTS,
                                         retry_budget.allow_retry(&route_name).is_ok(),
                                         alternate_backend.as_ref(),
@@ -480,7 +481,7 @@ impl QUICListener {
                                     let retry_reason = match retry_decision {
                                         RetryPolicyDecision::Retry { reason } => reason.into(),
                                         RetryPolicyDecision::DoNotRetry { denial } => {
-                                            retry_denial_reason = denial;
+                                            policy_telemetry.retry.record_denial(denial);
                                             debug!(
                                                 "request_id={} retry denied: route={} reason={:?}",
                                                 request_id, route_name, denial
@@ -496,8 +497,7 @@ impl QUICListener {
                                         backend_endpoints.as_ref(),
                                         pending_forward_for_upstream.as_ref(),
                                     ) {
-                                        retry_count = retry_count.saturating_add(1);
-                                        retry_attempt_reason = Some(retry_reason);
+                                        policy_telemetry.retry.record_attempt(retry_reason);
                                         info!(
                                             "request_id={} retrying request on alternate backend: route={} reason={:?}",
                                             request_id, route_name, retry_reason
@@ -532,7 +532,7 @@ impl QUICListener {
                                 Err(primary_err) => {
                                     let retry_decision = policy.retry_after_error(
                                         &primary_err,
-                                        retry_count,
+                                        policy_telemetry.retry.count,
                                         MAX_UPSTREAM_RETRY_ATTEMPTS,
                                         retry_budget.allow_retry(&route_name).is_ok(),
                                         alternate_backend.as_ref(),
@@ -540,7 +540,7 @@ impl QUICListener {
                                 let retry_reason = match retry_decision {
                                     RetryPolicyDecision::Retry { reason } => reason.into(),
                                     RetryPolicyDecision::DoNotRetry { denial } => {
-                                        retry_denial_reason = denial;
+                                        policy_telemetry.retry.record_denial(denial);
                                         debug!(
                                             "request_id={} retry denied: route={} reason={:?}",
                                             request_id, route_name, denial
@@ -556,8 +556,7 @@ impl QUICListener {
                                         backend_endpoints.as_ref(),
                                         pending_forward_for_upstream.as_ref(),
                                     ) {
-                                        retry_count = retry_count.saturating_add(1);
-                                        retry_attempt_reason = Some(retry_reason);
+                                        policy_telemetry.retry.record_attempt(retry_reason);
                                         info!(
                                             "request_id={} retrying request on alternate backend: route={} reason={:?}",
                                             request_id, route_name, retry_reason
@@ -589,10 +588,7 @@ impl QUICListener {
             .await;
             let _ = result_tx.send(UpstreamResult {
                 forward: result,
-                hedge: hedge_telemetry,
-                retry_count,
-                retry_attempt_reason,
-                retry_denial_reason,
+                policy: policy_telemetry,
             });
         };
         let spawned = match trace_span_for_upstream {

--- a/crates/edge/src/quic_listener/forwarding/dispatch.rs
+++ b/crates/edge/src/quic_listener/forwarding/dispatch.rs
@@ -42,16 +42,15 @@ struct AlternateBodylessCandidate {
 }
 
 #[derive(Clone, Copy)]
-struct ForwardingRetryHedgePolicy<'a> {
+struct ForwardingRetryHedgePolicy {
     method_idempotent: bool,
     bodyless_mode: bool,
     hedge_method_allowed: bool,
     hedge_configured: bool,
     hedge_tunnel_request: bool,
-    _marker: std::marker::PhantomData<&'a ()>,
 }
 
-impl<'a> ForwardingRetryHedgePolicy<'a> {
+impl ForwardingRetryHedgePolicy {
     fn new(
         method_idempotent: bool,
         bodyless_mode: bool,
@@ -65,7 +64,6 @@ impl<'a> ForwardingRetryHedgePolicy<'a> {
             hedge_method_allowed,
             hedge_configured,
             hedge_tunnel_request,
-            _marker: std::marker::PhantomData,
         }
     }
 
@@ -133,6 +131,27 @@ fn alternate_backend_policy_state(
 }
 
 impl QUICListener {
+    async fn send_upstream_request(
+        backend: String,
+        request: UpstreamRequest,
+        circuit_breakers: Arc<crate::resilience::circuit_breaker::CircuitBreakers>,
+        transport: Arc<UpstreamTransportPool>,
+        backend_timeout: Duration,
+    ) -> Result<Response<Incoming>, ProxyError> {
+        if !circuit_breakers.allow_request(&backend) {
+            return Err(ProxyError::Pool(PoolError::CircuitOpen(backend)));
+        }
+
+        let send_result = tokio::time::timeout(backend_timeout, transport.send(&backend, request))
+            .await
+            .map_err(|_| ProxyError::Timeout);
+        match &send_result {
+            Ok(Ok(_)) => circuit_breakers.record_success(&backend),
+            _ => circuit_breakers.record_failure(&backend),
+        }
+        Ok(send_result??)
+    }
+
     #[allow(clippy::too_many_arguments)]
     async fn forward_http1_websocket_tunnel(
         endpoint: BackendEndpoint,
@@ -285,6 +304,65 @@ impl QUICListener {
         }
     }
 
+    async fn retry_primary_error(
+        primary_err: ProxyError,
+        request_id: u64,
+        route_name: &str,
+        policy: ForwardingRetryHedgePolicy,
+        policy_telemetry: &mut ForwardingPolicyTelemetry,
+        retry_budget: &crate::resilience::retry_budget::RetryBudget,
+        alternate_backend: Option<&ResolvedAlternateBackend>,
+        backend_endpoints: &HashMap<String, BackendEndpoint>,
+        pending_forward: &PendingForward,
+        circuit_breakers: Arc<crate::resilience::circuit_breaker::CircuitBreakers>,
+        transport: Arc<UpstreamTransportPool>,
+        backend_timeout: Duration,
+    ) -> Result<Response<Incoming>, ProxyError> {
+        let retry_decision = policy.retry_after_error(
+            &primary_err,
+            policy_telemetry.retry.count,
+            MAX_UPSTREAM_RETRY_ATTEMPTS,
+            retry_budget.allow_retry(route_name).is_ok(),
+            alternate_backend,
+        );
+        let retry_reason = match retry_decision {
+            RetryPolicyDecision::Retry { reason } => reason.into(),
+            RetryPolicyDecision::DoNotRetry { denial } => {
+                policy_telemetry.retry.record_denial(denial);
+                debug!(
+                    "request_id={} retry denied: route={} reason={:?}",
+                    request_id, route_name, denial
+                );
+                return Err(primary_err);
+            }
+        };
+
+        let Some(AlternateBodylessCandidate {
+            backend: retry_backend,
+            request: retry_request,
+        }) = Self::build_alternate_bodyless_candidate(
+            alternate_backend,
+            backend_endpoints,
+            pending_forward,
+        ) else {
+            return Err(primary_err);
+        };
+
+        policy_telemetry.retry.record_attempt(retry_reason);
+        info!(
+            "request_id={} retrying request on alternate backend: route={} reason={:?}",
+            request_id, route_name, retry_reason
+        );
+        Self::send_upstream_request(
+            retry_backend,
+            retry_request,
+            circuit_breakers,
+            transport,
+            backend_timeout,
+        )
+        .await
+    }
+
     pub(super) fn spawn_upstream_forward_task(
         req: &RequestEnvelope,
         pending_forward: Arc<PendingForward>,
@@ -330,25 +408,6 @@ impl QUICListener {
             let result: ForwardResult = async {
                 retry_budget.mark_primary(&route_name);
 
-                let send_once =
-                    |backend: String,
-                     req: UpstreamRequest,
-                     cb: Arc<crate::resilience::circuit_breaker::CircuitBreakers>,
-                     transport: Arc<UpstreamTransportPool>| async move {
-                        if !cb.allow_request(&backend) {
-                            return Err(ProxyError::Pool(PoolError::CircuitOpen(backend)));
-                        }
-                        let send_result =
-                            tokio::time::timeout(backend_timeout, transport.send(&backend, req))
-                                .await
-                                .map_err(|_| ProxyError::Timeout);
-                        match &send_result {
-                            Ok(Ok(_)) => cb.record_success(&backend),
-                            _ => cb.record_failure(&backend),
-                        }
-                        Ok(send_result??)
-                    };
-
                 let forward_success: ForwardSuccess = if tunnel_mode == TunnelMode::Websocket
                     && backend_endpoint.scheme() == BackendScheme::Http
                 {
@@ -388,11 +447,12 @@ impl QUICListener {
                             {
                             let primary_started = Instant::now();
                             let primary_backend = fwd_addr.clone();
-                            let primary_fut = send_once(
+                            let primary_fut = Self::send_upstream_request(
                                 primary_backend,
                                 request,
                                 Arc::clone(&cb),
                                 Arc::clone(&transport),
+                                backend_timeout,
                             );
                             tokio::pin!(primary_fut);
                             let hedge_sleep = tokio::time::sleep(hedge_delay);
@@ -409,11 +469,12 @@ impl QUICListener {
                                 ) {
                                     HedgePolicyDecision::Hedge { reason } => {
                                         policy_telemetry.hedge.record_trigger(reason);
-                                        let hedge_fut = send_once(
+                                        let hedge_fut = Self::send_upstream_request(
                                             hedge_backend,
                                             hedge_request,
                                             Arc::clone(&cb),
                                             Arc::clone(&transport),
+                                            backend_timeout,
                                         );
                                         tokio::pin!(hedge_fut);
                                         tokio::select! {
@@ -447,11 +508,12 @@ impl QUICListener {
                                 }
                             }
                             } else {
-                                send_once(
+                                Self::send_upstream_request(
                                     fwd_addr.clone(),
                                     request,
                                     Arc::clone(&cb),
                                     Arc::clone(&transport),
+                                    backend_timeout,
                                 )
                                 .await?
                             }
@@ -461,58 +523,31 @@ impl QUICListener {
                                 "request_id={} hedging disabled for request: route={} reason={:?}",
                                 request_id, route_name, denial
                             );
-                            match send_once(
+                            match Self::send_upstream_request(
                                 fwd_addr.clone(),
                                 request,
                                 Arc::clone(&cb),
                                 Arc::clone(&transport),
+                                backend_timeout,
                             )
                             .await
                             {
                                 Ok(response) => response,
-                                Err(primary_err) => {
-                                    let retry_decision = policy.retry_after_error(
-                                        &primary_err,
-                                        policy_telemetry.retry.count,
-                                        MAX_UPSTREAM_RETRY_ATTEMPTS,
-                                        retry_budget.allow_retry(&route_name).is_ok(),
-                                        alternate_backend.as_ref(),
-                                    );
-                                    let retry_reason = match retry_decision {
-                                        RetryPolicyDecision::Retry { reason } => reason.into(),
-                                        RetryPolicyDecision::DoNotRetry { denial } => {
-                                            policy_telemetry.retry.record_denial(denial);
-                                            debug!(
-                                                "request_id={} retry denied: route={} reason={:?}",
-                                                request_id, route_name, denial
-                                            );
-                                            return Err(primary_err);
-                                        }
-                                    };
-                                    if let Some(AlternateBodylessCandidate {
-                                        backend: retry_backend,
-                                        request: retry_request,
-                                    }) = Self::build_alternate_bodyless_candidate(
+                                Err(primary_err) => Self::retry_primary_error(
+                                        primary_err,
+                                        request_id,
+                                        &route_name,
+                                        policy,
+                                        &mut policy_telemetry,
+                                        retry_budget.as_ref(),
                                         alternate_backend.as_ref(),
                                         backend_endpoints.as_ref(),
                                         pending_forward_for_upstream.as_ref(),
-                                    ) {
-                                        policy_telemetry.retry.record_attempt(retry_reason);
-                                        info!(
-                                            "request_id={} retrying request on alternate backend: route={} reason={:?}",
-                                            request_id, route_name, retry_reason
-                                        );
-                                        send_once(
-                                            retry_backend,
-                                            retry_request,
-                                            Arc::clone(&cb),
-                                            Arc::clone(&transport),
-                                        )
-                                        .await?
-                                    } else {
-                                        return Err(primary_err);
-                                    }
-                                }
+                                        Arc::clone(&cb),
+                                        Arc::clone(&transport),
+                                        backend_timeout,
+                                    )
+                                    .await?,
                             }
                         }
                         HedgePolicyDecision::Hedge { reason } => {
@@ -520,58 +555,31 @@ impl QUICListener {
                                 "request_id={} shared hedge policy triggered early: route={} reason={:?}",
                                 request_id, route_name, reason
                             );
-                            match send_once(
+                            match Self::send_upstream_request(
                                 fwd_addr.clone(),
                                 request,
                                 Arc::clone(&cb),
                                 Arc::clone(&transport),
+                                backend_timeout,
                             )
                             .await
                             {
                                 Ok(response) => response,
-                                Err(primary_err) => {
-                                    let retry_decision = policy.retry_after_error(
-                                        &primary_err,
-                                        policy_telemetry.retry.count,
-                                        MAX_UPSTREAM_RETRY_ATTEMPTS,
-                                        retry_budget.allow_retry(&route_name).is_ok(),
-                                        alternate_backend.as_ref(),
-                                    );
-                                let retry_reason = match retry_decision {
-                                    RetryPolicyDecision::Retry { reason } => reason.into(),
-                                    RetryPolicyDecision::DoNotRetry { denial } => {
-                                        policy_telemetry.retry.record_denial(denial);
-                                        debug!(
-                                            "request_id={} retry denied: route={} reason={:?}",
-                                            request_id, route_name, denial
-                                        );
-                                        return Err(primary_err);
-                                    }
-                                };
-                                    if let Some(AlternateBodylessCandidate {
-                                        backend: retry_backend,
-                                        request: retry_request,
-                                    }) = Self::build_alternate_bodyless_candidate(
+                                Err(primary_err) => Self::retry_primary_error(
+                                        primary_err,
+                                        request_id,
+                                        &route_name,
+                                        policy,
+                                        &mut policy_telemetry,
+                                        retry_budget.as_ref(),
                                         alternate_backend.as_ref(),
                                         backend_endpoints.as_ref(),
                                         pending_forward_for_upstream.as_ref(),
-                                    ) {
-                                        policy_telemetry.retry.record_attempt(retry_reason);
-                                        info!(
-                                            "request_id={} retrying request on alternate backend: route={} reason={:?}",
-                                            request_id, route_name, retry_reason
-                                        );
-                                        send_once(
-                                            retry_backend,
-                                            retry_request,
-                                            Arc::clone(&cb),
-                                            Arc::clone(&transport),
-                                        )
-                                        .await?
-                                    } else {
-                                        return Err(primary_err);
-                                    }
-                                }
+                                        Arc::clone(&cb),
+                                        Arc::clone(&transport),
+                                        backend_timeout,
+                                    )
+                                    .await?,
                             }
                         }
                     };

--- a/crates/edge/src/quic_listener/forwarding/dispatch.rs
+++ b/crates/edge/src/quic_listener/forwarding/dispatch.rs
@@ -41,6 +41,20 @@ struct AlternateBodylessCandidate {
     request: UpstreamRequest,
 }
 
+struct RetryExecutionCtx<'a> {
+    request_id: u64,
+    route_name: &'a str,
+    policy: ForwardingRetryHedgePolicy,
+    policy_telemetry: &'a mut ForwardingPolicyTelemetry,
+    retry_budget: &'a crate::resilience::retry_budget::RetryBudget,
+    alternate_backend: Option<&'a ResolvedAlternateBackend>,
+    backend_endpoints: &'a HashMap<String, BackendEndpoint>,
+    pending_forward: &'a PendingForward,
+    circuit_breakers: Arc<crate::resilience::circuit_breaker::CircuitBreakers>,
+    transport: Arc<UpstreamTransportPool>,
+    backend_timeout: Duration,
+}
+
 #[derive(Clone, Copy)]
 struct ForwardingRetryHedgePolicy {
     method_idempotent: bool,
@@ -315,18 +329,21 @@ impl QUICListener {
 
     async fn retry_primary_error(
         primary_err: ProxyError,
-        request_id: u64,
-        route_name: &str,
-        policy: ForwardingRetryHedgePolicy,
-        policy_telemetry: &mut ForwardingPolicyTelemetry,
-        retry_budget: &crate::resilience::retry_budget::RetryBudget,
-        alternate_backend: Option<&ResolvedAlternateBackend>,
-        backend_endpoints: &HashMap<String, BackendEndpoint>,
-        pending_forward: &PendingForward,
-        circuit_breakers: Arc<crate::resilience::circuit_breaker::CircuitBreakers>,
-        transport: Arc<UpstreamTransportPool>,
-        backend_timeout: Duration,
+        retry_ctx: RetryExecutionCtx<'_>,
     ) -> Result<Response<Incoming>, ProxyError> {
+        let RetryExecutionCtx {
+            request_id,
+            route_name,
+            policy,
+            policy_telemetry,
+            retry_budget,
+            alternate_backend,
+            backend_endpoints,
+            pending_forward,
+            circuit_breakers,
+            transport,
+            backend_timeout,
+        } = retry_ctx;
         let retry_decision = policy.retry_after_error(
             &primary_err,
             policy_telemetry.retry.count,
@@ -573,17 +590,19 @@ impl QUICListener {
                                 Ok(response) => response,
                                 Err(primary_err) => Self::retry_primary_error(
                                         primary_err,
-                                        request_id,
-                                        &route_name,
-                                        policy,
-                                        &mut policy_telemetry,
-                                        retry_budget.as_ref(),
-                                        alternate_backend.as_ref(),
-                                        backend_endpoints.as_ref(),
-                                        pending_forward_for_upstream.as_ref(),
-                                        Arc::clone(&cb),
-                                        Arc::clone(&transport),
-                                        backend_timeout,
+                                        RetryExecutionCtx {
+                                            request_id,
+                                            route_name: &route_name,
+                                            policy,
+                                            policy_telemetry: &mut policy_telemetry,
+                                            retry_budget: retry_budget.as_ref(),
+                                            alternate_backend: alternate_backend.as_ref(),
+                                            backend_endpoints: backend_endpoints.as_ref(),
+                                            pending_forward: pending_forward_for_upstream.as_ref(),
+                                            circuit_breakers: Arc::clone(&cb),
+                                            transport: Arc::clone(&transport),
+                                            backend_timeout,
+                                        },
                                     )
                                     .await?,
                             }
@@ -605,17 +624,19 @@ impl QUICListener {
                                 Ok(response) => response,
                                 Err(primary_err) => Self::retry_primary_error(
                                         primary_err,
-                                        request_id,
-                                        &route_name,
-                                        policy,
-                                        &mut policy_telemetry,
-                                        retry_budget.as_ref(),
-                                        alternate_backend.as_ref(),
-                                        backend_endpoints.as_ref(),
-                                        pending_forward_for_upstream.as_ref(),
-                                        Arc::clone(&cb),
-                                        Arc::clone(&transport),
-                                        backend_timeout,
+                                        RetryExecutionCtx {
+                                            request_id,
+                                            route_name: &route_name,
+                                            policy,
+                                            policy_telemetry: &mut policy_telemetry,
+                                            retry_budget: retry_budget.as_ref(),
+                                            alternate_backend: alternate_backend.as_ref(),
+                                            backend_endpoints: backend_endpoints.as_ref(),
+                                            pending_forward: pending_forward_for_upstream.as_ref(),
+                                            circuit_breakers: Arc::clone(&cb),
+                                            transport: Arc::clone(&transport),
+                                            backend_timeout,
+                                        },
                                     )
                                     .await?,
                             }

--- a/crates/edge/src/quic_listener/forwarding/dispatch.rs
+++ b/crates/edge/src/quic_listener/forwarding/dispatch.rs
@@ -1,25 +1,11 @@
 use spooky_errors::{
-    RetryPolicyDecision, RetryPolicyDenial, RetryPolicyInput, UpstreamRetryReason,
-    evaluate_retry_policy,
+    RetryPolicyDecision, RetryPolicyFacts, RetryPolicyDenialReason, RetryTelemetryReason,
+    evaluate_retry_policy, is_idempotent_method,
 };
 
 use super::*;
 
-fn metrics_retry_reason(reason: UpstreamRetryReason) -> RetryReason {
-    match reason {
-        UpstreamRetryReason::Timeout => RetryReason::BackendTimeout,
-        UpstreamRetryReason::Transport => RetryReason::BackendTransport,
-        UpstreamRetryReason::Pool => RetryReason::BackendPool,
-    }
-}
-
-fn metrics_retry_denial(reason: RetryPolicyDenial) -> RetryReason {
-    match reason {
-        RetryPolicyDenial::NotBodylessMode => RetryReason::NotBodylessMode,
-        RetryPolicyDenial::BudgetDenied => RetryReason::BudgetDenied,
-        RetryPolicyDenial::NoAlternateBackend => RetryReason::NoAlternateBackend,
-    }
-}
+const MAX_UPSTREAM_RETRY_ATTEMPTS: u8 = 1;
 
 impl QUICListener {
     #[allow(clippy::too_many_arguments)]
@@ -177,12 +163,13 @@ impl QUICListener {
         let tunnel_mode = req.tunnel_mode;
         let bodyless_mode = req.bodyless_mode;
         let request_id = req.request_id;
+        let method_idempotent = is_idempotent_method(&req.method);
         let fut = async move {
             let mut hedge_telemetry =
                 crate::runtime::connection::response::HedgeTelemetry::default();
             let mut retry_count: u8 = 0;
-            let mut retry_attempt_reason: Option<RetryReason> = None;
-            let mut retry_denial_reason: Option<RetryReason> = None;
+            let mut retry_attempt_reason: Option<RetryTelemetryReason> = None;
+            let mut retry_denial_reason: Option<RetryPolicyDenialReason> = None;
             let result: ForwardResult = async {
                 retry_budget.mark_primary(&route_name);
 
@@ -300,18 +287,20 @@ impl QUICListener {
                         {
                             Ok(response) => response,
                             Err(primary_err) => {
-                                let retry_decision = evaluate_retry_policy(RetryPolicyInput {
+                                let retry_decision = evaluate_retry_policy(RetryPolicyFacts {
                                     retryability: spooky_errors::classify_retryability(&primary_err),
-                                    bodyless_mode,
+                                    method_idempotent,
+                                    request_body_replayable: bodyless_mode,
+                                    attempt_count: retry_count,
+                                    max_attempts: MAX_UPSTREAM_RETRY_ATTEMPTS,
                                     budget_available: retry_budget.allow_retry(&route_name).is_ok(),
                                     alternate_backend_available: alternate_backend.is_some(),
+                                    alternate_backend_healthy: alternate_backend.is_some(),
                                 });
                                 let retry_reason = match retry_decision {
-                                    RetryPolicyDecision::Retry { reason } => {
-                                        metrics_retry_reason(reason)
-                                    }
+                                    RetryPolicyDecision::Retry { reason } => reason.into(),
                                     RetryPolicyDecision::DoNotRetry { denial } => {
-                                        retry_denial_reason = denial.map(metrics_retry_denial);
+                                        retry_denial_reason = denial;
                                         return Err(primary_err);
                                     }
                                 };

--- a/crates/edge/src/quic_listener/forwarding/resolve.rs
+++ b/crates/edge/src/quic_listener/forwarding/resolve.rs
@@ -349,26 +349,6 @@ impl QUICListener {
         ProxyError::Transport("no healthy servers".into())
     }
 
-    fn select_backend_readonly(
-        pool: &UpstreamPool,
-        plan: &BackendSelectionPlan,
-        begin_request: bool,
-    ) -> Option<SelectedBackend> {
-        if pool.pool.readmit_due() {
-            return None;
-        }
-
-        pool.pick_readonly(plan.lb_key.as_str())
-            .and_then(|idx| pool.pool.address(idx).map(|addr| (idx, addr.to_string())))
-            .and_then(|(idx, addr)| {
-                (!begin_request || pool.begin_request_if_healthy(idx)).then_some(SelectedBackend {
-                    backend_addr: addr,
-                    backend_index: idx,
-                    backend_lb: plan.lb_type.clone(),
-                })
-            })
-    }
-
     fn select_backend_with_write_lock(
         pool: &mut UpstreamPool,
         plan: &BackendSelectionPlan,
@@ -397,19 +377,6 @@ impl QUICListener {
         upstream_pool: &Arc<RwLock<UpstreamPool>>,
         begin_request: bool,
     ) -> Result<SelectedBackend, ProxyError> {
-        {
-            let pool = upstream_pool
-                .read()
-                .map_err(|_| ProxyError::Transport("upstream pool lock poisoned".into()))?;
-            if pool.pool.is_empty() {
-                return Err(Self::no_servers_in_upstream_error());
-            }
-            let plan = Self::build_backend_selection_plan(request, &pool);
-            if let Some(selected) = Self::select_backend_readonly(&pool, &plan, begin_request) {
-                return Ok(selected);
-            }
-        }
-
         let mut pool = upstream_pool
             .write()
             .map_err(|_| ProxyError::Transport("upstream pool lock poisoned".into()))?;

--- a/crates/edge/src/quic_listener/forwarding/stream_progress.rs
+++ b/crates/edge/src/quic_listener/forwarding/stream_progress.rs
@@ -8,7 +8,26 @@ use crate::runtime::connection::{
         checked_response_body_guardrails, evaluate_request_body_timeouts,
         response_body_limit_reason, response_chunk_ranges,
     },
+    response::ForwardingPolicyTelemetry,
 };
+
+fn record_forwarding_policy_metrics(metrics: &Metrics, policy: &ForwardingPolicyTelemetry) {
+    if let Some(reason) = policy.hedge.trigger_reason {
+        metrics.inc_hedge_trigger(reason);
+    }
+    if let Some(reason) = policy.hedge.outcome_reason {
+        metrics.inc_hedge_outcome(reason);
+    }
+    if policy.hedge.primary_late_ms > 0 {
+        metrics.observe_hedge_primary_late_ms(policy.hedge.primary_late_ms);
+    }
+    if let Some(reason) = policy.retry.attempt_reason {
+        metrics.inc_retry_attempt(reason);
+    }
+    if let Some(reason) = policy.retry.denial_reason {
+        metrics.inc_retry_denied(reason);
+    }
+}
 
 fn response_body_guardrail_error(decision: ResponseBodyGuardrailDecision) -> Option<ProxyError> {
     match decision {
@@ -245,10 +264,7 @@ impl QUICListener {
                             forward: Err(ProxyError::Transport(
                                 "upstream task dropped sender".into(),
                             )),
-                            hedge: crate::runtime::connection::response::HedgeTelemetry::default(),
-                            retry_count: 0,
-                            retry_attempt_reason: None,
-                            retry_denial_reason: None,
+                            policy: ForwardingPolicyTelemetry::default(),
                         }),
                     })
             } else {
@@ -256,25 +272,11 @@ impl QUICListener {
             };
 
             if let Some(forward_result) = upstream_ready {
-                if let Some(reason) = forward_result.hedge.trigger_reason {
-                    metrics.inc_hedge_trigger(reason);
-                }
-                if let Some(reason) = forward_result.hedge.outcome_reason {
-                    metrics.inc_hedge_outcome(reason);
-                }
-                if forward_result.hedge.primary_late_ms > 0 {
-                    metrics.observe_hedge_primary_late_ms(forward_result.hedge.primary_late_ms);
-                }
-                if let Some(reason) = forward_result.retry_attempt_reason {
-                    metrics.inc_retry_attempt(reason);
-                }
-                if let Some(reason) = forward_result.retry_denial_reason {
-                    metrics.inc_retry_denied(reason);
-                }
+                record_forwarding_policy_metrics(metrics, &forward_result.policy);
 
                 if let Some(req) = streams.get_mut(&stream_id) {
                     req.upstream_result_rx = None;
-                    req.retry_count = forward_result.retry_count;
+                    req.retry_count = forward_result.policy.retry.count;
                     req.error_kind = match &forward_result.forward {
                         Err(ProxyError::Timeout) => Some("timeout"),
                         Err(ProxyError::Tls(_)) => Some("tls"),

--- a/crates/edge/src/quic_listener/forwarding/stream_progress.rs
+++ b/crates/edge/src/quic_listener/forwarding/stream_progress.rs
@@ -9,6 +9,29 @@ use crate::runtime::connection::{
         response_body_limit_reason, response_chunk_ranges,
     },
 };
+use spooky_errors::{RetryPolicyDenialReason, RetryTelemetryReason};
+
+fn metrics_retry_reason(reason: RetryTelemetryReason) -> RetryReason {
+    match reason {
+        RetryTelemetryReason::Timeout => RetryReason::BackendTimeout,
+        RetryTelemetryReason::Transport => RetryReason::BackendTransport,
+        RetryTelemetryReason::Pool => RetryReason::BackendPool,
+    }
+}
+
+fn metrics_retry_denial(reason: RetryPolicyDenialReason) -> Option<RetryReason> {
+    match reason {
+        RetryPolicyDenialReason::MethodNotIdempotent
+        | RetryPolicyDenialReason::RequestBodyNotReplayable => Some(RetryReason::NotBodylessMode),
+        RetryPolicyDenialReason::BudgetDenied => Some(RetryReason::BudgetDenied),
+        RetryPolicyDenialReason::NoAlternateBackend
+        | RetryPolicyDenialReason::AlternateBackendUnhealthy => {
+            Some(RetryReason::NoAlternateBackend)
+        }
+        RetryPolicyDenialReason::TerminalError(_)
+        | RetryPolicyDenialReason::AttemptLimitReached => None,
+    }
+}
 
 fn response_body_guardrail_error(decision: ResponseBodyGuardrailDecision) -> Option<ProxyError> {
     match decision {
@@ -272,10 +295,12 @@ impl QUICListener {
                     metrics.observe_hedge_primary_late_ms(forward_result.hedge.primary_late_ms);
                 }
                 if let Some(reason) = forward_result.retry_attempt_reason {
-                    metrics.inc_retry_attempt(reason);
+                    metrics.inc_retry_attempt(metrics_retry_reason(reason));
                 }
                 if let Some(reason) = forward_result.retry_denial_reason {
-                    metrics.inc_retry_denied(reason);
+                    if let Some(reason) = metrics_retry_denial(reason) {
+                        metrics.inc_retry_denied(reason);
+                    }
                 }
 
                 if let Some(req) = streams.get_mut(&stream_id) {

--- a/crates/edge/src/quic_listener/forwarding/stream_progress.rs
+++ b/crates/edge/src/quic_listener/forwarding/stream_progress.rs
@@ -9,29 +9,6 @@ use crate::runtime::connection::{
         response_body_limit_reason, response_chunk_ranges,
     },
 };
-use spooky_errors::{RetryPolicyDenialReason, RetryTelemetryReason};
-
-fn metrics_retry_reason(reason: RetryTelemetryReason) -> RetryReason {
-    match reason {
-        RetryTelemetryReason::Timeout => RetryReason::BackendTimeout,
-        RetryTelemetryReason::Transport => RetryReason::BackendTransport,
-        RetryTelemetryReason::Pool => RetryReason::BackendPool,
-    }
-}
-
-fn metrics_retry_denial(reason: RetryPolicyDenialReason) -> Option<RetryReason> {
-    match reason {
-        RetryPolicyDenialReason::MethodNotIdempotent
-        | RetryPolicyDenialReason::RequestBodyNotReplayable => Some(RetryReason::NotBodylessMode),
-        RetryPolicyDenialReason::BudgetDenied => Some(RetryReason::BudgetDenied),
-        RetryPolicyDenialReason::NoAlternateBackend
-        | RetryPolicyDenialReason::AlternateBackendUnhealthy => {
-            Some(RetryReason::NoAlternateBackend)
-        }
-        RetryPolicyDenialReason::TerminalError(_)
-        | RetryPolicyDenialReason::AttemptLimitReached => None,
-    }
-}
 
 fn response_body_guardrail_error(decision: ResponseBodyGuardrailDecision) -> Option<ProxyError> {
     match decision {
@@ -279,28 +256,20 @@ impl QUICListener {
             };
 
             if let Some(forward_result) = upstream_ready {
-                if forward_result.hedge.launched {
-                    metrics.inc_hedge_triggered();
+                if let Some(reason) = forward_result.hedge.trigger_reason {
+                    metrics.inc_hedge_trigger(reason);
                 }
-                if forward_result.hedge.hedge_won {
-                    metrics.inc_hedge_won();
-                }
-                if forward_result.hedge.hedge_wasted {
-                    metrics.inc_hedge_wasted();
-                }
-                if forward_result.hedge.primary_won_after_trigger {
-                    metrics.inc_hedge_primary_won_after_trigger();
+                if let Some(reason) = forward_result.hedge.outcome_reason {
+                    metrics.inc_hedge_outcome(reason);
                 }
                 if forward_result.hedge.primary_late_ms > 0 {
                     metrics.observe_hedge_primary_late_ms(forward_result.hedge.primary_late_ms);
                 }
                 if let Some(reason) = forward_result.retry_attempt_reason {
-                    metrics.inc_retry_attempt(metrics_retry_reason(reason));
+                    metrics.inc_retry_attempt(reason);
                 }
                 if let Some(reason) = forward_result.retry_denial_reason {
-                    if let Some(reason) = metrics_retry_denial(reason) {
-                        metrics.inc_retry_denied(reason);
-                    }
+                    metrics.inc_retry_denied(reason);
                 }
 
                 if let Some(req) = streams.get_mut(&stream_id) {

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -72,7 +72,7 @@ use tokio_rustls::TlsAcceptor;
 use tracing::{Instrument, info_span};
 
 use crate::{
-    ChannelBody, Metrics, OverloadShedReason, REQUEST_ID_COUNTER, RetryReason, RouteOutcome,
+    ChannelBody, Metrics, OverloadShedReason, REQUEST_ID_COUNTER, RouteOutcome,
     cid_radix::CidRadix,
     constants::{
         DEFAULT_SCID_LEN_BYTES, MAX_DATAGRAM_SIZE_BYTES, MAX_UDP_PAYLOAD_BYTES, MIN_SCID_LEN_BYTES,

--- a/crates/edge/src/quic_listener/tests.rs
+++ b/crates/edge/src/quic_listener/tests.rs
@@ -2027,10 +2027,7 @@ fn abort_stream_awaiting_upstream_cancels_oneshot() {
     // Sending on the now-orphaned sender should return Err (closed).
     let send_result = result_tx.send(crate::runtime::connection::response::UpstreamResult {
         forward: Err(spooky_errors::ProxyError::Transport("test".into())),
-        hedge: crate::runtime::connection::response::HedgeTelemetry::default(),
-        retry_count: 0,
-        retry_attempt_reason: None,
-        retry_denial_reason: None,
+        policy: crate::runtime::connection::response::ForwardingPolicyTelemetry::default(),
     });
     assert!(
         send_result.is_err(),

--- a/crates/edge/src/resilience/retry_budget.rs
+++ b/crates/edge/src/resilience/retry_budget.rs
@@ -6,7 +6,7 @@ use std::{
     },
 };
 
-use crate::RetryReason;
+use spooky_errors::RetryPolicyDenialReason;
 
 pub struct RetryBudget {
     enabled: bool,
@@ -41,7 +41,7 @@ impl RetryBudget {
         }
     }
 
-    pub fn allow_retry(&self, route: &str) -> Result<(), RetryReason> {
+    pub fn allow_retry(&self, route: &str) -> Result<(), RetryPolicyDenialReason> {
         if !self.enabled {
             return Ok(());
         }
@@ -56,7 +56,7 @@ impl RetryBudget {
         let retries = self.global_retries.load(Ordering::Relaxed);
         let global_limit = ((primary * ratio as u64) / 100).saturating_add(1);
         if retries >= global_limit {
-            return Err(RetryReason::BudgetDenied);
+            return Err(RetryPolicyDenialReason::BudgetDenied);
         }
 
         let mut route_allowed = true;
@@ -70,7 +70,7 @@ impl RetryBudget {
             }
         }
         if !route_allowed {
-            return Err(RetryReason::BudgetDenied);
+            return Err(RetryPolicyDenialReason::BudgetDenied);
         }
 
         self.global_retries.fetch_add(1, Ordering::Relaxed);

--- a/crates/edge/src/resilience/runtime.rs
+++ b/crates/edge/src/resilience/runtime.rs
@@ -135,17 +135,22 @@ impl RuntimeResilience {
         }
     }
 
-    pub fn hedging_allowed_for(&self, method: &str, route: &str, bodyless: bool) -> bool {
-        if !self.hedging_enabled || self.brownout.is_active() || !bodyless {
-            return false;
-        }
-        let safe_method = self
-            .hedge_safe_methods
-            .contains(&method.to_ascii_uppercase());
-        if !safe_method {
+    pub fn hedging_route_enabled_for(&self, route: &str) -> bool {
+        if !self.hedging_enabled || self.brownout.is_active() {
             return false;
         }
         self.route_allowlist.is_empty() || self.route_allowlist.contains(route)
+    }
+
+    pub fn hedging_method_allowed(&self, method: &str) -> bool {
+        self.hedge_safe_methods
+            .contains(&method.to_ascii_uppercase())
+    }
+
+    pub fn hedging_allowed_for(&self, method: &str, route: &str, bodyless: bool) -> bool {
+        self.hedging_route_enabled_for(route)
+            && bodyless
+            && self.hedging_method_allowed(method)
     }
 
     pub fn early_data_allowed_for(&self, method: &str) -> bool {

--- a/crates/edge/src/resilience/runtime.rs
+++ b/crates/edge/src/resilience/runtime.rs
@@ -148,9 +148,7 @@ impl RuntimeResilience {
     }
 
     pub fn hedging_allowed_for(&self, method: &str, route: &str, bodyless: bool) -> bool {
-        self.hedging_route_enabled_for(route)
-            && bodyless
-            && self.hedging_method_allowed(method)
+        self.hedging_route_enabled_for(route) && bodyless && self.hedging_method_allowed(method)
     }
 
     pub fn early_data_allowed_for(&self, method: &str) -> bool {

--- a/crates/edge/src/runtime/connection/request.rs
+++ b/crates/edge/src/runtime/connection/request.rs
@@ -86,13 +86,13 @@ pub struct RequestEnvelope {
     /// True once the client has sent FIN on the request stream.
     pub request_fin_received: bool,
     /// Receives the upstream H2 response (status, headers, body stream).
-    pub upstream_result_rx: Option<oneshot::Receiver<UpstreamResult>>,
+    pub(crate) upstream_result_rx: Option<oneshot::Receiver<UpstreamResult>>,
     /// Receives response body chunks to write back over QUIC.
-    pub response_chunk_rx: Option<mpsc::Receiver<ResponseChunk>>,
+    pub(crate) response_chunk_rx: Option<mpsc::Receiver<ResponseChunk>>,
     /// True once downstream response headers are emitted on this stream.
     pub response_headers_sent: bool,
     /// A chunk that could not be written due to QUIC send backpressure; retried next poll.
-    pub pending_chunk: Option<ResponseChunk>,
+    pub(crate) pending_chunk: Option<ResponseChunk>,
 }
 
 impl RequestEnvelope {

--- a/crates/edge/src/runtime/connection/response.rs
+++ b/crates/edge/src/runtime/connection/response.rs
@@ -20,14 +20,35 @@ pub enum ForwardSuccess {
 
 pub type ForwardResult = Result<ForwardSuccess, ProxyError>;
 
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RetryTelemetry {
+    pub count: u8,
+    pub attempt_reason: Option<RetryAttemptTelemetryReason>,
+    pub denial_reason: Option<RetryPolicyDenialReason>,
+}
+
+impl RetryTelemetry {
+    pub fn record_attempt(&mut self, reason: RetryAttemptTelemetryReason) {
+        self.count = self.count.saturating_add(1);
+        self.attempt_reason = Some(reason);
+    }
+
+    pub fn record_denial(&mut self, denial_reason: Option<RetryPolicyDenialReason>) {
+        if self.denial_reason.is_none() {
+            self.denial_reason = denial_reason;
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ForwardingPolicyTelemetry {
+    pub hedge: HedgeTelemetry,
+    pub retry: RetryTelemetry,
+}
+
 pub struct UpstreamResult {
     pub forward: ForwardResult,
-    pub hedge: HedgeTelemetry,
-    pub retry_count: u8,
-    /// Set when a retry was attempted; the shared policy reason that triggered it.
-    pub retry_attempt_reason: Option<RetryAttemptTelemetryReason>,
-    /// Set when a retry was denied; the first shared policy denial encountered.
-    pub retry_denial_reason: Option<RetryPolicyDenialReason>,
+    pub policy: ForwardingPolicyTelemetry,
 }
 
 /// A chunk of the upstream response being streamed back to the client.
@@ -52,4 +73,18 @@ pub struct HedgeTelemetry {
     pub trigger_reason: Option<HedgeTriggerTelemetryReason>,
     pub outcome_reason: Option<HedgeOutcomeTelemetryReason>,
     pub primary_late_ms: u64,
+}
+
+impl HedgeTelemetry {
+    pub fn record_trigger(&mut self, reason: HedgeTriggerTelemetryReason) {
+        self.trigger_reason = Some(reason);
+    }
+
+    pub fn record_outcome(&mut self, reason: HedgeOutcomeTelemetryReason) {
+        self.outcome_reason = Some(reason);
+    }
+
+    pub fn observe_primary_late_ms(&mut self, late_ms: u64) {
+        self.primary_late_ms = late_ms;
+    }
 }

--- a/crates/edge/src/runtime/connection/response.rs
+++ b/crates/edge/src/runtime/connection/response.rs
@@ -5,7 +5,7 @@ use spooky_errors::{
 };
 use tokio::sync::mpsc;
 
-pub enum ForwardSuccess {
+pub(crate) enum ForwardSuccess {
     Response {
         status: http::StatusCode,
         headers: http::HeaderMap,
@@ -18,22 +18,22 @@ pub enum ForwardSuccess {
     },
 }
 
-pub type ForwardResult = Result<ForwardSuccess, ProxyError>;
+pub(crate) type ForwardResult = Result<ForwardSuccess, ProxyError>;
 
 #[derive(Debug, Clone, Copy, Default)]
-pub struct RetryTelemetry {
-    pub count: u8,
-    pub attempt_reason: Option<RetryAttemptTelemetryReason>,
-    pub denial_reason: Option<RetryPolicyDenialReason>,
+pub(crate) struct RetryTelemetry {
+    pub(crate) count: u8,
+    pub(crate) attempt_reason: Option<RetryAttemptTelemetryReason>,
+    pub(crate) denial_reason: Option<RetryPolicyDenialReason>,
 }
 
 impl RetryTelemetry {
-    pub fn record_attempt(&mut self, reason: RetryAttemptTelemetryReason) {
+    pub(crate) fn record_attempt(&mut self, reason: RetryAttemptTelemetryReason) {
         self.count = self.count.saturating_add(1);
         self.attempt_reason = Some(reason);
     }
 
-    pub fn record_denial(&mut self, denial_reason: Option<RetryPolicyDenialReason>) {
+    pub(crate) fn record_denial(&mut self, denial_reason: Option<RetryPolicyDenialReason>) {
         if self.denial_reason.is_none() {
             self.denial_reason = denial_reason;
         }
@@ -41,19 +41,19 @@ impl RetryTelemetry {
 }
 
 #[derive(Debug, Clone, Copy, Default)]
-pub struct ForwardingPolicyTelemetry {
-    pub hedge: HedgeTelemetry,
-    pub retry: RetryTelemetry,
+pub(crate) struct ForwardingPolicyTelemetry {
+    pub(crate) hedge: HedgeTelemetry,
+    pub(crate) retry: RetryTelemetry,
 }
 
-pub struct UpstreamResult {
-    pub forward: ForwardResult,
-    pub policy: ForwardingPolicyTelemetry,
+pub(crate) struct UpstreamResult {
+    pub(crate) forward: ForwardResult,
+    pub(crate) policy: ForwardingPolicyTelemetry,
 }
 
 /// A chunk of the upstream response being streamed back to the client.
 #[derive(Debug)]
-pub enum ResponseChunk {
+pub(crate) enum ResponseChunk {
     /// Emit downstream response headers (used when headers are deferred until
     /// body-size validation completes).
     Start {
@@ -69,22 +69,22 @@ pub enum ResponseChunk {
 }
 
 #[derive(Debug, Clone, Copy, Default)]
-pub struct HedgeTelemetry {
-    pub trigger_reason: Option<HedgeTriggerTelemetryReason>,
-    pub outcome_reason: Option<HedgeOutcomeTelemetryReason>,
-    pub primary_late_ms: u64,
+pub(crate) struct HedgeTelemetry {
+    pub(crate) trigger_reason: Option<HedgeTriggerTelemetryReason>,
+    pub(crate) outcome_reason: Option<HedgeOutcomeTelemetryReason>,
+    pub(crate) primary_late_ms: u64,
 }
 
 impl HedgeTelemetry {
-    pub fn record_trigger(&mut self, reason: HedgeTriggerTelemetryReason) {
+    pub(crate) fn record_trigger(&mut self, reason: HedgeTriggerTelemetryReason) {
         self.trigger_reason = Some(reason);
     }
 
-    pub fn record_outcome(&mut self, reason: HedgeOutcomeTelemetryReason) {
+    pub(crate) fn record_outcome(&mut self, reason: HedgeOutcomeTelemetryReason) {
         self.outcome_reason = Some(reason);
     }
 
-    pub fn observe_primary_late_ms(&mut self, late_ms: u64) {
+    pub(crate) fn observe_primary_late_ms(&mut self, late_ms: u64) {
         self.primary_late_ms = late_ms;
     }
 }

--- a/crates/edge/src/runtime/connection/response.rs
+++ b/crates/edge/src/runtime/connection/response.rs
@@ -1,8 +1,6 @@
 use bytes::Bytes;
-use spooky_errors::ProxyError;
+use spooky_errors::{ProxyError, RetryPolicyDenialReason, RetryTelemetryReason};
 use tokio::sync::mpsc;
-
-use crate::RetryReason;
 
 pub enum ForwardSuccess {
     Response {
@@ -23,10 +21,10 @@ pub struct UpstreamResult {
     pub forward: ForwardResult,
     pub hedge: HedgeTelemetry,
     pub retry_count: u8,
-    /// Set when a retry was attempted; the error reason that triggered it.
-    pub retry_attempt_reason: Option<RetryReason>,
-    /// Set when a retry was denied; the first denial reason encountered.
-    pub retry_denial_reason: Option<RetryReason>,
+    /// Set when a retry was attempted; the shared policy reason that triggered it.
+    pub retry_attempt_reason: Option<RetryTelemetryReason>,
+    /// Set when a retry was denied; the first shared policy denial encountered.
+    pub retry_denial_reason: Option<RetryPolicyDenialReason>,
 }
 
 /// A chunk of the upstream response being streamed back to the client.

--- a/crates/edge/src/runtime/connection/response.rs
+++ b/crates/edge/src/runtime/connection/response.rs
@@ -1,5 +1,8 @@
 use bytes::Bytes;
-use spooky_errors::{ProxyError, RetryPolicyDenialReason, RetryTelemetryReason};
+use spooky_errors::{
+    HedgeOutcomeTelemetryReason, HedgeTriggerTelemetryReason, ProxyError,
+    RetryAttemptTelemetryReason, RetryPolicyDenialReason,
+};
 use tokio::sync::mpsc;
 
 pub enum ForwardSuccess {
@@ -22,7 +25,7 @@ pub struct UpstreamResult {
     pub hedge: HedgeTelemetry,
     pub retry_count: u8,
     /// Set when a retry was attempted; the shared policy reason that triggered it.
-    pub retry_attempt_reason: Option<RetryTelemetryReason>,
+    pub retry_attempt_reason: Option<RetryAttemptTelemetryReason>,
     /// Set when a retry was denied; the first shared policy denial encountered.
     pub retry_denial_reason: Option<RetryPolicyDenialReason>,
 }
@@ -46,9 +49,7 @@ pub enum ResponseChunk {
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct HedgeTelemetry {
-    pub launched: bool,
-    pub hedge_won: bool,
-    pub hedge_wasted: bool,
-    pub primary_won_after_trigger: bool,
+    pub trigger_reason: Option<HedgeTriggerTelemetryReason>,
+    pub outcome_reason: Option<HedgeOutcomeTelemetryReason>,
     pub primary_late_ms: u64,
 }

--- a/crates/edge/src/runtime/connection/response.rs
+++ b/crates/edge/src/runtime/connection/response.rs
@@ -88,3 +88,59 @@ impl HedgeTelemetry {
         self.primary_late_ms = late_ms;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use spooky_errors::{
+        HedgeOutcomeTelemetryReason, HedgeTriggerTelemetryReason, RetryAttemptTelemetryReason,
+        RetryPolicyDenialReason,
+    };
+
+    use super::{HedgeTelemetry, RetryTelemetry};
+
+    #[test]
+    fn retry_telemetry_tracks_attempt_count_and_reason() {
+        let mut telemetry = RetryTelemetry::default();
+
+        telemetry.record_attempt(RetryAttemptTelemetryReason::Timeout);
+        telemetry.record_attempt(RetryAttemptTelemetryReason::Transport);
+
+        assert_eq!(telemetry.count, 2);
+        assert_eq!(
+            telemetry.attempt_reason,
+            Some(RetryAttemptTelemetryReason::Transport)
+        );
+    }
+
+    #[test]
+    fn retry_telemetry_preserves_first_denial_reason() {
+        let mut telemetry = RetryTelemetry::default();
+
+        telemetry.record_denial(Some(RetryPolicyDenialReason::BudgetDenied));
+        telemetry.record_denial(Some(RetryPolicyDenialReason::AttemptLimitReached));
+
+        assert_eq!(
+            telemetry.denial_reason,
+            Some(RetryPolicyDenialReason::BudgetDenied)
+        );
+    }
+
+    #[test]
+    fn hedge_telemetry_records_typed_trigger_and_outcome() {
+        let mut telemetry = HedgeTelemetry::default();
+
+        telemetry.record_trigger(HedgeTriggerTelemetryReason::DelayElapsed);
+        telemetry.record_outcome(HedgeOutcomeTelemetryReason::HedgeWon);
+        telemetry.observe_primary_late_ms(42);
+
+        assert_eq!(
+            telemetry.trigger_reason,
+            Some(HedgeTriggerTelemetryReason::DelayElapsed)
+        );
+        assert_eq!(
+            telemetry.outcome_reason,
+            Some(HedgeOutcomeTelemetryReason::HedgeWon)
+        );
+        assert_eq!(telemetry.primary_late_ms, 42);
+    }
+}

--- a/crates/errors/src/lib.rs
+++ b/crates/errors/src/lib.rs
@@ -13,11 +13,11 @@ pub use proxy::{
 pub use retry::{
     AlternateBackendChoice, AlternateBackendDecision, AlternateBackendDenialReason,
     AlternateBackendPolicyFacts, HedgePolicyDecision, HedgePolicyDenialReason,
-    HedgePolicyFacts, HedgeTelemetryReason, RetryPolicyDecision, RetryPolicyDenial,
+    HedgePolicyFacts, HedgePrimaryState, HedgeTelemetryReason, RetryPolicyDecision, RetryPolicyDenial,
     RetryPolicyDenialReason, RetryPolicyFacts, RetryPolicyInput, RetryTelemetryReason,
     UpstreamRetryReason, UpstreamRetryability, UpstreamTerminalErrorKind,
     is_idempotent_method,
-    classify_retryability, evaluate_retry_policy, is_retryable,
+    classify_retryability, evaluate_hedge_policy, evaluate_retry_policy, is_retryable,
 };
 pub use upstream::{
     UpstreamErrorCategory, UpstreamErrorClassification, UpstreamHealthFailureMapping,

--- a/crates/errors/src/lib.rs
+++ b/crates/errors/src/lib.rs
@@ -11,9 +11,13 @@ pub use proxy::{
     classify_upstream_proxy_error, classify_upstream_send_error,
 };
 pub use retry::{
-    RetryPolicyDecision, RetryPolicyDenial, RetryPolicyInput, UpstreamRetryReason,
-    UpstreamRetryability, UpstreamTerminalErrorKind, classify_retryability, evaluate_retry_policy,
-    is_retryable,
+    AlternateBackendChoice, AlternateBackendDecision, AlternateBackendDenialReason,
+    AlternateBackendPolicyFacts, HedgePolicyDecision, HedgePolicyDenialReason,
+    HedgePolicyFacts, HedgeTelemetryReason, RetryPolicyDecision, RetryPolicyDenial,
+    RetryPolicyDenialReason, RetryPolicyFacts, RetryPolicyInput, RetryTelemetryReason,
+    UpstreamRetryReason, UpstreamRetryability, UpstreamTerminalErrorKind,
+    is_idempotent_method,
+    classify_retryability, evaluate_retry_policy, is_retryable,
 };
 pub use upstream::{
     UpstreamErrorCategory, UpstreamErrorClassification, UpstreamHealthFailureMapping,

--- a/crates/errors/src/lib.rs
+++ b/crates/errors/src/lib.rs
@@ -10,17 +10,16 @@ pub use proxy::{
     ClassifiedUpstreamProxyError, ProxyError, UpstreamProxyErrorKind,
     classify_upstream_proxy_error, classify_upstream_send_error,
 };
+pub use retry::{
+    HedgeOutcomeTelemetryReason, HedgePolicyDecision, HedgePolicyDenialReason, HedgePolicyFacts,
+    HedgePrimaryState, HedgeTriggerTelemetryReason, RetryAttemptTelemetryReason,
+    RetryPolicyDecision, RetryPolicyDenialReason, RetryPolicyFacts, UpstreamRetryReason,
+    UpstreamRetryability, UpstreamTerminalErrorKind, classify_retryability, evaluate_hedge_policy,
+    evaluate_retry_policy, is_idempotent_method, is_retryable,
+};
 pub use spooky_lb::alternate_backend::{
     AlternateBackendChoice, AlternateBackendDecision, AlternateBackendFailureReason,
     AlternateBackendSelectionMode,
-};
-pub use retry::{
-    HedgeOutcomeTelemetryReason, HedgePolicyDecision, HedgePolicyDenialReason,
-    HedgePolicyFacts, HedgePrimaryState, HedgeTriggerTelemetryReason, RetryAttemptTelemetryReason,
-    RetryPolicyDecision, RetryPolicyDenialReason, RetryPolicyFacts,
-    UpstreamRetryReason, UpstreamRetryability, UpstreamTerminalErrorKind,
-    is_idempotent_method,
-    classify_retryability, evaluate_hedge_policy, evaluate_retry_policy, is_retryable,
 };
 pub use upstream::{
     UpstreamErrorCategory, UpstreamErrorClassification, UpstreamHealthFailureMapping,

--- a/crates/errors/src/lib.rs
+++ b/crates/errors/src/lib.rs
@@ -17,8 +17,7 @@ pub use spooky_lb::alternate_backend::{
 pub use retry::{
     HedgeOutcomeTelemetryReason, HedgePolicyDecision, HedgePolicyDenialReason,
     HedgePolicyFacts, HedgePrimaryState, HedgeTriggerTelemetryReason, RetryAttemptTelemetryReason,
-    RetryPolicyDecision, RetryPolicyDenial, RetryPolicyDenialReason, RetryPolicyFacts,
-    RetryPolicyInput,
+    RetryPolicyDecision, RetryPolicyDenialReason, RetryPolicyFacts,
     UpstreamRetryReason, UpstreamRetryability, UpstreamTerminalErrorKind,
     is_idempotent_method,
     classify_retryability, evaluate_hedge_policy, evaluate_retry_policy, is_retryable,

--- a/crates/errors/src/lib.rs
+++ b/crates/errors/src/lib.rs
@@ -10,11 +10,15 @@ pub use proxy::{
     ClassifiedUpstreamProxyError, ProxyError, UpstreamProxyErrorKind,
     classify_upstream_proxy_error, classify_upstream_send_error,
 };
+pub use spooky_lb::alternate_backend::{
+    AlternateBackendChoice, AlternateBackendDecision, AlternateBackendFailureReason,
+    AlternateBackendSelectionMode,
+};
 pub use retry::{
-    AlternateBackendChoice, AlternateBackendDecision, AlternateBackendDenialReason,
-    AlternateBackendPolicyFacts, HedgePolicyDecision, HedgePolicyDenialReason,
-    HedgePolicyFacts, HedgePrimaryState, HedgeTelemetryReason, RetryPolicyDecision, RetryPolicyDenial,
-    RetryPolicyDenialReason, RetryPolicyFacts, RetryPolicyInput, RetryTelemetryReason,
+    HedgeOutcomeTelemetryReason, HedgePolicyDecision, HedgePolicyDenialReason,
+    HedgePolicyFacts, HedgePrimaryState, HedgeTriggerTelemetryReason, RetryAttemptTelemetryReason,
+    RetryPolicyDecision, RetryPolicyDenial, RetryPolicyDenialReason, RetryPolicyFacts,
+    RetryPolicyInput,
     UpstreamRetryReason, UpstreamRetryability, UpstreamTerminalErrorKind,
     is_idempotent_method,
     classify_retryability, evaluate_hedge_policy, evaluate_retry_policy, is_retryable,

--- a/crates/errors/src/retry.rs
+++ b/crates/errors/src/retry.rs
@@ -72,26 +72,39 @@ impl From<UpstreamRetryReason> for RetryTelemetryReason {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct HedgePolicyFacts {
     pub hedging_configured: bool,
-    pub bodyless_mode: bool,
-    pub tunnel_allowed: bool,
     pub method_allowed: bool,
+    pub request_body_replayable: bool,
+    pub tunnel_request: bool,
     pub alternate_backend_available: bool,
+    pub alternate_backend_healthy: bool,
     pub budget_available: bool,
+    pub primary_state: HedgePrimaryState,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HedgePrimaryState {
+    InFlightBeforeDelay,
+    InFlightAfterDelay,
+    Completed,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum HedgePolicyDenialReason {
     HedgingDisabled,
-    NotBodylessMode,
+    PrimaryRequestCompleted,
+    DelayNotElapsed,
+    RequestBodyNotReplayable,
     TunnelRequest,
     MethodNotAllowed,
     NoAlternateBackend,
+    AlternateBackendUnhealthy,
     BudgetDenied,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum HedgePolicyDecision {
-    Hedge,
+    WaitForPrimary,
+    Hedge { reason: HedgeTelemetryReason },
     DoNotHedge { denial: HedgePolicyDenialReason },
 }
 
@@ -185,6 +198,62 @@ pub fn evaluate_retry_policy(input: RetryPolicyFacts) -> RetryPolicyDecision {
                 }
             } else {
                 RetryPolicyDecision::Retry { reason }
+            }
+        }
+    }
+}
+
+pub fn evaluate_hedge_policy(input: HedgePolicyFacts) -> HedgePolicyDecision {
+    if !input.hedging_configured {
+        return HedgePolicyDecision::DoNotHedge {
+            denial: HedgePolicyDenialReason::HedgingDisabled,
+        };
+    }
+
+    if !input.method_allowed {
+        return HedgePolicyDecision::DoNotHedge {
+            denial: HedgePolicyDenialReason::MethodNotAllowed,
+        };
+    }
+
+    if !input.request_body_replayable {
+        return HedgePolicyDecision::DoNotHedge {
+            denial: HedgePolicyDenialReason::RequestBodyNotReplayable,
+        };
+    }
+
+    if input.tunnel_request {
+        return HedgePolicyDecision::DoNotHedge {
+            denial: HedgePolicyDenialReason::TunnelRequest,
+        };
+    }
+
+    if !input.alternate_backend_available {
+        return HedgePolicyDecision::DoNotHedge {
+            denial: HedgePolicyDenialReason::NoAlternateBackend,
+        };
+    }
+
+    if !input.alternate_backend_healthy {
+        return HedgePolicyDecision::DoNotHedge {
+            denial: HedgePolicyDenialReason::AlternateBackendUnhealthy,
+        };
+    }
+
+    match input.primary_state {
+        HedgePrimaryState::Completed => HedgePolicyDecision::DoNotHedge {
+            denial: HedgePolicyDenialReason::PrimaryRequestCompleted,
+        },
+        HedgePrimaryState::InFlightBeforeDelay => HedgePolicyDecision::WaitForPrimary,
+        HedgePrimaryState::InFlightAfterDelay => {
+            if !input.budget_available {
+                HedgePolicyDecision::DoNotHedge {
+                    denial: HedgePolicyDenialReason::BudgetDenied,
+                }
+            } else {
+                HedgePolicyDecision::Hedge {
+                    reason: HedgeTelemetryReason::DelayElapsed,
+                }
             }
         }
     }
@@ -295,6 +364,76 @@ mod tests {
             evaluate_retry_policy(retry_facts()),
             RetryPolicyDecision::Retry {
                 reason: UpstreamRetryReason::Timeout,
+            }
+        );
+    }
+
+    fn hedge_facts() -> HedgePolicyFacts {
+        HedgePolicyFacts {
+            hedging_configured: true,
+            method_allowed: true,
+            request_body_replayable: true,
+            tunnel_request: false,
+            alternate_backend_available: true,
+            alternate_backend_healthy: true,
+            budget_available: true,
+            primary_state: HedgePrimaryState::InFlightAfterDelay,
+        }
+    }
+
+    #[test]
+    fn hedge_policy_waits_for_primary_before_delay() {
+        let mut facts = hedge_facts();
+        facts.primary_state = HedgePrimaryState::InFlightBeforeDelay;
+
+        assert_eq!(evaluate_hedge_policy(facts), HedgePolicyDecision::WaitForPrimary);
+    }
+
+    #[test]
+    fn hedge_policy_triggers_after_delay_when_eligible() {
+        assert_eq!(
+            evaluate_hedge_policy(hedge_facts()),
+            HedgePolicyDecision::Hedge {
+                reason: HedgeTelemetryReason::DelayElapsed,
+            }
+        );
+    }
+
+    #[test]
+    fn hedge_policy_rejects_non_replayable_requests() {
+        let mut facts = hedge_facts();
+        facts.request_body_replayable = false;
+
+        assert_eq!(
+            evaluate_hedge_policy(facts),
+            HedgePolicyDecision::DoNotHedge {
+                denial: HedgePolicyDenialReason::RequestBodyNotReplayable,
+            }
+        );
+    }
+
+    #[test]
+    fn hedge_policy_rejects_completed_primary() {
+        let mut facts = hedge_facts();
+        facts.primary_state = HedgePrimaryState::Completed;
+
+        assert_eq!(
+            evaluate_hedge_policy(facts),
+            HedgePolicyDecision::DoNotHedge {
+                denial: HedgePolicyDenialReason::PrimaryRequestCompleted,
+            }
+        );
+    }
+
+    #[test]
+    fn hedge_policy_rejects_when_budget_denied_after_delay() {
+        let mut facts = hedge_facts();
+        facts.budget_available = false;
+
+        assert_eq!(
+            evaluate_hedge_policy(facts),
+            HedgePolicyDecision::DoNotHedge {
+                denial: HedgePolicyDenialReason::BudgetDenied,
             }
         );
     }

--- a/crates/errors/src/retry.rs
+++ b/crates/errors/src/retry.rs
@@ -1,5 +1,6 @@
-use crate::{PoolError, ProxyError};
 use spooky_lb::alternate_backend::AlternateBackendFailureReason;
+
+use crate::{PoolError, ProxyError};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum UpstreamRetryReason {
@@ -46,7 +47,9 @@ pub struct RetryPolicyFacts {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RetryPolicyDecision {
-    Retry { reason: UpstreamRetryReason },
+    Retry {
+        reason: UpstreamRetryReason,
+    },
     DoNotRetry {
         denial: Option<RetryPolicyDenialReason>,
     },
@@ -165,9 +168,9 @@ pub fn evaluate_retry_policy(input: RetryPolicyFacts) -> RetryPolicyDecision {
             } else if !input.alternate_backend_available {
                 RetryPolicyDecision::DoNotRetry {
                     denial: Some(RetryPolicyDenialReason::AlternateBackendUnavailable(
-                        input.alternate_backend_failure.unwrap_or(
-                            AlternateBackendFailureReason::OnlyExcludedBackendsHealthy,
-                        ),
+                        input
+                            .alternate_backend_failure
+                            .unwrap_or(AlternateBackendFailureReason::OnlyExcludedBackendsHealthy),
                     )),
                 }
             } else {
@@ -205,9 +208,9 @@ pub fn evaluate_hedge_policy(input: HedgePolicyFacts) -> HedgePolicyDecision {
     if !input.alternate_backend_available {
         return HedgePolicyDecision::DoNotHedge {
             denial: HedgePolicyDenialReason::AlternateBackendUnavailable(
-                input.alternate_backend_failure.unwrap_or(
-                    AlternateBackendFailureReason::OnlyExcludedBackendsHealthy,
-                ),
+                input
+                    .alternate_backend_failure
+                    .unwrap_or(AlternateBackendFailureReason::OnlyExcludedBackendsHealthy),
             ),
         };
     }
@@ -432,7 +435,10 @@ mod tests {
         let mut facts = hedge_facts();
         facts.primary_state = HedgePrimaryState::InFlightBeforeDelay;
 
-        assert_eq!(evaluate_hedge_policy(facts), HedgePolicyDecision::WaitForPrimary);
+        assert_eq!(
+            evaluate_hedge_policy(facts),
+            HedgePolicyDecision::WaitForPrimary
+        );
     }
 
     #[test]

--- a/crates/errors/src/retry.rs
+++ b/crates/errors/src/retry.rs
@@ -22,24 +22,119 @@ pub enum UpstreamRetryability {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum RetryPolicyDenial {
-    NotBodylessMode,
+pub enum RetryPolicyDenialReason {
+    TerminalError(UpstreamTerminalErrorKind),
+    MethodNotIdempotent,
+    RequestBodyNotReplayable,
+    AttemptLimitReached,
     BudgetDenied,
     NoAlternateBackend,
+    AlternateBackendUnhealthy,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct RetryPolicyInput {
+pub struct RetryPolicyFacts {
     pub retryability: UpstreamRetryability,
-    pub bodyless_mode: bool,
+    pub method_idempotent: bool,
+    pub request_body_replayable: bool,
+    pub attempt_count: u8,
+    pub max_attempts: u8,
     pub budget_available: bool,
     pub alternate_backend_available: bool,
+    pub alternate_backend_healthy: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RetryPolicyDecision {
     Retry { reason: UpstreamRetryReason },
-    DoNotRetry { denial: Option<RetryPolicyDenial> },
+    DoNotRetry {
+        denial: Option<RetryPolicyDenialReason>,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RetryTelemetryReason {
+    Timeout,
+    Transport,
+    Pool,
+}
+
+impl From<UpstreamRetryReason> for RetryTelemetryReason {
+    fn from(value: UpstreamRetryReason) -> Self {
+        match value {
+            UpstreamRetryReason::Timeout => Self::Timeout,
+            UpstreamRetryReason::Transport => Self::Transport,
+            UpstreamRetryReason::Pool => Self::Pool,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct HedgePolicyFacts {
+    pub hedging_configured: bool,
+    pub bodyless_mode: bool,
+    pub tunnel_allowed: bool,
+    pub method_allowed: bool,
+    pub alternate_backend_available: bool,
+    pub budget_available: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HedgePolicyDenialReason {
+    HedgingDisabled,
+    NotBodylessMode,
+    TunnelRequest,
+    MethodNotAllowed,
+    NoAlternateBackend,
+    BudgetDenied,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HedgePolicyDecision {
+    Hedge,
+    DoNotHedge { denial: HedgePolicyDenialReason },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HedgeTelemetryReason {
+    DelayElapsed,
+    PrimaryWonAfterTrigger,
+    HedgeWon,
+    HedgeWasted,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AlternateBackendChoice<Backend> {
+    pub backend: Backend,
+    pub index: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct AlternateBackendPolicyFacts {
+    pub candidate_available: bool,
+    pub excluded_primary_backend: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AlternateBackendDenialReason {
+    NoCandidateAvailable,
+    PrimaryBackendNotExcluded,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AlternateBackendDecision<Backend> {
+    Select(AlternateBackendChoice<Backend>),
+    DoNotSelect { denial: AlternateBackendDenialReason },
+}
+
+pub type RetryPolicyInput = RetryPolicyFacts;
+pub type RetryPolicyDenial = RetryPolicyDenialReason;
+
+pub fn is_idempotent_method(method: &str) -> bool {
+    matches!(
+        method.to_ascii_uppercase().as_str(),
+        "GET" | "HEAD" | "PUT" | "DELETE" | "OPTIONS" | "TRACE"
+    )
 }
 
 pub fn classify_retryability(err: &ProxyError) -> UpstreamRetryability {
@@ -58,21 +153,35 @@ pub fn classify_retryability(err: &ProxyError) -> UpstreamRetryability {
     }
 }
 
-pub fn evaluate_retry_policy(input: RetryPolicyInput) -> RetryPolicyDecision {
+pub fn evaluate_retry_policy(input: RetryPolicyFacts) -> RetryPolicyDecision {
     match input.retryability {
-        UpstreamRetryability::Terminal(_) => RetryPolicyDecision::DoNotRetry { denial: None },
+        UpstreamRetryability::Terminal(kind) => RetryPolicyDecision::DoNotRetry {
+            denial: Some(RetryPolicyDenialReason::TerminalError(kind)),
+        },
         UpstreamRetryability::Retryable(reason) => {
-            if !input.bodyless_mode {
+            if !input.method_idempotent {
                 RetryPolicyDecision::DoNotRetry {
-                    denial: Some(RetryPolicyDenial::NotBodylessMode),
+                    denial: Some(RetryPolicyDenialReason::MethodNotIdempotent),
+                }
+            } else if !input.request_body_replayable {
+                RetryPolicyDecision::DoNotRetry {
+                    denial: Some(RetryPolicyDenialReason::RequestBodyNotReplayable),
+                }
+            } else if input.attempt_count >= input.max_attempts {
+                RetryPolicyDecision::DoNotRetry {
+                    denial: Some(RetryPolicyDenialReason::AttemptLimitReached),
                 }
             } else if !input.budget_available {
                 RetryPolicyDecision::DoNotRetry {
-                    denial: Some(RetryPolicyDenial::BudgetDenied),
+                    denial: Some(RetryPolicyDenialReason::BudgetDenied),
                 }
             } else if !input.alternate_backend_available {
                 RetryPolicyDecision::DoNotRetry {
-                    denial: Some(RetryPolicyDenial::NoAlternateBackend),
+                    denial: Some(RetryPolicyDenialReason::NoAlternateBackend),
+                }
+            } else if !input.alternate_backend_healthy {
+                RetryPolicyDecision::DoNotRetry {
+                    denial: Some(RetryPolicyDenialReason::AlternateBackendUnhealthy),
                 }
             } else {
                 RetryPolicyDecision::Retry { reason }
@@ -86,4 +195,107 @@ pub fn is_retryable(err: &ProxyError) -> bool {
         classify_retryability(err),
         UpstreamRetryability::Retryable(_)
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn retry_facts() -> RetryPolicyFacts {
+        RetryPolicyFacts {
+            retryability: UpstreamRetryability::Retryable(UpstreamRetryReason::Timeout),
+            method_idempotent: true,
+            request_body_replayable: true,
+            attempt_count: 0,
+            max_attempts: 1,
+            budget_available: true,
+            alternate_backend_available: true,
+            alternate_backend_healthy: true,
+        }
+    }
+
+    #[test]
+    fn idempotent_method_helper_matches_expected_methods() {
+        assert!(is_idempotent_method("GET"));
+        assert!(is_idempotent_method("delete"));
+        assert!(!is_idempotent_method("POST"));
+        assert!(!is_idempotent_method("PATCH"));
+    }
+
+    #[test]
+    fn terminal_errors_return_explicit_denial() {
+        let mut facts = retry_facts();
+        facts.retryability = UpstreamRetryability::Terminal(UpstreamTerminalErrorKind::Tls);
+
+        assert_eq!(
+            evaluate_retry_policy(facts),
+            RetryPolicyDecision::DoNotRetry {
+                denial: Some(RetryPolicyDenialReason::TerminalError(
+                    UpstreamTerminalErrorKind::Tls
+                )),
+            }
+        );
+    }
+
+    #[test]
+    fn method_idempotency_blocks_retry() {
+        let mut facts = retry_facts();
+        facts.method_idempotent = false;
+
+        assert_eq!(
+            evaluate_retry_policy(facts),
+            RetryPolicyDecision::DoNotRetry {
+                denial: Some(RetryPolicyDenialReason::MethodNotIdempotent),
+            }
+        );
+    }
+
+    #[test]
+    fn request_body_replayability_blocks_retry() {
+        let mut facts = retry_facts();
+        facts.request_body_replayable = false;
+
+        assert_eq!(
+            evaluate_retry_policy(facts),
+            RetryPolicyDecision::DoNotRetry {
+                denial: Some(RetryPolicyDenialReason::RequestBodyNotReplayable),
+            }
+        );
+    }
+
+    #[test]
+    fn attempt_limit_blocks_retry() {
+        let mut facts = retry_facts();
+        facts.attempt_count = 1;
+
+        assert_eq!(
+            evaluate_retry_policy(facts),
+            RetryPolicyDecision::DoNotRetry {
+                denial: Some(RetryPolicyDenialReason::AttemptLimitReached),
+            }
+        );
+    }
+
+    #[test]
+    fn unhealthy_alternate_backend_blocks_retry() {
+        let mut facts = retry_facts();
+        facts.alternate_backend_healthy = false;
+
+        assert_eq!(
+            evaluate_retry_policy(facts),
+            RetryPolicyDecision::DoNotRetry {
+                denial: Some(RetryPolicyDenialReason::AlternateBackendUnhealthy),
+            }
+        );
+    }
+
+    #[test]
+    fn retryable_timeout_allows_retry() {
+        assert_eq!(
+            evaluate_retry_policy(retry_facts()),
+            RetryPolicyDecision::Retry {
+                reason: UpstreamRetryReason::Timeout,
+            }
+        );
+    }
 }

--- a/crates/errors/src/retry.rs
+++ b/crates/errors/src/retry.rs
@@ -337,6 +337,77 @@ mod tests {
     }
 
     #[test]
+    fn missing_alternate_backend_reason_defaults_to_only_excluded_backends_healthy() {
+        let mut facts = retry_facts();
+        facts.alternate_backend_available = false;
+        facts.alternate_backend_failure = None;
+
+        assert_eq!(
+            evaluate_retry_policy(facts),
+            RetryPolicyDecision::DoNotRetry {
+                denial: Some(RetryPolicyDenialReason::AlternateBackendUnavailable(
+                    AlternateBackendFailureReason::OnlyExcludedBackendsHealthy,
+                )),
+            }
+        );
+    }
+
+    #[test]
+    fn budget_denied_blocks_retry() {
+        let mut facts = retry_facts();
+        facts.budget_available = false;
+
+        assert_eq!(
+            evaluate_retry_policy(facts),
+            RetryPolicyDecision::DoNotRetry {
+                denial: Some(RetryPolicyDenialReason::BudgetDenied),
+            }
+        );
+    }
+
+    #[test]
+    fn retryable_transport_allows_retry() {
+        let mut facts = retry_facts();
+        facts.retryability = UpstreamRetryability::Retryable(UpstreamRetryReason::Transport);
+
+        assert_eq!(
+            evaluate_retry_policy(facts),
+            RetryPolicyDecision::Retry {
+                reason: UpstreamRetryReason::Transport,
+            }
+        );
+    }
+
+    #[test]
+    fn retryable_pool_allows_retry() {
+        let mut facts = retry_facts();
+        facts.retryability = UpstreamRetryability::Retryable(UpstreamRetryReason::Pool);
+
+        assert_eq!(
+            evaluate_retry_policy(facts),
+            RetryPolicyDecision::Retry {
+                reason: UpstreamRetryReason::Pool,
+            }
+        );
+    }
+
+    #[test]
+    fn retry_attempt_telemetry_reason_matches_upstream_retry_reason() {
+        assert_eq!(
+            RetryAttemptTelemetryReason::from(UpstreamRetryReason::Timeout),
+            RetryAttemptTelemetryReason::Timeout
+        );
+        assert_eq!(
+            RetryAttemptTelemetryReason::from(UpstreamRetryReason::Transport),
+            RetryAttemptTelemetryReason::Transport
+        );
+        assert_eq!(
+            RetryAttemptTelemetryReason::from(UpstreamRetryReason::Pool),
+            RetryAttemptTelemetryReason::Pool
+        );
+    }
+
+    #[test]
     fn retryable_timeout_allows_retry() {
         assert_eq!(
             evaluate_retry_policy(retry_facts()),
@@ -386,6 +457,77 @@ mod tests {
             evaluate_hedge_policy(facts),
             HedgePolicyDecision::DoNotHedge {
                 denial: HedgePolicyDenialReason::RequestBodyNotReplayable,
+            }
+        );
+    }
+
+    #[test]
+    fn hedge_policy_rejects_when_disabled() {
+        let mut facts = hedge_facts();
+        facts.hedging_configured = false;
+
+        assert_eq!(
+            evaluate_hedge_policy(facts),
+            HedgePolicyDecision::DoNotHedge {
+                denial: HedgePolicyDenialReason::HedgingDisabled,
+            }
+        );
+    }
+
+    #[test]
+    fn hedge_policy_rejects_method_not_allowed() {
+        let mut facts = hedge_facts();
+        facts.method_allowed = false;
+
+        assert_eq!(
+            evaluate_hedge_policy(facts),
+            HedgePolicyDecision::DoNotHedge {
+                denial: HedgePolicyDenialReason::MethodNotAllowed,
+            }
+        );
+    }
+
+    #[test]
+    fn hedge_policy_rejects_tunnel_requests() {
+        let mut facts = hedge_facts();
+        facts.tunnel_request = true;
+
+        assert_eq!(
+            evaluate_hedge_policy(facts),
+            HedgePolicyDecision::DoNotHedge {
+                denial: HedgePolicyDenialReason::TunnelRequest,
+            }
+        );
+    }
+
+    #[test]
+    fn hedge_policy_rejects_when_no_alternate_backend_is_available() {
+        let mut facts = hedge_facts();
+        facts.alternate_backend_available = false;
+        facts.alternate_backend_failure = Some(AlternateBackendFailureReason::NoHealthyBackends);
+
+        assert_eq!(
+            evaluate_hedge_policy(facts),
+            HedgePolicyDecision::DoNotHedge {
+                denial: HedgePolicyDenialReason::AlternateBackendUnavailable(
+                    AlternateBackendFailureReason::NoHealthyBackends,
+                ),
+            }
+        );
+    }
+
+    #[test]
+    fn hedge_policy_defaults_alternate_backend_failure_reason_when_missing() {
+        let mut facts = hedge_facts();
+        facts.alternate_backend_available = false;
+        facts.alternate_backend_failure = None;
+
+        assert_eq!(
+            evaluate_hedge_policy(facts),
+            HedgePolicyDecision::DoNotHedge {
+                denial: HedgePolicyDenialReason::AlternateBackendUnavailable(
+                    AlternateBackendFailureReason::OnlyExcludedBackendsHealthy,
+                ),
             }
         );
     }

--- a/crates/errors/src/retry.rs
+++ b/crates/errors/src/retry.rs
@@ -1,4 +1,5 @@
 use crate::{PoolError, ProxyError};
+use spooky_lb::alternate_backend::AlternateBackendFailureReason;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum UpstreamRetryReason {
@@ -28,8 +29,7 @@ pub enum RetryPolicyDenialReason {
     RequestBodyNotReplayable,
     AttemptLimitReached,
     BudgetDenied,
-    NoAlternateBackend,
-    AlternateBackendUnhealthy,
+    AlternateBackendUnavailable(AlternateBackendFailureReason),
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -41,7 +41,7 @@ pub struct RetryPolicyFacts {
     pub max_attempts: u8,
     pub budget_available: bool,
     pub alternate_backend_available: bool,
-    pub alternate_backend_healthy: bool,
+    pub alternate_backend_failure: Option<AlternateBackendFailureReason>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -53,13 +53,13 @@ pub enum RetryPolicyDecision {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum RetryTelemetryReason {
+pub enum RetryAttemptTelemetryReason {
     Timeout,
     Transport,
     Pool,
 }
 
-impl From<UpstreamRetryReason> for RetryTelemetryReason {
+impl From<UpstreamRetryReason> for RetryAttemptTelemetryReason {
     fn from(value: UpstreamRetryReason) -> Self {
         match value {
             UpstreamRetryReason::Timeout => Self::Timeout,
@@ -76,7 +76,7 @@ pub struct HedgePolicyFacts {
     pub request_body_replayable: bool,
     pub tunnel_request: bool,
     pub alternate_backend_available: bool,
-    pub alternate_backend_healthy: bool,
+    pub alternate_backend_failure: Option<AlternateBackendFailureReason>,
     pub budget_available: bool,
     pub primary_state: HedgePrimaryState,
 }
@@ -92,52 +92,29 @@ pub enum HedgePrimaryState {
 pub enum HedgePolicyDenialReason {
     HedgingDisabled,
     PrimaryRequestCompleted,
-    DelayNotElapsed,
     RequestBodyNotReplayable,
     TunnelRequest,
     MethodNotAllowed,
-    NoAlternateBackend,
-    AlternateBackendUnhealthy,
+    AlternateBackendUnavailable(AlternateBackendFailureReason),
     BudgetDenied,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum HedgePolicyDecision {
     WaitForPrimary,
-    Hedge { reason: HedgeTelemetryReason },
+    Hedge { reason: HedgeTriggerTelemetryReason },
     DoNotHedge { denial: HedgePolicyDenialReason },
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum HedgeTelemetryReason {
+pub enum HedgeTriggerTelemetryReason {
     DelayElapsed,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HedgeOutcomeTelemetryReason {
     PrimaryWonAfterTrigger,
     HedgeWon,
-    HedgeWasted,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AlternateBackendChoice<Backend> {
-    pub backend: Backend,
-    pub index: usize,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct AlternateBackendPolicyFacts {
-    pub candidate_available: bool,
-    pub excluded_primary_backend: bool,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum AlternateBackendDenialReason {
-    NoCandidateAvailable,
-    PrimaryBackendNotExcluded,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum AlternateBackendDecision<Backend> {
-    Select(AlternateBackendChoice<Backend>),
-    DoNotSelect { denial: AlternateBackendDenialReason },
 }
 
 pub type RetryPolicyInput = RetryPolicyFacts;
@@ -190,11 +167,11 @@ pub fn evaluate_retry_policy(input: RetryPolicyFacts) -> RetryPolicyDecision {
                 }
             } else if !input.alternate_backend_available {
                 RetryPolicyDecision::DoNotRetry {
-                    denial: Some(RetryPolicyDenialReason::NoAlternateBackend),
-                }
-            } else if !input.alternate_backend_healthy {
-                RetryPolicyDecision::DoNotRetry {
-                    denial: Some(RetryPolicyDenialReason::AlternateBackendUnhealthy),
+                    denial: Some(RetryPolicyDenialReason::AlternateBackendUnavailable(
+                        input.alternate_backend_failure.unwrap_or(
+                            AlternateBackendFailureReason::OnlyExcludedBackendsHealthy,
+                        ),
+                    )),
                 }
             } else {
                 RetryPolicyDecision::Retry { reason }
@@ -230,13 +207,11 @@ pub fn evaluate_hedge_policy(input: HedgePolicyFacts) -> HedgePolicyDecision {
 
     if !input.alternate_backend_available {
         return HedgePolicyDecision::DoNotHedge {
-            denial: HedgePolicyDenialReason::NoAlternateBackend,
-        };
-    }
-
-    if !input.alternate_backend_healthy {
-        return HedgePolicyDecision::DoNotHedge {
-            denial: HedgePolicyDenialReason::AlternateBackendUnhealthy,
+            denial: HedgePolicyDenialReason::AlternateBackendUnavailable(
+                input.alternate_backend_failure.unwrap_or(
+                    AlternateBackendFailureReason::OnlyExcludedBackendsHealthy,
+                ),
+            ),
         };
     }
 
@@ -252,7 +227,7 @@ pub fn evaluate_hedge_policy(input: HedgePolicyFacts) -> HedgePolicyDecision {
                 }
             } else {
                 HedgePolicyDecision::Hedge {
-                    reason: HedgeTelemetryReason::DelayElapsed,
+                    reason: HedgeTriggerTelemetryReason::DelayElapsed,
                 }
             }
         }
@@ -279,7 +254,7 @@ mod tests {
             max_attempts: 1,
             budget_available: true,
             alternate_backend_available: true,
-            alternate_backend_healthy: true,
+            alternate_backend_failure: None,
         }
     }
 
@@ -348,12 +323,15 @@ mod tests {
     #[test]
     fn unhealthy_alternate_backend_blocks_retry() {
         let mut facts = retry_facts();
-        facts.alternate_backend_healthy = false;
+        facts.alternate_backend_available = false;
+        facts.alternate_backend_failure = Some(AlternateBackendFailureReason::NoHealthyBackends);
 
         assert_eq!(
             evaluate_retry_policy(facts),
             RetryPolicyDecision::DoNotRetry {
-                denial: Some(RetryPolicyDenialReason::AlternateBackendUnhealthy),
+                denial: Some(RetryPolicyDenialReason::AlternateBackendUnavailable(
+                    AlternateBackendFailureReason::NoHealthyBackends,
+                )),
             }
         );
     }
@@ -375,7 +353,7 @@ mod tests {
             request_body_replayable: true,
             tunnel_request: false,
             alternate_backend_available: true,
-            alternate_backend_healthy: true,
+            alternate_backend_failure: None,
             budget_available: true,
             primary_state: HedgePrimaryState::InFlightAfterDelay,
         }
@@ -394,7 +372,7 @@ mod tests {
         assert_eq!(
             evaluate_hedge_policy(hedge_facts()),
             HedgePolicyDecision::Hedge {
-                reason: HedgeTelemetryReason::DelayElapsed,
+                reason: HedgeTriggerTelemetryReason::DelayElapsed,
             }
         );
     }

--- a/crates/errors/src/retry.rs
+++ b/crates/errors/src/retry.rs
@@ -117,9 +117,6 @@ pub enum HedgeOutcomeTelemetryReason {
     HedgeWon,
 }
 
-pub type RetryPolicyInput = RetryPolicyFacts;
-pub type RetryPolicyDenial = RetryPolicyDenialReason;
-
 pub fn is_idempotent_method(method: &str) -> bool {
     matches!(
         method.to_ascii_uppercase().as_str(),

--- a/crates/errors/tests/proxy.rs
+++ b/crates/errors/tests/proxy.rs
@@ -52,29 +52,45 @@ fn retry_policy_evaluation_preserves_existing_denial_behavior() {
     assert_eq!(
         evaluate_retry_policy(RetryPolicyInput {
             retryability: UpstreamRetryability::Terminal(UpstreamTerminalErrorKind::Protocol),
-            bodyless_mode: true,
+            method_idempotent: true,
+            request_body_replayable: true,
+            attempt_count: 0,
+            max_attempts: 1,
             budget_available: true,
             alternate_backend_available: true,
+            alternate_backend_healthy: true,
         }),
-        RetryPolicyDecision::DoNotRetry { denial: None }
+        RetryPolicyDecision::DoNotRetry {
+            denial: Some(RetryPolicyDenial::TerminalError(
+                UpstreamTerminalErrorKind::Protocol,
+            )),
+        }
     );
     assert_eq!(
         evaluate_retry_policy(RetryPolicyInput {
             retryability: UpstreamRetryability::Retryable(UpstreamRetryReason::Transport),
-            bodyless_mode: false,
+            method_idempotent: true,
+            request_body_replayable: false,
+            attempt_count: 0,
+            max_attempts: 1,
             budget_available: true,
             alternate_backend_available: true,
+            alternate_backend_healthy: true,
         }),
         RetryPolicyDecision::DoNotRetry {
-            denial: Some(RetryPolicyDenial::NotBodylessMode),
+            denial: Some(RetryPolicyDenial::RequestBodyNotReplayable),
         }
     );
     assert_eq!(
         evaluate_retry_policy(RetryPolicyInput {
             retryability: UpstreamRetryability::Retryable(UpstreamRetryReason::Pool),
-            bodyless_mode: true,
+            method_idempotent: true,
+            request_body_replayable: true,
+            attempt_count: 0,
+            max_attempts: 1,
             budget_available: false,
             alternate_backend_available: true,
+            alternate_backend_healthy: true,
         }),
         RetryPolicyDecision::DoNotRetry {
             denial: Some(RetryPolicyDenial::BudgetDenied),
@@ -83,9 +99,13 @@ fn retry_policy_evaluation_preserves_existing_denial_behavior() {
     assert_eq!(
         evaluate_retry_policy(RetryPolicyInput {
             retryability: UpstreamRetryability::Retryable(UpstreamRetryReason::Timeout),
-            bodyless_mode: true,
+            method_idempotent: true,
+            request_body_replayable: true,
+            attempt_count: 0,
+            max_attempts: 1,
             budget_available: true,
             alternate_backend_available: true,
+            alternate_backend_healthy: true,
         }),
         RetryPolicyDecision::Retry {
             reason: UpstreamRetryReason::Timeout,

--- a/crates/errors/tests/proxy.rs
+++ b/crates/errors/tests/proxy.rs
@@ -1,6 +1,6 @@
 use spooky_errors::{
     AlternateBackendFailureReason,
-    PoolError, ProxyError, RetryPolicyDecision, RetryPolicyDenial, RetryPolicyInput,
+    PoolError, ProxyError, RetryPolicyDecision, RetryPolicyDenialReason, RetryPolicyFacts,
     UpstreamErrorClassification, UpstreamHealthFailureMapping, UpstreamProxyErrorKind,
     UpstreamRetryReason, UpstreamRetryability, UpstreamTerminalErrorKind, UpstreamTlsReason,
     classify_retryability, classify_upstream_proxy_error, evaluate_retry_policy, is_retryable,
@@ -51,7 +51,7 @@ fn retryability_classification_distinguishes_retryable_and_terminal_errors() {
 #[test]
 fn retry_policy_evaluation_preserves_existing_denial_behavior() {
     assert_eq!(
-        evaluate_retry_policy(RetryPolicyInput {
+        evaluate_retry_policy(RetryPolicyFacts {
             retryability: UpstreamRetryability::Terminal(UpstreamTerminalErrorKind::Protocol),
             method_idempotent: true,
             request_body_replayable: true,
@@ -62,13 +62,13 @@ fn retry_policy_evaluation_preserves_existing_denial_behavior() {
             alternate_backend_failure: None,
         }),
         RetryPolicyDecision::DoNotRetry {
-            denial: Some(RetryPolicyDenial::TerminalError(
+            denial: Some(RetryPolicyDenialReason::TerminalError(
                 UpstreamTerminalErrorKind::Protocol,
             )),
         }
     );
     assert_eq!(
-        evaluate_retry_policy(RetryPolicyInput {
+        evaluate_retry_policy(RetryPolicyFacts {
             retryability: UpstreamRetryability::Retryable(UpstreamRetryReason::Transport),
             method_idempotent: true,
             request_body_replayable: false,
@@ -79,11 +79,11 @@ fn retry_policy_evaluation_preserves_existing_denial_behavior() {
             alternate_backend_failure: None,
         }),
         RetryPolicyDecision::DoNotRetry {
-            denial: Some(RetryPolicyDenial::RequestBodyNotReplayable),
+            denial: Some(RetryPolicyDenialReason::RequestBodyNotReplayable),
         }
     );
     assert_eq!(
-        evaluate_retry_policy(RetryPolicyInput {
+        evaluate_retry_policy(RetryPolicyFacts {
             retryability: UpstreamRetryability::Retryable(UpstreamRetryReason::Pool),
             method_idempotent: true,
             request_body_replayable: true,
@@ -94,11 +94,11 @@ fn retry_policy_evaluation_preserves_existing_denial_behavior() {
             alternate_backend_failure: None,
         }),
         RetryPolicyDecision::DoNotRetry {
-            denial: Some(RetryPolicyDenial::BudgetDenied),
+            denial: Some(RetryPolicyDenialReason::BudgetDenied),
         }
     );
     assert_eq!(
-        evaluate_retry_policy(RetryPolicyInput {
+        evaluate_retry_policy(RetryPolicyFacts {
             retryability: UpstreamRetryability::Retryable(UpstreamRetryReason::Timeout),
             method_idempotent: true,
             request_body_replayable: true,
@@ -114,7 +114,7 @@ fn retry_policy_evaluation_preserves_existing_denial_behavior() {
     );
 
     assert_eq!(
-        evaluate_retry_policy(RetryPolicyInput {
+        evaluate_retry_policy(RetryPolicyFacts {
             retryability: UpstreamRetryability::Retryable(UpstreamRetryReason::Timeout),
             method_idempotent: true,
             request_body_replayable: true,
@@ -125,7 +125,7 @@ fn retry_policy_evaluation_preserves_existing_denial_behavior() {
             alternate_backend_failure: Some(AlternateBackendFailureReason::NoHealthyBackends),
         }),
         RetryPolicyDecision::DoNotRetry {
-            denial: Some(RetryPolicyDenial::AlternateBackendUnavailable(
+            denial: Some(RetryPolicyDenialReason::AlternateBackendUnavailable(
                 AlternateBackendFailureReason::NoHealthyBackends,
             )),
         }

--- a/crates/errors/tests/proxy.rs
+++ b/crates/errors/tests/proxy.rs
@@ -1,9 +1,9 @@
 use spooky_errors::{
-    AlternateBackendFailureReason,
-    PoolError, ProxyError, RetryPolicyDecision, RetryPolicyDenialReason, RetryPolicyFacts,
-    UpstreamErrorClassification, UpstreamHealthFailureMapping, UpstreamProxyErrorKind,
-    UpstreamRetryReason, UpstreamRetryability, UpstreamTerminalErrorKind, UpstreamTlsReason,
-    classify_retryability, classify_upstream_proxy_error, evaluate_retry_policy, is_retryable,
+    AlternateBackendFailureReason, PoolError, ProxyError, RetryPolicyDecision,
+    RetryPolicyDenialReason, RetryPolicyFacts, UpstreamErrorClassification,
+    UpstreamHealthFailureMapping, UpstreamProxyErrorKind, UpstreamRetryReason,
+    UpstreamRetryability, UpstreamTerminalErrorKind, UpstreamTlsReason, classify_retryability,
+    classify_upstream_proxy_error, evaluate_retry_policy, is_retryable,
 };
 
 #[test]

--- a/crates/errors/tests/proxy.rs
+++ b/crates/errors/tests/proxy.rs
@@ -1,4 +1,5 @@
 use spooky_errors::{
+    AlternateBackendFailureReason,
     PoolError, ProxyError, RetryPolicyDecision, RetryPolicyDenial, RetryPolicyInput,
     UpstreamErrorClassification, UpstreamHealthFailureMapping, UpstreamProxyErrorKind,
     UpstreamRetryReason, UpstreamRetryability, UpstreamTerminalErrorKind, UpstreamTlsReason,
@@ -58,7 +59,7 @@ fn retry_policy_evaluation_preserves_existing_denial_behavior() {
             max_attempts: 1,
             budget_available: true,
             alternate_backend_available: true,
-            alternate_backend_healthy: true,
+            alternate_backend_failure: None,
         }),
         RetryPolicyDecision::DoNotRetry {
             denial: Some(RetryPolicyDenial::TerminalError(
@@ -75,7 +76,7 @@ fn retry_policy_evaluation_preserves_existing_denial_behavior() {
             max_attempts: 1,
             budget_available: true,
             alternate_backend_available: true,
-            alternate_backend_healthy: true,
+            alternate_backend_failure: None,
         }),
         RetryPolicyDecision::DoNotRetry {
             denial: Some(RetryPolicyDenial::RequestBodyNotReplayable),
@@ -90,7 +91,7 @@ fn retry_policy_evaluation_preserves_existing_denial_behavior() {
             max_attempts: 1,
             budget_available: false,
             alternate_backend_available: true,
-            alternate_backend_healthy: true,
+            alternate_backend_failure: None,
         }),
         RetryPolicyDecision::DoNotRetry {
             denial: Some(RetryPolicyDenial::BudgetDenied),
@@ -105,10 +106,28 @@ fn retry_policy_evaluation_preserves_existing_denial_behavior() {
             max_attempts: 1,
             budget_available: true,
             alternate_backend_available: true,
-            alternate_backend_healthy: true,
+            alternate_backend_failure: None,
         }),
         RetryPolicyDecision::Retry {
             reason: UpstreamRetryReason::Timeout,
+        }
+    );
+
+    assert_eq!(
+        evaluate_retry_policy(RetryPolicyInput {
+            retryability: UpstreamRetryability::Retryable(UpstreamRetryReason::Timeout),
+            method_idempotent: true,
+            request_body_replayable: true,
+            attempt_count: 0,
+            max_attempts: 1,
+            budget_available: true,
+            alternate_backend_available: false,
+            alternate_backend_failure: Some(AlternateBackendFailureReason::NoHealthyBackends),
+        }),
+        RetryPolicyDecision::DoNotRetry {
+            denial: Some(RetryPolicyDenial::AlternateBackendUnavailable(
+                AlternateBackendFailureReason::NoHealthyBackends,
+            )),
         }
     );
 }

--- a/crates/lb/src/alternate_backend.rs
+++ b/crates/lb/src/alternate_backend.rs
@@ -1,0 +1,172 @@
+use crate::upstream_pool::UpstreamPool;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AlternateBackendSelectionMode {
+    LoadBalancerReadonly,
+    HealthyFallback,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct AlternateBackendChoice {
+    pub index: usize,
+    pub mode: AlternateBackendSelectionMode,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AlternateBackendDenialReason {
+    NoHealthyBackends,
+    OnlyExcludedBackendsHealthy,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AlternateBackendDecision {
+    Select(AlternateBackendChoice),
+    DoNotSelect { denial: AlternateBackendDenialReason },
+}
+
+fn is_excluded(index: usize, excluded_indices: &[usize]) -> bool {
+    excluded_indices.contains(&index)
+}
+
+pub fn choose_alternate_backend(
+    pool: &UpstreamPool,
+    excluded_indices: &[usize],
+    lb_key: Option<&str>,
+) -> AlternateBackendDecision {
+    let readonly_candidate = pool
+        .pick_readonly(lb_key.unwrap_or_default())
+        .filter(|index| !is_excluded(*index, excluded_indices));
+    if let Some(index) = readonly_candidate {
+        return AlternateBackendDecision::Select(AlternateBackendChoice {
+            index,
+            mode: AlternateBackendSelectionMode::LoadBalancerReadonly,
+        });
+    }
+
+    let fallback_candidate = pool
+        .pool
+        .healthy_indices_iter()
+        .find(|index| !is_excluded(*index, excluded_indices));
+    if let Some(index) = fallback_candidate {
+        return AlternateBackendDecision::Select(AlternateBackendChoice {
+            index,
+            mode: AlternateBackendSelectionMode::HealthyFallback,
+        });
+    }
+
+    if pool.pool.healthy_len() == 0 {
+        AlternateBackendDecision::DoNotSelect {
+            denial: AlternateBackendDenialReason::NoHealthyBackends,
+        }
+    } else {
+        AlternateBackendDecision::DoNotSelect {
+            denial: AlternateBackendDenialReason::OnlyExcludedBackendsHealthy,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use spooky_config::config::{Backend, HealthCheck, LoadBalancing, RouteMatch, Upstream};
+
+    use super::*;
+
+    fn upstream(lb_type: &str, backends: &[&str]) -> Upstream {
+        Upstream {
+            tls: None,
+            load_balancing: LoadBalancing {
+                lb_type: lb_type.to_string(),
+                key: None,
+            },
+            auth: Default::default(),
+            host_policy: Default::default(),
+            forwarded_headers: Default::default(),
+            route: RouteMatch::default(),
+            backends: backends
+                .iter()
+                .enumerate()
+                .map(|(index, address)| Backend {
+                    id: format!("backend-{index}"),
+                    address: (*address).to_string(),
+                    weight: 1,
+                    health_check: Some(HealthCheck {
+                        path: "/health".to_string(),
+                        interval: 0,
+                        timeout_ms: 1000,
+                        failure_threshold: 1,
+                        success_threshold: 1,
+                        cooldown_ms: 1000,
+                    }),
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn chooses_non_excluded_backend_from_readonly_lb_pick() {
+        let pool = UpstreamPool::from_upstream(&upstream(
+            "round-robin",
+            &["http://a", "http://b", "http://c"],
+        ))
+        .expect("pool");
+
+        let decision = choose_alternate_backend(&pool, &[2], None);
+        assert_eq!(
+            decision,
+            AlternateBackendDecision::Select(AlternateBackendChoice {
+                index: 0,
+                mode: AlternateBackendSelectionMode::LoadBalancerReadonly,
+            })
+        );
+    }
+
+    #[test]
+    fn falls_back_when_readonly_pick_hits_excluded_backend() {
+        let pool = UpstreamPool::from_upstream(&upstream(
+            "round-robin",
+            &["http://a", "http://b", "http://c"],
+        ))
+        .expect("pool");
+
+        let decision = choose_alternate_backend(&pool, &[0], None);
+        assert_eq!(
+            decision,
+            AlternateBackendDecision::Select(AlternateBackendChoice {
+                index: 1,
+                mode: AlternateBackendSelectionMode::HealthyFallback,
+            })
+        );
+    }
+
+    #[test]
+    fn falls_back_to_healthy_scan_when_readonly_strategy_is_unavailable() {
+        let pool = UpstreamPool::from_upstream(&upstream(
+            "consistent-hash",
+            &["http://a", "http://b"],
+        ))
+        .expect("pool");
+
+        let decision = choose_alternate_backend(&pool, &[0], None);
+        assert_eq!(
+            decision,
+            AlternateBackendDecision::Select(AlternateBackendChoice {
+                index: 1,
+                mode: AlternateBackendSelectionMode::HealthyFallback,
+            })
+        );
+    }
+
+    #[test]
+    fn reports_when_only_excluded_backends_are_healthy() {
+        let pool = UpstreamPool::from_upstream(&upstream("round-robin", &["http://a"]))
+            .expect("pool");
+
+        let decision = choose_alternate_backend(&pool, &[0], None);
+        assert_eq!(
+            decision,
+            AlternateBackendDecision::DoNotSelect {
+                denial: AlternateBackendDenialReason::OnlyExcludedBackendsHealthy,
+            }
+        );
+    }
+}

--- a/crates/lb/src/alternate_backend.rs
+++ b/crates/lb/src/alternate_backend.rs
@@ -72,6 +72,7 @@ mod tests {
     use spooky_config::config::{Backend, HealthCheck, LoadBalancing, RouteMatch, Upstream};
 
     use super::*;
+    use crate::health::HealthFailureReason;
 
     fn upstream(lb_type: &str, backends: &[&str]) -> Upstream {
         Upstream {
@@ -168,6 +169,30 @@ mod tests {
             decision,
             AlternateBackendDecision::DoNotSelect {
                 denial: AlternateBackendFailureReason::OnlyExcludedBackendsHealthy,
+            }
+        );
+    }
+
+    #[test]
+    fn reports_when_no_backends_are_healthy() {
+        let mut pool = UpstreamPool::from_upstream(&upstream(
+            "round-robin",
+            &["http://a", "http://b"],
+        ))
+        .expect("pool");
+
+        let _ = pool
+            .pool
+            .mark_failure_with_reason(0, HealthFailureReason::Transport);
+        let _ = pool
+            .pool
+            .mark_failure_with_reason(1, HealthFailureReason::Transport);
+
+        let decision = choose_alternate_backend(&pool, &[], None);
+        assert_eq!(
+            decision,
+            AlternateBackendDecision::DoNotSelect {
+                denial: AlternateBackendFailureReason::NoHealthyBackends,
             }
         );
     }

--- a/crates/lb/src/alternate_backend.rs
+++ b/crates/lb/src/alternate_backend.rs
@@ -23,7 +23,9 @@ pub enum AlternateBackendFailureReason {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum AlternateBackendDecision {
     Select(AlternateBackendChoice),
-    DoNotSelect { denial: AlternateBackendFailureReason },
+    DoNotSelect {
+        denial: AlternateBackendFailureReason,
+    },
 }
 
 fn is_excluded(index: usize, excluded_indices: &[usize]) -> bool {
@@ -143,11 +145,9 @@ mod tests {
 
     #[test]
     fn falls_back_to_healthy_scan_when_readonly_strategy_is_unavailable() {
-        let pool = UpstreamPool::from_upstream(&upstream(
-            "consistent-hash",
-            &["http://a", "http://b"],
-        ))
-        .expect("pool");
+        let pool =
+            UpstreamPool::from_upstream(&upstream("consistent-hash", &["http://a", "http://b"]))
+                .expect("pool");
 
         let decision = choose_alternate_backend(&pool, &[0], None);
         assert_eq!(
@@ -161,8 +161,8 @@ mod tests {
 
     #[test]
     fn reports_when_only_excluded_backends_are_healthy() {
-        let pool = UpstreamPool::from_upstream(&upstream("round-robin", &["http://a"]))
-            .expect("pool");
+        let pool =
+            UpstreamPool::from_upstream(&upstream("round-robin", &["http://a"])).expect("pool");
 
         let decision = choose_alternate_backend(&pool, &[0], None);
         assert_eq!(
@@ -175,11 +175,9 @@ mod tests {
 
     #[test]
     fn reports_when_no_backends_are_healthy() {
-        let mut pool = UpstreamPool::from_upstream(&upstream(
-            "round-robin",
-            &["http://a", "http://b"],
-        ))
-        .expect("pool");
+        let mut pool =
+            UpstreamPool::from_upstream(&upstream("round-robin", &["http://a", "http://b"]))
+                .expect("pool");
 
         let _ = pool
             .pool

--- a/crates/lb/src/alternate_backend.rs
+++ b/crates/lb/src/alternate_backend.rs
@@ -13,15 +13,17 @@ pub struct AlternateBackendChoice {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum AlternateBackendDenialReason {
+pub enum AlternateBackendFailureReason {
     NoHealthyBackends,
     OnlyExcludedBackendsHealthy,
+    PoolUnavailable,
+    BackendAddressMissing,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum AlternateBackendDecision {
     Select(AlternateBackendChoice),
-    DoNotSelect { denial: AlternateBackendDenialReason },
+    DoNotSelect { denial: AlternateBackendFailureReason },
 }
 
 fn is_excluded(index: usize, excluded_indices: &[usize]) -> bool {
@@ -56,11 +58,11 @@ pub fn choose_alternate_backend(
 
     if pool.pool.healthy_len() == 0 {
         AlternateBackendDecision::DoNotSelect {
-            denial: AlternateBackendDenialReason::NoHealthyBackends,
+            denial: AlternateBackendFailureReason::NoHealthyBackends,
         }
     } else {
         AlternateBackendDecision::DoNotSelect {
-            denial: AlternateBackendDenialReason::OnlyExcludedBackendsHealthy,
+            denial: AlternateBackendFailureReason::OnlyExcludedBackendsHealthy,
         }
     }
 }
@@ -165,7 +167,7 @@ mod tests {
         assert_eq!(
             decision,
             AlternateBackendDecision::DoNotSelect {
-                denial: AlternateBackendDenialReason::OnlyExcludedBackendsHealthy,
+                denial: AlternateBackendFailureReason::OnlyExcludedBackendsHealthy,
             }
         );
     }

--- a/crates/lb/src/lib.rs
+++ b/crates/lb/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod alternate_backend;
 pub mod algorithms;
 pub mod backend;
 pub mod backend_pool;

--- a/crates/lb/src/lib.rs
+++ b/crates/lb/src/lib.rs
@@ -1,5 +1,5 @@
-pub mod alternate_backend;
 pub mod algorithms;
+pub mod alternate_backend;
 pub mod backend;
 pub mod backend_pool;
 pub mod hash;


### PR DESCRIPTION
## Summary
This PR pulls retry and hedging behavior out of forwarding-local control flow into a shared policy layer, so `edge` orchestration consumes typed decisions instead of re-deriving retry, hedge, alternate-backend, and telemetry behavior inline.

## What Changed
- added shared retry and hedge policy types and evaluators
- centralized retry eligibility and denial-reason handling
- centralized hedge trigger and suppression decision logic
- extracted alternate backend selection into a shared helper in `lb`
- unified retry/hedge telemetry reason mapping
- switched QUIC forwarding and remaining callers to the shared policy contract
- added focused tests for retry eligibility, hedge behavior, alternate backend selection, and telemetry stability

## Follow-up Fixes Included
- preserved failover availability when circuit-open paths should not consume retry budget
- restored stateful round-robin behavior in primary backend selection
- reduced argument sprawl in retry dispatch helpers with internal typed context

## Outcome
- forwarding is closer to orchestration-only
- retry/hedge behavior is more canonical and reusable across crates
- policy decisions are easier to test and evolve without touching stream execution code