### PR TITLE
refactor(edge): centralize canonical request outcome recording and health accounting

### DIFF
--- a/crates/edge/src/quic_listener/bootstrap_tls.rs
+++ b/crates/edge/src/quic_listener/bootstrap_tls.rs
@@ -6,7 +6,7 @@ use std::{
         Arc, RwLock,
         atomic::{AtomicBool, AtomicUsize, Ordering},
     },
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use bytes::Bytes;
@@ -37,7 +37,7 @@ use spooky_config::{
     backend_endpoint::{BackendEndpoint, BackendScheme},
     runtime::{ListenerRuntimeConfig, RuntimeUpstreamPolicy},
 };
-use spooky_errors::{ProxyError, classify_upstream_proxy_error};
+use spooky_errors::{BridgeError, ProxyError, classify_upstream_proxy_error};
 use spooky_lb::upstream_pool::UpstreamPool;
 use spooky_transport::transport_pool::UpstreamTransportPool;
 
@@ -52,7 +52,7 @@ use super::{
     runtime_handle, spawn_supervised_async_task, validate_http_request,
 };
 use crate::{
-    Metrics, REQUEST_ID_COUNTER, RouteOutcome,
+    Metrics, REQUEST_ID_COUNTER,
     resilience::runtime::RuntimeResilience,
     routing::index::RouteIndex,
     runtime::{
@@ -63,6 +63,11 @@ use crate::{
             RequestBodyGuardrailConfig, RequestBodyGuardrailDecision, RequestBodyGuardrailInput,
             ResponseBodyGuardrailConfig, ResponseBodyGuardrailDecision, ResponseBodyGuardrailInput,
             checked_request_body_ingress, checked_response_body_guardrails,
+        },
+        connection::outcome::{
+            AdmissionOutcomeClass, OutcomeBackendTarget, OutcomeRouteTarget,
+            observe_admission_outcome, observe_backend_response_status,
+            observe_proxy_error_outcome, observe_status_outcome,
         },
         shared_state::SharedRuntimeState,
         tls::store::ListenerTlsReloadStore,
@@ -147,6 +152,22 @@ fn bootstrap_request_build_input<'a>(
             traceparent,
         },
         forwarded: RequestForwardedContext { client_addr: peer },
+    }
+}
+
+fn bootstrap_route_target<'a>(route: &'a str) -> OutcomeRouteTarget<'a> {
+    OutcomeRouteTarget { route }
+}
+
+fn bootstrap_backend_target<'a>(
+    upstream_name: &'a str,
+    backend_addr: &'a str,
+    backend_index: usize,
+) -> OutcomeBackendTarget<'a> {
+    OutcomeBackendTarget {
+        upstream: upstream_name,
+        backend_addr: Some(backend_addr),
+        backend_index: Some(backend_index),
     }
 }
 
@@ -398,6 +419,7 @@ impl QUICListener {
                             let peer = peer;
 
                             Box::pin(async move {
+                                let request_start = Instant::now();
                                 let is_websocket_upgrade =
                                     is_websocket_upgrade_request(&req, use_h2);
                                 let client_upgrade = if is_websocket_upgrade {
@@ -409,15 +431,18 @@ impl QUICListener {
                                 let request = match validate_http_request(&req, &resilience) {
                                     Ok(request) => request,
                                     Err((status, body, is_policy)) => {
-                                        metrics.inc_failure();
                                         metrics.inc_request_validation_reject();
                                         if is_policy {
                                             metrics.inc_policy_denied();
                                         }
-                                        metrics.record_route(
-                                            "unrouted",
-                                            Duration::from_millis(0),
-                                            RouteOutcome::Failure,
+                                        let _ = observe_proxy_error_outcome(
+                                            metrics.as_ref(),
+                                            OutcomeRouteTarget::UNROUTED,
+                                            None,
+                                            request_start.elapsed(),
+                                            Some(status),
+                                            &ProxyError::Bridge(BridgeError::InvalidHeader),
+                                            None,
                                         );
                                         return Ok(Response::builder()
                                             .status(status)
@@ -510,12 +535,18 @@ impl QUICListener {
                                 match admission {
                                     AdmissionPolicyDecision::AdmitReady => {}
                                     AdmissionPolicyDecision::Unauthorized(_) => {
-                                        metrics.inc_failure();
                                         metrics.inc_policy_denied();
-                                        metrics.record_route(
-                                            &upstream_name,
-                                            Duration::from_millis(0),
-                                            RouteOutcome::Failure,
+                                        let _ = observe_admission_outcome(
+                                            metrics.as_ref(),
+                                            bootstrap_route_target(&upstream_name),
+                                            Some(bootstrap_backend_target(
+                                                &upstream_name,
+                                                &backend_addr,
+                                                backend_index,
+                                            )),
+                                            request_start.elapsed(),
+                                            StatusCode::UNAUTHORIZED,
+                                            AdmissionOutcomeClass::AuthDenied,
                                         );
                                         warn!(
                                             "Bootstrap request route={} denied by auth policy",
@@ -567,12 +598,18 @@ impl QUICListener {
                                             }));
                                     }
                                     AdmissionPolicyDecision::RateLimited(decision) => {
-                                        metrics.inc_failure();
                                         metrics.inc_request_rate_limited();
-                                        metrics.record_route(
-                                            &upstream_name,
-                                            Duration::from_millis(0),
-                                            RouteOutcome::RateLimited,
+                                        let _ = observe_admission_outcome(
+                                            metrics.as_ref(),
+                                            bootstrap_route_target(&upstream_name),
+                                            Some(bootstrap_backend_target(
+                                                &upstream_name,
+                                                &backend_addr,
+                                                backend_index,
+                                            )),
+                                            request_start.elapsed(),
+                                            StatusCode::TOO_MANY_REQUESTS,
+                                            AdmissionOutcomeClass::RateLimited,
                                         );
                                         warn!(
                                             "Bootstrap request route={} scoped rate limit exceeded by rule={}",
@@ -626,18 +663,23 @@ impl QUICListener {
                                             }));
                                     }
                                     AdmissionPolicyDecision::Overloaded(decision) => {
-                                        metrics.inc_failure();
-                                        metrics.inc_overload_shed_reason(
-                                            decision.reason.metrics_reason(),
-                                        );
-                                        metrics.record_route(
-                                            &upstream_name,
-                                            Duration::from_millis(0),
-                                            RouteOutcome::OverloadShed,
+                                        let _ = observe_admission_outcome(
+                                            metrics.as_ref(),
+                                            bootstrap_route_target(&upstream_name),
+                                            Some(bootstrap_backend_target(
+                                                &upstream_name,
+                                                &backend_addr,
+                                                backend_index,
+                                            )),
+                                            request_start.elapsed(),
+                                            StatusCode::SERVICE_UNAVAILABLE,
+                                            AdmissionOutcomeClass::OverloadShed {
+                                                reason: Some(decision.reason.metrics_reason()),
+                                            },
                                         );
                                         resilience
                                             .adaptive_admission
-                                            .observe(Duration::from_millis(0), true);
+                                            .observe(request_start.elapsed(), true);
                                         let Some(response) = rejection_response.as_ref() else {
                                             warn!(
                                                 "Bootstrap request route={} missing admission rejection response for overload decision",
@@ -690,6 +732,19 @@ impl QUICListener {
                                 let endpoint = match backend_endpoints.get(&backend_addr) {
                                     Some(ep) => ep.clone(),
                                     None => {
+                                        let _ = observe_proxy_error_outcome(
+                                            metrics.as_ref(),
+                                            bootstrap_route_target(&upstream_name),
+                                            Some(bootstrap_backend_target(
+                                                &upstream_name,
+                                                &backend_addr,
+                                                backend_index,
+                                            )),
+                                            request_start.elapsed(),
+                                            Some(StatusCode::BAD_GATEWAY),
+                                            &ProxyError::Transport("no endpoint".into()),
+                                            None,
+                                        );
                                         return Ok(Response::builder()
                                             .status(StatusCode::BAD_GATEWAY)
                                             .header("alt-svc", &alt)
@@ -726,6 +781,19 @@ impl QUICListener {
                                         kind: BodyLimitKind::BodySize,
                                     })
                                 ) {
+                                    let _ = observe_proxy_error_outcome(
+                                        metrics.as_ref(),
+                                        bootstrap_route_target(&upstream_name),
+                                        Some(bootstrap_backend_target(
+                                            &upstream_name,
+                                            &backend_addr,
+                                            backend_index,
+                                        )),
+                                        request_start.elapsed(),
+                                        Some(StatusCode::PAYLOAD_TOO_LARGE),
+                                        &ProxyError::Transport("request body too large".into()),
+                                        None,
+                                    );
                                     return Ok(Response::builder()
                                         .status(StatusCode::PAYLOAD_TOO_LARGE)
                                         .header("alt-svc", &alt)
@@ -776,6 +844,20 @@ impl QUICListener {
                                                     b"invalid request\n".as_slice(),
                                                 ),
                                             };
+                                            let proxy_err = ProxyError::from(err);
+                                            let _ = observe_proxy_error_outcome(
+                                                metrics.as_ref(),
+                                                bootstrap_route_target(&upstream_name),
+                                                Some(bootstrap_backend_target(
+                                                    &upstream_name,
+                                                    &backend_addr,
+                                                    backend_index,
+                                                )),
+                                                request_start.elapsed(),
+                                                Some(status),
+                                                &proxy_err,
+                                                None,
+                                            );
                                             return Ok(Response::builder()
                                                 .status(status)
                                                 .header("alt-svc", &alt)
@@ -826,6 +908,20 @@ impl QUICListener {
                                         Ok(request) => request,
                                         Err(err) => {
                                             warn!("Bootstrap request build failed: {}", err);
+                                            let proxy_err = ProxyError::from(err);
+                                            let _ = observe_proxy_error_outcome(
+                                                metrics.as_ref(),
+                                                bootstrap_route_target(&upstream_name),
+                                                Some(bootstrap_backend_target(
+                                                    &upstream_name,
+                                                    &backend_addr,
+                                                    backend_index,
+                                                )),
+                                                request_start.elapsed(),
+                                                Some(StatusCode::BAD_REQUEST),
+                                                &proxy_err,
+                                                None,
+                                            );
                                             return Ok(Response::builder()
                                                 .status(StatusCode::BAD_REQUEST)
                                                 .header("alt-svc", &alt)
@@ -952,6 +1048,19 @@ impl QUICListener {
                                         Ok(Ok(resp)) => resp,
                                         Ok(Err(err)) => {
                                             let proxy_err = ProxyError::Transport(err.to_string());
+                                            let _ = observe_proxy_error_outcome(
+                                                metrics.as_ref(),
+                                                bootstrap_route_target(&upstream_name),
+                                                Some(bootstrap_backend_target(
+                                                    &upstream_name,
+                                                    &backend_addr,
+                                                    backend_index,
+                                                )),
+                                                request_start.elapsed(),
+                                                Some(StatusCode::BAD_GATEWAY),
+                                                &proxy_err,
+                                                None,
+                                            );
                                             if let Some(classified) =
                                                 classify_upstream_proxy_error(&proxy_err)
                                             {
@@ -989,6 +1098,19 @@ impl QUICListener {
                                                 }));
                                         }
                                         Err(_) => {
+                                            let _ = observe_proxy_error_outcome(
+                                                metrics.as_ref(),
+                                                bootstrap_route_target(&upstream_name),
+                                                Some(bootstrap_backend_target(
+                                                    &upstream_name,
+                                                    &backend_addr,
+                                                    backend_index,
+                                                )),
+                                                request_start.elapsed(),
+                                                Some(StatusCode::GATEWAY_TIMEOUT),
+                                                &ProxyError::Timeout,
+                                                None,
+                                            );
                                             if let Some(classified) =
                                                 classify_upstream_proxy_error(&ProxyError::Timeout)
                                             {
@@ -1031,6 +1153,19 @@ impl QUICListener {
                                         Ok(Ok(resp)) => resp,
                                         Ok(Err(err)) => {
                                             let proxy_err = ProxyError::Pool(err);
+                                            let _ = observe_proxy_error_outcome(
+                                                metrics.as_ref(),
+                                                bootstrap_route_target(&upstream_name),
+                                                Some(bootstrap_backend_target(
+                                                    &upstream_name,
+                                                    &backend_addr,
+                                                    backend_index,
+                                                )),
+                                                request_start.elapsed(),
+                                                Some(StatusCode::BAD_GATEWAY),
+                                                &proxy_err,
+                                                None,
+                                            );
                                             if let Some(classified) =
                                                 classify_upstream_proxy_error(&proxy_err)
                                             {
@@ -1068,6 +1203,19 @@ impl QUICListener {
                                                 }));
                                         }
                                         Err(_) => {
+                                            let _ = observe_proxy_error_outcome(
+                                                metrics.as_ref(),
+                                                bootstrap_route_target(&upstream_name),
+                                                Some(bootstrap_backend_target(
+                                                    &upstream_name,
+                                                    &backend_addr,
+                                                    backend_index,
+                                                )),
+                                                request_start.elapsed(),
+                                                Some(StatusCode::GATEWAY_TIMEOUT),
+                                                &ProxyError::Timeout,
+                                                None,
+                                            );
                                             if let Some(classified) =
                                                 classify_upstream_proxy_error(&ProxyError::Timeout)
                                             {
@@ -1161,6 +1309,21 @@ impl QUICListener {
                                         kind: BodyLimitKind::BodySize,
                                     })
                                 ) {
+                                    let _ = observe_proxy_error_outcome(
+                                        metrics.as_ref(),
+                                        bootstrap_route_target(&upstream_name),
+                                        Some(bootstrap_backend_target(
+                                            &upstream_name,
+                                            &backend_addr,
+                                            backend_index,
+                                        )),
+                                        request_start.elapsed(),
+                                        Some(StatusCode::SERVICE_UNAVAILABLE),
+                                        &ProxyError::Pool(spooky_errors::PoolError::BackendOverloaded(
+                                            "response prebuffer cap".into(),
+                                        )),
+                                        Some(crate::OverloadShedReason::ResponsePrebufferCap),
+                                    );
                                     return Ok(Response::builder()
                                         .status(StatusCode::SERVICE_UNAVAILABLE)
                                         .header("alt-svc", &alt)
@@ -1172,6 +1335,27 @@ impl QUICListener {
                                                 b"error\n",
                                             )))
                                         }));
+                                }
+                                let _ = observe_status_outcome(
+                                    metrics.as_ref(),
+                                    bootstrap_route_target(&upstream_name),
+                                    Some(bootstrap_backend_target(
+                                        &upstream_name,
+                                        &backend_addr,
+                                        backend_index,
+                                    )),
+                                    request_start.elapsed(),
+                                    status,
+                                );
+                                if let Some(transition) = observe_backend_response_status(
+                                    crate::runtime::connection::outcome::BackendHealthObservationInput {
+                                        backend_addr: &backend_addr,
+                                        backend_index,
+                                        upstream_pool: Some(&upstream_pool),
+                                        status,
+                                    },
+                                ) {
+                                    Self::log_health_transition(&backend_addr, transition);
                                 }
                                 let mut resp_builder =
                                     Response::builder().status(normalized_response.head.status);
@@ -1221,6 +1405,14 @@ impl QUICListener {
                                         )
                                         .await;
                                     });
+                                    crate::runtime::connection::outcome::finish_backend_request_accounting(
+                                        crate::runtime::connection::outcome::BackendRequestFinishInput {
+                                            upstream_pool: Some(&upstream_pool),
+                                            backend_index: Some(backend_index),
+                                            elapsed: request_start.elapsed(),
+                                            status: Some(status.as_u16()),
+                                        },
+                                    );
                                     return Ok(resp_builder
                                         .body(boxed_full(Bytes::new()))
                                         .unwrap_or_else(|_| {
@@ -1231,12 +1423,24 @@ impl QUICListener {
                                     normalized_response.emission.body,
                                     ResponseBodyPolicy::Suppress
                                 ) {
+                                    crate::runtime::connection::outcome::finish_backend_request_accounting(
+                                        crate::runtime::connection::outcome::BackendRequestFinishInput {
+                                            upstream_pool: Some(&upstream_pool),
+                                            backend_index: Some(backend_index),
+                                            elapsed: request_start.elapsed(),
+                                            status: Some(status.as_u16()),
+                                        },
+                                    );
                                     boxed_full(Bytes::new())
                                 } else {
                                     BootstrapStreamingBody::with_response_guardrails(
                                         upstream_resp.into_body(),
                                         max_response_body_bytes,
                                         upstream_content_length,
+                                        Arc::clone(&upstream_pool),
+                                        backend_index,
+                                        request_start,
+                                        Some(status.as_u16()),
                                     )
                                     .map_err(|never| match never {})
                                     .boxed()

--- a/crates/edge/src/quic_listener/bootstrap_tls.rs
+++ b/crates/edge/src/quic_listener/bootstrap_tls.rs
@@ -58,16 +58,19 @@ use crate::{
     runtime::{
         backend::store::RuntimeBackendResolutionStore,
         bundle::RuntimeBundleHandle,
-        connection::guardrails::{
-            BodyLimitKind, REQUEST_BODY_TOO_LARGE_BODY, RESPONSE_BODY_TOO_LARGE_BODY,
-            RequestBodyGuardrailConfig, RequestBodyGuardrailDecision, RequestBodyGuardrailInput,
-            ResponseBodyGuardrailConfig, ResponseBodyGuardrailDecision, ResponseBodyGuardrailInput,
-            checked_request_body_ingress, checked_response_body_guardrails,
-        },
-        connection::outcome::{
-            AdmissionOutcomeClass, OutcomeBackendTarget, OutcomeRouteTarget,
-            observe_admission_outcome, observe_backend_response_status,
-            observe_proxy_error_outcome, observe_status_outcome,
+        connection::{
+            guardrails::{
+                BodyLimitKind, REQUEST_BODY_TOO_LARGE_BODY, RESPONSE_BODY_TOO_LARGE_BODY,
+                RequestBodyGuardrailConfig, RequestBodyGuardrailDecision,
+                RequestBodyGuardrailInput, ResponseBodyGuardrailConfig,
+                ResponseBodyGuardrailDecision, ResponseBodyGuardrailInput,
+                checked_request_body_ingress, checked_response_body_guardrails,
+            },
+            outcome::{
+                AdmissionOutcomeClass, OutcomeBackendTarget, OutcomeRouteTarget,
+                observe_admission_outcome, observe_backend_response_status,
+                observe_proxy_error_outcome, observe_status_outcome,
+            },
         },
         shared_state::SharedRuntimeState,
         tls::store::ListenerTlsReloadStore,
@@ -1347,9 +1350,11 @@ impl QUICListener {
                                         )),
                                         request_start.elapsed(),
                                         Some(StatusCode::SERVICE_UNAVAILABLE),
-                                        &ProxyError::Pool(spooky_errors::PoolError::BackendOverloaded(
-                                            "response prebuffer cap".into(),
-                                        )),
+                                        &ProxyError::Pool(
+                                            spooky_errors::PoolError::BackendOverloaded(
+                                                "response prebuffer cap".into(),
+                                            ),
+                                        ),
                                         Some(crate::OverloadShedReason::ResponsePrebufferCap),
                                     );
                                     return Ok(Response::builder()

--- a/crates/edge/src/quic_listener/bootstrap_tls.rs
+++ b/crates/edge/src/quic_listener/bootstrap_tls.rs
@@ -1071,14 +1071,21 @@ impl QUICListener {
                                                     &backend_addr,
                                                     &classified,
                                                 );
-                                                Self::mark_classified_upstream_health_failure(
-                                                    "bootstrap",
-                                                    &backend_addr,
-                                                    backend_index,
-                                                    Some(&upstream_pool),
-                                                    metrics.as_ref(),
-                                                    &classified,
-                                                );
+                                                if let Some(transition) = crate::runtime::connection::outcome::observe_classified_backend_failure(
+                                                    crate::runtime::connection::outcome::ClassifiedBackendFailureInput {
+                                                        metrics_phase: "bootstrap",
+                                                        backend_addr: &backend_addr,
+                                                        backend_index,
+                                                        upstream_pool: Some(&upstream_pool),
+                                                        metrics: metrics.as_ref(),
+                                                        classified: &classified,
+                                                    },
+                                                ) {
+                                                    crate::runtime::connection::outcome::log_backend_health_transition(
+                                                        &backend_addr,
+                                                        transition,
+                                                    );
+                                                }
                                             } else {
                                                 warn!(
                                                     "Bootstrap WebSocket upstream error route={} backend={}: {}",
@@ -1121,14 +1128,21 @@ impl QUICListener {
                                                     &backend_addr,
                                                     &classified,
                                                 );
-                                                Self::mark_classified_upstream_health_failure(
-                                                    "bootstrap",
-                                                    &backend_addr,
-                                                    backend_index,
-                                                    Some(&upstream_pool),
-                                                    metrics.as_ref(),
-                                                    &classified,
-                                                );
+                                                if let Some(transition) = crate::runtime::connection::outcome::observe_classified_backend_failure(
+                                                    crate::runtime::connection::outcome::ClassifiedBackendFailureInput {
+                                                        metrics_phase: "bootstrap",
+                                                        backend_addr: &backend_addr,
+                                                        backend_index,
+                                                        upstream_pool: Some(&upstream_pool),
+                                                        metrics: metrics.as_ref(),
+                                                        classified: &classified,
+                                                    },
+                                                ) {
+                                                    crate::runtime::connection::outcome::log_backend_health_transition(
+                                                        &backend_addr,
+                                                        transition,
+                                                    );
+                                                }
                                             }
                                             return Ok(Response::builder()
                                                 .status(StatusCode::GATEWAY_TIMEOUT)
@@ -1176,14 +1190,21 @@ impl QUICListener {
                                                     &backend_addr,
                                                     &classified,
                                                 );
-                                                Self::mark_classified_upstream_health_failure(
-                                                    "bootstrap",
-                                                    &backend_addr,
-                                                    backend_index,
-                                                    Some(&upstream_pool),
-                                                    metrics.as_ref(),
-                                                    &classified,
-                                                );
+                                                if let Some(transition) = crate::runtime::connection::outcome::observe_classified_backend_failure(
+                                                    crate::runtime::connection::outcome::ClassifiedBackendFailureInput {
+                                                        metrics_phase: "bootstrap",
+                                                        backend_addr: &backend_addr,
+                                                        backend_index,
+                                                        upstream_pool: Some(&upstream_pool),
+                                                        metrics: metrics.as_ref(),
+                                                        classified: &classified,
+                                                    },
+                                                ) {
+                                                    crate::runtime::connection::outcome::log_backend_health_transition(
+                                                        &backend_addr,
+                                                        transition,
+                                                    );
+                                                }
                                             } else {
                                                 warn!(
                                                     "Bootstrap proxy upstream error route={} backend={}: {}",
@@ -1226,14 +1247,21 @@ impl QUICListener {
                                                     &backend_addr,
                                                     &classified,
                                                 );
-                                                Self::mark_classified_upstream_health_failure(
-                                                    "bootstrap",
-                                                    &backend_addr,
-                                                    backend_index,
-                                                    Some(&upstream_pool),
-                                                    metrics.as_ref(),
-                                                    &classified,
-                                                );
+                                                if let Some(transition) = crate::runtime::connection::outcome::observe_classified_backend_failure(
+                                                    crate::runtime::connection::outcome::ClassifiedBackendFailureInput {
+                                                        metrics_phase: "bootstrap",
+                                                        backend_addr: &backend_addr,
+                                                        backend_index,
+                                                        upstream_pool: Some(&upstream_pool),
+                                                        metrics: metrics.as_ref(),
+                                                        classified: &classified,
+                                                    },
+                                                ) {
+                                                    crate::runtime::connection::outcome::log_backend_health_transition(
+                                                        &backend_addr,
+                                                        transition,
+                                                    );
+                                                }
                                             }
                                             return Ok(Response::builder()
                                                 .status(StatusCode::GATEWAY_TIMEOUT)
@@ -1355,7 +1383,10 @@ impl QUICListener {
                                         status,
                                     },
                                 ) {
-                                    Self::log_health_transition(&backend_addr, transition);
+                                    crate::runtime::connection::outcome::log_backend_health_transition(
+                                        &backend_addr,
+                                        transition,
+                                    );
                                 }
                                 let mut resp_builder =
                                     Response::builder().status(normalized_response.head.status);

--- a/crates/edge/src/quic_listener/forwarding/auth.rs
+++ b/crates/edge/src/quic_listener/forwarding/auth.rs
@@ -16,6 +16,10 @@ use crate::runtime::connection::{
         oidc_authorization_check, oidc_discovery_target, oidc_scope_satisfied,
         validate_oidc_provider_metadata,
     },
+    outcome::{
+        AdmissionOutcomeClass, OutcomeBackendTarget, OutcomeRouteTarget,
+        observe_admission_outcome,
+    },
     request::PendingForward,
     stream::StreamAdmissionState,
 };
@@ -473,13 +477,21 @@ impl QUICListener {
             ExternalAuthCompletion::Respond(decision) => {
                 req.admission_state = StreamAdmissionState::Denied;
                 req.response_status = Some(decision.status().as_u16());
-                metrics.inc_failure();
                 metrics.inc_policy_denied();
                 metrics.inc_external_auth_denied();
-                metrics.record_route(
-                    req.upstream_name.as_deref().unwrap_or("unrouted"),
+                let _ = observe_admission_outcome(
+                    metrics,
+                    OutcomeRouteTarget {
+                        route: req.upstream_name.as_deref().unwrap_or("unrouted"),
+                    },
+                    Some(OutcomeBackendTarget {
+                        upstream: req.upstream_name.as_deref().unwrap_or("unrouted"),
+                        backend_addr: req.backend_addr.as_deref(),
+                        backend_index: req.backend_index,
+                    }),
                     req.start.elapsed(),
-                    RouteOutcome::Failure,
+                    decision.status(),
+                    AdmissionOutcomeClass::AuthDenied,
                 );
                 warn!(
                     "request_id={} route={} external auth denied with status={}",
@@ -530,16 +542,22 @@ impl QUICListener {
                         );
                     }
                 }
-                metrics.inc_failure();
-                let route_label = req.upstream_name.as_deref().unwrap_or("unrouted");
-                let route_outcome = if timed_out {
-                    RouteOutcome::Timeout
-                } else {
-                    RouteOutcome::Failure
-                };
                 req.admission_state = StreamAdmissionState::Denied;
                 req.response_status = Some(status.as_u16());
-                metrics.record_route(route_label, req.start.elapsed(), route_outcome);
+                let _ = observe_admission_outcome(
+                    metrics,
+                    OutcomeRouteTarget {
+                        route: req.upstream_name.as_deref().unwrap_or("unrouted"),
+                    },
+                    Some(OutcomeBackendTarget {
+                        upstream: req.upstream_name.as_deref().unwrap_or("unrouted"),
+                        backend_addr: req.backend_addr.as_deref(),
+                        backend_index: req.backend_index,
+                    }),
+                    req.start.elapsed(),
+                    status,
+                    AdmissionOutcomeClass::Failed { timed_out },
+                );
                 Self::send_simple_response(h3, quic, stream_id, status, body)?;
                 Ok(false)
             }

--- a/crates/edge/src/quic_listener/forwarding/auth.rs
+++ b/crates/edge/src/quic_listener/forwarding/auth.rs
@@ -17,8 +17,7 @@ use crate::runtime::connection::{
         validate_oidc_provider_metadata,
     },
     outcome::{
-        AdmissionOutcomeClass, OutcomeBackendTarget, OutcomeRouteTarget,
-        observe_admission_outcome,
+        AdmissionOutcomeClass, OutcomeBackendTarget, OutcomeRouteTarget, observe_admission_outcome,
     },
     request::PendingForward,
     stream::StreamAdmissionState,

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -17,7 +17,13 @@ pub(in crate::quic_listener) use self::resolve::BootstrapResolutionInput;
 pub(in crate::quic_listener) use self::resolve::RouteResolutionRequest as TestRouteResolutionRequest;
 use super::*;
 use crate::runtime::connection::{
-    outcome::classify_status_outcome, request::PendingForward, stream::StreamAdmissionState,
+    outcome::{
+        OutcomeBackendTarget, OutcomeRouteTarget, RequestMetricsObservation,
+        classify_status_outcome,
+        record_request_metrics_observation,
+    },
+    request::PendingForward,
+    stream::StreamAdmissionState,
 };
 
 pub(super) fn abort_stream(req: &mut RequestEnvelope, metrics: &Metrics) -> StreamPhase {
@@ -255,13 +261,24 @@ impl QUICListener {
         req: &RequestEnvelope,
         status: Option<u16>,
         outcome: RouteOutcome,
+        overload_reason: Option<OverloadShedReason>,
     ) {
-        metrics.record_request_result(
-            req.upstream_name.as_deref().unwrap_or("unrouted"),
-            req.backend_addr.as_deref(),
-            status,
-            outcome,
-            req.start.elapsed(),
+        record_request_metrics_observation(
+            metrics,
+            RequestMetricsObservation {
+                route_target: OutcomeRouteTarget {
+                    route: req.upstream_name.as_deref().unwrap_or("unrouted"),
+                },
+                backend_target: Some(OutcomeBackendTarget {
+                    upstream: req.upstream_name.as_deref().unwrap_or("unrouted"),
+                    backend_addr: req.backend_addr.as_deref(),
+                    backend_index: req.backend_index,
+                }),
+                elapsed: req.start.elapsed(),
+                status,
+                metrics_outcome: outcome,
+                overload_reason,
+            },
         );
     }
 

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -16,7 +16,9 @@ pub(in crate::quic_listener) use self::resolve::BootstrapResolutionInput;
 #[cfg(test)]
 pub(in crate::quic_listener) use self::resolve::RouteResolutionRequest as TestRouteResolutionRequest;
 use super::*;
-use crate::runtime::connection::{request::PendingForward, stream::StreamAdmissionState};
+use crate::runtime::connection::{
+    outcome::classify_status_outcome, request::PendingForward, stream::StreamAdmissionState,
+};
 
 pub(super) fn abort_stream(req: &mut RequestEnvelope, metrics: &Metrics) -> StreamPhase {
     let phase = req.phase.clone();
@@ -157,11 +159,11 @@ impl QUICListener {
     }
 
     fn request_metrics_outcome_for_status(status: StatusCode) -> (bool, RouteOutcome) {
-        if status.is_server_error() {
-            (false, RouteOutcome::Failure)
-        } else {
-            (true, RouteOutcome::Success)
-        }
+        let decision = classify_status_outcome(status);
+        (
+            matches!(decision.route_outcome, crate::runtime::connection::outcome::CanonicalRouteOutcome::Success),
+            decision.route_outcome.as_metrics_outcome(),
+        )
     }
 
     fn log_access(req: &RequestEnvelope, status: u16) {

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -18,8 +18,10 @@ pub(in crate::quic_listener) use self::resolve::RouteResolutionRequest as TestRo
 use super::*;
 use crate::runtime::connection::{
     outcome::{
+        BackendRequestFinishInput, ClassifiedBackendFailureInput,
         OutcomeBackendTarget, OutcomeRouteTarget, RequestMetricsObservation,
-        classify_status_outcome,
+        classify_status_outcome, finish_backend_request_accounting,
+        log_backend_health_transition, observe_classified_backend_failure,
         record_request_metrics_observation,
     },
     request::PendingForward,
@@ -29,15 +31,12 @@ use crate::runtime::connection::{
 pub(super) fn abort_stream(req: &mut RequestEnvelope, metrics: &Metrics) -> StreamPhase {
     let phase = req.phase.clone();
     if req.backend_request_started && !req.backend_request_finished {
-        if let (Some(pool), Some(index)) = (&req.upstream_pool, req.backend_index)
-            && let Ok(mut guard) = pool.write()
-        {
-            guard.finish_request(
-                index,
-                req.start.elapsed(),
-                req.response_status.or(Some(503)),
-            );
-        }
+        finish_backend_request_accounting(BackendRequestFinishInput {
+            upstream_pool: req.upstream_pool.as_ref(),
+            backend_index: req.backend_index,
+            elapsed: req.start.elapsed(),
+            status: req.response_status.or(Some(503)),
+        });
         req.backend_request_finished = true;
     }
     if req.body_buf_bytes > 0 {
@@ -135,24 +134,14 @@ impl QUICListener {
         metrics: &Metrics,
         classified: &ClassifiedUpstreamProxyError,
     ) {
-        let Some(health_mapping) = classified.health_failure else {
-            return;
-        };
-
-        metrics.inc_health_failure(health_mapping.failure_reason);
-        if health_mapping.failure_reason == HealthFailureReason::Tls {
-            metrics.record_upstream_tls_failure(
-                backend_addr,
-                metrics_phase,
-                health_mapping.metrics_reason,
-            );
-        }
-        if let Some(pool) = upstream_pool
-            && let Some(transition) = pool.write().ok().and_then(|mut p| {
-                p.pool
-                    .mark_request_failure(backend_index, health_mapping.failure_reason)
-            })
-        {
+        if let Some(transition) = observe_classified_backend_failure(ClassifiedBackendFailureInput {
+            metrics_phase,
+            backend_addr,
+            backend_index,
+            upstream_pool,
+            metrics,
+            classified,
+        }) {
             Self::log_health_transition(backend_addr, transition);
         }
     }
@@ -395,9 +384,12 @@ impl QUICListener {
             .get(pending_forward.backend_addr.as_ref())
             .cloned()
         else {
-            if let Ok(mut guard) = upstream_pool.write() {
-                guard.finish_request(backend_index, req.start.elapsed(), Some(503));
-            }
+            finish_backend_request_accounting(BackendRequestFinishInput {
+                upstream_pool: Some(&upstream_pool),
+                backend_index: Some(backend_index),
+                elapsed: req.start.elapsed(),
+                status: Some(503),
+            });
             metrics.inc_failure();
             metrics.record_route(&upstream_name, req.start.elapsed(), RouteOutcome::Failure);
             Self::send_simple_response(
@@ -434,9 +426,12 @@ impl QUICListener {
             ) {
                 Ok(request) => Some(request),
                 Err(err) => {
-                    if let Ok(mut guard) = upstream_pool.write() {
-                        guard.finish_request(backend_index, req.start.elapsed(), Some(503));
-                    }
+                    finish_backend_request_accounting(BackendRequestFinishInput {
+                        upstream_pool: Some(&upstream_pool),
+                        backend_index: Some(backend_index),
+                        elapsed: req.start.elapsed(),
+                        status: Some(503),
+                    });
                     metrics.inc_failure();
                     metrics.record_route(
                         &upstream_name,
@@ -470,9 +465,12 @@ impl QUICListener {
         ) {
             Ok(result_rx) => result_rx,
             Err(err) => {
-                if let Ok(mut guard) = upstream_pool.write() {
-                    guard.finish_request(backend_index, req.start.elapsed(), Some(503));
-                }
+                finish_backend_request_accounting(BackendRequestFinishInput {
+                    upstream_pool: Some(&upstream_pool),
+                    backend_index: Some(backend_index),
+                    elapsed: req.start.elapsed(),
+                    status: Some(503),
+                });
                 metrics.inc_failure();
                 metrics.record_route(&upstream_name, req.start.elapsed(), RouteOutcome::Failure);
                 Self::send_simple_response(
@@ -546,14 +544,7 @@ impl QUICListener {
     }
 
     pub(crate) fn log_health_transition(addr: &str, transition: HealthTransition) {
-        match transition {
-            HealthTransition::BecameHealthy => {
-                info!("Backend {} became healthy", addr);
-            }
-            HealthTransition::BecameUnhealthy => {
-                error!("Backend {} became unhealthy", addr);
-            }
-        }
+        log_backend_health_transition(addr, transition);
     }
 }
 

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -19,8 +19,7 @@ use super::*;
 use crate::runtime::connection::{
     outcome::{
         BackendRequestFinishInput, OutcomeBackendTarget, OutcomeRouteTarget,
-        finish_backend_request_accounting, observe_admission_outcome,
-        observe_proxy_error_outcome,
+        finish_backend_request_accounting, observe_admission_outcome, observe_proxy_error_outcome,
     },
     request::PendingForward,
     stream::StreamAdmissionState,
@@ -222,11 +221,13 @@ impl QUICListener {
     }
 
     fn request_outcome_backend_target(req: &RequestEnvelope) -> Option<OutcomeBackendTarget<'_>> {
-        req.upstream_name.as_deref().map(|upstream| OutcomeBackendTarget {
-            upstream,
-            backend_addr: req.backend_addr.as_deref(),
-            backend_index: req.backend_index,
-        })
+        req.upstream_name
+            .as_deref()
+            .map(|upstream| OutcomeBackendTarget {
+                upstream,
+                backend_addr: req.backend_addr.as_deref(),
+                backend_index: req.backend_index,
+            })
     }
 
     fn materialize_forward_after_auth(
@@ -577,7 +578,6 @@ impl QUICListener {
             debug!("Sent {} packets", packet_count);
         }
     }
-
 }
 
 impl QUICListener {
@@ -1015,7 +1015,9 @@ impl QUICListener {
                             if let Some((route_label, elapsed)) = reject_body_for_bodyless {
                                 let _ = observe_proxy_error_outcome(
                                     &metrics,
-                                    OutcomeRouteTarget { route: &route_label },
+                                    OutcomeRouteTarget {
+                                        route: &route_label,
+                                    },
                                     None,
                                     elapsed,
                                     Some(http::StatusCode::BAD_REQUEST),
@@ -1039,7 +1041,9 @@ impl QUICListener {
                             if let Some((route_label, elapsed)) = payload_too_large {
                                 let _ = observe_proxy_error_outcome(
                                     &metrics,
-                                    OutcomeRouteTarget { route: &route_label },
+                                    OutcomeRouteTarget {
+                                        route: &route_label,
+                                    },
                                     None,
                                     elapsed,
                                     Some(http::StatusCode::PAYLOAD_TOO_LARGE),
@@ -1069,7 +1073,10 @@ impl QUICListener {
                                         route: req.upstream_name.as_deref().unwrap_or("unrouted"),
                                     },
                                     Some(OutcomeBackendTarget {
-                                        upstream: req.upstream_name.as_deref().unwrap_or("unrouted"),
+                                        upstream: req
+                                            .upstream_name
+                                            .as_deref()
+                                            .unwrap_or("unrouted"),
                                         backend_addr: req.backend_addr.as_deref(),
                                         backend_index: req.backend_index,
                                     }),
@@ -1113,7 +1120,10 @@ impl QUICListener {
                                         route: req.upstream_name.as_deref().unwrap_or("unrouted"),
                                     },
                                     Some(OutcomeBackendTarget {
-                                        upstream: req.upstream_name.as_deref().unwrap_or("unrouted"),
+                                        upstream: req
+                                            .upstream_name
+                                            .as_deref()
+                                            .unwrap_or("unrouted"),
                                         backend_addr: req.backend_addr.as_deref(),
                                         backend_index: req.backend_index,
                                     }),

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -18,12 +18,9 @@ pub(in crate::quic_listener) use self::resolve::RouteResolutionRequest as TestRo
 use super::*;
 use crate::runtime::connection::{
     outcome::{
-        BackendRequestFinishInput, ClassifiedBackendFailureInput,
-        OutcomeBackendTarget, OutcomeRouteTarget, RequestMetricsObservation,
-        classify_status_outcome, finish_backend_request_accounting,
-        log_backend_health_transition, observe_classified_backend_failure,
-        observe_admission_outcome, observe_proxy_error_outcome,
-        record_request_metrics_observation,
+        BackendRequestFinishInput, OutcomeBackendTarget, OutcomeRouteTarget,
+        finish_backend_request_accounting, observe_admission_outcome,
+        observe_proxy_error_outcome,
     },
     request::PendingForward,
     stream::StreamAdmissionState,
@@ -127,38 +124,10 @@ impl QUICListener {
         }
     }
 
-    pub(super) fn mark_classified_upstream_health_failure(
-        metrics_phase: &str,
-        backend_addr: &str,
-        backend_index: usize,
-        upstream_pool: Option<&Arc<RwLock<UpstreamPool>>>,
-        metrics: &Metrics,
-        classified: &ClassifiedUpstreamProxyError,
-    ) {
-        if let Some(transition) = observe_classified_backend_failure(ClassifiedBackendFailureInput {
-            metrics_phase,
-            backend_addr,
-            backend_index,
-            upstream_pool,
-            metrics,
-            classified,
-        }) {
-            Self::log_health_transition(backend_addr, transition);
-        }
-    }
-
     fn is_internal_pool_control_error(error: &PoolError) -> bool {
         matches!(
             error,
             PoolError::InflightLimiterClosed | PoolError::UnknownBackend(_)
-        )
-    }
-
-    fn request_metrics_outcome_for_status(status: StatusCode) -> (bool, RouteOutcome) {
-        let decision = classify_status_outcome(status);
-        (
-            matches!(decision.route_outcome, crate::runtime::connection::outcome::CanonicalRouteOutcome::Success),
-            decision.route_outcome.as_metrics_outcome(),
         )
     }
 
@@ -246,30 +215,18 @@ impl QUICListener {
         }
     }
 
-    fn record_request_observation(
-        metrics: &Metrics,
-        req: &RequestEnvelope,
-        status: Option<u16>,
-        outcome: RouteOutcome,
-        overload_reason: Option<OverloadShedReason>,
-    ) {
-        record_request_metrics_observation(
-            metrics,
-            RequestMetricsObservation {
-                route_target: OutcomeRouteTarget {
-                    route: req.upstream_name.as_deref().unwrap_or("unrouted"),
-                },
-                backend_target: Some(OutcomeBackendTarget {
-                    upstream: req.upstream_name.as_deref().unwrap_or("unrouted"),
-                    backend_addr: req.backend_addr.as_deref(),
-                    backend_index: req.backend_index,
-                }),
-                elapsed: req.start.elapsed(),
-                status,
-                metrics_outcome: outcome,
-                overload_reason,
-            },
-        );
+    fn request_outcome_route_target(req: &RequestEnvelope) -> OutcomeRouteTarget<'_> {
+        OutcomeRouteTarget {
+            route: req.upstream_name.as_deref().unwrap_or("unrouted"),
+        }
+    }
+
+    fn request_outcome_backend_target(req: &RequestEnvelope) -> Option<OutcomeBackendTarget<'_>> {
+        req.upstream_name.as_deref().map(|upstream| OutcomeBackendTarget {
+            upstream,
+            backend_addr: req.backend_addr.as_deref(),
+            backend_index: req.backend_index,
+        })
     }
 
     fn materialize_forward_after_auth(
@@ -621,9 +578,6 @@ impl QUICListener {
         }
     }
 
-    pub(crate) fn log_health_transition(addr: &str, transition: HealthTransition) {
-        log_backend_health_transition(addr, transition);
-    }
 }
 
 impl QUICListener {
@@ -1399,28 +1353,6 @@ mod tests {
             spooky_errors::classify_upstream_error_detail("request timed out", false),
             spooky_errors::UpstreamErrorClassification::timeout()
         );
-    }
-
-    #[test]
-    fn request_metrics_treat_server_error_as_failure() {
-        let (is_success, route_outcome) =
-            QUICListener::request_metrics_outcome_for_status(StatusCode::INTERNAL_SERVER_ERROR);
-        assert!(!is_success);
-        match route_outcome {
-            RouteOutcome::Failure => {}
-            _ => panic!("unexpected route outcome"),
-        }
-    }
-
-    #[test]
-    fn request_metrics_treat_success_response_as_success() {
-        let (is_success, route_outcome) =
-            QUICListener::request_metrics_outcome_for_status(StatusCode::OK);
-        assert!(is_success);
-        match route_outcome {
-            RouteOutcome::Success => {}
-            _ => panic!("unexpected route outcome"),
-        }
     }
 
     #[test]

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -22,6 +22,7 @@ use crate::runtime::connection::{
         OutcomeBackendTarget, OutcomeRouteTarget, RequestMetricsObservation,
         classify_status_outcome, finish_backend_request_accounting,
         log_backend_health_transition, observe_classified_backend_failure,
+        observe_admission_outcome, observe_proxy_error_outcome,
         record_request_metrics_observation,
     },
     request::PendingForward,
@@ -282,7 +283,15 @@ impl QUICListener {
         let metrics = shared_ctx.metrics.as_ref();
         let resilience = shared_ctx.resilience;
         let Some(pending_forward) = req.pending_forward.as_ref().cloned() else {
-            metrics.inc_failure();
+            let _ = observe_proxy_error_outcome(
+                metrics,
+                OutcomeRouteTarget::UNROUTED,
+                None,
+                req.start.elapsed(),
+                Some(http::StatusCode::INTERNAL_SERVER_ERROR),
+                &ProxyError::Transport("missing deferred forward snapshot".into()),
+                None,
+            );
             Self::send_simple_response(
                 h3,
                 quic,
@@ -293,7 +302,15 @@ impl QUICListener {
             return Ok(false);
         };
         let Some(upstream_name) = req.upstream_name.clone() else {
-            metrics.inc_failure();
+            let _ = observe_proxy_error_outcome(
+                metrics,
+                OutcomeRouteTarget::UNROUTED,
+                None,
+                req.start.elapsed(),
+                Some(http::StatusCode::INTERNAL_SERVER_ERROR),
+                &ProxyError::Transport("missing upstream route".into()),
+                None,
+            );
             Self::send_simple_response(
                 h3,
                 quic,
@@ -340,12 +357,21 @@ impl QUICListener {
             crate::quic_listener::admission::PostAuthAdmissionExecution::Rejected(
                 crate::quic_listener::admission::PostAuthAdmissionRejection::Overloaded(decision),
             ) => {
-                metrics.inc_failure();
-                metrics.inc_overload_shed_reason(decision.reason.metrics_reason());
-                metrics.record_route(
-                    &upstream_name,
+                let _ = observe_admission_outcome(
+                    metrics,
+                    OutcomeRouteTarget {
+                        route: &upstream_name,
+                    },
+                    Some(OutcomeBackendTarget {
+                        upstream: &upstream_name,
+                        backend_addr: Some(pending_forward.backend_addr.as_ref()),
+                        backend_index: Some(pending_forward.backend_index),
+                    }),
                     req.start.elapsed(),
-                    RouteOutcome::OverloadShed,
+                    http::StatusCode::SERVICE_UNAVAILABLE,
+                    crate::runtime::connection::outcome::AdmissionOutcomeClass::OverloadShed {
+                        reason: Some(decision.reason.metrics_reason()),
+                    },
                 );
                 Self::send_overload_response(
                     h3,
@@ -362,13 +388,29 @@ impl QUICListener {
             crate::quic_listener::admission::PostAuthAdmissionExecution::Rejected(
                 crate::quic_listener::admission::PostAuthAdmissionRejection::Failed(decision),
             ) => {
-                metrics.inc_failure();
-                if let Some(reason) = decision.overload_reason {
-                    metrics.inc_overload_shed_reason(reason.metrics_reason());
-                }
-                if let Some(route_outcome) = decision.route_outcome {
-                    metrics.record_route(&upstream_name, req.start.elapsed(), route_outcome);
-                }
+                let outcome = if let Some(reason) = decision.overload_reason {
+                    crate::runtime::connection::outcome::AdmissionOutcomeClass::OverloadShed {
+                        reason: Some(reason.metrics_reason()),
+                    }
+                } else {
+                    crate::runtime::connection::outcome::AdmissionOutcomeClass::Failed {
+                        timed_out: matches!(decision.route_outcome, Some(RouteOutcome::Timeout)),
+                    }
+                };
+                let _ = observe_admission_outcome(
+                    metrics,
+                    OutcomeRouteTarget {
+                        route: &upstream_name,
+                    },
+                    Some(OutcomeBackendTarget {
+                        upstream: &upstream_name,
+                        backend_addr: Some(pending_forward.backend_addr.as_ref()),
+                        backend_index: Some(pending_forward.backend_index),
+                    }),
+                    req.start.elapsed(),
+                    decision.status,
+                    outcome,
+                );
                 Self::send_simple_response(h3, quic, stream_id, decision.status, decision.body)?;
                 if decision.observe_adaptive_overload {
                     resilience
@@ -390,8 +432,21 @@ impl QUICListener {
                 elapsed: req.start.elapsed(),
                 status: Some(503),
             });
-            metrics.inc_failure();
-            metrics.record_route(&upstream_name, req.start.elapsed(), RouteOutcome::Failure);
+            let _ = observe_proxy_error_outcome(
+                metrics,
+                OutcomeRouteTarget {
+                    route: &upstream_name,
+                },
+                Some(OutcomeBackendTarget {
+                    upstream: &upstream_name,
+                    backend_addr: Some(pending_forward.backend_addr.as_ref()),
+                    backend_index: Some(backend_index),
+                }),
+                req.start.elapsed(),
+                Some(http::StatusCode::BAD_GATEWAY),
+                &ProxyError::Transport("unknown backend endpoint".into()),
+                None,
+            );
             Self::send_simple_response(
                 h3,
                 quic,
@@ -426,17 +481,27 @@ impl QUICListener {
             ) {
                 Ok(request) => Some(request),
                 Err(err) => {
+                    let err_text = err.to_string();
                     finish_backend_request_accounting(BackendRequestFinishInput {
                         upstream_pool: Some(&upstream_pool),
                         backend_index: Some(backend_index),
                         elapsed: req.start.elapsed(),
                         status: Some(503),
                     });
-                    metrics.inc_failure();
-                    metrics.record_route(
-                        &upstream_name,
+                    let _ = observe_proxy_error_outcome(
+                        metrics,
+                        OutcomeRouteTarget {
+                            route: &upstream_name,
+                        },
+                        Some(OutcomeBackendTarget {
+                            upstream: &upstream_name,
+                            backend_addr: Some(pending_forward.backend_addr.as_ref()),
+                            backend_index: Some(backend_index),
+                        }),
                         req.start.elapsed(),
-                        RouteOutcome::Failure,
+                        Some(http::StatusCode::BAD_REQUEST),
+                        &err,
+                        None,
                     );
                     Self::send_simple_response(
                         h3,
@@ -445,7 +510,7 @@ impl QUICListener {
                         http::StatusCode::BAD_REQUEST,
                         b"invalid request\n",
                     )?;
-                    error!("failed to build upstream request after auth: {}", err);
+                    error!("failed to build upstream request after auth: {}", err_text);
                     resilience
                         .adaptive_admission
                         .observe(req.start.elapsed(), true);
@@ -471,8 +536,21 @@ impl QUICListener {
                     elapsed: req.start.elapsed(),
                     status: Some(503),
                 });
-                metrics.inc_failure();
-                metrics.record_route(&upstream_name, req.start.elapsed(), RouteOutcome::Failure);
+                let _ = observe_proxy_error_outcome(
+                    metrics,
+                    OutcomeRouteTarget {
+                        route: &upstream_name,
+                    },
+                    Some(OutcomeBackendTarget {
+                        upstream: &upstream_name,
+                        backend_addr: Some(pending_forward.backend_addr.as_ref()),
+                        backend_index: Some(backend_index),
+                    }),
+                    req.start.elapsed(),
+                    Some(http::StatusCode::SERVICE_UNAVAILABLE),
+                    &ProxyError::Transport("upstream runtime unavailable".into()),
+                    None,
+                );
                 Self::send_simple_response(
                     h3,
                     quic,
@@ -621,15 +699,18 @@ impl QUICListener {
                     let request = match validate_request_headers(&list, resilience) {
                         Ok(request) => request,
                         Err((status, body, is_policy)) => {
-                            metrics.inc_failure();
                             metrics.inc_request_validation_reject();
                             if is_policy {
                                 metrics.inc_policy_denied();
                             }
-                            metrics.record_route(
-                                "unrouted",
+                            let _ = observe_proxy_error_outcome(
+                                &metrics,
+                                OutcomeRouteTarget::UNROUTED,
+                                None,
                                 Duration::from_millis(0),
-                                RouteOutcome::Failure,
+                                Some(status),
+                                &ProxyError::Bridge(spooky_errors::BridgeError::InvalidHeader),
+                                None,
                             );
                             let _ = Self::send_simple_response(
                                 h3,
@@ -661,13 +742,18 @@ impl QUICListener {
                         if resilience.early_data_allowed_for(&method) {
                             metrics.inc_early_data_accepted();
                         } else {
-                            metrics.inc_failure();
                             metrics.inc_early_data_rejected();
                             metrics.inc_policy_denied();
-                            metrics.record_route(
-                                "unrouted",
+                            let _ = observe_proxy_error_outcome(
+                                &metrics,
+                                OutcomeRouteTarget::UNROUTED,
+                                None,
                                 request_start.elapsed(),
-                                RouteOutcome::Failure,
+                                Some(http::StatusCode::TOO_EARLY),
+                                &ProxyError::Transport(
+                                    "request blocked by early-data policy".into(),
+                                ),
+                                None,
                             );
                             Self::send_simple_response(
                                 h3,
@@ -973,8 +1059,15 @@ impl QUICListener {
                                 }
                             }
                             if let Some((route_label, elapsed)) = reject_body_for_bodyless {
-                                metrics.inc_failure();
-                                metrics.record_route(&route_label, elapsed, RouteOutcome::Failure);
+                                let _ = observe_proxy_error_outcome(
+                                    &metrics,
+                                    OutcomeRouteTarget { route: &route_label },
+                                    None,
+                                    elapsed,
+                                    Some(http::StatusCode::BAD_REQUEST),
+                                    &ProxyError::Bridge(spooky_errors::BridgeError::InvalidHeader),
+                                    None,
+                                );
                                 Self::send_simple_response(
                                     h3,
                                     &mut connection.quic,
@@ -990,8 +1083,15 @@ impl QUICListener {
                                 break;
                             }
                             if let Some((route_label, elapsed)) = payload_too_large {
-                                metrics.inc_failure();
-                                metrics.record_route(&route_label, elapsed, RouteOutcome::Failure);
+                                let _ = observe_proxy_error_outcome(
+                                    &metrics,
+                                    OutcomeRouteTarget { route: &route_label },
+                                    None,
+                                    elapsed,
+                                    Some(http::StatusCode::PAYLOAD_TOO_LARGE),
+                                    &ProxyError::Transport("request body too large".into()),
+                                    None,
+                                );
                                 Self::send_simple_response(
                                     h3,
                                     &mut connection.quic,
@@ -1009,15 +1109,22 @@ impl QUICListener {
                             if shed_due_to_buffer_pressure
                                 && let Some(req) = connection.streams.get(&stream_id)
                             {
-                                metrics.inc_failure();
-                                metrics
-                                    .inc_overload_shed_reason(OverloadShedReason::RequestBufferCap);
-                                let route_label =
-                                    req.upstream_name.as_deref().unwrap_or("unrouted");
-                                metrics.record_route(
-                                    route_label,
+                                let _ = observe_proxy_error_outcome(
+                                    &metrics,
+                                    OutcomeRouteTarget {
+                                        route: req.upstream_name.as_deref().unwrap_or("unrouted"),
+                                    },
+                                    Some(OutcomeBackendTarget {
+                                        upstream: req.upstream_name.as_deref().unwrap_or("unrouted"),
+                                        backend_addr: req.backend_addr.as_deref(),
+                                        backend_index: req.backend_index,
+                                    }),
                                     req.start.elapsed(),
-                                    RouteOutcome::OverloadShed,
+                                    Some(http::StatusCode::SERVICE_UNAVAILABLE),
+                                    &ProxyError::Pool(PoolError::BackendOverloaded(
+                                        "request body backpressure overload".into(),
+                                    )),
+                                    Some(OverloadShedReason::RequestBufferCap),
                                 );
                                 Self::send_overload_response(
                                     h3,
@@ -1046,13 +1153,23 @@ impl QUICListener {
                                 err
                             );
                             if let Some(req) = connection.streams.get(&stream_id) {
-                                metrics.inc_failure();
-                                let route_label =
-                                    req.upstream_name.as_deref().unwrap_or("unrouted");
-                                metrics.record_route(
-                                    route_label,
+                                let _ = observe_proxy_error_outcome(
+                                    &metrics,
+                                    OutcomeRouteTarget {
+                                        route: req.upstream_name.as_deref().unwrap_or("unrouted"),
+                                    },
+                                    Some(OutcomeBackendTarget {
+                                        upstream: req.upstream_name.as_deref().unwrap_or("unrouted"),
+                                        backend_addr: req.backend_addr.as_deref(),
+                                        backend_index: req.backend_index,
+                                    }),
                                     req.start.elapsed(),
-                                    RouteOutcome::Failure,
+                                    Some(http::StatusCode::BAD_GATEWAY),
+                                    &ProxyError::Protocol(format!(
+                                        "recv_body protocol error on stream {}",
+                                        stream_id
+                                    )),
+                                    None,
                                 );
                                 resilience
                                     .adaptive_admission

--- a/crates/edge/src/quic_listener/forwarding/prepare.rs
+++ b/crates/edge/src/quic_listener/forwarding/prepare.rs
@@ -18,6 +18,11 @@ use crate::{
             ExternalAuthCompletion, ExternalAuthFailureDisposition, ExternalAuthTaskConfig,
             apply_auth_request_mutations, evaluate_external_auth_completion,
         },
+        outcome::{
+            AdmissionOutcomeClass, OutcomeBackendTarget, OutcomeRouteTarget,
+            RequestMetricsObservation, classify_admission_outcome,
+            record_request_metrics_observation,
+        },
         request::PendingForward,
     },
 };
@@ -240,12 +245,25 @@ impl QUICListener {
                 match admission {
                     AdmissionPolicyDecision::AdmitReady => {}
                     AdmissionPolicyDecision::Unauthorized(_) => {
-                        metrics.inc_failure();
                         metrics.inc_policy_denied();
-                        metrics.record_route(
-                            &upstream_name,
-                            request_start.elapsed(),
-                            RouteOutcome::Failure,
+                        let decision =
+                            classify_admission_outcome(AdmissionOutcomeClass::AuthDenied);
+                        record_request_metrics_observation(
+                            metrics,
+                            RequestMetricsObservation {
+                                route_target: OutcomeRouteTarget {
+                                    route: &upstream_name,
+                                },
+                                backend_target: Some(OutcomeBackendTarget {
+                                    upstream: &upstream_name,
+                                    backend_addr: Some(backend_addr.as_str()),
+                                    backend_index: Some(backend_index),
+                                }),
+                                elapsed: request_start.elapsed(),
+                                status: Some(http::StatusCode::UNAUTHORIZED.as_u16()),
+                                metrics_outcome: decision.route_outcome.as_metrics_outcome(),
+                                overload_reason: decision.overload_reason,
+                            },
                         );
                         warn!(
                             "request_id=unassigned route={} denied by local auth policy",
@@ -269,12 +287,26 @@ impl QUICListener {
                         return Ok(None);
                     }
                     AdmissionPolicyDecision::RateLimited(decision) => {
-                        metrics.inc_failure();
                         metrics.inc_request_rate_limited();
-                        metrics.record_route(
-                            &upstream_name,
-                            request_start.elapsed(),
-                            RouteOutcome::RateLimited,
+                        let observation = classify_admission_outcome(
+                            AdmissionOutcomeClass::RateLimited,
+                        );
+                        record_request_metrics_observation(
+                            metrics,
+                            RequestMetricsObservation {
+                                route_target: OutcomeRouteTarget {
+                                    route: &upstream_name,
+                                },
+                                backend_target: Some(OutcomeBackendTarget {
+                                    upstream: &upstream_name,
+                                    backend_addr: Some(backend_addr.as_str()),
+                                    backend_index: Some(backend_index),
+                                }),
+                                elapsed: request_start.elapsed(),
+                                status: Some(http::StatusCode::TOO_MANY_REQUESTS.as_u16()),
+                                metrics_outcome: observation.route_outcome.as_metrics_outcome(),
+                                overload_reason: observation.overload_reason,
+                            },
                         );
                         warn!(
                             "request_id=unassigned route={} scoped rate limit exceeded by rule={}",
@@ -298,12 +330,27 @@ impl QUICListener {
                         return Ok(None);
                     }
                     AdmissionPolicyDecision::Overloaded(decision) => {
-                        metrics.inc_failure();
-                        metrics.inc_overload_shed_reason(decision.reason.metrics_reason());
-                        metrics.record_route(
-                            &upstream_name,
-                            request_start.elapsed(),
-                            RouteOutcome::OverloadShed,
+                        let observation = classify_admission_outcome(
+                            AdmissionOutcomeClass::OverloadShed {
+                                reason: Some(decision.reason.metrics_reason()),
+                            },
+                        );
+                        record_request_metrics_observation(
+                            metrics,
+                            RequestMetricsObservation {
+                                route_target: OutcomeRouteTarget {
+                                    route: &upstream_name,
+                                },
+                                backend_target: Some(OutcomeBackendTarget {
+                                    upstream: &upstream_name,
+                                    backend_addr: Some(backend_addr.as_str()),
+                                    backend_index: Some(backend_index),
+                                }),
+                                elapsed: request_start.elapsed(),
+                                status: Some(http::StatusCode::SERVICE_UNAVAILABLE.as_u16()),
+                                metrics_outcome: observation.route_outcome.as_metrics_outcome(),
+                                overload_reason: observation.overload_reason,
+                            },
                         );
                         let Some(response) = rejection_response.as_ref() else {
                             warn!(
@@ -477,15 +524,26 @@ impl QUICListener {
                             timed_out,
                             error,
                         } => {
-                            metrics.inc_failure();
                             metrics.inc_external_auth_error();
-                            metrics.record_route(
-                                &request.upstream_name,
-                                request_start.elapsed(),
-                                if timed_out {
-                                    RouteOutcome::Timeout
-                                } else {
-                                    RouteOutcome::Failure
+                            let observation =
+                                classify_admission_outcome(AdmissionOutcomeClass::Failed {
+                                    timed_out,
+                                });
+                            record_request_metrics_observation(
+                                metrics,
+                                RequestMetricsObservation {
+                                    route_target: OutcomeRouteTarget {
+                                        route: &request.upstream_name,
+                                    },
+                                    backend_target: Some(OutcomeBackendTarget {
+                                        upstream: &request.upstream_name,
+                                        backend_addr: Some(request.backend_addr.as_str()),
+                                        backend_index: Some(request.backend_index),
+                                    }),
+                                    elapsed: request_start.elapsed(),
+                                    status: Some(status.as_u16()),
+                                    metrics_outcome: observation.route_outcome.as_metrics_outcome(),
+                                    overload_reason: observation.overload_reason,
                                 },
                             );
                             if let Some(error) = error {

--- a/crates/edge/src/quic_listener/forwarding/prepare.rs
+++ b/crates/edge/src/quic_listener/forwarding/prepare.rs
@@ -20,8 +20,7 @@ use crate::{
         },
         outcome::{
             AdmissionOutcomeClass, OutcomeBackendTarget, OutcomeRouteTarget,
-            RequestMetricsObservation, classify_admission_outcome,
-            record_request_metrics_observation,
+            observe_admission_outcome,
         },
         request::PendingForward,
     },
@@ -246,24 +245,19 @@ impl QUICListener {
                     AdmissionPolicyDecision::AdmitReady => {}
                     AdmissionPolicyDecision::Unauthorized(_) => {
                         metrics.inc_policy_denied();
-                        let decision =
-                            classify_admission_outcome(AdmissionOutcomeClass::AuthDenied);
-                        record_request_metrics_observation(
+                        let _ = observe_admission_outcome(
                             metrics,
-                            RequestMetricsObservation {
-                                route_target: OutcomeRouteTarget {
-                                    route: &upstream_name,
-                                },
-                                backend_target: Some(OutcomeBackendTarget {
-                                    upstream: &upstream_name,
-                                    backend_addr: Some(backend_addr.as_str()),
-                                    backend_index: Some(backend_index),
-                                }),
-                                elapsed: request_start.elapsed(),
-                                status: Some(http::StatusCode::UNAUTHORIZED.as_u16()),
-                                metrics_outcome: decision.route_outcome.as_metrics_outcome(),
-                                overload_reason: decision.overload_reason,
+                            OutcomeRouteTarget {
+                                route: &upstream_name,
                             },
+                            Some(OutcomeBackendTarget {
+                                upstream: &upstream_name,
+                                backend_addr: Some(backend_addr.as_str()),
+                                backend_index: Some(backend_index),
+                            }),
+                            request_start.elapsed(),
+                            http::StatusCode::UNAUTHORIZED,
+                            AdmissionOutcomeClass::AuthDenied,
                         );
                         warn!(
                             "request_id=unassigned route={} denied by local auth policy",
@@ -288,25 +282,19 @@ impl QUICListener {
                     }
                     AdmissionPolicyDecision::RateLimited(decision) => {
                         metrics.inc_request_rate_limited();
-                        let observation = classify_admission_outcome(
-                            AdmissionOutcomeClass::RateLimited,
-                        );
-                        record_request_metrics_observation(
+                        let _ = observe_admission_outcome(
                             metrics,
-                            RequestMetricsObservation {
-                                route_target: OutcomeRouteTarget {
-                                    route: &upstream_name,
-                                },
-                                backend_target: Some(OutcomeBackendTarget {
-                                    upstream: &upstream_name,
-                                    backend_addr: Some(backend_addr.as_str()),
-                                    backend_index: Some(backend_index),
-                                }),
-                                elapsed: request_start.elapsed(),
-                                status: Some(http::StatusCode::TOO_MANY_REQUESTS.as_u16()),
-                                metrics_outcome: observation.route_outcome.as_metrics_outcome(),
-                                overload_reason: observation.overload_reason,
+                            OutcomeRouteTarget {
+                                route: &upstream_name,
                             },
+                            Some(OutcomeBackendTarget {
+                                upstream: &upstream_name,
+                                backend_addr: Some(backend_addr.as_str()),
+                                backend_index: Some(backend_index),
+                            }),
+                            request_start.elapsed(),
+                            http::StatusCode::TOO_MANY_REQUESTS,
+                            AdmissionOutcomeClass::RateLimited,
                         );
                         warn!(
                             "request_id=unassigned route={} scoped rate limit exceeded by rule={}",
@@ -330,26 +318,20 @@ impl QUICListener {
                         return Ok(None);
                     }
                     AdmissionPolicyDecision::Overloaded(decision) => {
-                        let observation = classify_admission_outcome(
+                        let _ = observe_admission_outcome(
+                            metrics,
+                            OutcomeRouteTarget {
+                                route: &upstream_name,
+                            },
+                            Some(OutcomeBackendTarget {
+                                upstream: &upstream_name,
+                                backend_addr: Some(backend_addr.as_str()),
+                                backend_index: Some(backend_index),
+                            }),
+                            request_start.elapsed(),
+                            http::StatusCode::SERVICE_UNAVAILABLE,
                             AdmissionOutcomeClass::OverloadShed {
                                 reason: Some(decision.reason.metrics_reason()),
-                            },
-                        );
-                        record_request_metrics_observation(
-                            metrics,
-                            RequestMetricsObservation {
-                                route_target: OutcomeRouteTarget {
-                                    route: &upstream_name,
-                                },
-                                backend_target: Some(OutcomeBackendTarget {
-                                    upstream: &upstream_name,
-                                    backend_addr: Some(backend_addr.as_str()),
-                                    backend_index: Some(backend_index),
-                                }),
-                                elapsed: request_start.elapsed(),
-                                status: Some(http::StatusCode::SERVICE_UNAVAILABLE.as_u16()),
-                                metrics_outcome: observation.route_outcome.as_metrics_outcome(),
-                                overload_reason: observation.overload_reason,
                             },
                         );
                         let Some(response) = rejection_response.as_ref() else {
@@ -525,26 +507,19 @@ impl QUICListener {
                             error,
                         } => {
                             metrics.inc_external_auth_error();
-                            let observation =
-                                classify_admission_outcome(AdmissionOutcomeClass::Failed {
-                                    timed_out,
-                                });
-                            record_request_metrics_observation(
+                            let _ = observe_admission_outcome(
                                 metrics,
-                                RequestMetricsObservation {
-                                    route_target: OutcomeRouteTarget {
-                                        route: &request.upstream_name,
-                                    },
-                                    backend_target: Some(OutcomeBackendTarget {
-                                        upstream: &request.upstream_name,
-                                        backend_addr: Some(request.backend_addr.as_str()),
-                                        backend_index: Some(request.backend_index),
-                                    }),
-                                    elapsed: request_start.elapsed(),
-                                    status: Some(status.as_u16()),
-                                    metrics_outcome: observation.route_outcome.as_metrics_outcome(),
-                                    overload_reason: observation.overload_reason,
+                                OutcomeRouteTarget {
+                                    route: &request.upstream_name,
                                 },
+                                Some(OutcomeBackendTarget {
+                                    upstream: &request.upstream_name,
+                                    backend_addr: Some(request.backend_addr.as_str()),
+                                    backend_index: Some(request.backend_index),
+                                }),
+                                request_start.elapsed(),
+                                status,
+                                AdmissionOutcomeClass::Failed { timed_out },
                             );
                             if let Some(error) = error {
                                 error!(

--- a/crates/edge/src/quic_listener/forwarding/resolve.rs
+++ b/crates/edge/src/quic_listener/forwarding/resolve.rs
@@ -1,6 +1,10 @@
 use spooky_config::runtime::RuntimeUpstreamPolicy;
 
 use super::{lb_key::ResolvedLbKey, *};
+use crate::runtime::connection::outcome::{
+    OutcomeRouteTarget, RequestMetricsObservation, classify_proxy_error_outcome,
+    record_request_metrics_observation,
+};
 
 pub(in crate::quic_listener) struct RouteResolutionRequest<'a> {
     pub(in crate::quic_listener) method: &'a str,
@@ -148,8 +152,18 @@ impl QUICListener {
         metrics: &Metrics,
         elapsed: Duration,
     ) {
-        metrics.inc_failure();
-        metrics.record_route("unrouted", elapsed, RouteOutcome::Failure);
+        let observation = classify_proxy_error_outcome(err, None);
+        record_request_metrics_observation(
+            metrics,
+            RequestMetricsObservation {
+                route_target: OutcomeRouteTarget::UNROUTED,
+                backend_target: None,
+                elapsed,
+                status: None,
+                metrics_outcome: observation.route_outcome.as_metrics_outcome(),
+                overload_reason: observation.overload_reason,
+            },
+        );
         Self::log_route_resolution_failure(request, err);
     }
 

--- a/crates/edge/src/quic_listener/forwarding/resolve.rs
+++ b/crates/edge/src/quic_listener/forwarding/resolve.rs
@@ -1,9 +1,7 @@
 use spooky_config::runtime::RuntimeUpstreamPolicy;
 
 use super::{lb_key::ResolvedLbKey, *};
-use crate::runtime::connection::outcome::{
-    OutcomeRouteTarget, observe_proxy_error_outcome,
-};
+use crate::runtime::connection::outcome::{OutcomeRouteTarget, observe_proxy_error_outcome};
 
 pub(in crate::quic_listener) struct RouteResolutionRequest<'a> {
     pub(in crate::quic_listener) method: &'a str,

--- a/crates/edge/src/quic_listener/forwarding/resolve.rs
+++ b/crates/edge/src/quic_listener/forwarding/resolve.rs
@@ -2,8 +2,7 @@ use spooky_config::runtime::RuntimeUpstreamPolicy;
 
 use super::{lb_key::ResolvedLbKey, *};
 use crate::runtime::connection::outcome::{
-    OutcomeRouteTarget, RequestMetricsObservation, classify_proxy_error_outcome,
-    record_request_metrics_observation,
+    OutcomeRouteTarget, observe_proxy_error_outcome,
 };
 
 pub(in crate::quic_listener) struct RouteResolutionRequest<'a> {
@@ -152,17 +151,14 @@ impl QUICListener {
         metrics: &Metrics,
         elapsed: Duration,
     ) {
-        let observation = classify_proxy_error_outcome(err, None);
-        record_request_metrics_observation(
+        let _ = observe_proxy_error_outcome(
             metrics,
-            RequestMetricsObservation {
-                route_target: OutcomeRouteTarget::UNROUTED,
-                backend_target: None,
-                elapsed,
-                status: None,
-                metrics_outcome: observation.route_outcome.as_metrics_outcome(),
-                overload_reason: observation.overload_reason,
-            },
+            OutcomeRouteTarget::UNROUTED,
+            None,
+            elapsed,
+            None,
+            err,
+            None,
         );
         Self::log_route_resolution_failure(request, err);
     }

--- a/crates/edge/src/quic_listener/forwarding/response.rs
+++ b/crates/edge/src/quic_listener/forwarding/response.rs
@@ -21,14 +21,10 @@ impl QUICListener {
         let routing_index = shared_ctx.routing_index;
         let upstream_pools = shared_ctx.upstream_pools;
         let overload_retry_after_seconds = shared_ctx.resilience.shed_retry_after_seconds;
-        let start = req.start;
-        let route_label = req.upstream_name.as_deref().unwrap_or("unrouted");
 
         let (backend_addr, backend_index) = match (&req.backend_addr, req.backend_index) {
             (Some(a), Some(i)) => (a.as_str(), i),
             _ => {
-                metrics.inc_failure();
-                metrics.record_route(route_label, start.elapsed(), RouteOutcome::Failure);
                 Self::record_request_observation(
                     metrics,
                     req,
@@ -38,6 +34,7 @@ impl QUICListener {
                         http::StatusCode::SERVICE_UNAVAILABLE.as_u16()
                     }),
                     RouteOutcome::Failure,
+                    None,
                 );
                 return Self::send_simple_response(
                     h3,
@@ -63,14 +60,13 @@ impl QUICListener {
         match result {
             Ok(_) => {
                 error!("Unexpected successful forward result in error handler path");
-                metrics.inc_failure();
                 metrics.inc_backend_error();
-                metrics.record_route(route_label, start.elapsed(), RouteOutcome::BackendError);
                 Self::record_request_observation(
                     metrics,
                     req,
                     Some(http::StatusCode::BAD_GATEWAY.as_u16()),
                     RouteOutcome::BackendError,
+                    None,
                 );
                 Self::send_simple_response(
                     h3,
@@ -82,13 +78,12 @@ impl QUICListener {
             }
             Err(ProxyError::Bridge(err)) => {
                 error!("Bridge error: {:?}", err);
-                metrics.inc_failure();
-                metrics.record_route(route_label, start.elapsed(), RouteOutcome::Failure);
                 Self::record_request_observation(
                     metrics,
                     req,
                     Some(http::StatusCode::BAD_REQUEST.as_u16()),
                     RouteOutcome::Failure,
+                    None,
                 );
                 Self::log_access(req, 400);
                 Self::send_simple_response(
@@ -100,19 +95,19 @@ impl QUICListener {
                 )
             }
             Err(ProxyError::Pool(PoolError::BackendOverloaded(reason))) => {
-                metrics.inc_failure();
-                if is_unknown_length_response_prebuffer_reason(&reason) {
-                    metrics.inc_response_prebuffer_limit_reject();
-                    metrics.inc_overload_shed_reason(OverloadShedReason::ResponsePrebufferCap);
-                } else {
-                    metrics.inc_overload_shed_reason(OverloadShedReason::BackendInflight);
-                }
-                metrics.record_route(route_label, start.elapsed(), RouteOutcome::OverloadShed);
+                let overload_reason =
+                    if is_unknown_length_response_prebuffer_reason(&reason) {
+                        metrics.inc_response_prebuffer_limit_reject();
+                        OverloadShedReason::ResponsePrebufferCap
+                    } else {
+                        OverloadShedReason::BackendInflight
+                    };
                 Self::record_request_observation(
                     metrics,
                     req,
                     Some(http::StatusCode::SERVICE_UNAVAILABLE.as_u16()),
                     RouteOutcome::OverloadShed,
+                    Some(overload_reason),
                 );
                 Self::log_access(req, 503);
                 Self::send_overload_response(
@@ -124,15 +119,13 @@ impl QUICListener {
                 )
             }
             Err(ProxyError::Pool(PoolError::CircuitOpen(_))) => {
-                metrics.inc_failure();
                 metrics.inc_circuit_breaker_rejected();
-                metrics.inc_overload_shed_reason(OverloadShedReason::CircuitOpen);
-                metrics.record_route(route_label, start.elapsed(), RouteOutcome::OverloadShed);
                 Self::record_request_observation(
                     metrics,
                     req,
                     Some(http::StatusCode::SERVICE_UNAVAILABLE.as_u16()),
                     RouteOutcome::OverloadShed,
+                    Some(OverloadShedReason::CircuitOpen),
                 );
                 Self::log_access(req, 503);
                 Self::send_overload_response(
@@ -155,14 +148,13 @@ impl QUICListener {
                     }
                     _ => {}
                 }
-                metrics.inc_failure();
                 metrics.inc_backend_error();
-                metrics.record_route(route_label, start.elapsed(), RouteOutcome::BackendError);
                 Self::record_request_observation(
                     metrics,
                     req,
                     Some(http::StatusCode::BAD_GATEWAY.as_u16()),
                     RouteOutcome::BackendError,
+                    None,
                 );
                 Self::log_access(req, 502);
                 Self::send_simple_response(
@@ -182,14 +174,13 @@ impl QUICListener {
                         backend_addr,
                         err
                     );
-                    metrics.inc_failure();
                     metrics.inc_backend_error();
-                    metrics.record_route(route_label, start.elapsed(), RouteOutcome::BackendError);
                     Self::record_request_observation(
                         metrics,
                         req,
                         Some(http::StatusCode::BAD_GATEWAY.as_u16()),
                         RouteOutcome::BackendError,
+                        None,
                     );
                     Self::log_access(req, 502);
                     return Self::send_simple_response(
@@ -218,14 +209,13 @@ impl QUICListener {
 
                 match classified.kind {
                     UpstreamProxyErrorKind::Timeout => {
-                        metrics.inc_failure();
                         metrics.inc_timeout();
-                        metrics.record_route(route_label, start.elapsed(), RouteOutcome::Timeout);
                         Self::record_request_observation(
                             metrics,
                             req,
                             Some(http::StatusCode::SERVICE_UNAVAILABLE.as_u16()),
                             RouteOutcome::Timeout,
+                            None,
                         );
                         Self::log_access(req, 503);
                         Self::send_simple_response(
@@ -237,13 +227,12 @@ impl QUICListener {
                         )
                     }
                     UpstreamProxyErrorKind::Tls => {
-                        metrics.inc_failure();
-                        metrics.record_route(route_label, start.elapsed(), RouteOutcome::Failure);
                         Self::record_request_observation(
                             metrics,
                             req,
                             Some(http::StatusCode::INTERNAL_SERVER_ERROR.as_u16()),
                             RouteOutcome::Failure,
+                            None,
                         );
                         Self::log_access(req, 500);
                         Self::send_simple_response(
@@ -255,18 +244,13 @@ impl QUICListener {
                         )
                     }
                     UpstreamProxyErrorKind::Protocol => {
-                        metrics.inc_failure();
                         metrics.inc_backend_error();
-                        metrics.record_route(
-                            route_label,
-                            start.elapsed(),
-                            RouteOutcome::BackendError,
-                        );
                         Self::record_request_observation(
                             metrics,
                             req,
                             Some(http::StatusCode::BAD_GATEWAY.as_u16()),
                             RouteOutcome::BackendError,
+                            None,
                         );
                         Self::log_access(req, 502);
                         Self::send_simple_response(
@@ -278,18 +262,13 @@ impl QUICListener {
                         )
                     }
                     UpstreamProxyErrorKind::Send | UpstreamProxyErrorKind::Transport => {
-                        metrics.inc_failure();
                         metrics.inc_backend_error();
-                        metrics.record_route(
-                            route_label,
-                            start.elapsed(),
-                            RouteOutcome::BackendError,
-                        );
                         Self::record_request_observation(
                             metrics,
                             req,
                             Some(http::StatusCode::BAD_GATEWAY.as_u16()),
                             RouteOutcome::BackendError,
+                            None,
                         );
                         Self::log_access(req, 502);
                         Self::send_simple_response(
@@ -518,19 +497,13 @@ impl QUICListener {
                                 stream_id, err
                             );
                             req.phase = StreamPhase::Failed;
-                            metrics.inc_failure();
                             metrics.inc_backend_error();
-                            let route_label = req.upstream_name.as_deref().unwrap_or("unrouted");
-                            metrics.record_route(
-                                route_label,
-                                req.start.elapsed(),
-                                RouteOutcome::BackendError,
-                            );
                             Self::record_request_observation(
                                 metrics,
                                 req,
                                 Some(status.as_u16()),
                                 RouteOutcome::BackendError,
+                                None,
                             );
                             resilience
                                 .adaptive_admission
@@ -552,19 +525,13 @@ impl QUICListener {
                             stream_id, err
                         );
                         req.phase = StreamPhase::Failed;
-                        metrics.inc_failure();
                         metrics.inc_backend_error();
-                        let route_label = req.upstream_name.as_deref().unwrap_or("unrouted");
-                        metrics.record_route(
-                            route_label,
-                            req.start.elapsed(),
-                            RouteOutcome::BackendError,
-                        );
                         Self::record_request_observation(
                             metrics,
                             req,
                             req.response_status,
                             RouteOutcome::BackendError,
+                            None,
                         );
                         resilience
                             .adaptive_admission
@@ -590,19 +557,13 @@ impl QUICListener {
                                 stream_id, err
                             );
                             req.phase = StreamPhase::Failed;
-                            metrics.inc_failure();
                             metrics.inc_backend_error();
-                            let route_label = req.upstream_name.as_deref().unwrap_or("unrouted");
-                            metrics.record_route(
-                                route_label,
-                                req.start.elapsed(),
-                                RouteOutcome::BackendError,
-                            );
                             Self::record_request_observation(
                                 metrics,
                                 req,
                                 req.response_status,
                                 RouteOutcome::BackendError,
+                                None,
                             );
                             resilience
                                 .adaptive_admission
@@ -628,19 +589,13 @@ impl QUICListener {
                             stream_id, err
                         );
                         req.phase = StreamPhase::Failed;
-                        metrics.inc_failure();
                         metrics.inc_backend_error();
-                        let route_label = req.upstream_name.as_deref().unwrap_or("unrouted");
-                        metrics.record_route(
-                            route_label,
-                            req.start.elapsed(),
-                            RouteOutcome::BackendError,
-                        );
                         Self::record_request_observation(
                             metrics,
                             req,
                             req.response_status,
                             RouteOutcome::BackendError,
+                            None,
                         );
                         resilience
                             .adaptive_admission
@@ -696,20 +651,14 @@ impl QUICListener {
                     }
                     match err {
                         ProxyError::Timeout => {
-                            metrics.inc_failure();
                             metrics.inc_timeout();
-                            let route_label = req.upstream_name.as_deref().unwrap_or("unrouted");
-                            metrics.record_route(
-                                route_label,
-                                req.start.elapsed(),
-                                RouteOutcome::Timeout,
-                            );
                             Self::record_request_observation(
                                 metrics,
                                 req,
                                 req.response_status
                                     .or(Some(http::StatusCode::SERVICE_UNAVAILABLE.as_u16())),
                                 RouteOutcome::Timeout,
+                                None,
                             );
                             resilience
                                 .adaptive_admission
@@ -721,28 +670,20 @@ impl QUICListener {
                             );
                         }
                         ProxyError::Pool(PoolError::BackendOverloaded(reason)) => {
-                            metrics.inc_failure();
-                            if is_unknown_length_response_prebuffer_reason(&reason) {
-                                metrics.inc_response_prebuffer_limit_reject();
-                                metrics.inc_overload_shed_reason(
-                                    OverloadShedReason::ResponsePrebufferCap,
-                                );
-                            } else {
-                                metrics
-                                    .inc_overload_shed_reason(OverloadShedReason::BackendInflight);
-                            }
-                            let route_label = req.upstream_name.as_deref().unwrap_or("unrouted");
-                            metrics.record_route(
-                                route_label,
-                                req.start.elapsed(),
-                                RouteOutcome::OverloadShed,
-                            );
+                            let overload_reason =
+                                if is_unknown_length_response_prebuffer_reason(&reason) {
+                                    metrics.inc_response_prebuffer_limit_reject();
+                                    OverloadShedReason::ResponsePrebufferCap
+                                } else {
+                                    OverloadShedReason::BackendInflight
+                                };
                             Self::record_request_observation(
                                 metrics,
                                 req,
                                 req.response_status
                                     .or(Some(http::StatusCode::SERVICE_UNAVAILABLE.as_u16())),
                                 RouteOutcome::OverloadShed,
+                                Some(overload_reason),
                             );
                             resilience
                                 .adaptive_admission
@@ -754,20 +695,14 @@ impl QUICListener {
                             );
                         }
                         _ => {
-                            metrics.inc_failure();
                             metrics.inc_backend_error();
-                            let route_label = req.upstream_name.as_deref().unwrap_or("unrouted");
-                            metrics.record_route(
-                                route_label,
-                                req.start.elapsed(),
-                                RouteOutcome::BackendError,
-                            );
                             Self::record_request_observation(
                                 metrics,
                                 req,
                                 req.response_status
                                     .or(Some(http::StatusCode::BAD_GATEWAY.as_u16())),
                                 RouteOutcome::BackendError,
+                                None,
                             );
                             resilience
                                 .adaptive_admission

--- a/crates/edge/src/quic_listener/forwarding/response.rs
+++ b/crates/edge/src/quic_listener/forwarding/response.rs
@@ -94,13 +94,12 @@ impl QUICListener {
                 )
             }
             Err(ProxyError::Pool(PoolError::BackendOverloaded(reason))) => {
-                let overload_reason =
-                    if is_unknown_length_response_prebuffer_reason(&reason) {
-                        metrics.inc_response_prebuffer_limit_reject();
-                        OverloadShedReason::ResponsePrebufferCap
-                    } else {
-                        OverloadShedReason::BackendInflight
-                    };
+                let overload_reason = if is_unknown_length_response_prebuffer_reason(&reason) {
+                    metrics.inc_response_prebuffer_limit_reject();
+                    OverloadShedReason::ResponsePrebufferCap
+                } else {
+                    OverloadShedReason::BackendInflight
+                };
                 let overload_error = ProxyError::Pool(PoolError::BackendOverloaded(reason));
                 let _ = crate::runtime::connection::outcome::observe_proxy_error_outcome(
                     metrics,
@@ -203,16 +202,18 @@ impl QUICListener {
                     backend_addr,
                     &classified,
                 );
-                if let Some(transition) = crate::runtime::connection::outcome::observe_classified_backend_failure(
-                    crate::runtime::connection::outcome::ClassifiedBackendFailureInput {
-                        metrics_phase: "data_plane",
-                        backend_addr,
-                        backend_index,
-                        upstream_pool: upstream_pool.as_ref(),
-                        metrics,
-                        classified: &classified,
-                    },
-                ) {
+                if let Some(transition) =
+                    crate::runtime::connection::outcome::observe_classified_backend_failure(
+                        crate::runtime::connection::outcome::ClassifiedBackendFailureInput {
+                            metrics_phase: "data_plane",
+                            backend_addr,
+                            backend_index,
+                            upstream_pool: upstream_pool.as_ref(),
+                            metrics,
+                            classified: &classified,
+                        },
+                    )
+                {
                     crate::runtime::connection::outcome::log_backend_health_transition(
                         backend_addr,
                         transition,
@@ -686,17 +687,18 @@ impl QUICListener {
                     match err {
                         ProxyError::Timeout => {
                             metrics.inc_timeout();
-                            let _ = crate::runtime::connection::outcome::observe_proxy_error_outcome(
-                                metrics,
-                                Self::request_outcome_route_target(req),
-                                Self::request_outcome_backend_target(req),
-                                req.start.elapsed(),
-                                req.response_status
-                                    .and_then(|status| http::StatusCode::from_u16(status).ok())
-                                    .or(Some(http::StatusCode::SERVICE_UNAVAILABLE)),
-                                &err,
-                                None,
-                            );
+                            let _ =
+                                crate::runtime::connection::outcome::observe_proxy_error_outcome(
+                                    metrics,
+                                    Self::request_outcome_route_target(req),
+                                    Self::request_outcome_backend_target(req),
+                                    req.start.elapsed(),
+                                    req.response_status
+                                        .and_then(|status| http::StatusCode::from_u16(status).ok())
+                                        .or(Some(http::StatusCode::SERVICE_UNAVAILABLE)),
+                                    &err,
+                                    None,
+                                );
                             resilience
                                 .adaptive_admission
                                 .observe(req.start.elapsed(), true);
@@ -716,17 +718,18 @@ impl QUICListener {
                                 };
                             let overload_error =
                                 ProxyError::Pool(PoolError::BackendOverloaded(reason.clone()));
-                            let _ = crate::runtime::connection::outcome::observe_proxy_error_outcome(
-                                metrics,
-                                Self::request_outcome_route_target(req),
-                                Self::request_outcome_backend_target(req),
-                                req.start.elapsed(),
-                                req.response_status
-                                    .and_then(|status| http::StatusCode::from_u16(status).ok())
-                                    .or(Some(http::StatusCode::SERVICE_UNAVAILABLE)),
-                                &overload_error,
-                                Some(overload_reason),
-                            );
+                            let _ =
+                                crate::runtime::connection::outcome::observe_proxy_error_outcome(
+                                    metrics,
+                                    Self::request_outcome_route_target(req),
+                                    Self::request_outcome_backend_target(req),
+                                    req.start.elapsed(),
+                                    req.response_status
+                                        .and_then(|status| http::StatusCode::from_u16(status).ok())
+                                        .or(Some(http::StatusCode::SERVICE_UNAVAILABLE)),
+                                    &overload_error,
+                                    Some(overload_reason),
+                                );
                             resilience
                                 .adaptive_admission
                                 .observe(req.start.elapsed(), true);
@@ -738,17 +741,18 @@ impl QUICListener {
                         }
                         _ => {
                             metrics.inc_backend_error();
-                            let _ = crate::runtime::connection::outcome::observe_proxy_error_outcome(
-                                metrics,
-                                Self::request_outcome_route_target(req),
-                                Self::request_outcome_backend_target(req),
-                                req.start.elapsed(),
-                                req.response_status
-                                    .and_then(|status| http::StatusCode::from_u16(status).ok())
-                                    .or(Some(http::StatusCode::BAD_GATEWAY)),
-                                &err,
-                                None,
-                            );
+                            let _ =
+                                crate::runtime::connection::outcome::observe_proxy_error_outcome(
+                                    metrics,
+                                    Self::request_outcome_route_target(req),
+                                    Self::request_outcome_backend_target(req),
+                                    req.start.elapsed(),
+                                    req.response_status
+                                        .and_then(|status| http::StatusCode::from_u16(status).ok())
+                                        .or(Some(http::StatusCode::BAD_GATEWAY)),
+                                    &err,
+                                    None,
+                                );
                             resilience
                                 .adaptive_admission
                                 .observe(req.start.elapsed(), true);

--- a/crates/edge/src/quic_listener/forwarding/response.rs
+++ b/crates/edge/src/quic_listener/forwarding/response.rs
@@ -21,30 +21,29 @@ impl QUICListener {
         let routing_index = shared_ctx.routing_index;
         let upstream_pools = shared_ctx.upstream_pools;
         let overload_retry_after_seconds = shared_ctx.resilience.shed_retry_after_seconds;
+        let route_target = Self::request_outcome_route_target(req);
+        let backend_target = Self::request_outcome_backend_target(req);
 
         let (backend_addr, backend_index) = match (&req.backend_addr, req.backend_index) {
             (Some(a), Some(i)) => (a.as_str(), i),
             _ => {
-                Self::record_request_observation(
+                let status = if req.method.is_empty() || req.path.is_empty() {
+                    http::StatusCode::BAD_REQUEST
+                } else {
+                    http::StatusCode::SERVICE_UNAVAILABLE
+                };
+                let _ = crate::runtime::connection::outcome::observe_status_outcome(
                     metrics,
-                    req,
-                    Some(if req.method.is_empty() || req.path.is_empty() {
-                        http::StatusCode::BAD_REQUEST.as_u16()
-                    } else {
-                        http::StatusCode::SERVICE_UNAVAILABLE.as_u16()
-                    }),
-                    RouteOutcome::Failure,
-                    None,
+                    route_target,
+                    backend_target,
+                    req.start.elapsed(),
+                    status,
                 );
                 return Self::send_simple_response(
                     h3,
                     quic,
                     stream_id,
-                    if req.method.is_empty() || req.path.is_empty() {
-                        http::StatusCode::BAD_REQUEST
-                    } else {
-                        http::StatusCode::SERVICE_UNAVAILABLE
-                    },
+                    status,
                     b"no upstream available\n",
                 );
             }
@@ -61,12 +60,12 @@ impl QUICListener {
             Ok(_) => {
                 error!("Unexpected successful forward result in error handler path");
                 metrics.inc_backend_error();
-                Self::record_request_observation(
+                let _ = crate::runtime::connection::outcome::observe_status_outcome(
                     metrics,
-                    req,
-                    Some(http::StatusCode::BAD_GATEWAY.as_u16()),
-                    RouteOutcome::BackendError,
-                    None,
+                    route_target,
+                    backend_target,
+                    req.start.elapsed(),
+                    http::StatusCode::BAD_GATEWAY,
                 );
                 Self::send_simple_response(
                     h3,
@@ -78,12 +77,12 @@ impl QUICListener {
             }
             Err(ProxyError::Bridge(err)) => {
                 error!("Bridge error: {:?}", err);
-                Self::record_request_observation(
+                let _ = crate::runtime::connection::outcome::observe_status_outcome(
                     metrics,
-                    req,
-                    Some(http::StatusCode::BAD_REQUEST.as_u16()),
-                    RouteOutcome::Failure,
-                    None,
+                    route_target,
+                    backend_target,
+                    req.start.elapsed(),
+                    http::StatusCode::BAD_REQUEST,
                 );
                 Self::log_access(req, 400);
                 Self::send_simple_response(
@@ -102,11 +101,14 @@ impl QUICListener {
                     } else {
                         OverloadShedReason::BackendInflight
                     };
-                Self::record_request_observation(
+                let overload_error = ProxyError::Pool(PoolError::BackendOverloaded(reason));
+                let _ = crate::runtime::connection::outcome::observe_proxy_error_outcome(
                     metrics,
-                    req,
-                    Some(http::StatusCode::SERVICE_UNAVAILABLE.as_u16()),
-                    RouteOutcome::OverloadShed,
+                    route_target,
+                    backend_target,
+                    req.start.elapsed(),
+                    Some(http::StatusCode::SERVICE_UNAVAILABLE),
+                    &overload_error,
                     Some(overload_reason),
                 );
                 Self::log_access(req, 503);
@@ -118,13 +120,16 @@ impl QUICListener {
                     overload_retry_after_seconds,
                 )
             }
-            Err(ProxyError::Pool(PoolError::CircuitOpen(_))) => {
+            Err(ProxyError::Pool(PoolError::CircuitOpen(reason))) => {
                 metrics.inc_circuit_breaker_rejected();
-                Self::record_request_observation(
+                let circuit_open = ProxyError::Pool(PoolError::CircuitOpen(reason));
+                let _ = crate::runtime::connection::outcome::observe_proxy_error_outcome(
                     metrics,
-                    req,
-                    Some(http::StatusCode::SERVICE_UNAVAILABLE.as_u16()),
-                    RouteOutcome::OverloadShed,
+                    route_target,
+                    backend_target,
+                    req.start.elapsed(),
+                    Some(http::StatusCode::SERVICE_UNAVAILABLE),
+                    &circuit_open,
                     Some(OverloadShedReason::CircuitOpen),
                 );
                 Self::log_access(req, 503);
@@ -149,12 +154,12 @@ impl QUICListener {
                     _ => {}
                 }
                 metrics.inc_backend_error();
-                Self::record_request_observation(
+                let _ = crate::runtime::connection::outcome::observe_status_outcome(
                     metrics,
-                    req,
-                    Some(http::StatusCode::BAD_GATEWAY.as_u16()),
-                    RouteOutcome::BackendError,
-                    None,
+                    route_target,
+                    backend_target,
+                    req.start.elapsed(),
+                    http::StatusCode::BAD_GATEWAY,
                 );
                 Self::log_access(req, 502);
                 Self::send_simple_response(
@@ -175,12 +180,12 @@ impl QUICListener {
                         err
                     );
                     metrics.inc_backend_error();
-                    Self::record_request_observation(
+                    let _ = crate::runtime::connection::outcome::observe_status_outcome(
                         metrics,
-                        req,
-                        Some(http::StatusCode::BAD_GATEWAY.as_u16()),
-                        RouteOutcome::BackendError,
-                        None,
+                        route_target,
+                        backend_target,
+                        req.start.elapsed(),
+                        http::StatusCode::BAD_GATEWAY,
                     );
                     Self::log_access(req, 502);
                     return Self::send_simple_response(
@@ -198,23 +203,32 @@ impl QUICListener {
                     backend_addr,
                     &classified,
                 );
-                Self::mark_classified_upstream_health_failure(
-                    "data_plane",
-                    backend_addr,
-                    backend_index,
-                    upstream_pool.as_ref(),
-                    metrics,
-                    &classified,
-                );
+                if let Some(transition) = crate::runtime::connection::outcome::observe_classified_backend_failure(
+                    crate::runtime::connection::outcome::ClassifiedBackendFailureInput {
+                        metrics_phase: "data_plane",
+                        backend_addr,
+                        backend_index,
+                        upstream_pool: upstream_pool.as_ref(),
+                        metrics,
+                        classified: &classified,
+                    },
+                ) {
+                    crate::runtime::connection::outcome::log_backend_health_transition(
+                        backend_addr,
+                        transition,
+                    );
+                }
 
                 match classified.kind {
                     UpstreamProxyErrorKind::Timeout => {
                         metrics.inc_timeout();
-                        Self::record_request_observation(
+                        let _ = crate::runtime::connection::outcome::observe_proxy_error_outcome(
                             metrics,
-                            req,
-                            Some(http::StatusCode::SERVICE_UNAVAILABLE.as_u16()),
-                            RouteOutcome::Timeout,
+                            route_target,
+                            backend_target,
+                            req.start.elapsed(),
+                            Some(http::StatusCode::SERVICE_UNAVAILABLE),
+                            &err,
                             None,
                         );
                         Self::log_access(req, 503);
@@ -227,12 +241,12 @@ impl QUICListener {
                         )
                     }
                     UpstreamProxyErrorKind::Tls => {
-                        Self::record_request_observation(
+                        let _ = crate::runtime::connection::outcome::observe_status_outcome(
                             metrics,
-                            req,
-                            Some(http::StatusCode::INTERNAL_SERVER_ERROR.as_u16()),
-                            RouteOutcome::Failure,
-                            None,
+                            route_target,
+                            backend_target,
+                            req.start.elapsed(),
+                            http::StatusCode::INTERNAL_SERVER_ERROR,
                         );
                         Self::log_access(req, 500);
                         Self::send_simple_response(
@@ -245,12 +259,12 @@ impl QUICListener {
                     }
                     UpstreamProxyErrorKind::Protocol => {
                         metrics.inc_backend_error();
-                        Self::record_request_observation(
+                        let _ = crate::runtime::connection::outcome::observe_status_outcome(
                             metrics,
-                            req,
-                            Some(http::StatusCode::BAD_GATEWAY.as_u16()),
-                            RouteOutcome::BackendError,
-                            None,
+                            route_target,
+                            backend_target,
+                            req.start.elapsed(),
+                            http::StatusCode::BAD_GATEWAY,
                         );
                         Self::log_access(req, 502);
                         Self::send_simple_response(
@@ -263,12 +277,12 @@ impl QUICListener {
                     }
                     UpstreamProxyErrorKind::Send | UpstreamProxyErrorKind::Transport => {
                         metrics.inc_backend_error();
-                        Self::record_request_observation(
+                        let _ = crate::runtime::connection::outcome::observe_status_outcome(
                             metrics,
-                            req,
-                            Some(http::StatusCode::BAD_GATEWAY.as_u16()),
-                            RouteOutcome::BackendError,
-                            None,
+                            route_target,
+                            backend_target,
+                            req.start.elapsed(),
+                            http::StatusCode::BAD_GATEWAY,
                         );
                         Self::log_access(req, 502);
                         Self::send_simple_response(
@@ -498,12 +512,12 @@ impl QUICListener {
                             );
                             req.phase = StreamPhase::Failed;
                             metrics.inc_backend_error();
-                            Self::record_request_observation(
+                            let _ = crate::runtime::connection::outcome::observe_status_outcome(
                                 metrics,
-                                req,
-                                Some(status.as_u16()),
-                                RouteOutcome::BackendError,
-                                None,
+                                Self::request_outcome_route_target(req),
+                                Self::request_outcome_backend_target(req),
+                                req.start.elapsed(),
+                                status,
                             );
                             resilience
                                 .adaptive_admission
@@ -526,12 +540,14 @@ impl QUICListener {
                         );
                         req.phase = StreamPhase::Failed;
                         metrics.inc_backend_error();
-                        Self::record_request_observation(
+                        let _ = crate::runtime::connection::outcome::observe_status_outcome(
                             metrics,
-                            req,
-                            req.response_status,
-                            RouteOutcome::BackendError,
-                            None,
+                            Self::request_outcome_route_target(req),
+                            Self::request_outcome_backend_target(req),
+                            req.start.elapsed(),
+                            req.response_status
+                                .and_then(|status| http::StatusCode::from_u16(status).ok())
+                                .unwrap_or(http::StatusCode::BAD_GATEWAY),
                         );
                         resilience
                             .adaptive_admission
@@ -558,12 +574,14 @@ impl QUICListener {
                             );
                             req.phase = StreamPhase::Failed;
                             metrics.inc_backend_error();
-                            Self::record_request_observation(
+                            let _ = crate::runtime::connection::outcome::observe_status_outcome(
                                 metrics,
-                                req,
-                                req.response_status,
-                                RouteOutcome::BackendError,
-                                None,
+                                Self::request_outcome_route_target(req),
+                                Self::request_outcome_backend_target(req),
+                                req.start.elapsed(),
+                                req.response_status
+                                    .and_then(|status| http::StatusCode::from_u16(status).ok())
+                                    .unwrap_or(http::StatusCode::BAD_GATEWAY),
                             );
                             resilience
                                 .adaptive_admission
@@ -590,12 +608,14 @@ impl QUICListener {
                         );
                         req.phase = StreamPhase::Failed;
                         metrics.inc_backend_error();
-                        Self::record_request_observation(
+                        let _ = crate::runtime::connection::outcome::observe_status_outcome(
                             metrics,
-                            req,
-                            req.response_status,
-                            RouteOutcome::BackendError,
-                            None,
+                            Self::request_outcome_route_target(req),
+                            Self::request_outcome_backend_target(req),
+                            req.start.elapsed(),
+                            req.response_status
+                                .and_then(|status| http::StatusCode::from_u16(status).ok())
+                                .unwrap_or(http::StatusCode::BAD_GATEWAY),
                         );
                         resilience
                             .adaptive_admission
@@ -632,14 +652,21 @@ impl QUICListener {
                         req.backend_index,
                         classified.as_ref(),
                     ) {
-                        Self::mark_classified_upstream_health_failure(
-                            "data_plane",
-                            addr,
-                            idx,
-                            upstream_pool,
-                            metrics,
-                            classified,
-                        );
+                        if let Some(transition) = crate::runtime::connection::outcome::observe_classified_backend_failure(
+                            crate::runtime::connection::outcome::ClassifiedBackendFailureInput {
+                                metrics_phase: "data_plane",
+                                backend_addr: addr,
+                                backend_index: idx,
+                                upstream_pool,
+                                metrics,
+                                classified,
+                            },
+                        ) {
+                            crate::runtime::connection::outcome::log_backend_health_transition(
+                                addr,
+                                transition,
+                            );
+                        }
                     } else if let (Some(addr), Some(idx)) =
                         (req.backend_addr.as_deref(), req.backend_index)
                         && let Some(t) = crate::runtime::connection::outcome::observe_backend_response_status(
@@ -654,17 +681,20 @@ impl QUICListener {
                             },
                         )
                     {
-                        Self::log_health_transition(addr, t);
+                        crate::runtime::connection::outcome::log_backend_health_transition(addr, t);
                     }
                     match err {
                         ProxyError::Timeout => {
                             metrics.inc_timeout();
-                            Self::record_request_observation(
+                            let _ = crate::runtime::connection::outcome::observe_proxy_error_outcome(
                                 metrics,
-                                req,
+                                Self::request_outcome_route_target(req),
+                                Self::request_outcome_backend_target(req),
+                                req.start.elapsed(),
                                 req.response_status
-                                    .or(Some(http::StatusCode::SERVICE_UNAVAILABLE.as_u16())),
-                                RouteOutcome::Timeout,
+                                    .and_then(|status| http::StatusCode::from_u16(status).ok())
+                                    .or(Some(http::StatusCode::SERVICE_UNAVAILABLE)),
+                                &err,
                                 None,
                             );
                             resilience
@@ -684,12 +714,17 @@ impl QUICListener {
                                 } else {
                                     OverloadShedReason::BackendInflight
                                 };
-                            Self::record_request_observation(
+                            let overload_error =
+                                ProxyError::Pool(PoolError::BackendOverloaded(reason.clone()));
+                            let _ = crate::runtime::connection::outcome::observe_proxy_error_outcome(
                                 metrics,
-                                req,
+                                Self::request_outcome_route_target(req),
+                                Self::request_outcome_backend_target(req),
+                                req.start.elapsed(),
                                 req.response_status
-                                    .or(Some(http::StatusCode::SERVICE_UNAVAILABLE.as_u16())),
-                                RouteOutcome::OverloadShed,
+                                    .and_then(|status| http::StatusCode::from_u16(status).ok())
+                                    .or(Some(http::StatusCode::SERVICE_UNAVAILABLE)),
+                                &overload_error,
                                 Some(overload_reason),
                             );
                             resilience
@@ -703,12 +738,15 @@ impl QUICListener {
                         }
                         _ => {
                             metrics.inc_backend_error();
-                            Self::record_request_observation(
+                            let _ = crate::runtime::connection::outcome::observe_proxy_error_outcome(
                                 metrics,
-                                req,
+                                Self::request_outcome_route_target(req),
+                                Self::request_outcome_backend_target(req),
+                                req.start.elapsed(),
                                 req.response_status
-                                    .or(Some(http::StatusCode::BAD_GATEWAY.as_u16())),
-                                RouteOutcome::BackendError,
+                                    .and_then(|status| http::StatusCode::from_u16(status).ok())
+                                    .or(Some(http::StatusCode::BAD_GATEWAY)),
+                                &err,
                                 None,
                             );
                             resilience

--- a/crates/edge/src/quic_listener/forwarding/response.rs
+++ b/crates/edge/src/quic_listener/forwarding/response.rs
@@ -640,12 +640,19 @@ impl QUICListener {
                             metrics,
                             classified,
                         );
-                    } else if let (Some(idx), Some(pool)) = (req.backend_index, upstream_pool)
-                        && let Some(t) = pool.write().ok().and_then(|mut p| {
-                            p.pool
-                                .mark_request_failure(idx, HealthFailureReason::HttpStatus5xx)
-                        })
-                        && let Some(addr) = &req.backend_addr
+                    } else if let (Some(addr), Some(idx)) =
+                        (req.backend_addr.as_deref(), req.backend_index)
+                        && let Some(t) = crate::runtime::connection::outcome::observe_backend_response_status(
+                            crate::runtime::connection::outcome::BackendHealthObservationInput {
+                                backend_addr: addr,
+                                backend_index: idx,
+                                upstream_pool,
+                                status: req
+                                    .response_status
+                                    .and_then(|code| http::StatusCode::from_u16(code).ok())
+                                    .unwrap_or(http::StatusCode::INTERNAL_SERVER_ERROR),
+                            },
+                        )
                     {
                         Self::log_health_transition(addr, t);
                     }

--- a/crates/edge/src/quic_listener/forwarding/stream_progress.rs
+++ b/crates/edge/src/quic_listener/forwarding/stream_progress.rs
@@ -784,16 +784,13 @@ impl QUICListener {
                                 Self::request_metrics_outcome_for_status(status);
                             if is_success {
                                 metrics.inc_success();
-                            } else {
-                                metrics.inc_failure();
                             }
-                            let route_label = req.upstream_name.as_deref().unwrap_or("unrouted");
-                            metrics.record_route(route_label, req.start.elapsed(), route_outcome);
                             Self::record_request_observation(
                                 metrics,
                                 req,
                                 Some(status.as_u16()),
                                 route_outcome,
+                                None,
                             );
                             resilience
                                 .adaptive_admission

--- a/crates/edge/src/quic_listener/forwarding/stream_progress.rs
+++ b/crates/edge/src/quic_listener/forwarding/stream_progress.rs
@@ -146,10 +146,22 @@ impl QUICListener {
                         kind: BodyTimeoutKind::Idle,
                     }
                 ) {
-                    metrics.inc_failure();
                     metrics.inc_timeout();
-                    let route_label = req.upstream_name.as_deref().unwrap_or("unrouted");
-                    metrics.record_route(route_label, req.start.elapsed(), RouteOutcome::Timeout);
+                    let _ = crate::runtime::connection::outcome::observe_proxy_error_outcome(
+                        metrics,
+                        crate::runtime::connection::outcome::OutcomeRouteTarget {
+                            route: req.upstream_name.as_deref().unwrap_or("unrouted"),
+                        },
+                        Some(crate::runtime::connection::outcome::OutcomeBackendTarget {
+                            upstream: req.upstream_name.as_deref().unwrap_or("unrouted"),
+                            backend_addr: req.backend_addr.as_deref(),
+                            backend_index: req.backend_index,
+                        }),
+                        req.start.elapsed(),
+                        Some(http::StatusCode::REQUEST_TIMEOUT),
+                        &ProxyError::Timeout,
+                        None,
+                    );
                     let _ = Self::send_simple_response(
                         h3,
                         quic,
@@ -370,16 +382,22 @@ impl QUICListener {
                             })
                         ) {
                             if let Some(req) = streams.get(&stream_id) {
-                                metrics.inc_failure();
-                                metrics.inc_overload_shed_reason(
-                                    OverloadShedReason::ResponsePrebufferCap,
-                                );
-                                let route_label =
-                                    req.upstream_name.as_deref().unwrap_or("unrouted");
-                                metrics.record_route(
-                                    route_label,
+                                let _ = crate::runtime::connection::outcome::observe_proxy_error_outcome(
+                                    metrics,
+                                    crate::runtime::connection::outcome::OutcomeRouteTarget {
+                                        route: req.upstream_name.as_deref().unwrap_or("unrouted"),
+                                    },
+                                    Some(crate::runtime::connection::outcome::OutcomeBackendTarget {
+                                        upstream: req.upstream_name.as_deref().unwrap_or("unrouted"),
+                                        backend_addr: req.backend_addr.as_deref(),
+                                        backend_index: req.backend_index,
+                                    }),
                                     req.start.elapsed(),
-                                    RouteOutcome::OverloadShed,
+                                    Some(http::StatusCode::SERVICE_UNAVAILABLE),
+                                    &ProxyError::Pool(PoolError::BackendOverloaded(
+                                        "response prebuffer cap".into(),
+                                    )),
+                                    Some(OverloadShedReason::ResponsePrebufferCap),
                                 );
                                 resilience
                                     .adaptive_admission

--- a/crates/edge/src/quic_listener/forwarding/stream_progress.rs
+++ b/crates/edge/src/quic_listener/forwarding/stream_progress.rs
@@ -786,20 +786,15 @@ impl QUICListener {
                                     },
                                 );
                                 if let Some(t) = transition {
-                                    Self::log_health_transition(addr, t);
+                                    crate::runtime::connection::outcome::log_backend_health_transition(addr, t);
                                 }
                             }
-                            let (is_success, route_outcome) =
-                                Self::request_metrics_outcome_for_status(status);
-                            if is_success {
-                                metrics.inc_success();
-                            }
-                            Self::record_request_observation(
+                            let _ = crate::runtime::connection::outcome::observe_status_outcome(
                                 metrics,
-                                req,
-                                Some(status.as_u16()),
-                                route_outcome,
-                                None,
+                                Self::request_outcome_route_target(req),
+                                Self::request_outcome_backend_target(req),
+                                req.start.elapsed(),
+                                status,
                             );
                             resilience
                                 .adaptive_admission

--- a/crates/edge/src/quic_listener/forwarding/stream_progress.rs
+++ b/crates/edge/src/quic_listener/forwarding/stream_progress.rs
@@ -758,24 +758,15 @@ impl QUICListener {
 
                         if let Some(req) = streams.get(&stream_id) {
                             if let (Some(addr), Some(idx)) = (&req.backend_addr, req.backend_index)
-                                && let Some(pool) = req.upstream_pool.as_ref()
                             {
-                                let transition = pool.write().ok().and_then(|mut p| {
-                                    match outcome_from_status(status) {
-                                        crate::runtime::health::HealthClassification::Success => {
-                                            p.pool.mark_success(idx)
-                                        }
-                                        crate::runtime::health::HealthClassification::Failure => {
-                                            p.pool.mark_request_failure(
-                                                idx,
-                                                HealthFailureReason::HttpStatus5xx,
-                                            )
-                                        }
-                                        crate::runtime::health::HealthClassification::Neutral => {
-                                            None
-                                        }
-                                    }
-                                });
+                                let transition = crate::runtime::connection::outcome::observe_backend_response_status(
+                                    crate::runtime::connection::outcome::BackendHealthObservationInput {
+                                        backend_addr: addr,
+                                        backend_index: idx,
+                                        upstream_pool: req.upstream_pool.as_ref(),
+                                        status,
+                                    },
+                                );
                                 if let Some(t) = transition {
                                     Self::log_health_transition(addr, t);
                                 }

--- a/crates/edge/src/quic_listener/health_check.rs
+++ b/crates/edge/src/quic_listener/health_check.rs
@@ -137,14 +137,21 @@ impl QUICListener {
                                         &job.backend_identity,
                                         &classified,
                                     );
-                                    Self::mark_classified_upstream_health_failure(
-                                        "health_check",
-                                        &job.backend_identity,
-                                        job.index,
-                                        Some(&job.upstream_pool),
-                                        task_metrics.as_ref(),
-                                        &classified,
-                                    );
+                                    if let Some(transition) = crate::runtime::connection::outcome::observe_classified_backend_failure(
+                                        crate::runtime::connection::outcome::ClassifiedBackendFailureInput {
+                                            metrics_phase: "health_check",
+                                            backend_addr: &job.backend_identity,
+                                            backend_index: job.index,
+                                            upstream_pool: Some(&job.upstream_pool),
+                                            metrics: task_metrics.as_ref(),
+                                            classified: &classified,
+                                        },
+                                    ) {
+                                        crate::runtime::connection::outcome::log_backend_health_transition(
+                                            &job.backend_identity,
+                                            transition,
+                                        );
+                                    }
                                     HealthClassification::Failure
                                 }
                                 Ok(Err(pool_err)) => {
@@ -159,14 +166,21 @@ impl QUICListener {
                                             &job.backend_identity,
                                             &classified,
                                         );
-                                        Self::mark_classified_upstream_health_failure(
-                                            "health_check",
-                                            &job.backend_identity,
-                                            job.index,
-                                            Some(&job.upstream_pool),
-                                            task_metrics.as_ref(),
-                                            &classified,
-                                        );
+                                        if let Some(transition) = crate::runtime::connection::outcome::observe_classified_backend_failure(
+                                            crate::runtime::connection::outcome::ClassifiedBackendFailureInput {
+                                                metrics_phase: "health_check",
+                                                backend_addr: &job.backend_identity,
+                                                backend_index: job.index,
+                                                upstream_pool: Some(&job.upstream_pool),
+                                                metrics: task_metrics.as_ref(),
+                                                classified: &classified,
+                                            },
+                                        ) {
+                                            crate::runtime::connection::outcome::log_backend_health_transition(
+                                                &job.backend_identity,
+                                                transition,
+                                            );
+                                        }
                                     } else {
                                         task_metrics
                                             .inc_health_failure(HealthFailureReason::Transport);
@@ -184,14 +198,21 @@ impl QUICListener {
                                             &job.backend_identity,
                                             &classified,
                                         );
-                                        Self::mark_classified_upstream_health_failure(
-                                            "health_check",
-                                            &job.backend_identity,
-                                            job.index,
-                                            Some(&job.upstream_pool),
-                                            task_metrics.as_ref(),
-                                            &classified,
-                                        );
+                                        if let Some(transition) = crate::runtime::connection::outcome::observe_classified_backend_failure(
+                                            crate::runtime::connection::outcome::ClassifiedBackendFailureInput {
+                                                metrics_phase: "health_check",
+                                                backend_addr: &job.backend_identity,
+                                                backend_index: job.index,
+                                                upstream_pool: Some(&job.upstream_pool),
+                                                metrics: task_metrics.as_ref(),
+                                                classified: &classified,
+                                            },
+                                        ) {
+                                            crate::runtime::connection::outcome::log_backend_health_transition(
+                                                &job.backend_identity,
+                                                transition,
+                                            );
+                                        }
                                     } else {
                                         task_metrics
                                             .inc_health_failure(HealthFailureReason::Timeout);
@@ -226,7 +247,10 @@ impl QUICListener {
                             job.next_due_at = Instant::now() + Duration::from_millis(delay_ms);
 
                             if let Some(transition) = transition {
-                                Self::log_health_transition(&job.backend_identity, transition);
+                                crate::runtime::connection::outcome::log_backend_health_transition(
+                                    &job.backend_identity,
+                                    transition,
+                                );
                             }
                         }
                     }

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -55,9 +55,7 @@ use spooky_config::{
     },
 };
 use spooky_errors::{PoolError, ProxyError};
-use spooky_lb::{
-    backend::HealthTransition, health::HealthFailureReason, upstream_pool::UpstreamPool,
-};
+use spooky_lb::{health::HealthFailureReason, upstream_pool::UpstreamPool};
 use spooky_transport::{
     h2_client::{SharedDnsResolver, TlsClientConfig},
     transport_pool::{BackendTransportKind, UpstreamTransportPool},

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -341,6 +341,15 @@ struct BootstrapStreamingBody {
     bytes_seen: usize,
     prebuffered_bytes: usize,
     capped: bool,
+    backend_accounting: Option<BootstrapBackendAccounting>,
+}
+
+struct BootstrapBackendAccounting {
+    upstream_pool: Arc<RwLock<UpstreamPool>>,
+    backend_index: usize,
+    start: Instant,
+    status: Option<u16>,
+    finished: bool,
 }
 
 impl BootstrapStreamingBody {
@@ -352,6 +361,7 @@ impl BootstrapStreamingBody {
             bytes_seen: 0,
             prebuffered_bytes: 0,
             capped: false,
+            backend_accounting: None,
         }
     }
 
@@ -359,6 +369,10 @@ impl BootstrapStreamingBody {
         inner: Incoming,
         max_body_bytes: usize,
         declared_content_length: Option<usize>,
+        upstream_pool: Arc<RwLock<UpstreamPool>>,
+        backend_index: usize,
+        start: Instant,
+        status: Option<u16>,
     ) -> Self {
         Self {
             inner,
@@ -373,6 +387,30 @@ impl BootstrapStreamingBody {
             bytes_seen: 0,
             prebuffered_bytes: 0,
             capped: false,
+            backend_accounting: Some(BootstrapBackendAccounting {
+                upstream_pool,
+                backend_index,
+                start,
+                status,
+                finished: false,
+            }),
+        }
+    }
+
+    fn finish_backend_accounting(&mut self) {
+        if let Some(accounting) = self.backend_accounting.as_mut() {
+            if accounting.finished {
+                return;
+            }
+            crate::runtime::connection::outcome::finish_backend_request_accounting(
+                crate::runtime::connection::outcome::BackendRequestFinishInput {
+                    upstream_pool: Some(&accounting.upstream_pool),
+                    backend_index: Some(accounting.backend_index),
+                    elapsed: accounting.start.elapsed(),
+                    status: accounting.status,
+                },
+            );
+            accounting.finished = true;
         }
     }
 }
@@ -413,15 +451,28 @@ impl Body for BootstrapStreamingBody {
                         self.prebuffered_bytes = next_state.next_state.prebuffered_bytes;
                     } else {
                         self.capped = true;
+                        self.finish_backend_accounting();
                         return Poll::Ready(None);
                     }
                 }
                 Poll::Ready(Some(Ok(frame)))
             }
-            Poll::Ready(Some(Err(_))) => Poll::Ready(None),
-            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Ready(Some(Err(_))) => {
+                self.finish_backend_accounting();
+                Poll::Ready(None)
+            }
+            Poll::Ready(None) => {
+                self.finish_backend_accounting();
+                Poll::Ready(None)
+            }
             Poll::Pending => Poll::Pending,
         }
+    }
+}
+
+impl Drop for BootstrapStreamingBody {
+    fn drop(&mut self) {
+        self.finish_backend_accounting();
     }
 }
 

--- a/crates/edge/src/runtime/connection/mod.rs
+++ b/crates/edge/src/runtime/connection/mod.rs
@@ -1,5 +1,6 @@
 pub mod auth;
 pub(crate) mod guardrails;
+pub mod outcome;
 pub mod quic;
 pub mod request;
 pub mod response;

--- a/crates/edge/src/runtime/connection/outcome.rs
+++ b/crates/edge/src/runtime/connection/outcome.rs
@@ -1,9 +1,10 @@
 use std::time::Duration;
 
 use http::StatusCode;
+use spooky_errors::{PoolError, ProxyError};
 use spooky_lb::health::HealthFailureReason;
 
-use crate::OverloadShedReason;
+use crate::{OverloadShedReason, RouteOutcome};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CanonicalRouteOutcome {
@@ -103,4 +104,249 @@ pub struct RequestOutcomeDecision {
     pub backend_outcome: CanonicalBackendOutcome,
     pub overload_reason: Option<OverloadShedReason>,
     pub health_effect: HealthEffectHint,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AdmissionOutcomeClass {
+    AuthDenied,
+    RateLimited,
+    OverloadShed {
+        reason: Option<OverloadShedReason>,
+    },
+    Failed {
+        timed_out: bool,
+    },
+}
+
+impl CanonicalRouteOutcome {
+    pub fn as_metrics_outcome(self) -> RouteOutcome {
+        match self {
+            Self::Success => RouteOutcome::Success,
+            Self::UpstreamFailure | Self::AuthDenied | Self::Unrouted => RouteOutcome::Failure,
+            Self::Timeout => RouteOutcome::Timeout,
+            Self::OverloadShed => RouteOutcome::OverloadShed,
+            Self::RateLimited => RouteOutcome::RateLimited,
+        }
+    }
+}
+
+impl CanonicalBackendOutcome {
+    fn from_route_outcome(outcome: CanonicalRouteOutcome) -> Self {
+        match outcome {
+            CanonicalRouteOutcome::Success => Self::Success,
+            CanonicalRouteOutcome::UpstreamFailure => Self::UpstreamFailure,
+            CanonicalRouteOutcome::Timeout => Self::Timeout,
+            CanonicalRouteOutcome::OverloadShed => Self::OverloadShed,
+            CanonicalRouteOutcome::RateLimited => Self::RateLimited,
+            CanonicalRouteOutcome::AuthDenied => Self::AuthDenied,
+            CanonicalRouteOutcome::Unrouted => Self::Unrouted,
+        }
+    }
+}
+
+fn health_effect_from_status_class(status_class: OutcomeStatusClass) -> HealthEffectHint {
+    match status_class {
+        OutcomeStatusClass::ServerError => HealthEffectHint::Failure {
+            reason: HealthFailureReason::HttpStatus5xx,
+        },
+        OutcomeStatusClass::ClientError => HealthEffectHint::Neutral,
+        OutcomeStatusClass::Informational
+        | OutcomeStatusClass::Success
+        | OutcomeStatusClass::Redirection => HealthEffectHint::Success,
+        OutcomeStatusClass::Other => HealthEffectHint::None,
+    }
+}
+
+pub fn classify_status_outcome(status: StatusCode) -> RequestOutcomeDecision {
+    let status_class = OutcomeStatusClass::from(status);
+    let route_outcome = match status_class {
+        OutcomeStatusClass::Informational
+        | OutcomeStatusClass::Success
+        | OutcomeStatusClass::Redirection => CanonicalRouteOutcome::Success,
+        OutcomeStatusClass::ClientError => CanonicalRouteOutcome::UpstreamFailure,
+        OutcomeStatusClass::ServerError => CanonicalRouteOutcome::UpstreamFailure,
+        OutcomeStatusClass::Other => CanonicalRouteOutcome::UpstreamFailure,
+    };
+
+    RequestOutcomeDecision {
+        route_outcome,
+        backend_outcome: CanonicalBackendOutcome::from_route_outcome(route_outcome),
+        overload_reason: None,
+        health_effect: health_effect_from_status_class(status_class),
+    }
+}
+
+pub fn classify_proxy_error_outcome(
+    err: &ProxyError,
+    overload_reason: Option<OverloadShedReason>,
+) -> RequestOutcomeDecision {
+    let (route_outcome, health_effect) = match err {
+        ProxyError::Timeout => (
+            CanonicalRouteOutcome::Timeout,
+            HealthEffectHint::Failure {
+                reason: HealthFailureReason::Timeout,
+            },
+        ),
+        ProxyError::Pool(PoolError::BackendOverloaded(_))
+        | ProxyError::Pool(PoolError::CircuitOpen(_)) => {
+            (CanonicalRouteOutcome::OverloadShed, HealthEffectHint::None)
+        }
+        ProxyError::Pool(PoolError::InflightLimiterClosed)
+        | ProxyError::Pool(PoolError::UnknownBackend(_)) => {
+            (CanonicalRouteOutcome::UpstreamFailure, HealthEffectHint::None)
+        }
+        ProxyError::Pool(PoolError::Send(_)) => (
+            CanonicalRouteOutcome::UpstreamFailure,
+            HealthEffectHint::Failure {
+                reason: HealthFailureReason::Transport,
+            },
+        ),
+        ProxyError::Transport(_) | ProxyError::Protocol(_) => (
+            CanonicalRouteOutcome::UpstreamFailure,
+            HealthEffectHint::Failure {
+                reason: HealthFailureReason::Transport,
+            },
+        ),
+        ProxyError::Tls(_) => (CanonicalRouteOutcome::UpstreamFailure, HealthEffectHint::None),
+        ProxyError::Bridge(_) => (CanonicalRouteOutcome::UpstreamFailure, HealthEffectHint::None),
+    };
+
+    RequestOutcomeDecision {
+        route_outcome,
+        backend_outcome: CanonicalBackendOutcome::from_route_outcome(route_outcome),
+        overload_reason,
+        health_effect,
+    }
+}
+
+pub fn classify_admission_outcome(outcome: AdmissionOutcomeClass) -> RequestOutcomeDecision {
+    let (route_outcome, overload_reason) = match outcome {
+        AdmissionOutcomeClass::AuthDenied => (CanonicalRouteOutcome::AuthDenied, None),
+        AdmissionOutcomeClass::RateLimited => (CanonicalRouteOutcome::RateLimited, None),
+        AdmissionOutcomeClass::OverloadShed { reason } => {
+            (CanonicalRouteOutcome::OverloadShed, reason)
+        }
+        AdmissionOutcomeClass::Failed { timed_out } => (
+            if timed_out {
+                CanonicalRouteOutcome::Timeout
+            } else {
+                CanonicalRouteOutcome::UpstreamFailure
+            },
+            None,
+        ),
+    };
+
+    RequestOutcomeDecision {
+        route_outcome,
+        backend_outcome: CanonicalBackendOutcome::from_route_outcome(route_outcome),
+        overload_reason,
+        health_effect: HealthEffectHint::None,
+    }
+}
+
+pub fn classify_request_outcome(input: RequestOutcomeInput<'_>) -> RequestOutcomeDecision {
+    let RequestOutcomeInput {
+        request_outcome,
+        result_class,
+        overload_reason,
+        health_effect,
+        ..
+    } = input;
+
+    let decision = match result_class {
+        OutcomeResultClass::HttpStatus(status_class) => RequestOutcomeDecision {
+            route_outcome: match status_class {
+                OutcomeStatusClass::Informational
+                | OutcomeStatusClass::Success
+                | OutcomeStatusClass::Redirection => CanonicalRouteOutcome::Success,
+                OutcomeStatusClass::ClientError
+                | OutcomeStatusClass::ServerError
+                | OutcomeStatusClass::Other => request_outcome,
+            },
+            backend_outcome: CanonicalBackendOutcome::from_route_outcome(request_outcome),
+            overload_reason,
+            health_effect: health_effect_from_status_class(status_class),
+        },
+        OutcomeResultClass::UpstreamError | OutcomeResultClass::InternalError => {
+            RequestOutcomeDecision {
+                route_outcome: request_outcome,
+                backend_outcome: CanonicalBackendOutcome::from_route_outcome(request_outcome),
+                overload_reason,
+                health_effect,
+            }
+        }
+        OutcomeResultClass::Timeout => RequestOutcomeDecision {
+            route_outcome: CanonicalRouteOutcome::Timeout,
+            backend_outcome: CanonicalBackendOutcome::Timeout,
+            overload_reason,
+            health_effect,
+        },
+        OutcomeResultClass::Overload => RequestOutcomeDecision {
+            route_outcome: CanonicalRouteOutcome::OverloadShed,
+            backend_outcome: CanonicalBackendOutcome::OverloadShed,
+            overload_reason,
+            health_effect,
+        },
+        OutcomeResultClass::RateLimited => RequestOutcomeDecision {
+            route_outcome: CanonicalRouteOutcome::RateLimited,
+            backend_outcome: CanonicalBackendOutcome::RateLimited,
+            overload_reason,
+            health_effect,
+        },
+        OutcomeResultClass::AuthDenied => RequestOutcomeDecision {
+            route_outcome: CanonicalRouteOutcome::AuthDenied,
+            backend_outcome: CanonicalBackendOutcome::AuthDenied,
+            overload_reason,
+            health_effect,
+        },
+        OutcomeResultClass::Unrouted => RequestOutcomeDecision {
+            route_outcome: CanonicalRouteOutcome::Unrouted,
+            backend_outcome: CanonicalBackendOutcome::Unrouted,
+            overload_reason,
+            health_effect,
+        },
+    };
+
+    RequestOutcomeDecision {
+        route_outcome: decision.route_outcome,
+        backend_outcome: decision.backend_outcome,
+        overload_reason: decision.overload_reason,
+        health_effect: decision.health_effect,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_success_status_as_success() {
+        let decision = classify_status_outcome(StatusCode::OK);
+        assert_eq!(decision.route_outcome, CanonicalRouteOutcome::Success);
+        assert_eq!(decision.backend_outcome, CanonicalBackendOutcome::Success);
+        assert_eq!(decision.health_effect, HealthEffectHint::Success);
+    }
+
+    #[test]
+    fn classifies_timeout_proxy_error_as_timeout() {
+        let decision = classify_proxy_error_outcome(&ProxyError::Timeout, None);
+        assert_eq!(decision.route_outcome, CanonicalRouteOutcome::Timeout);
+        assert_eq!(decision.backend_outcome, CanonicalBackendOutcome::Timeout);
+        assert_eq!(
+            decision.health_effect,
+            HealthEffectHint::Failure {
+                reason: HealthFailureReason::Timeout,
+            }
+        );
+    }
+
+    #[test]
+    fn classifies_overload_admission_outcome() {
+        let decision = classify_admission_outcome(AdmissionOutcomeClass::OverloadShed {
+            reason: Some(OverloadShedReason::GlobalInflight),
+        });
+        assert_eq!(decision.route_outcome, CanonicalRouteOutcome::OverloadShed);
+        assert_eq!(decision.backend_outcome, CanonicalBackendOutcome::OverloadShed);
+        assert_eq!(decision.overload_reason, Some(OverloadShedReason::GlobalInflight));
+    }
 }

--- a/crates/edge/src/runtime/connection/outcome.rs
+++ b/crates/edge/src/runtime/connection/outcome.rs
@@ -1,0 +1,106 @@
+use std::time::Duration;
+
+use http::StatusCode;
+use spooky_lb::health::HealthFailureReason;
+
+use crate::OverloadShedReason;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CanonicalRouteOutcome {
+    Success,
+    UpstreamFailure,
+    Timeout,
+    OverloadShed,
+    RateLimited,
+    AuthDenied,
+    Unrouted,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CanonicalBackendOutcome {
+    Success,
+    UpstreamFailure,
+    Timeout,
+    OverloadShed,
+    RateLimited,
+    AuthDenied,
+    Unrouted,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OutcomeStatusClass {
+    Informational,
+    Success,
+    Redirection,
+    ClientError,
+    ServerError,
+    Other,
+}
+
+impl From<StatusCode> for OutcomeStatusClass {
+    fn from(status: StatusCode) -> Self {
+        match status.as_u16() {
+            100..=199 => Self::Informational,
+            200..=299 => Self::Success,
+            300..=399 => Self::Redirection,
+            400..=499 => Self::ClientError,
+            500..=599 => Self::ServerError,
+            _ => Self::Other,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OutcomeResultClass {
+    HttpStatus(OutcomeStatusClass),
+    UpstreamError,
+    Timeout,
+    Overload,
+    RateLimited,
+    AuthDenied,
+    Unrouted,
+    InternalError,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HealthEffectHint {
+    None,
+    Success,
+    Neutral,
+    Failure { reason: HealthFailureReason },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct OutcomeRouteTarget<'a> {
+    pub route: &'a str,
+}
+
+impl<'a> OutcomeRouteTarget<'a> {
+    pub const UNROUTED: Self = Self { route: "unrouted" };
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct OutcomeBackendTarget<'a> {
+    pub upstream: &'a str,
+    pub backend_addr: Option<&'a str>,
+    pub backend_index: Option<usize>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RequestOutcomeInput<'a> {
+    pub request_outcome: CanonicalRouteOutcome,
+    pub route_target: OutcomeRouteTarget<'a>,
+    pub backend_target: Option<OutcomeBackendTarget<'a>>,
+    pub elapsed: Duration,
+    pub result_class: OutcomeResultClass,
+    pub overload_reason: Option<OverloadShedReason>,
+    pub health_effect: HealthEffectHint,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RequestOutcomeDecision {
+    pub route_outcome: CanonicalRouteOutcome,
+    pub backend_outcome: CanonicalBackendOutcome,
+    pub overload_reason: Option<OverloadShedReason>,
+    pub health_effect: HealthEffectHint,
+}

--- a/crates/edge/src/runtime/connection/outcome.rs
+++ b/crates/edge/src/runtime/connection/outcome.rs
@@ -106,6 +106,16 @@ pub struct RequestOutcomeDecision {
     pub health_effect: HealthEffectHint,
 }
 
+#[derive(Clone, Copy, Debug)]
+pub struct RequestMetricsObservation<'a> {
+    pub route_target: OutcomeRouteTarget<'a>,
+    pub backend_target: Option<OutcomeBackendTarget<'a>>,
+    pub elapsed: Duration,
+    pub status: Option<u16>,
+    pub metrics_outcome: RouteOutcome,
+    pub overload_reason: Option<OverloadShedReason>,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum AdmissionOutcomeClass {
     AuthDenied,
@@ -313,6 +323,41 @@ pub fn classify_request_outcome(input: RequestOutcomeInput<'_>) -> RequestOutcom
         overload_reason: decision.overload_reason,
         health_effect: decision.health_effect,
     }
+}
+
+pub fn record_request_metrics_observation(
+    metrics: &crate::Metrics,
+    observation: RequestMetricsObservation<'_>,
+) {
+    let RequestMetricsObservation {
+        route_target,
+        backend_target,
+        elapsed,
+        status,
+        metrics_outcome,
+        overload_reason,
+    } = observation;
+
+    if !matches!(metrics_outcome, RouteOutcome::Success) {
+        metrics.inc_failure();
+    }
+
+    if matches!(metrics_outcome, RouteOutcome::OverloadShed) {
+        if let Some(reason) = overload_reason {
+            metrics.inc_overload_shed_reason(reason);
+        } else {
+            metrics.inc_overload_shed();
+        }
+    }
+
+    metrics.record_route(route_target.route, elapsed, metrics_outcome);
+    metrics.record_request_result(
+        route_target.route,
+        backend_target.and_then(|target| target.backend_addr),
+        status,
+        metrics_outcome,
+        elapsed,
+    );
 }
 
 #[cfg(test)]

--- a/crates/edge/src/runtime/connection/outcome.rs
+++ b/crates/edge/src/runtime/connection/outcome.rs
@@ -13,29 +13,27 @@ use spooky_lb::{
 use crate::{Metrics, OverloadShedReason, RouteOutcome, runtime::health::outcome_from_status};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum CanonicalRouteOutcome {
+pub(crate) enum CanonicalRouteOutcome {
     Success,
     UpstreamFailure,
     Timeout,
     OverloadShed,
     RateLimited,
     AuthDenied,
-    Unrouted,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum CanonicalBackendOutcome {
+pub(crate) enum CanonicalBackendOutcome {
     Success,
     UpstreamFailure,
     Timeout,
     OverloadShed,
     RateLimited,
     AuthDenied,
-    Unrouted,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum OutcomeStatusClass {
+pub(crate) enum OutcomeStatusClass {
     Informational,
     Success,
     Redirection,
@@ -58,19 +56,7 @@ impl From<StatusCode> for OutcomeStatusClass {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum OutcomeResultClass {
-    HttpStatus(OutcomeStatusClass),
-    UpstreamError,
-    Timeout,
-    Overload,
-    RateLimited,
-    AuthDenied,
-    Unrouted,
-    InternalError,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum HealthEffectHint {
+enum HealthEffectHint {
     None,
     Success,
     Neutral,
@@ -78,52 +64,41 @@ pub enum HealthEffectHint {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct OutcomeRouteTarget<'a> {
-    pub route: &'a str,
+pub(crate) struct OutcomeRouteTarget<'a> {
+    pub(crate) route: &'a str,
 }
 
 impl<'a> OutcomeRouteTarget<'a> {
-    pub const UNROUTED: Self = Self { route: "unrouted" };
+    pub(crate) const UNROUTED: Self = Self { route: "unrouted" };
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct OutcomeBackendTarget<'a> {
-    pub upstream: &'a str,
-    pub backend_addr: Option<&'a str>,
-    pub backend_index: Option<usize>,
+pub(crate) struct OutcomeBackendTarget<'a> {
+    pub(crate) upstream: &'a str,
+    pub(crate) backend_addr: Option<&'a str>,
+    pub(crate) backend_index: Option<usize>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct RequestOutcomeInput<'a> {
-    pub request_outcome: CanonicalRouteOutcome,
-    pub route_target: OutcomeRouteTarget<'a>,
-    pub backend_target: Option<OutcomeBackendTarget<'a>>,
-    pub elapsed: Duration,
-    pub result_class: OutcomeResultClass,
-    pub overload_reason: Option<OverloadShedReason>,
-    pub health_effect: HealthEffectHint,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct RequestOutcomeDecision {
-    pub route_outcome: CanonicalRouteOutcome,
-    pub backend_outcome: CanonicalBackendOutcome,
-    pub overload_reason: Option<OverloadShedReason>,
-    pub health_effect: HealthEffectHint,
+pub(crate) struct RequestOutcomeDecision {
+    pub(crate) route_outcome: CanonicalRouteOutcome,
+    pub(crate) backend_outcome: CanonicalBackendOutcome,
+    pub(crate) overload_reason: Option<OverloadShedReason>,
+    health_effect: HealthEffectHint,
 }
 
 #[derive(Clone, Copy, Debug)]
-pub struct RequestMetricsObservation<'a> {
-    pub route_target: OutcomeRouteTarget<'a>,
-    pub backend_target: Option<OutcomeBackendTarget<'a>>,
-    pub elapsed: Duration,
-    pub status: Option<u16>,
-    pub metrics_outcome: RouteOutcome,
-    pub overload_reason: Option<OverloadShedReason>,
+pub(crate) struct RequestMetricsObservation<'a> {
+    pub(crate) route_target: OutcomeRouteTarget<'a>,
+    pub(crate) backend_target: Option<OutcomeBackendTarget<'a>>,
+    pub(crate) elapsed: Duration,
+    pub(crate) status: Option<u16>,
+    pub(crate) metrics_outcome: RouteOutcome,
+    pub(crate) overload_reason: Option<OverloadShedReason>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum AdmissionOutcomeClass {
+pub(crate) enum AdmissionOutcomeClass {
     AuthDenied,
     RateLimited,
     OverloadShed {
@@ -135,10 +110,10 @@ pub enum AdmissionOutcomeClass {
 }
 
 impl CanonicalRouteOutcome {
-    pub fn as_metrics_outcome(self) -> RouteOutcome {
+    pub(crate) fn as_metrics_outcome(self) -> RouteOutcome {
         match self {
             Self::Success => RouteOutcome::Success,
-            Self::UpstreamFailure | Self::AuthDenied | Self::Unrouted => RouteOutcome::Failure,
+            Self::UpstreamFailure | Self::AuthDenied => RouteOutcome::Failure,
             Self::Timeout => RouteOutcome::Timeout,
             Self::OverloadShed => RouteOutcome::OverloadShed,
             Self::RateLimited => RouteOutcome::RateLimited,
@@ -155,7 +130,6 @@ impl CanonicalBackendOutcome {
             CanonicalRouteOutcome::OverloadShed => Self::OverloadShed,
             CanonicalRouteOutcome::RateLimited => Self::RateLimited,
             CanonicalRouteOutcome::AuthDenied => Self::AuthDenied,
-            CanonicalRouteOutcome::Unrouted => Self::Unrouted,
         }
     }
 }
@@ -173,7 +147,7 @@ fn health_effect_from_status_class(status_class: OutcomeStatusClass) -> HealthEf
     }
 }
 
-pub fn classify_status_outcome(status: StatusCode) -> RequestOutcomeDecision {
+pub(crate) fn classify_status_outcome(status: StatusCode) -> RequestOutcomeDecision {
     let status_class = OutcomeStatusClass::from(status);
     let route_outcome = match status_class {
         OutcomeStatusClass::Informational
@@ -192,7 +166,7 @@ pub fn classify_status_outcome(status: StatusCode) -> RequestOutcomeDecision {
     }
 }
 
-pub fn classify_proxy_error_outcome(
+pub(crate) fn classify_proxy_error_outcome(
     err: &ProxyError,
     overload_reason: Option<OverloadShedReason>,
 ) -> RequestOutcomeDecision {
@@ -235,7 +209,7 @@ pub fn classify_proxy_error_outcome(
     }
 }
 
-pub fn classify_admission_outcome(outcome: AdmissionOutcomeClass) -> RequestOutcomeDecision {
+pub(crate) fn classify_admission_outcome(outcome: AdmissionOutcomeClass) -> RequestOutcomeDecision {
     let (route_outcome, overload_reason) = match outcome {
         AdmissionOutcomeClass::AuthDenied => (CanonicalRouteOutcome::AuthDenied, None),
         AdmissionOutcomeClass::RateLimited => (CanonicalRouteOutcome::RateLimited, None),
@@ -260,78 +234,7 @@ pub fn classify_admission_outcome(outcome: AdmissionOutcomeClass) -> RequestOutc
     }
 }
 
-pub fn classify_request_outcome(input: RequestOutcomeInput<'_>) -> RequestOutcomeDecision {
-    let RequestOutcomeInput {
-        request_outcome,
-        result_class,
-        overload_reason,
-        health_effect,
-        ..
-    } = input;
-
-    let decision = match result_class {
-        OutcomeResultClass::HttpStatus(status_class) => RequestOutcomeDecision {
-            route_outcome: match status_class {
-                OutcomeStatusClass::Informational
-                | OutcomeStatusClass::Success
-                | OutcomeStatusClass::Redirection => CanonicalRouteOutcome::Success,
-                OutcomeStatusClass::ClientError
-                | OutcomeStatusClass::ServerError
-                | OutcomeStatusClass::Other => request_outcome,
-            },
-            backend_outcome: CanonicalBackendOutcome::from_route_outcome(request_outcome),
-            overload_reason,
-            health_effect: health_effect_from_status_class(status_class),
-        },
-        OutcomeResultClass::UpstreamError | OutcomeResultClass::InternalError => {
-            RequestOutcomeDecision {
-                route_outcome: request_outcome,
-                backend_outcome: CanonicalBackendOutcome::from_route_outcome(request_outcome),
-                overload_reason,
-                health_effect,
-            }
-        }
-        OutcomeResultClass::Timeout => RequestOutcomeDecision {
-            route_outcome: CanonicalRouteOutcome::Timeout,
-            backend_outcome: CanonicalBackendOutcome::Timeout,
-            overload_reason,
-            health_effect,
-        },
-        OutcomeResultClass::Overload => RequestOutcomeDecision {
-            route_outcome: CanonicalRouteOutcome::OverloadShed,
-            backend_outcome: CanonicalBackendOutcome::OverloadShed,
-            overload_reason,
-            health_effect,
-        },
-        OutcomeResultClass::RateLimited => RequestOutcomeDecision {
-            route_outcome: CanonicalRouteOutcome::RateLimited,
-            backend_outcome: CanonicalBackendOutcome::RateLimited,
-            overload_reason,
-            health_effect,
-        },
-        OutcomeResultClass::AuthDenied => RequestOutcomeDecision {
-            route_outcome: CanonicalRouteOutcome::AuthDenied,
-            backend_outcome: CanonicalBackendOutcome::AuthDenied,
-            overload_reason,
-            health_effect,
-        },
-        OutcomeResultClass::Unrouted => RequestOutcomeDecision {
-            route_outcome: CanonicalRouteOutcome::Unrouted,
-            backend_outcome: CanonicalBackendOutcome::Unrouted,
-            overload_reason,
-            health_effect,
-        },
-    };
-
-    RequestOutcomeDecision {
-        route_outcome: decision.route_outcome,
-        backend_outcome: decision.backend_outcome,
-        overload_reason: decision.overload_reason,
-        health_effect: decision.health_effect,
-    }
-}
-
-pub fn record_request_metrics_observation(
+pub(crate) fn record_request_metrics_observation(
     metrics: &crate::Metrics,
     observation: RequestMetricsObservation<'_>,
 ) {
@@ -366,7 +269,7 @@ pub fn record_request_metrics_observation(
     );
 }
 
-pub fn observe_request_outcome(
+pub(crate) fn observe_request_outcome(
     metrics: &Metrics,
     route_target: OutcomeRouteTarget<'_>,
     backend_target: Option<OutcomeBackendTarget<'_>>,
@@ -393,7 +296,7 @@ pub fn observe_request_outcome(
     decision
 }
 
-pub fn observe_status_outcome(
+pub(crate) fn observe_status_outcome(
     metrics: &Metrics,
     route_target: OutcomeRouteTarget<'_>,
     backend_target: Option<OutcomeBackendTarget<'_>>,
@@ -410,7 +313,7 @@ pub fn observe_status_outcome(
     )
 }
 
-pub fn observe_proxy_error_outcome(
+pub(crate) fn observe_proxy_error_outcome(
     metrics: &Metrics,
     route_target: OutcomeRouteTarget<'_>,
     backend_target: Option<OutcomeBackendTarget<'_>>,
@@ -429,7 +332,7 @@ pub fn observe_proxy_error_outcome(
     )
 }
 
-pub fn observe_admission_outcome(
+pub(crate) fn observe_admission_outcome(
     metrics: &Metrics,
     route_target: OutcomeRouteTarget<'_>,
     backend_target: Option<OutcomeBackendTarget<'_>>,
@@ -448,32 +351,32 @@ pub fn observe_admission_outcome(
 }
 
 #[derive(Clone, Copy)]
-pub struct BackendRequestFinishInput<'a> {
-    pub upstream_pool: Option<&'a Arc<RwLock<UpstreamPool>>>,
-    pub backend_index: Option<usize>,
-    pub elapsed: Duration,
-    pub status: Option<u16>,
+pub(crate) struct BackendRequestFinishInput<'a> {
+    pub(crate) upstream_pool: Option<&'a Arc<RwLock<UpstreamPool>>>,
+    pub(crate) backend_index: Option<usize>,
+    pub(crate) elapsed: Duration,
+    pub(crate) status: Option<u16>,
 }
 
 #[derive(Clone, Copy)]
-pub struct BackendHealthObservationInput<'a> {
-    pub backend_addr: &'a str,
-    pub backend_index: usize,
-    pub upstream_pool: Option<&'a Arc<RwLock<UpstreamPool>>>,
-    pub status: StatusCode,
+pub(crate) struct BackendHealthObservationInput<'a> {
+    pub(crate) backend_addr: &'a str,
+    pub(crate) backend_index: usize,
+    pub(crate) upstream_pool: Option<&'a Arc<RwLock<UpstreamPool>>>,
+    pub(crate) status: StatusCode,
 }
 
 #[derive(Clone, Copy)]
-pub struct ClassifiedBackendFailureInput<'a> {
-    pub metrics_phase: &'a str,
-    pub backend_addr: &'a str,
-    pub backend_index: usize,
-    pub upstream_pool: Option<&'a Arc<RwLock<UpstreamPool>>>,
-    pub metrics: &'a Metrics,
-    pub classified: &'a ClassifiedUpstreamProxyError,
+pub(crate) struct ClassifiedBackendFailureInput<'a> {
+    pub(crate) metrics_phase: &'a str,
+    pub(crate) backend_addr: &'a str,
+    pub(crate) backend_index: usize,
+    pub(crate) upstream_pool: Option<&'a Arc<RwLock<UpstreamPool>>>,
+    pub(crate) metrics: &'a Metrics,
+    pub(crate) classified: &'a ClassifiedUpstreamProxyError,
 }
 
-pub fn finish_backend_request_accounting(input: BackendRequestFinishInput<'_>) {
+pub(crate) fn finish_backend_request_accounting(input: BackendRequestFinishInput<'_>) {
     let BackendRequestFinishInput {
         upstream_pool,
         backend_index,
@@ -488,7 +391,7 @@ pub fn finish_backend_request_accounting(input: BackendRequestFinishInput<'_>) {
     }
 }
 
-pub fn observe_backend_response_status(
+pub(crate) fn observe_backend_response_status(
     input: BackendHealthObservationInput<'_>,
 ) -> Option<HealthTransition> {
     let BackendHealthObservationInput {
@@ -510,7 +413,7 @@ pub fn observe_backend_response_status(
     }
 }
 
-pub fn observe_classified_backend_failure(
+pub(crate) fn observe_classified_backend_failure(
     input: ClassifiedBackendFailureInput<'_>,
 ) -> Option<HealthTransition> {
     let ClassifiedBackendFailureInput {
@@ -537,7 +440,7 @@ pub fn observe_classified_backend_failure(
         .mark_request_failure(backend_index, health_mapping.failure_reason)
 }
 
-pub fn log_backend_health_transition(addr: &str, transition: HealthTransition) {
+pub(crate) fn log_backend_health_transition(addr: &str, transition: HealthTransition) {
     match transition {
         HealthTransition::BecameHealthy => {
             info!("Backend {} became healthy", addr);

--- a/crates/edge/src/runtime/connection/outcome.rs
+++ b/crates/edge/src/runtime/connection/outcome.rs
@@ -1,10 +1,16 @@
-use std::time::Duration;
+use std::{
+    sync::{Arc, RwLock},
+    time::Duration,
+};
 
 use http::StatusCode;
-use spooky_errors::{PoolError, ProxyError};
-use spooky_lb::health::HealthFailureReason;
+use log::{error, info};
+use spooky_errors::{ClassifiedUpstreamProxyError, PoolError, ProxyError};
+use spooky_lb::{
+    backend::HealthTransition, health::HealthFailureReason, upstream_pool::UpstreamPool,
+};
 
-use crate::{OverloadShedReason, RouteOutcome};
+use crate::{Metrics, OverloadShedReason, RouteOutcome, runtime::health::outcome_from_status};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CanonicalRouteOutcome {
@@ -358,6 +364,107 @@ pub fn record_request_metrics_observation(
         metrics_outcome,
         elapsed,
     );
+}
+
+#[derive(Clone, Copy)]
+pub struct BackendRequestFinishInput<'a> {
+    pub upstream_pool: Option<&'a Arc<RwLock<UpstreamPool>>>,
+    pub backend_index: Option<usize>,
+    pub elapsed: Duration,
+    pub status: Option<u16>,
+}
+
+#[derive(Clone, Copy)]
+pub struct BackendHealthObservationInput<'a> {
+    pub backend_addr: &'a str,
+    pub backend_index: usize,
+    pub upstream_pool: Option<&'a Arc<RwLock<UpstreamPool>>>,
+    pub status: StatusCode,
+}
+
+#[derive(Clone, Copy)]
+pub struct ClassifiedBackendFailureInput<'a> {
+    pub metrics_phase: &'a str,
+    pub backend_addr: &'a str,
+    pub backend_index: usize,
+    pub upstream_pool: Option<&'a Arc<RwLock<UpstreamPool>>>,
+    pub metrics: &'a Metrics,
+    pub classified: &'a ClassifiedUpstreamProxyError,
+}
+
+pub fn finish_backend_request_accounting(input: BackendRequestFinishInput<'_>) {
+    let BackendRequestFinishInput {
+        upstream_pool,
+        backend_index,
+        elapsed,
+        status,
+    } = input;
+
+    if let (Some(pool), Some(index)) = (upstream_pool, backend_index)
+        && let Ok(mut guard) = pool.write()
+    {
+        guard.finish_request(index, elapsed, status);
+    }
+}
+
+pub fn observe_backend_response_status(
+    input: BackendHealthObservationInput<'_>,
+) -> Option<HealthTransition> {
+    let BackendHealthObservationInput {
+        backend_addr: _backend_addr,
+        backend_index,
+        upstream_pool,
+        status,
+    } = input;
+
+    let pool = upstream_pool?;
+    let mut pool = pool.write().ok()?;
+    match outcome_from_status(status) {
+        crate::runtime::health::HealthClassification::Success => pool.pool.mark_success(backend_index),
+        crate::runtime::health::HealthClassification::Failure => {
+            pool.pool
+                .mark_request_failure(backend_index, HealthFailureReason::HttpStatus5xx)
+        }
+        crate::runtime::health::HealthClassification::Neutral => None,
+    }
+}
+
+pub fn observe_classified_backend_failure(
+    input: ClassifiedBackendFailureInput<'_>,
+) -> Option<HealthTransition> {
+    let ClassifiedBackendFailureInput {
+        metrics_phase,
+        backend_addr,
+        backend_index,
+        upstream_pool,
+        metrics,
+        classified,
+    } = input;
+
+    let health_mapping = classified.health_failure?;
+    metrics.inc_health_failure(health_mapping.failure_reason);
+    if health_mapping.failure_reason == HealthFailureReason::Tls {
+        metrics.record_upstream_tls_failure(
+            backend_addr,
+            metrics_phase,
+            health_mapping.metrics_reason,
+        );
+    }
+    let pool = upstream_pool?;
+    let mut pool = pool.write().ok()?;
+    pool.pool
+        .mark_request_failure(backend_index, health_mapping.failure_reason)
+}
+
+pub fn log_backend_health_transition(addr: &str, transition: HealthTransition) {
+    match transition {
+        HealthTransition::BecameHealthy => {
+            info!("Backend {} became healthy", addr);
+        }
+        HealthTransition::BecameUnhealthy => {
+            error!("Backend {} became unhealthy", addr);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/edge/src/runtime/connection/outcome.rs
+++ b/crates/edge/src/runtime/connection/outcome.rs
@@ -366,6 +366,87 @@ pub fn record_request_metrics_observation(
     );
 }
 
+pub fn observe_request_outcome(
+    metrics: &Metrics,
+    route_target: OutcomeRouteTarget<'_>,
+    backend_target: Option<OutcomeBackendTarget<'_>>,
+    elapsed: Duration,
+    status: Option<StatusCode>,
+    decision: RequestOutcomeDecision,
+) -> RequestOutcomeDecision {
+    if matches!(decision.route_outcome, CanonicalRouteOutcome::Success) {
+        metrics.inc_success();
+    }
+
+    record_request_metrics_observation(
+        metrics,
+        RequestMetricsObservation {
+            route_target,
+            backend_target,
+            elapsed,
+            status: status.map(|value| value.as_u16()),
+            metrics_outcome: decision.route_outcome.as_metrics_outcome(),
+            overload_reason: decision.overload_reason,
+        },
+    );
+
+    decision
+}
+
+pub fn observe_status_outcome(
+    metrics: &Metrics,
+    route_target: OutcomeRouteTarget<'_>,
+    backend_target: Option<OutcomeBackendTarget<'_>>,
+    elapsed: Duration,
+    status: StatusCode,
+) -> RequestOutcomeDecision {
+    observe_request_outcome(
+        metrics,
+        route_target,
+        backend_target,
+        elapsed,
+        Some(status),
+        classify_status_outcome(status),
+    )
+}
+
+pub fn observe_proxy_error_outcome(
+    metrics: &Metrics,
+    route_target: OutcomeRouteTarget<'_>,
+    backend_target: Option<OutcomeBackendTarget<'_>>,
+    elapsed: Duration,
+    status: Option<StatusCode>,
+    err: &ProxyError,
+    overload_reason: Option<OverloadShedReason>,
+) -> RequestOutcomeDecision {
+    observe_request_outcome(
+        metrics,
+        route_target,
+        backend_target,
+        elapsed,
+        status,
+        classify_proxy_error_outcome(err, overload_reason),
+    )
+}
+
+pub fn observe_admission_outcome(
+    metrics: &Metrics,
+    route_target: OutcomeRouteTarget<'_>,
+    backend_target: Option<OutcomeBackendTarget<'_>>,
+    elapsed: Duration,
+    status: StatusCode,
+    outcome: AdmissionOutcomeClass,
+) -> RequestOutcomeDecision {
+    observe_request_outcome(
+        metrics,
+        route_target,
+        backend_target,
+        elapsed,
+        Some(status),
+        classify_admission_outcome(outcome),
+    )
+}
+
 #[derive(Clone, Copy)]
 pub struct BackendRequestFinishInput<'a> {
     pub upstream_pool: Option<&'a Arc<RwLock<UpstreamPool>>>,

--- a/crates/edge/src/runtime/connection/outcome.rs
+++ b/crates/edge/src/runtime/connection/outcome.rs
@@ -101,12 +101,8 @@ pub(crate) struct RequestMetricsObservation<'a> {
 pub(crate) enum AdmissionOutcomeClass {
     AuthDenied,
     RateLimited,
-    OverloadShed {
-        reason: Option<OverloadShedReason>,
-    },
-    Failed {
-        timed_out: bool,
-    },
+    OverloadShed { reason: Option<OverloadShedReason> },
+    Failed { timed_out: bool },
 }
 
 impl CanonicalRouteOutcome {
@@ -182,9 +178,10 @@ pub(crate) fn classify_proxy_error_outcome(
             (CanonicalRouteOutcome::OverloadShed, HealthEffectHint::None)
         }
         ProxyError::Pool(PoolError::InflightLimiterClosed)
-        | ProxyError::Pool(PoolError::UnknownBackend(_)) => {
-            (CanonicalRouteOutcome::UpstreamFailure, HealthEffectHint::None)
-        }
+        | ProxyError::Pool(PoolError::UnknownBackend(_)) => (
+            CanonicalRouteOutcome::UpstreamFailure,
+            HealthEffectHint::None,
+        ),
         ProxyError::Pool(PoolError::Send(_)) => (
             CanonicalRouteOutcome::UpstreamFailure,
             HealthEffectHint::Failure {
@@ -197,8 +194,14 @@ pub(crate) fn classify_proxy_error_outcome(
                 reason: HealthFailureReason::Transport,
             },
         ),
-        ProxyError::Tls(_) => (CanonicalRouteOutcome::UpstreamFailure, HealthEffectHint::None),
-        ProxyError::Bridge(_) => (CanonicalRouteOutcome::UpstreamFailure, HealthEffectHint::None),
+        ProxyError::Tls(_) => (
+            CanonicalRouteOutcome::UpstreamFailure,
+            HealthEffectHint::None,
+        ),
+        ProxyError::Bridge(_) => (
+            CanonicalRouteOutcome::UpstreamFailure,
+            HealthEffectHint::None,
+        ),
     };
 
     RequestOutcomeDecision {
@@ -404,11 +407,12 @@ pub(crate) fn observe_backend_response_status(
     let pool = upstream_pool?;
     let mut pool = pool.write().ok()?;
     match outcome_from_status(status) {
-        crate::runtime::health::HealthClassification::Success => pool.pool.mark_success(backend_index),
-        crate::runtime::health::HealthClassification::Failure => {
-            pool.pool
-                .mark_request_failure(backend_index, HealthFailureReason::HttpStatus5xx)
+        crate::runtime::health::HealthClassification::Success => {
+            pool.pool.mark_success(backend_index)
         }
+        crate::runtime::health::HealthClassification::Failure => pool
+            .pool
+            .mark_request_failure(backend_index, HealthFailureReason::HttpStatus5xx),
         crate::runtime::health::HealthClassification::Neutral => None,
     }
 }
@@ -453,13 +457,14 @@ pub(crate) fn log_backend_health_transition(addr: &str, transition: HealthTransi
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::time::Duration;
 
     use spooky_config::config::{
         Backend, ForwardedHeaderPolicy, HealthCheck, LoadBalancing, RouteAuth, RouteMatch,
         Upstream, UpstreamHostPolicy,
     };
+
+    use super::*;
 
     fn test_metrics() -> Metrics {
         Metrics::new(1, [String::from("api"), String::from("unrouted")])
@@ -564,8 +569,14 @@ mod tests {
             reason: Some(OverloadShedReason::GlobalInflight),
         });
         assert_eq!(decision.route_outcome, CanonicalRouteOutcome::OverloadShed);
-        assert_eq!(decision.backend_outcome, CanonicalBackendOutcome::OverloadShed);
-        assert_eq!(decision.overload_reason, Some(OverloadShedReason::GlobalInflight));
+        assert_eq!(
+            decision.backend_outcome,
+            CanonicalBackendOutcome::OverloadShed
+        );
+        assert_eq!(
+            decision.overload_reason,
+            Some(OverloadShedReason::GlobalInflight)
+        );
     }
 
     #[test]
@@ -585,8 +596,18 @@ mod tests {
         );
 
         assert_eq!(decision.route_outcome, CanonicalRouteOutcome::Success);
-        assert_eq!(metrics.requests_success.load(std::sync::atomic::Ordering::Relaxed), 1);
-        assert_eq!(metrics.requests_failure.load(std::sync::atomic::Ordering::Relaxed), 0);
+        assert_eq!(
+            metrics
+                .requests_success
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1
+        );
+        assert_eq!(
+            metrics
+                .requests_failure
+                .load(std::sync::atomic::Ordering::Relaxed),
+            0
+        );
         assert_eq!(upstream_request_count(&metrics, "api", "2xx", "success"), 1);
         assert_eq!(
             backend_request_count(&metrics, "api", "backend-a", "2xx", "success"),
@@ -622,10 +643,21 @@ mod tests {
         );
 
         assert_eq!(timeout.route_outcome, CanonicalRouteOutcome::Timeout);
-        assert_eq!(unrouted.route_outcome, CanonicalRouteOutcome::UpstreamFailure);
-        assert_eq!(metrics.requests_failure.load(std::sync::atomic::Ordering::Relaxed), 2);
+        assert_eq!(
+            unrouted.route_outcome,
+            CanonicalRouteOutcome::UpstreamFailure
+        );
+        assert_eq!(
+            metrics
+                .requests_failure
+                .load(std::sync::atomic::Ordering::Relaxed),
+            2
+        );
         assert_eq!(upstream_request_count(&metrics, "api", "4xx", "timeout"), 1);
-        assert_eq!(upstream_request_count(&metrics, "unrouted", "5xx", "failure"), 1);
+        assert_eq!(
+            upstream_request_count(&metrics, "unrouted", "5xx", "failure"),
+            1
+        );
     }
 
     #[test]
@@ -673,17 +705,31 @@ mod tests {
 
         assert_eq!(overload.route_outcome, CanonicalRouteOutcome::OverloadShed);
         assert_eq!(auth.route_outcome, CanonicalRouteOutcome::AuthDenied);
-        assert_eq!(rate_limited.route_outcome, CanonicalRouteOutcome::RateLimited);
-        assert_eq!(metrics.overload_shed.load(std::sync::atomic::Ordering::Relaxed), 1);
+        assert_eq!(
+            rate_limited.route_outcome,
+            CanonicalRouteOutcome::RateLimited
+        );
+        assert_eq!(
+            metrics
+                .overload_shed
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1
+        );
         assert_eq!(
             metrics
                 .overload_shed_global_inflight
                 .load(std::sync::atomic::Ordering::Relaxed),
             1
         );
-        assert_eq!(upstream_request_count(&metrics, "api", "5xx", "overload_shed"), 1);
+        assert_eq!(
+            upstream_request_count(&metrics, "api", "5xx", "overload_shed"),
+            1
+        );
         assert_eq!(upstream_request_count(&metrics, "api", "4xx", "failure"), 1);
-        assert_eq!(upstream_request_count(&metrics, "api", "4xx", "rate_limited"), 1);
+        assert_eq!(
+            upstream_request_count(&metrics, "api", "4xx", "rate_limited"),
+            1
+        );
     }
 
     #[test]
@@ -733,7 +779,10 @@ mod tests {
             metrics: &metrics,
             classified: &classified,
         });
-        assert!(matches!(transition, Some(HealthTransition::BecameUnhealthy)));
+        assert!(matches!(
+            transition,
+            Some(HealthTransition::BecameUnhealthy)
+        ));
         assert_eq!(
             metrics
                 .health_failure_timeout

--- a/crates/edge/src/runtime/connection/outcome.rs
+++ b/crates/edge/src/runtime/connection/outcome.rs
@@ -551,6 +551,88 @@ pub fn log_backend_health_transition(addr: &str, transition: HealthTransition) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
+
+    use spooky_config::config::{
+        Backend, ForwardedHeaderPolicy, HealthCheck, LoadBalancing, RouteAuth, RouteMatch,
+        Upstream, UpstreamHostPolicy,
+    };
+
+    fn test_metrics() -> Metrics {
+        Metrics::new(1, [String::from("api"), String::from("unrouted")])
+    }
+
+    fn test_upstream_pool() -> Arc<RwLock<UpstreamPool>> {
+        Arc::new(RwLock::new(
+            UpstreamPool::from_upstream(&Upstream {
+                load_balancing: LoadBalancing {
+                    lb_type: "round-robin".to_string(),
+                    key: None,
+                },
+                auth: RouteAuth::default(),
+                host_policy: UpstreamHostPolicy::default(),
+                forwarded_headers: ForwardedHeaderPolicy::default(),
+                tls: None,
+                route: RouteMatch {
+                    host: None,
+                    path_prefix: Some("/".to_string()),
+                    method: None,
+                },
+                backends: vec![Backend {
+                    id: "a".to_string(),
+                    address: "http://127.0.0.1:8080".to_string(),
+                    weight: 1,
+                    health_check: Some(HealthCheck {
+                        path: "/health".to_string(),
+                        interval: 0,
+                        timeout_ms: 1000,
+                        failure_threshold: 1,
+                        success_threshold: 1,
+                        cooldown_ms: 0,
+                    }),
+                }],
+            })
+            .expect("pool"),
+        ))
+    }
+
+    fn upstream_request_count(
+        metrics: &Metrics,
+        upstream: &str,
+        status_class: &str,
+        outcome: &str,
+    ) -> u64 {
+        metrics
+            .snapshot_upstream_request_counts()
+            .into_iter()
+            .find(|(key, _)| {
+                key.upstream == upstream
+                    && key.status_class == status_class
+                    && key.outcome == outcome
+            })
+            .map(|(_, count)| count)
+            .unwrap_or_default()
+    }
+
+    fn backend_request_count(
+        metrics: &Metrics,
+        upstream: &str,
+        backend: &str,
+        status_class: &str,
+        outcome: &str,
+    ) -> u64 {
+        metrics
+            .snapshot_backend_request_counts()
+            .into_iter()
+            .find(|(key, _)| {
+                key.upstream == upstream
+                    && key.backend == backend
+                    && key.status_class == status_class
+                    && key.outcome == outcome
+            })
+            .map(|(_, count)| count)
+            .unwrap_or_default()
+    }
 
     #[test]
     fn classifies_success_status_as_success() {
@@ -581,5 +663,219 @@ mod tests {
         assert_eq!(decision.route_outcome, CanonicalRouteOutcome::OverloadShed);
         assert_eq!(decision.backend_outcome, CanonicalBackendOutcome::OverloadShed);
         assert_eq!(decision.overload_reason, Some(OverloadShedReason::GlobalInflight));
+    }
+
+    #[test]
+    fn observe_status_outcome_records_success_metrics() {
+        let metrics = test_metrics();
+
+        let decision = observe_status_outcome(
+            &metrics,
+            OutcomeRouteTarget { route: "api" },
+            Some(OutcomeBackendTarget {
+                upstream: "api",
+                backend_addr: Some("backend-a"),
+                backend_index: Some(0),
+            }),
+            Duration::from_millis(12),
+            StatusCode::OK,
+        );
+
+        assert_eq!(decision.route_outcome, CanonicalRouteOutcome::Success);
+        assert_eq!(metrics.requests_success.load(std::sync::atomic::Ordering::Relaxed), 1);
+        assert_eq!(metrics.requests_failure.load(std::sync::atomic::Ordering::Relaxed), 0);
+        assert_eq!(upstream_request_count(&metrics, "api", "2xx", "success"), 1);
+        assert_eq!(
+            backend_request_count(&metrics, "api", "backend-a", "2xx", "success"),
+            1
+        );
+    }
+
+    #[test]
+    fn observe_proxy_error_outcome_records_timeout_and_unrouted_failure() {
+        let metrics = test_metrics();
+
+        let timeout = observe_proxy_error_outcome(
+            &metrics,
+            OutcomeRouteTarget { route: "api" },
+            Some(OutcomeBackendTarget {
+                upstream: "api",
+                backend_addr: Some("backend-a"),
+                backend_index: Some(0),
+            }),
+            Duration::from_millis(50),
+            Some(StatusCode::REQUEST_TIMEOUT),
+            &ProxyError::Timeout,
+            None,
+        );
+        let unrouted = observe_proxy_error_outcome(
+            &metrics,
+            OutcomeRouteTarget::UNROUTED,
+            None,
+            Duration::from_millis(5),
+            Some(StatusCode::BAD_GATEWAY),
+            &ProxyError::Transport("no route".into()),
+            None,
+        );
+
+        assert_eq!(timeout.route_outcome, CanonicalRouteOutcome::Timeout);
+        assert_eq!(unrouted.route_outcome, CanonicalRouteOutcome::UpstreamFailure);
+        assert_eq!(metrics.requests_failure.load(std::sync::atomic::Ordering::Relaxed), 2);
+        assert_eq!(upstream_request_count(&metrics, "api", "4xx", "timeout"), 1);
+        assert_eq!(upstream_request_count(&metrics, "unrouted", "5xx", "failure"), 1);
+    }
+
+    #[test]
+    fn observe_admission_outcome_records_overload_auth_and_rate_limit() {
+        let metrics = test_metrics();
+
+        let overload = observe_admission_outcome(
+            &metrics,
+            OutcomeRouteTarget { route: "api" },
+            Some(OutcomeBackendTarget {
+                upstream: "api",
+                backend_addr: Some("backend-a"),
+                backend_index: Some(0),
+            }),
+            Duration::from_millis(1),
+            StatusCode::SERVICE_UNAVAILABLE,
+            AdmissionOutcomeClass::OverloadShed {
+                reason: Some(OverloadShedReason::GlobalInflight),
+            },
+        );
+        let auth = observe_admission_outcome(
+            &metrics,
+            OutcomeRouteTarget { route: "api" },
+            Some(OutcomeBackendTarget {
+                upstream: "api",
+                backend_addr: Some("backend-a"),
+                backend_index: Some(0),
+            }),
+            Duration::from_millis(2),
+            StatusCode::UNAUTHORIZED,
+            AdmissionOutcomeClass::AuthDenied,
+        );
+        let rate_limited = observe_admission_outcome(
+            &metrics,
+            OutcomeRouteTarget { route: "api" },
+            Some(OutcomeBackendTarget {
+                upstream: "api",
+                backend_addr: Some("backend-a"),
+                backend_index: Some(0),
+            }),
+            Duration::from_millis(3),
+            StatusCode::TOO_MANY_REQUESTS,
+            AdmissionOutcomeClass::RateLimited,
+        );
+
+        assert_eq!(overload.route_outcome, CanonicalRouteOutcome::OverloadShed);
+        assert_eq!(auth.route_outcome, CanonicalRouteOutcome::AuthDenied);
+        assert_eq!(rate_limited.route_outcome, CanonicalRouteOutcome::RateLimited);
+        assert_eq!(metrics.overload_shed.load(std::sync::atomic::Ordering::Relaxed), 1);
+        assert_eq!(
+            metrics
+                .overload_shed_global_inflight
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1
+        );
+        assert_eq!(upstream_request_count(&metrics, "api", "5xx", "overload_shed"), 1);
+        assert_eq!(upstream_request_count(&metrics, "api", "4xx", "failure"), 1);
+        assert_eq!(upstream_request_count(&metrics, "api", "4xx", "rate_limited"), 1);
+    }
+
+    #[test]
+    fn backend_accounting_and_health_hooks_remain_stable() {
+        let metrics = test_metrics();
+        let pool = test_upstream_pool();
+
+        {
+            let guard = pool.read().expect("read");
+            assert!(guard.begin_request_if_healthy(0));
+        }
+        finish_backend_request_accounting(BackendRequestFinishInput {
+            upstream_pool: Some(&pool),
+            backend_index: Some(0),
+            elapsed: Duration::from_millis(20),
+            status: Some(StatusCode::OK.as_u16()),
+        });
+        {
+            let guard = pool.read().expect("read");
+            assert_eq!(guard.pool.backends[0].active_requests(), 0);
+            assert!(guard.pool.backends[0].ewma_latency_ms().is_some());
+        }
+
+        let unhealthy = observe_backend_response_status(BackendHealthObservationInput {
+            backend_addr: "backend-a",
+            backend_index: 0,
+            upstream_pool: Some(&pool),
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+        });
+        assert!(matches!(unhealthy, Some(HealthTransition::BecameUnhealthy)));
+
+        let healthy = observe_backend_response_status(BackendHealthObservationInput {
+            backend_addr: "backend-a",
+            backend_index: 0,
+            upstream_pool: Some(&pool),
+            status: StatusCode::OK,
+        });
+        assert!(matches!(healthy, Some(HealthTransition::BecameHealthy)));
+
+        let classified = spooky_errors::classify_upstream_proxy_error(&ProxyError::Timeout)
+            .expect("classified timeout");
+        let transition = observe_classified_backend_failure(ClassifiedBackendFailureInput {
+            metrics_phase: "bootstrap",
+            backend_addr: "backend-a",
+            backend_index: 0,
+            upstream_pool: Some(&pool),
+            metrics: &metrics,
+            classified: &classified,
+        });
+        assert!(matches!(transition, Some(HealthTransition::BecameUnhealthy)));
+        assert_eq!(
+            metrics
+                .health_failure_timeout
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1
+        );
+    }
+
+    #[test]
+    fn forwarding_and_bootstrap_shared_recorders_emit_same_metrics_shape() {
+        let metrics = test_metrics();
+
+        let forwarding = observe_proxy_error_outcome(
+            &metrics,
+            OutcomeRouteTarget { route: "api" },
+            Some(OutcomeBackendTarget {
+                upstream: "api",
+                backend_addr: Some("backend-a"),
+                backend_index: Some(0),
+            }),
+            Duration::from_millis(10),
+            Some(StatusCode::BAD_GATEWAY),
+            &ProxyError::Transport("forwarding upstream error".into()),
+            None,
+        );
+        let bootstrap = observe_proxy_error_outcome(
+            &metrics,
+            OutcomeRouteTarget { route: "api" },
+            Some(OutcomeBackendTarget {
+                upstream: "api",
+                backend_addr: Some("backend-a"),
+                backend_index: Some(0),
+            }),
+            Duration::from_millis(12),
+            Some(StatusCode::BAD_GATEWAY),
+            &ProxyError::Transport("bootstrap upstream error".into()),
+            None,
+        );
+
+        assert_eq!(forwarding.route_outcome, bootstrap.route_outcome);
+        assert_eq!(forwarding.backend_outcome, bootstrap.backend_outcome);
+        assert_eq!(upstream_request_count(&metrics, "api", "5xx", "failure"), 2);
+        assert_eq!(
+            backend_request_count(&metrics, "api", "backend-a", "5xx", "failure"),
+            2
+        );
     }
 }


### PR DESCRIPTION
## Summary
This PR completes the outcome-recording refactor in `edge` by moving request outcome classification, metrics observation, backend accounting, and health-transition hooks behind canonical shared helpers.

## What Changed
- introduced a shared outcome-recording layer in `crates/edge/src/runtime/connection/outcome.rs`
- unified route/backend outcome classification for success, timeout, overload, auth/rate-limit rejection, and upstream failure paths
- routed QUIC forwarding and bootstrap HTTP/TLS through the same canonical outcome observation APIs
- removed forwarding-local metrics/logging wrappers and stale duplicate helper paths
- tightened visibility around the shared outcome module and removed dead compatibility code

## Why
Previously, forwarding and bootstrap still carried local branching for:
- request outcome mapping
- metrics emission
- backend request finish accounting
- health failure observation and transition logging

That made outcome behavior harder to reason about and easier to drift across request paths. This change leaves request-path code focused on orchestration while the shared layer owns the outcome contract.