### PR TITLE
refactor(config): canonicalize runtime config interpretation and align downstream consumers

### DIFF
--- a/crates/bench/src/benchmark/lb.rs
+++ b/crates/bench/src/benchmark/lb.rs
@@ -1,4 +1,9 @@
-use spooky_config::config::{Backend, HealthCheck, LoadBalancing, RouteMatch, Upstream};
+use std::collections::HashMap;
+
+use spooky_config::{
+    config::{Backend, Config, HealthCheck, Listen, LoadBalancing, RouteMatch, Tls, Upstream},
+    runtime::{RuntimeConfig, RuntimeUpstream},
+};
 use spooky_lb::upstream_pool::UpstreamPool;
 
 use crate::{
@@ -80,8 +85,40 @@ fn build_lb_upstream(scale: usize, lb_type: &str) -> Upstream {
     }
 }
 
+fn build_runtime_lb_upstream(scale: usize, lb_type: &str) -> Result<RuntimeUpstream, String> {
+    let mut upstreams = HashMap::new();
+    upstreams.insert("bench".to_string(), build_lb_upstream(scale, lb_type));
+
+    RuntimeConfig::from_config(&Config {
+        version: 1,
+        listen: Listen {
+            protocol: "http1".to_string(),
+            tls: Tls {
+                cert: "/tmp/test-cert.pem".to_string(),
+                key: "/tmp/test-key.pem".to_string(),
+                ..Tls::default()
+            },
+            ..Listen::default()
+        },
+        listeners: Vec::new(),
+        upstream: upstreams,
+        load_balancing: None,
+        upstream_tls: Default::default(),
+        log: Default::default(),
+        performance: Default::default(),
+        observability: Default::default(),
+        resilience: Default::default(),
+        security: Default::default(),
+    })
+    .map_err(|err| format!("failed to normalize benchmark upstream '{lb_type}': {err}"))?
+    .upstreams
+    .remove("bench")
+    .ok_or_else(|| "missing normalized benchmark upstream".to_string())
+}
+
 pub fn build_lb_pool(scale: usize, lb_type: &str) -> Result<UpstreamPool, String> {
-    UpstreamPool::from_upstream(&build_lb_upstream(scale, lb_type))
+    let runtime_upstream = build_runtime_lb_upstream(scale, lb_type)?;
+    UpstreamPool::from_runtime_upstream(&runtime_upstream)
         .map_err(|err| format!("failed to build LB pool '{lb_type}' for scale {scale}: {err}"))
 }
 

--- a/crates/config/src/runtime.rs
+++ b/crates/config/src/runtime.rs
@@ -79,7 +79,8 @@ impl RuntimeConfig {
         self.listener_runtime_configs().into_iter().next()
     }
 
-    pub fn upstreams_as_config(&self) -> HashMap<String, Upstream> {
+    #[cfg(test)]
+    pub(crate) fn upstreams_as_config(&self) -> HashMap<String, Upstream> {
         self.upstreams
             .iter()
             .map(|(name, upstream)| (name.clone(), upstream.as_config_upstream()))
@@ -90,7 +91,8 @@ impl RuntimeConfig {
         self.policies.clone()
     }
 
-    pub fn upstream_policy_sets(&self) -> HashMap<String, RuntimeUpstreamPolicySet> {
+    #[cfg(test)]
+    pub(crate) fn upstream_policy_sets(&self) -> HashMap<String, RuntimeUpstreamPolicySet> {
         self.upstreams
             .iter()
             .map(|(name, upstream)| (name.clone(), upstream.policy_set.clone()))
@@ -270,12 +272,6 @@ pub struct RuntimeUpstreamPolicy {
     pub host: RuntimeHostPolicy,
     pub forwarded_headers: RuntimeForwardedHeaderPolicy,
     pub protocol: RuntimeProtocolPolicy,
-}
-
-impl RuntimeUpstream {
-    pub fn policy_set(&self) -> RuntimeUpstreamPolicySet {
-        self.policy_set.clone()
-    }
 }
 
 #[cfg(test)]

--- a/crates/config/src/runtime.rs
+++ b/crates/config/src/runtime.rs
@@ -11,8 +11,17 @@ use crate::{
 
 #[path = "runtime/listeners.rs"]
 mod listeners;
+#[path = "runtime/policies.rs"]
+mod policies;
 #[path = "runtime/upstreams.rs"]
 mod upstreams;
+
+pub use policies::{
+    RuntimeAdmissionPolicy, RuntimeListenerPolicySet, RuntimeLoadBalancingPolicy,
+    RuntimeLoadBalancingStrategy, RuntimePolicySet, RuntimeRateLimitPolicy,
+    RuntimeScopedRateLimitPolicy, RuntimeTimeoutPolicy, RuntimeTransportPolicy,
+    RuntimeUpstreamPolicySet, RuntimeUpstreamTransportPolicy,
+};
 
 #[derive(Debug, Clone)]
 pub struct RuntimeConfig {
@@ -58,6 +67,22 @@ impl RuntimeConfig {
         self.upstreams
             .iter()
             .map(|(name, upstream)| (name.clone(), upstream.as_config_upstream()))
+            .collect()
+    }
+
+    pub fn policies(&self) -> RuntimePolicySet {
+        RuntimePolicySet::from_runtime_config(self)
+    }
+
+    pub fn upstream_policy_sets(&self) -> HashMap<String, RuntimeUpstreamPolicySet> {
+        self.upstreams
+            .iter()
+            .map(|(name, upstream)| {
+                (
+                    name.clone(),
+                    upstream.policy_set(&self.performance, &self.resilience),
+                )
+            })
             .collect()
     }
 }
@@ -174,6 +199,12 @@ pub struct ListenerRuntimeConfig {
     pub observability: Observability,
 }
 
+impl ListenerRuntimeConfig {
+    pub fn policies(&self) -> RuntimeListenerPolicySet {
+        RuntimeListenerPolicySet::from_listener_runtime_config(self)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RuntimeListenerSource {
     LegacyListen,
@@ -284,6 +315,16 @@ pub struct RuntimeUpstreamPolicy {
     pub host: RuntimeHostPolicy,
     pub forwarded_headers: RuntimeForwardedHeaderPolicy,
     pub protocol: RuntimeProtocolPolicy,
+}
+
+impl RuntimeUpstream {
+    pub fn policy_set(
+        &self,
+        performance: &Performance,
+        resilience: &Resilience,
+    ) -> RuntimeUpstreamPolicySet {
+        RuntimeUpstreamPolicySet::from_runtime_parts(self, performance, resilience)
+    }
 }
 
 #[cfg(test)]
@@ -449,6 +490,82 @@ mod tests {
             }
             other => panic!("unexpected external_auth contract: {:?}", other),
         }
+    }
+
+    #[test]
+    fn runtime_policy_set_normalizes_timeout_and_transport_knobs() {
+        let mut config = sample_config();
+        config.performance.backend_timeout_ms = 2_500;
+        config.performance.backend_connect_timeout_ms = 400;
+        config.performance.h2_pool_idle_timeout_ms = 91_000;
+        config.performance.max_active_connections = 1234;
+        config.performance.request_buffer_global_cap_bytes = 9_999;
+        config.resilience.route_queue.shed_retry_after_seconds = 17;
+
+        let runtime = RuntimeConfig::from_config(&config).expect("runtime config");
+        let policies = runtime.policies();
+
+        assert_eq!(policies.timeouts.backend_request, Duration::from_millis(2_500));
+        assert_eq!(policies.timeouts.backend_connect, Duration::from_millis(400));
+        assert_eq!(policies.timeouts.h2_pool_idle, Duration::from_millis(91_000));
+        assert_eq!(policies.transport.max_active_connections, 1234);
+        assert_eq!(policies.transport.request_buffer_global_cap_bytes, 9_999);
+        assert_eq!(policies.admission.route_queue.shed_retry_after_seconds, 17);
+    }
+
+    #[test]
+    fn runtime_upstream_policy_set_carries_canonical_lb_auth_and_tls_shapes() {
+        let mut config = sample_config();
+        let upstream = config.upstream.get_mut("api").expect("api upstream");
+        upstream.load_balancing = LoadBalancing {
+            lb_type: "sticky-cid".to_string(),
+            key: Some("header:x-user-id".to_string()),
+        };
+        upstream.auth.api_key = Some(crate::config::ApiKeyAuth {
+            header_name: "x-api-key".to_string(),
+            keys: vec!["secret-1".to_string()],
+        });
+        upstream.tls = Some(UpstreamTls {
+            verify_certificates: false,
+            strict_sni: false,
+            ca_file: Some("/tmp/upstream-ca.pem".to_string()),
+            ca_dir: None,
+        });
+        config.resilience.scoped_rate_limits = vec![crate::config::ScopedRateLimit {
+            name: "client-default".to_string(),
+            scope: crate::config::ScopedRateLimitScope::Client,
+            requests_per_sec: 10,
+            burst: 20,
+            key: Some("peer_ip".to_string()),
+            route_allowlist: vec!["api".to_string()],
+            idle_ttl_secs: 30,
+        }];
+
+        let runtime = RuntimeConfig::from_config(&config).expect("runtime config");
+        let upstream_policies = runtime.upstream_policy_sets();
+        let api = upstream_policies.get("api").expect("api runtime policy set");
+
+        assert_eq!(
+            api.load_balancing.strategy,
+            RuntimeLoadBalancingStrategy::StickyCid
+        );
+        assert_eq!(
+            api.load_balancing.key.as_deref(),
+            Some("header:x-user-id")
+        );
+        assert_eq!(
+            api.auth.api_key.as_ref().map(|auth| auth.header_name.as_str()),
+            Some("x-api-key")
+        );
+        assert_eq!(
+            api.transport.effective_tls.ca_file.as_deref(),
+            Some("/tmp/upstream-ca.pem")
+        );
+        assert_eq!(api.rate_limits.scoped_limits.len(), 1);
+        assert_eq!(
+            api.rate_limits.scoped_limits[0].idle_ttl,
+            Duration::from_secs(30)
+        );
     }
 
     #[test]

--- a/crates/config/src/runtime.rs
+++ b/crates/config/src/runtime.rs
@@ -17,10 +17,14 @@ mod policies;
 mod upstreams;
 
 pub use policies::{
-    RuntimeAdmissionPolicy, RuntimeListenerPolicySet, RuntimeLoadBalancingPolicy,
-    RuntimeLoadBalancingStrategy, RuntimePolicySet, RuntimeRateLimitPolicy,
-    RuntimeScopedRateLimitPolicy, RuntimeTimeoutPolicy, RuntimeTransportPolicy,
-    RuntimeUpstreamPolicySet, RuntimeUpstreamTransportPolicy,
+    RuntimeAdmissionPolicy, RuntimeApiKeyAuth, RuntimeAuthPolicy, RuntimeBrownoutPolicy,
+    RuntimeCircuitBreakerPolicy, RuntimeExternalAuth, RuntimeExternalAuthFailureMode,
+    RuntimeExternalAuthRequestHeader, RuntimeHedgingPolicy, RuntimeJwtAuth,
+    RuntimeListenerPolicySet, RuntimeLoadBalancingPolicy, RuntimeLoadBalancingStrategy,
+    RuntimePolicySet, RuntimeRateLimitPolicy, RuntimeRetryBudgetPolicy,
+    RuntimeRouteQueuePolicy, RuntimeScopedRateLimitPolicy, RuntimeTimeoutPolicy,
+    RuntimeTransportPolicy, RuntimeUpstreamPolicySet, RuntimeUpstreamTransportPolicy,
+    RuntimeWatchdogPolicy,
 };
 
 #[derive(Debug, Clone)]
@@ -255,65 +259,6 @@ pub struct RuntimeForwardedHeaderPolicy(pub ForwardedHeaderPolicy);
 pub struct RuntimeProtocolPolicy(pub ProtocolPolicy);
 
 #[derive(Debug, Clone, Default)]
-pub struct RuntimeApiKeyAuth {
-    pub header_name: String,
-    pub keys: Vec<String>,
-}
-
-#[derive(Debug, Clone, Default)]
-pub struct RuntimeJwtAuth {
-    pub secret: String,
-    pub issuer: Option<String>,
-    pub audience: Option<String>,
-    pub clock_skew_secs: u64,
-}
-
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub enum RuntimeExternalAuthFailureMode {
-    FailOpen,
-    #[default]
-    FailClosed,
-}
-
-#[derive(Debug, Clone, Default)]
-pub struct RuntimeExternalAuthRequestHeader {
-    pub name: String,
-    pub value: String,
-}
-
-#[derive(Debug, Clone)]
-pub enum RuntimeExternalAuth {
-    Http {
-        endpoint: String,
-        request_headers: Vec<RuntimeExternalAuthRequestHeader>,
-        response_header_allowlist: Vec<String>,
-        timeout_ms: u64,
-        failure_mode: RuntimeExternalAuthFailureMode,
-    },
-    Oidc {
-        discovery_url: Option<String>,
-        issuer_url: Option<String>,
-        client_id: String,
-        client_secret: Option<String>,
-        audience: Option<String>,
-        scopes: Vec<String>,
-        request_headers: Vec<RuntimeExternalAuthRequestHeader>,
-        response_header_allowlist: Vec<String>,
-        timeout_ms: u64,
-        failure_mode: RuntimeExternalAuthFailureMode,
-    },
-}
-
-#[derive(Debug, Clone, Default)]
-pub struct RuntimeAuthPolicy {
-    pub api_key: Option<RuntimeApiKeyAuth>,
-    pub jwt: Option<RuntimeJwtAuth>,
-    pub external_auth: Option<RuntimeExternalAuth>,
-    pub required_scopes: Vec<String>,
-    pub required_roles: Vec<String>,
-}
-
-#[derive(Debug, Clone, Default)]
 pub struct RuntimeUpstreamPolicy {
     /// Upstream-owned auth policy selected after route lookup resolves an upstream.
     pub upstream_auth: RuntimeAuthPolicy,
@@ -330,6 +275,8 @@ impl RuntimeUpstream {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::{listeners::runtime_listeners, *};
     use crate::config::{
         Config, ForwardedHeaderPolicyMode, Listen, RouteMatch, Tls, TlsCertificate, Upstream,
@@ -364,7 +311,10 @@ mod tests {
         config.upstream.insert(
             "api".to_string(),
             Upstream {
-                load_balancing: LoadBalancing::default(),
+                load_balancing: LoadBalancing {
+                    lb_type: "round-robin".to_string(),
+                    key: None,
+                },
                 auth: Default::default(),
                 host_policy: UpstreamHostPolicy {
                     mode: UpstreamHostPolicyMode::Rewrite,
@@ -419,13 +369,13 @@ mod tests {
                 endpoint,
                 request_headers,
                 response_header_allowlist,
-                timeout_ms,
+                timeout,
                 ..
             }) => {
                 assert_eq!(endpoint, "https://auth.internal/check");
                 assert!(request_headers.is_empty());
                 assert!(response_header_allowlist.is_empty());
-                assert_eq!(*timeout_ms, 1_000);
+                assert_eq!(*timeout, Duration::from_millis(1_000));
             }
             other => panic!("unexpected external_auth contract: {:?}", other),
         }
@@ -473,7 +423,7 @@ mod tests {
                 scopes,
                 request_headers,
                 response_header_allowlist,
-                timeout_ms,
+                timeout,
                 ..
             }) => {
                 assert_eq!(
@@ -487,7 +437,7 @@ mod tests {
                 assert_eq!(scopes, &vec!["openid".to_string(), "profile".to_string()]);
                 assert!(request_headers.is_empty());
                 assert!(response_header_allowlist.is_empty());
-                assert_eq!(*timeout_ms, 1_500);
+                assert_eq!(*timeout, Duration::from_millis(1_500));
             }
             other => panic!("unexpected external_auth contract: {:?}", other),
         }

--- a/crates/config/src/runtime.rs
+++ b/crates/config/src/runtime.rs
@@ -28,6 +28,7 @@ pub struct RuntimeConfig {
     pub version: u32,
     pub listeners: Vec<RuntimeListener>,
     pub upstreams: HashMap<String, RuntimeUpstream>,
+    pub policies: RuntimePolicySet,
     pub performance: Performance,
     pub observability: Observability,
     pub resilience: Resilience,
@@ -36,10 +37,12 @@ pub struct RuntimeConfig {
 
 impl RuntimeConfig {
     pub fn from_config(config: &Config) -> Result<Self, RuntimeConfigError> {
+        let policies = RuntimePolicySet::from_config(config)?;
         Ok(Self {
             version: config.version,
             listeners: listeners::runtime_listeners(config)?,
-            upstreams: upstreams::normalize_upstreams(config)?,
+            upstreams: upstreams::normalize_upstreams(config, &policies)?,
+            policies,
             performance: config.performance.clone(),
             observability: config.observability.clone(),
             resilience: config.resilience.clone(),
@@ -52,6 +55,11 @@ impl RuntimeConfig {
             .iter()
             .cloned()
             .map(|listen| ListenerRuntimeConfig {
+                policies: RuntimeListenerPolicySet {
+                    timeouts: self.policies.timeouts.clone(),
+                    transport: self.policies.transport.clone(),
+                    tls: listen.tls.clone(),
+                },
                 listen,
                 performance: self.performance.clone(),
                 observability: self.observability.clone(),
@@ -71,18 +79,13 @@ impl RuntimeConfig {
     }
 
     pub fn policies(&self) -> RuntimePolicySet {
-        RuntimePolicySet::from_runtime_config(self)
+        self.policies.clone()
     }
 
     pub fn upstream_policy_sets(&self) -> HashMap<String, RuntimeUpstreamPolicySet> {
         self.upstreams
             .iter()
-            .map(|(name, upstream)| {
-                (
-                    name.clone(),
-                    upstream.policy_set(&self.performance, &self.resilience),
-                )
-            })
+            .map(|(name, upstream)| (name.clone(), upstream.policy_set.clone()))
             .collect()
     }
 }
@@ -195,6 +198,7 @@ pub struct RuntimeListener {
 #[derive(Debug, Clone)]
 pub struct ListenerRuntimeConfig {
     pub listen: RuntimeListener,
+    pub policies: RuntimeListenerPolicySet,
     pub performance: Performance,
     pub observability: Observability,
 }
@@ -230,6 +234,7 @@ pub struct RuntimeUpstream {
     pub load_balancing: LoadBalancing,
     pub route: RouteMatch,
     pub policy: RuntimeUpstreamPolicy,
+    pub policy_set: RuntimeUpstreamPolicySet,
     pub effective_tls: UpstreamTls,
     pub backends: Vec<RuntimeBackend>,
 }
@@ -318,12 +323,8 @@ pub struct RuntimeUpstreamPolicy {
 }
 
 impl RuntimeUpstream {
-    pub fn policy_set(
-        &self,
-        performance: &Performance,
-        resilience: &Resilience,
-    ) -> RuntimeUpstreamPolicySet {
-        RuntimeUpstreamPolicySet::from_runtime_parts(self, performance, resilience)
+    pub fn policy_set(&self) -> RuntimeUpstreamPolicySet {
+        self.policy_set.clone()
     }
 }
 

--- a/crates/config/src/runtime.rs
+++ b/crates/config/src/runtime.rs
@@ -18,8 +18,11 @@ mod upstreams;
 
 pub use policies::{
     RuntimeAdmissionPolicy, RuntimeApiKeyAuth, RuntimeAuthPolicy, RuntimeBrownoutPolicy,
-    RuntimeCircuitBreakerPolicy, RuntimeExternalAuth, RuntimeExternalAuthFailureMode,
-    RuntimeExternalAuthRequestHeader, RuntimeHedgingPolicy, RuntimeJwtAuth,
+    RuntimeBackendAddressKind, RuntimeBackendConnectionPolicy, RuntimeBackendDnsPolicy,
+    RuntimeBackendEndpoint, RuntimeBackendHealthCheck, RuntimeBackendTlsPolicy,
+    RuntimeBackendTransportKind, RuntimeCircuitBreakerPolicy, RuntimeConnectionLimits,
+    RuntimeExternalAuth, RuntimeExternalAuthFailureMode, RuntimeExternalAuthRequestHeader,
+    RuntimeHedgingPolicy, RuntimeJwtAuth,
     RuntimeListenerPolicySet, RuntimeLoadBalancingPolicy, RuntimeLoadBalancingStrategy,
     RuntimePolicySet, RuntimeRateLimitPolicy, RuntimeRetryBudgetPolicy,
     RuntimeRouteQueuePolicy, RuntimeScopedRateLimitPolicy, RuntimeTimeoutPolicy,
@@ -246,7 +249,8 @@ pub struct RuntimeUpstream {
 #[derive(Debug, Clone)]
 pub struct RuntimeBackend {
     pub backend: Backend,
-    pub effective_tls: UpstreamTls,
+    pub endpoint: RuntimeBackendEndpoint,
+    pub health_check: Option<RuntimeBackendHealthCheck>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -509,8 +513,12 @@ mod tests {
             Some("x-api-key")
         );
         assert_eq!(
-            api.transport.effective_tls.ca_file.as_deref(),
+            api.transport.tls.ca_file.as_deref(),
             Some("/tmp/upstream-ca.pem")
+        );
+        assert_eq!(
+            api.transport.connection.max_inflight,
+            runtime.policies.transport.connection_limits.backend_pool_max_inflight
         );
         assert_eq!(api.rate_limits.scoped_limits.len(), 1);
         assert_eq!(
@@ -623,6 +631,16 @@ mod tests {
             upstream.backends[0].backend.address,
             "https://api.internal:8443"
         );
+        assert_eq!(upstream.backends[0].endpoint.authority_host, "api.internal");
+        assert_eq!(upstream.backends[0].endpoint.authority_port, 8443);
+        assert_eq!(
+            upstream.backends[0].endpoint.transport_kind,
+            RuntimeBackendTransportKind::H2
+        );
+        assert_eq!(
+            upstream.policy_set.transport.tls.ca_file.as_deref(),
+            Some("/tmp/roots/upstream.pem")
+        );
         assert_eq!(upstream.policy.host.0.mode, UpstreamHostPolicyMode::Rewrite);
         assert_eq!(
             upstream.policy.forwarded_headers.0.mode,
@@ -679,6 +697,31 @@ mod tests {
             err.to_string()
                 .contains("upstream 'api' has an empty effective upstream_tls.ca_file")
         );
+    }
+
+    #[test]
+    fn runtime_backend_health_check_and_endpoint_are_canonicalized() {
+        let mut config = sample_config();
+        config.upstream.get_mut("api").expect("api").backends[0].health_check =
+            Some(crate::config::HealthCheck {
+                path: String::new(),
+                interval: 2_000,
+                timeout_ms: 250,
+                failure_threshold: 4,
+                success_threshold: 3,
+                cooldown_ms: 5_000,
+            });
+
+        let runtime = RuntimeConfig::from_config(&config).expect("runtime config");
+        let backend = &runtime.upstreams.get("api").expect("api").backends[0];
+        let health = backend.health_check.as_ref().expect("health check");
+
+        assert_eq!(backend.endpoint.origin, "https://api.internal:8443");
+        assert_eq!(health.path, "/");
+        assert_eq!(health.interval, Duration::from_millis(2_000));
+        assert_eq!(health.timeout, Duration::from_millis(250));
+        assert_eq!(health.failure_threshold, 4);
+        assert_eq!(health.success_threshold, 3);
     }
 
     #[test]

--- a/crates/config/src/runtime.rs
+++ b/crates/config/src/runtime.rs
@@ -4,7 +4,7 @@ use crate::{
     backend_endpoint::BackendEndpoint,
     config::{
         Backend, ClientAuth, Config, ForwardedHeaderPolicy, Listen, LoadBalancing, Observability,
-        Performance, ProtocolPolicy, Resilience, RouteMatch, Security, TlsCertificate, Upstream,
+        Performance, ProtocolPolicy, Resilience, Security, TlsCertificate, Upstream,
         UpstreamHostPolicy, UpstreamHostPolicyMode, UpstreamTls,
     },
 };
@@ -22,10 +22,11 @@ pub use policies::{
     RuntimeBackendEndpoint, RuntimeBackendHealthCheck, RuntimeBackendTlsPolicy,
     RuntimeBackendTransportKind, RuntimeCircuitBreakerPolicy, RuntimeConnectionLimits,
     RuntimeExternalAuth, RuntimeExternalAuthFailureMode, RuntimeExternalAuthRequestHeader,
-    RuntimeHedgingPolicy, RuntimeJwtAuth,
+    RuntimeHedgingPolicy, RuntimeJwtAuth, RuntimeAlternateBackendPolicy, RuntimeRequestKeySpec,
     RuntimeListenerPolicySet, RuntimeLoadBalancingPolicy, RuntimeLoadBalancingStrategy,
     RuntimePolicySet, RuntimeRateLimitPolicy, RuntimeRetryBudgetPolicy,
-    RuntimeRouteQueuePolicy, RuntimeScopedRateLimitPolicy, RuntimeTimeoutPolicy,
+    RuntimeRouteHostPattern, RuntimeRouteMatchPolicy, RuntimeRouteQueuePolicy,
+    RuntimeScopedRateLimitPolicy, RuntimeTimeoutPolicy,
     RuntimeTransportPolicy, RuntimeUpstreamPolicySet, RuntimeUpstreamTransportPolicy,
     RuntimeWatchdogPolicy,
 };
@@ -238,8 +239,8 @@ pub struct RuntimeTlsIdentity {
 #[derive(Debug, Clone)]
 pub struct RuntimeUpstream {
     pub name: String,
-    pub load_balancing: LoadBalancing,
-    pub route: RouteMatch,
+    pub load_balancing: RuntimeLoadBalancingPolicy,
+    pub route: RuntimeRouteMatchPolicy,
     pub policy: RuntimeUpstreamPolicy,
     pub policy_set: RuntimeUpstreamPolicySet,
     pub effective_tls: UpstreamTls,

--- a/crates/config/src/runtime.rs
+++ b/crates/config/src/runtime.rs
@@ -453,8 +453,12 @@ mod tests {
         let mut config = sample_config();
         config.performance.backend_timeout_ms = 2_500;
         config.performance.backend_connect_timeout_ms = 400;
+        config.performance.backend_body_idle_timeout_ms = 3_500;
+        config.performance.backend_body_total_timeout_ms = 4_500;
+        config.performance.backend_total_request_timeout_ms = 5_500;
         config.performance.h2_pool_idle_timeout_ms = 91_000;
         config.performance.max_active_connections = 1234;
+        config.performance.max_request_body_bytes = 8_000;
         config.performance.request_buffer_global_cap_bytes = 9_999;
         config.resilience.route_queue.shed_retry_after_seconds = 17;
 
@@ -467,6 +471,38 @@ mod tests {
         assert_eq!(policies.transport.max_active_connections, 1234);
         assert_eq!(policies.transport.request_buffer_global_cap_bytes, 9_999);
         assert_eq!(policies.admission.route_queue.shed_retry_after_seconds, 17);
+    }
+
+    #[test]
+    fn runtime_defaults_produce_listener_and_runtime_policy_parity() {
+        let config = sample_config();
+        let runtime = RuntimeConfig::from_config(&config).expect("runtime config");
+        let listener = runtime
+            .primary_listener_runtime_config()
+            .expect("primary listener");
+
+        assert_eq!(
+            runtime.policies.timeouts.backend_request,
+            Duration::from_millis(config.performance.backend_timeout_ms)
+        );
+        assert_eq!(
+            runtime.policies.timeouts.quic_max_idle,
+            Duration::from_millis(config.performance.quic_max_idle_timeout_ms)
+        );
+        assert_eq!(
+            runtime.policies.transport.connection_limits.global_inflight,
+            config.performance.global_inflight_limit
+        );
+        assert_eq!(
+            runtime.policies.transport.quic_initial_max_data,
+            config.performance.quic_initial_max_data
+        );
+        assert_eq!(
+            runtime.policies.admission.watchdog.check_interval,
+            Duration::from_millis(config.resilience.watchdog.check_interval_ms)
+        );
+        assert_eq!(listener.policies.timeouts, runtime.policies.timeouts);
+        assert_eq!(listener.policies.transport, runtime.policies.transport);
     }
 
     #[test]
@@ -526,6 +562,103 @@ mod tests {
             api.rate_limits.scoped_limits[0].idle_ttl,
             Duration::from_secs(30)
         );
+    }
+
+    #[test]
+    fn runtime_config_normalizes_jwt_and_scoped_rate_limit_shapes() {
+        let mut config = sample_config();
+        let upstream = config.upstream.get_mut("api").expect("api upstream");
+        upstream.auth.jwt = Some(crate::config::JwtAuth {
+            secret: "jwt-secret".to_string(),
+            issuer: Some(" issuer-1 ".to_string()),
+            audience: Some(" spooky-api ".to_string()),
+            clock_skew_secs: 45,
+        });
+        upstream.auth.required_scopes = vec![" read:api ".to_string()];
+        upstream.auth.required_roles = vec![" admin ".to_string()];
+        config.resilience.scoped_rate_limits = vec![crate::config::ScopedRateLimit {
+            name: " tenant-default ".to_string(),
+            scope: crate::config::ScopedRateLimitScope::Tenant,
+            requests_per_sec: 12,
+            burst: 34,
+            key: Some("header:x-tenant-id".to_string()),
+            route_allowlist: vec![" api ".to_string()],
+            idle_ttl_secs: 9,
+        }];
+
+        let runtime = RuntimeConfig::from_config(&config).expect("runtime config");
+        let api = runtime.upstreams.get("api").expect("api runtime upstream");
+        let jwt = api
+            .policy
+            .upstream_auth
+            .jwt
+            .as_ref()
+            .expect("jwt policy");
+        let scoped_limit = runtime
+            .policies
+            .rate_limits
+            .scoped_limits
+            .first()
+            .expect("scoped rate limit");
+
+        assert_eq!(jwt.issuer.as_deref(), Some("issuer-1"));
+        assert_eq!(jwt.audience.as_deref(), Some("spooky-api"));
+        assert_eq!(jwt.clock_skew, Duration::from_secs(45));
+        assert_eq!(
+            api.policy.upstream_auth.required_scopes,
+            vec!["read:api".to_string()]
+        );
+        assert_eq!(
+            api.policy.upstream_auth.required_roles,
+            vec!["admin".to_string()]
+        );
+        assert_eq!(scoped_limit.name, " tenant-default ");
+        assert_eq!(
+            scoped_limit.route_allowlist,
+            vec!["api".to_string()]
+        );
+        assert_eq!(scoped_limit.key.as_deref(), Some("header:x-tenant-id"));
+        assert_eq!(scoped_limit.idle_ttl, Duration::from_secs(9));
+    }
+
+    #[test]
+    fn runtime_upstreams_as_config_canonicalizes_route_and_lb_shapes() {
+        let mut config = sample_config();
+        let upstream = config.upstream.get_mut("api").expect("api upstream");
+        upstream.load_balancing = LoadBalancing {
+            lb_type: "cid_sticky".to_string(),
+            key: Some("header:x-user-id".to_string()),
+        };
+        upstream.route = RouteMatch {
+            host: Some("API.EXAMPLE.COM:443.".to_string()),
+            path_prefix: Some("/v1".to_string()),
+            method: Some("get".to_string()),
+        };
+
+        let runtime = RuntimeConfig::from_config(&config).expect("runtime config");
+        let runtime_upstream = runtime.upstreams.get("api").expect("api runtime upstream");
+        let exported = runtime
+            .upstreams_as_config()
+            .remove("api")
+            .expect("api exported upstream");
+
+        assert_eq!(
+            runtime_upstream.load_balancing.strategy,
+            RuntimeLoadBalancingStrategy::StickyCid
+        );
+        assert_eq!(
+            runtime_upstream.load_balancing.key_spec,
+            Some(RuntimeRequestKeySpec::Header("x-user-id".to_string()))
+        );
+        assert!(!runtime_upstream.load_balancing.alternate_backend.readonly_lb_pick);
+        assert!(runtime_upstream.load_balancing.alternate_backend.healthy_fallback);
+        assert_eq!(runtime_upstream.route.host.as_deref(), Some("api.example.com:443"));
+        assert_eq!(runtime_upstream.route.method.as_deref(), Some("GET"));
+        assert_eq!(runtime_upstream.route.path_prefix.as_deref(), Some("/v1"));
+        assert_eq!(exported.load_balancing.lb_type, "sticky-cid");
+        assert_eq!(exported.route.host.as_deref(), Some("api.example.com:443"));
+        assert_eq!(exported.route.method.as_deref(), Some("GET"));
+        assert_eq!(exported.route.path_prefix.as_deref(), Some("/v1"));
     }
 
     #[test]
@@ -825,6 +958,32 @@ mod tests {
         let err = RuntimeConfig::from_config(&config).expect_err("duplicate routes");
         assert_eq!(err.category(), "duplicate_route_ambiguity");
         assert!(err.to_string().contains("conflicts with upstream"));
+    }
+
+    #[test]
+    fn runtime_config_rejects_invalid_timeout_ordering() {
+        let mut config = sample_config();
+        config.performance.backend_connect_timeout_ms = 2_000;
+        config.performance.backend_timeout_ms = 1_000;
+
+        let err =
+            RuntimeConfig::from_config(&config).expect_err("timeout ordering must be validated");
+        assert_eq!(err.category(), "config_invalid");
+        assert!(
+            err.to_string()
+                .contains("backend_connect_timeout_ms must be <= backend_timeout_ms")
+        );
+    }
+
+    #[test]
+    fn runtime_config_rejects_invalid_lb_key_spec() {
+        let mut config = sample_config();
+        config.upstream.get_mut("api").expect("api").load_balancing.key =
+            Some("header:   ".to_string());
+
+        let err = RuntimeConfig::from_config(&config).expect_err("invalid key spec must fail");
+        assert_eq!(err.category(), "config_invalid");
+        assert!(err.to_string().contains("unsupported request key spec"));
     }
 
     #[test]

--- a/crates/config/src/runtime.rs
+++ b/crates/config/src/runtime.rs
@@ -17,18 +17,17 @@ mod policies;
 mod upstreams;
 
 pub use policies::{
-    RuntimeAdmissionPolicy, RuntimeApiKeyAuth, RuntimeAuthPolicy, RuntimeBrownoutPolicy,
+    RuntimeAdmissionPolicy, RuntimeAlternateBackendPolicy, RuntimeApiKeyAuth, RuntimeAuthPolicy,
     RuntimeBackendAddressKind, RuntimeBackendConnectionPolicy, RuntimeBackendDnsPolicy,
     RuntimeBackendEndpoint, RuntimeBackendHealthCheck, RuntimeBackendTlsPolicy,
-    RuntimeBackendTransportKind, RuntimeCircuitBreakerPolicy, RuntimeConnectionLimits,
-    RuntimeExternalAuth, RuntimeExternalAuthFailureMode, RuntimeExternalAuthRequestHeader,
-    RuntimeHedgingPolicy, RuntimeJwtAuth, RuntimeAlternateBackendPolicy, RuntimeRequestKeySpec,
+    RuntimeBackendTransportKind, RuntimeBrownoutPolicy, RuntimeCircuitBreakerPolicy,
+    RuntimeConnectionLimits, RuntimeExternalAuth, RuntimeExternalAuthFailureMode,
+    RuntimeExternalAuthRequestHeader, RuntimeHedgingPolicy, RuntimeJwtAuth,
     RuntimeListenerPolicySet, RuntimeLoadBalancingPolicy, RuntimeLoadBalancingStrategy,
-    RuntimePolicySet, RuntimeRateLimitPolicy, RuntimeRetryBudgetPolicy,
+    RuntimePolicySet, RuntimeRateLimitPolicy, RuntimeRequestKeySpec, RuntimeRetryBudgetPolicy,
     RuntimeRouteHostPattern, RuntimeRouteMatchPolicy, RuntimeRouteQueuePolicy,
-    RuntimeScopedRateLimitPolicy, RuntimeTimeoutPolicy,
-    RuntimeTransportPolicy, RuntimeUpstreamPolicySet, RuntimeUpstreamTransportPolicy,
-    RuntimeWatchdogPolicy,
+    RuntimeScopedRateLimitPolicy, RuntimeTimeoutPolicy, RuntimeTransportPolicy,
+    RuntimeUpstreamPolicySet, RuntimeUpstreamTransportPolicy, RuntimeWatchdogPolicy,
 };
 
 #[derive(Debug, Clone)]
@@ -461,9 +460,18 @@ mod tests {
         let runtime = RuntimeConfig::from_config(&config).expect("runtime config");
         let policies = runtime.policies();
 
-        assert_eq!(policies.timeouts.backend_request, Duration::from_millis(2_500));
-        assert_eq!(policies.timeouts.backend_connect, Duration::from_millis(400));
-        assert_eq!(policies.timeouts.h2_pool_idle, Duration::from_millis(91_000));
+        assert_eq!(
+            policies.timeouts.backend_request,
+            Duration::from_millis(2_500)
+        );
+        assert_eq!(
+            policies.timeouts.backend_connect,
+            Duration::from_millis(400)
+        );
+        assert_eq!(
+            policies.timeouts.h2_pool_idle,
+            Duration::from_millis(91_000)
+        );
         assert_eq!(policies.transport.max_active_connections, 1234);
         assert_eq!(policies.transport.request_buffer_global_cap_bytes, 9_999);
         assert_eq!(policies.admission.route_queue.shed_retry_after_seconds, 17);
@@ -531,18 +539,20 @@ mod tests {
 
         let runtime = RuntimeConfig::from_config(&config).expect("runtime config");
         let upstream_policies = runtime.upstream_policy_sets();
-        let api = upstream_policies.get("api").expect("api runtime policy set");
+        let api = upstream_policies
+            .get("api")
+            .expect("api runtime policy set");
 
         assert_eq!(
             api.load_balancing.strategy,
             RuntimeLoadBalancingStrategy::StickyCid
         );
+        assert_eq!(api.load_balancing.key.as_deref(), Some("header:x-user-id"));
         assert_eq!(
-            api.load_balancing.key.as_deref(),
-            Some("header:x-user-id")
-        );
-        assert_eq!(
-            api.auth.api_key.as_ref().map(|auth| auth.header_name.as_str()),
+            api.auth
+                .api_key
+                .as_ref()
+                .map(|auth| auth.header_name.as_str()),
             Some("x-api-key")
         );
         assert_eq!(
@@ -551,7 +561,11 @@ mod tests {
         );
         assert_eq!(
             api.transport.connection.max_inflight,
-            runtime.policies.transport.connection_limits.backend_pool_max_inflight
+            runtime
+                .policies
+                .transport
+                .connection_limits
+                .backend_pool_max_inflight
         );
         assert_eq!(api.rate_limits.scoped_limits.len(), 1);
         assert_eq!(
@@ -584,12 +598,7 @@ mod tests {
 
         let runtime = RuntimeConfig::from_config(&config).expect("runtime config");
         let api = runtime.upstreams.get("api").expect("api runtime upstream");
-        let jwt = api
-            .policy
-            .upstream_auth
-            .jwt
-            .as_ref()
-            .expect("jwt policy");
+        let jwt = api.policy.upstream_auth.jwt.as_ref().expect("jwt policy");
         let scoped_limit = runtime
             .policies
             .rate_limits
@@ -609,10 +618,7 @@ mod tests {
             vec!["admin".to_string()]
         );
         assert_eq!(scoped_limit.name, " tenant-default ");
-        assert_eq!(
-            scoped_limit.route_allowlist,
-            vec!["api".to_string()]
-        );
+        assert_eq!(scoped_limit.route_allowlist, vec!["api".to_string()]);
         assert_eq!(scoped_limit.key.as_deref(), Some("header:x-tenant-id"));
         assert_eq!(scoped_limit.idle_ttl, Duration::from_secs(9));
     }
@@ -646,9 +652,22 @@ mod tests {
             runtime_upstream.load_balancing.key_spec,
             Some(RuntimeRequestKeySpec::Header("x-user-id".to_string()))
         );
-        assert!(!runtime_upstream.load_balancing.alternate_backend.readonly_lb_pick);
-        assert!(runtime_upstream.load_balancing.alternate_backend.healthy_fallback);
-        assert_eq!(runtime_upstream.route.host.as_deref(), Some("api.example.com:443"));
+        assert!(
+            !runtime_upstream
+                .load_balancing
+                .alternate_backend
+                .readonly_lb_pick
+        );
+        assert!(
+            runtime_upstream
+                .load_balancing
+                .alternate_backend
+                .healthy_fallback
+        );
+        assert_eq!(
+            runtime_upstream.route.host.as_deref(),
+            Some("api.example.com:443")
+        );
         assert_eq!(runtime_upstream.route.method.as_deref(), Some("GET"));
         assert_eq!(runtime_upstream.route.path_prefix.as_deref(), Some("/v1"));
         assert_eq!(exported.load_balancing.lb_type, "sticky-cid");
@@ -974,8 +993,12 @@ mod tests {
     #[test]
     fn runtime_config_rejects_invalid_lb_key_spec() {
         let mut config = sample_config();
-        config.upstream.get_mut("api").expect("api").load_balancing.key =
-            Some("header:   ".to_string());
+        config
+            .upstream
+            .get_mut("api")
+            .expect("api")
+            .load_balancing
+            .key = Some("header:   ".to_string());
 
         let err = RuntimeConfig::from_config(&config).expect_err("invalid key spec must fail");
         assert_eq!(err.category(), "config_invalid");

--- a/crates/config/src/runtime/policies.rs
+++ b/crates/config/src/runtime/policies.rs
@@ -47,6 +47,19 @@ fn normalize_string_vec(values: &[String]) -> Vec<String> {
         .collect()
 }
 
+fn normalize_nonempty_string_vec(
+    field_name: &str,
+    values: &[String],
+) -> Result<Vec<String>, RuntimeConfigError> {
+    let normalized = normalize_string_vec(values);
+    if normalized.len() != values.len() {
+        return Err(config_invalid(format!(
+            "{field_name} must not contain empty values"
+        )));
+    }
+    Ok(normalized)
+}
+
 fn is_valid_http_token(value: &str) -> bool {
     !value.is_empty()
         && value
@@ -97,6 +110,353 @@ impl RuntimeLoadBalancingStrategy {
             "latency-aware" => Self::LatencyAware,
             "sticky-cid" => Self::StickyCid,
             _ => Self::Other,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct RuntimeApiKeyAuth {
+    pub header_name: String,
+    pub keys: Vec<String>,
+}
+
+impl RuntimeApiKeyAuth {
+    pub fn normalize(
+        api_key: &crate::config::ApiKeyAuth,
+        upstream_name: &str,
+    ) -> Result<Self, RuntimeConfigError> {
+        let header_name = api_key.header_name.trim();
+        if header_name.is_empty() {
+            return Err(config_invalid(format!(
+                "upstream '{upstream_name}' auth.api_key.header_name must be non-empty"
+            )));
+        }
+        let keys = normalize_nonempty_string_vec(
+            &format!("upstream '{upstream_name}' auth.api_key.keys"),
+            &api_key.keys,
+        )?;
+        Ok(Self {
+            header_name: header_name.to_string(),
+            keys,
+        })
+    }
+
+    pub fn as_config(&self) -> crate::config::ApiKeyAuth {
+        crate::config::ApiKeyAuth {
+            header_name: self.header_name.clone(),
+            keys: self.keys.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct RuntimeJwtAuth {
+    pub secret: String,
+    pub issuer: Option<String>,
+    pub audience: Option<String>,
+    pub clock_skew: Duration,
+}
+
+impl RuntimeJwtAuth {
+    pub fn normalize(
+        jwt: &crate::config::JwtAuth,
+        upstream_name: &str,
+    ) -> Result<Self, RuntimeConfigError> {
+        let secret = jwt.secret.trim();
+        if secret.is_empty() {
+            return Err(config_invalid(format!(
+                "upstream '{upstream_name}' auth.jwt.secret must be non-empty"
+            )));
+        }
+
+        Ok(Self {
+            secret: secret.to_string(),
+            issuer: normalize_optional_string(jwt.issuer.as_deref()),
+            audience: normalize_optional_string(jwt.audience.as_deref()),
+            clock_skew: Duration::from_secs(jwt.clock_skew_secs),
+        })
+    }
+
+    pub fn as_config(&self) -> crate::config::JwtAuth {
+        crate::config::JwtAuth {
+            secret: self.secret.clone(),
+            issuer: self.issuer.clone(),
+            audience: self.audience.clone(),
+            clock_skew_secs: self.clock_skew.as_secs(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum RuntimeExternalAuthFailureMode {
+    FailOpen,
+    #[default]
+    FailClosed,
+}
+
+impl RuntimeExternalAuthFailureMode {
+    pub fn from_config(mode: crate::config::ExternalAuthFailureMode) -> Self {
+        match mode {
+            crate::config::ExternalAuthFailureMode::FailOpen => Self::FailOpen,
+            crate::config::ExternalAuthFailureMode::FailClosed => Self::FailClosed,
+        }
+    }
+
+    pub fn as_config(self) -> crate::config::ExternalAuthFailureMode {
+        match self {
+            Self::FailOpen => crate::config::ExternalAuthFailureMode::FailOpen,
+            Self::FailClosed => crate::config::ExternalAuthFailureMode::FailClosed,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct RuntimeExternalAuthRequestHeader {
+    pub name: String,
+    pub value: String,
+}
+
+impl RuntimeExternalAuthRequestHeader {
+    fn normalize(
+        header: &crate::config::ExternalAuthRequestHeader,
+        field_name: &str,
+    ) -> Result<Self, RuntimeConfigError> {
+        let name = header.name.trim();
+        if name.is_empty() {
+            return Err(config_invalid(format!("{field_name}.name must be non-empty")));
+        }
+        http::header::HeaderName::from_bytes(name.as_bytes()).map_err(|_| {
+            config_invalid(format!("{field_name}.name must be a valid HTTP header name"))
+        })?;
+
+        Ok(Self {
+            name: name.to_string(),
+            value: header.value.clone(),
+        })
+    }
+
+    fn normalize_many(
+        headers: &[crate::config::ExternalAuthRequestHeader],
+        field_name: &str,
+    ) -> Result<Vec<Self>, RuntimeConfigError> {
+        headers
+            .iter()
+            .enumerate()
+            .map(|(index, header)| Self::normalize(header, &format!("{field_name}[{index}]")))
+            .collect()
+    }
+
+    fn as_config(&self) -> crate::config::ExternalAuthRequestHeader {
+        crate::config::ExternalAuthRequestHeader {
+            name: self.name.clone(),
+            value: self.value.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RuntimeExternalAuth {
+    Http {
+        endpoint: String,
+        request_headers: Vec<RuntimeExternalAuthRequestHeader>,
+        response_header_allowlist: Vec<String>,
+        timeout: Duration,
+        failure_mode: RuntimeExternalAuthFailureMode,
+    },
+    Oidc {
+        discovery_url: Option<String>,
+        issuer_url: Option<String>,
+        client_id: String,
+        client_secret: Option<String>,
+        audience: Option<String>,
+        scopes: Vec<String>,
+        request_headers: Vec<RuntimeExternalAuthRequestHeader>,
+        response_header_allowlist: Vec<String>,
+        timeout: Duration,
+        failure_mode: RuntimeExternalAuthFailureMode,
+    },
+}
+
+impl RuntimeExternalAuth {
+    fn normalize(
+        external_auth: &crate::config::ExternalAuth,
+        upstream_name: &str,
+    ) -> Result<Self, RuntimeConfigError> {
+        match external_auth {
+            crate::config::ExternalAuth::Http {
+                endpoint,
+                request_headers,
+                response_header_allowlist,
+                timeout_ms,
+                failure_mode,
+            } => {
+                if *timeout_ms == 0 {
+                    return Err(config_invalid(format!(
+                        "upstream '{upstream_name}' auth.external_auth.http.timeout_ms must be greater than 0"
+                    )));
+                }
+                Ok(Self::Http {
+                    endpoint: endpoint.clone(),
+                    request_headers: RuntimeExternalAuthRequestHeader::normalize_many(
+                        request_headers,
+                        &format!("upstream '{upstream_name}' auth.external_auth.http.request_headers"),
+                    )?,
+                    response_header_allowlist: normalize_nonempty_string_vec(
+                        &format!(
+                            "upstream '{upstream_name}' auth.external_auth.http.response_header_allowlist"
+                        ),
+                        response_header_allowlist,
+                    )?,
+                    timeout: Duration::from_millis(*timeout_ms),
+                    failure_mode: RuntimeExternalAuthFailureMode::from_config(*failure_mode),
+                })
+            }
+            crate::config::ExternalAuth::Oidc {
+                discovery_url,
+                issuer_url,
+                client_id,
+                client_secret,
+                audience,
+                scopes,
+                request_headers,
+                response_header_allowlist,
+                timeout_ms,
+                failure_mode,
+            } => {
+                if *timeout_ms == 0 {
+                    return Err(config_invalid(format!(
+                        "upstream '{upstream_name}' auth.external_auth.oidc.timeout_ms must be greater than 0"
+                    )));
+                }
+                let client_id = client_id.trim();
+                if client_id.is_empty() {
+                    return Err(config_invalid(format!(
+                        "upstream '{upstream_name}' auth.external_auth.oidc.client_id must be non-empty"
+                    )));
+                }
+                Ok(Self::Oidc {
+                    discovery_url: normalize_optional_string(discovery_url.as_deref()),
+                    issuer_url: normalize_optional_string(issuer_url.as_deref()),
+                    client_id: client_id.to_string(),
+                    client_secret: normalize_optional_string(client_secret.as_deref()),
+                    audience: normalize_optional_string(audience.as_deref()),
+                    scopes: normalize_nonempty_string_vec(
+                        &format!("upstream '{upstream_name}' auth.external_auth.oidc.scopes"),
+                        scopes,
+                    )?,
+                    request_headers: RuntimeExternalAuthRequestHeader::normalize_many(
+                        request_headers,
+                        &format!("upstream '{upstream_name}' auth.external_auth.oidc.request_headers"),
+                    )?,
+                    response_header_allowlist: normalize_nonempty_string_vec(
+                        &format!(
+                            "upstream '{upstream_name}' auth.external_auth.oidc.response_header_allowlist"
+                        ),
+                        response_header_allowlist,
+                    )?,
+                    timeout: Duration::from_millis(*timeout_ms),
+                    failure_mode: RuntimeExternalAuthFailureMode::from_config(*failure_mode),
+                })
+            }
+        }
+    }
+
+    fn as_config(&self) -> crate::config::ExternalAuth {
+        match self {
+            Self::Http {
+                endpoint,
+                request_headers,
+                response_header_allowlist,
+                timeout,
+                failure_mode,
+            } => crate::config::ExternalAuth::Http {
+                endpoint: endpoint.clone(),
+                request_headers: request_headers.iter().map(Self::header_as_config).collect(),
+                response_header_allowlist: response_header_allowlist.clone(),
+                timeout_ms: timeout.as_millis().try_into().unwrap_or(u64::MAX),
+                failure_mode: failure_mode.as_config(),
+            },
+            Self::Oidc {
+                discovery_url,
+                issuer_url,
+                client_id,
+                client_secret,
+                audience,
+                scopes,
+                request_headers,
+                response_header_allowlist,
+                timeout,
+                failure_mode,
+            } => crate::config::ExternalAuth::Oidc {
+                discovery_url: discovery_url.clone(),
+                issuer_url: issuer_url.clone(),
+                client_id: client_id.clone(),
+                client_secret: client_secret.clone(),
+                audience: audience.clone(),
+                scopes: scopes.clone(),
+                request_headers: request_headers.iter().map(Self::header_as_config).collect(),
+                response_header_allowlist: response_header_allowlist.clone(),
+                timeout_ms: timeout.as_millis().try_into().unwrap_or(u64::MAX),
+                failure_mode: failure_mode.as_config(),
+            },
+        }
+    }
+
+    fn header_as_config(
+        header: &RuntimeExternalAuthRequestHeader,
+    ) -> crate::config::ExternalAuthRequestHeader {
+        header.as_config()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct RuntimeAuthPolicy {
+    pub api_key: Option<RuntimeApiKeyAuth>,
+    pub jwt: Option<RuntimeJwtAuth>,
+    pub external_auth: Option<RuntimeExternalAuth>,
+    pub required_scopes: Vec<String>,
+    pub required_roles: Vec<String>,
+}
+
+impl RuntimeAuthPolicy {
+    pub fn normalize(
+        auth: &crate::config::RouteAuth,
+        upstream_name: &str,
+    ) -> Result<Self, RuntimeConfigError> {
+        Ok(Self {
+            api_key: auth
+                .api_key
+                .as_ref()
+                .map(|api_key| RuntimeApiKeyAuth::normalize(api_key, upstream_name))
+                .transpose()?,
+            jwt: auth
+                .jwt
+                .as_ref()
+                .map(|jwt| RuntimeJwtAuth::normalize(jwt, upstream_name))
+                .transpose()?,
+            external_auth: auth
+                .external_auth
+                .as_ref()
+                .map(|external_auth| RuntimeExternalAuth::normalize(external_auth, upstream_name))
+                .transpose()?,
+            required_scopes: normalize_nonempty_string_vec(
+                &format!("upstream '{upstream_name}' auth.required_scopes"),
+                &auth.required_scopes,
+            )?,
+            required_roles: normalize_nonempty_string_vec(
+                &format!("upstream '{upstream_name}' auth.required_roles"),
+                &auth.required_roles,
+            )?,
+        })
+    }
+
+    pub fn as_config(&self) -> crate::config::RouteAuth {
+        crate::config::RouteAuth {
+            api_key: self.api_key.as_ref().map(RuntimeApiKeyAuth::as_config),
+            jwt: self.jwt.as_ref().map(RuntimeJwtAuth::as_config),
+            external_auth: self.external_auth.as_ref().map(RuntimeExternalAuth::as_config),
+            required_scopes: self.required_scopes.clone(),
+            required_roles: self.required_roles.clone(),
         }
     }
 }
@@ -515,6 +875,81 @@ impl RuntimeScopedRateLimitPolicy {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeAdaptiveAdmissionPolicy {
+    pub enabled: bool,
+    pub min_limit: usize,
+    pub max_limit: usize,
+    pub decrease_step: usize,
+    pub increase_step: usize,
+    pub high_latency: Duration,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeRouteQueuePolicy {
+    pub default_cap: usize,
+    pub global_cap: usize,
+    pub shed_retry_after_seconds: u32,
+    pub caps: HashMap<String, usize>,
+}
+
+impl RuntimeRouteQueuePolicy {
+    pub fn clamped(&self, default_cap_limit: usize, global_cap_limit: usize) -> Self {
+        let mut clamped = self.clone();
+        clamped.default_cap = clamped.default_cap.min(default_cap_limit).max(1);
+        clamped.global_cap = clamped.global_cap.min(global_cap_limit).max(1);
+        for cap in clamped.caps.values_mut() {
+            *cap = (*cap).min(default_cap_limit).max(1);
+        }
+        clamped
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeCircuitBreakerPolicy {
+    pub enabled: bool,
+    pub failure_threshold: u32,
+    pub open: Duration,
+    pub half_open_max_probes: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeHedgingPolicy {
+    pub enabled: bool,
+    pub delay: Duration,
+    pub safe_methods: Vec<String>,
+    pub route_allowlist: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeRetryBudgetPolicy {
+    pub enabled: bool,
+    pub ratio_percent: u8,
+    pub per_route_ratio_percent: HashMap<String, u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeBrownoutPolicy {
+    pub enabled: bool,
+    pub trigger_inflight_percent: u8,
+    pub recover_inflight_percent: u8,
+    pub core_routes: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeWatchdogPolicy {
+    pub enabled: bool,
+    pub check_interval: Duration,
+    pub poll_stall_timeout: Duration,
+    pub timeout_error_rate_percent: u8,
+    pub min_requests_per_window: u64,
+    pub overload_inflight_percent: u8,
+    pub unhealthy_consecutive_windows: u32,
+    pub drain_grace: Duration,
+    pub restart_cooldown: Duration,
+    pub restart_command: Vec<String>,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RuntimeRateLimitPolicy {
     pub scoped_limits: Vec<RuntimeScopedRateLimitPolicy>,
@@ -541,20 +976,20 @@ impl RuntimeRateLimitPolicy {
 
 #[derive(Debug, Clone)]
 pub struct RuntimeAdmissionPolicy {
-    pub adaptive_admission: crate::config::AdaptiveAdmission,
-    pub route_queue: crate::config::RouteQueue,
-    pub circuit_breaker: crate::config::CircuitBreaker,
-    pub hedging: crate::config::Hedging,
-    pub retry_budget: crate::config::RetryBudget,
-    pub brownout: crate::config::Brownout,
-    pub watchdog: crate::config::Watchdog,
+    pub adaptive_admission: RuntimeAdaptiveAdmissionPolicy,
+    pub route_queue: RuntimeRouteQueuePolicy,
+    pub circuit_breaker: RuntimeCircuitBreakerPolicy,
+    pub hedging: RuntimeHedgingPolicy,
+    pub retry_budget: RuntimeRetryBudgetPolicy,
+    pub brownout: RuntimeBrownoutPolicy,
+    pub watchdog: RuntimeWatchdogPolicy,
     pub protocol: RuntimeProtocolPolicy,
 }
 
 impl RuntimeAdmissionPolicy {
     pub fn normalize(
         resilience: &Resilience,
-        transport: &RuntimeTransportPolicy,
+        global_inflight_limit: usize,
     ) -> Result<Self, RuntimeConfigError> {
         if resilience.adaptive_admission.min_limit == 0 {
             return Err(config_invalid(
@@ -573,10 +1008,10 @@ impl RuntimeAdmissionPolicy {
                     max_limit, resilience.adaptive_admission.min_limit
                 )));
             }
-            if max_limit > transport.global_inflight_limit {
+            if max_limit > global_inflight_limit {
                 return Err(config_invalid(format!(
                     "resilience.adaptive_admission.max_limit ({}) must be <= performance.global_inflight_limit ({})",
-                    max_limit, transport.global_inflight_limit
+                    max_limit, global_inflight_limit
                 )));
             }
         }
@@ -608,29 +1043,24 @@ impl RuntimeAdmissionPolicy {
             ));
         }
 
-        let early_data_safe_methods = normalize_string_vec(&resilience.protocol.early_data_safe_methods);
-        if early_data_safe_methods.len() != resilience.protocol.early_data_safe_methods.len() {
-            return Err(config_invalid(
-                "resilience.protocol.early_data_safe_methods must not contain empty values",
-            ));
-        }
-        let allowed_methods = normalize_string_vec(&resilience.protocol.allowed_methods);
-        if allowed_methods.len() != resilience.protocol.allowed_methods.len() {
-            return Err(config_invalid(
-                "resilience.protocol.allowed_methods must not contain empty values",
-            ));
-        }
+        let early_data_safe_methods = normalize_nonempty_string_vec(
+            "resilience.protocol.early_data_safe_methods",
+            &resilience.protocol.early_data_safe_methods,
+        )?;
+        let allowed_methods = normalize_nonempty_string_vec(
+            "resilience.protocol.allowed_methods",
+            &resilience.protocol.allowed_methods,
+        )?;
         if allowed_methods.iter().any(|method| !is_valid_http_token(method)) {
             return Err(config_invalid(
                 "resilience.protocol.allowed_methods must contain valid HTTP method tokens",
             ));
         }
-        let denied_path_prefixes = normalize_string_vec(&resilience.protocol.denied_path_prefixes);
-        if denied_path_prefixes.len() != resilience.protocol.denied_path_prefixes.len()
-            || denied_path_prefixes
-                .iter()
-                .any(|prefix| !prefix.starts_with('/'))
-        {
+        let denied_path_prefixes = normalize_nonempty_string_vec(
+            "resilience.protocol.denied_path_prefixes",
+            &resilience.protocol.denied_path_prefixes,
+        )?;
+        if denied_path_prefixes.iter().any(|prefix| !prefix.starts_with('/')) {
             return Err(config_invalid(
                 "resilience.protocol.denied_path_prefixes must contain '/'-prefixed paths",
             ));
@@ -779,15 +1209,83 @@ impl RuntimeAdmissionPolicy {
         protocol.denied_path_prefixes = denied_path_prefixes;
 
         Ok(Self {
-            adaptive_admission: resilience.adaptive_admission.clone(),
-            route_queue: resilience.route_queue.clone(),
-            circuit_breaker: resilience.circuit_breaker.clone(),
-            hedging: resilience.hedging.clone(),
-            retry_budget: resilience.retry_budget.clone(),
-            brownout: resilience.brownout.clone(),
-            watchdog: resilience.watchdog.clone(),
+            adaptive_admission: RuntimeAdaptiveAdmissionPolicy {
+                enabled: resilience.adaptive_admission.enabled,
+                min_limit: resilience.adaptive_admission.min_limit,
+                max_limit: resilience
+                    .adaptive_admission
+                    .max_limit
+                    .unwrap_or(global_inflight_limit)
+                    .max(resilience.adaptive_admission.min_limit),
+                decrease_step: resilience.adaptive_admission.decrease_step,
+                increase_step: resilience.adaptive_admission.increase_step,
+                high_latency: Duration::from_millis(resilience.adaptive_admission.high_latency_ms),
+            },
+            route_queue: RuntimeRouteQueuePolicy {
+                default_cap: resilience.route_queue.default_cap,
+                global_cap: resilience.route_queue.global_cap,
+                shed_retry_after_seconds: resilience.route_queue.shed_retry_after_seconds.max(1),
+                caps: resilience.route_queue.caps.clone(),
+            },
+            circuit_breaker: RuntimeCircuitBreakerPolicy {
+                enabled: resilience.circuit_breaker.enabled,
+                failure_threshold: resilience.circuit_breaker.failure_threshold,
+                open: Duration::from_millis(resilience.circuit_breaker.open_ms.max(1)),
+                half_open_max_probes: resilience.circuit_breaker.half_open_max_probes,
+            },
+            hedging: RuntimeHedgingPolicy {
+                enabled: resilience.hedging.enabled,
+                delay: Duration::from_millis(resilience.hedging.delay_ms),
+                safe_methods: normalize_string_vec(&resilience.hedging.safe_methods),
+                route_allowlist: normalize_string_vec(&resilience.hedging.route_allowlist),
+            },
+            retry_budget: RuntimeRetryBudgetPolicy {
+                enabled: resilience.retry_budget.enabled,
+                ratio_percent: resilience.retry_budget.ratio_percent,
+                per_route_ratio_percent: resilience.retry_budget.per_route_ratio_percent.clone(),
+            },
+            brownout: RuntimeBrownoutPolicy {
+                enabled: resilience.brownout.enabled,
+                trigger_inflight_percent: resilience.brownout.trigger_inflight_percent,
+                recover_inflight_percent: resilience.brownout.recover_inflight_percent,
+                core_routes: normalize_string_vec(&resilience.brownout.core_routes),
+            },
+            watchdog: RuntimeWatchdogPolicy {
+                enabled: resilience.watchdog.enabled,
+                check_interval: Duration::from_millis(resilience.watchdog.check_interval_ms),
+                poll_stall_timeout: Duration::from_millis(
+                    resilience.watchdog.poll_stall_timeout_ms,
+                ),
+                timeout_error_rate_percent: resilience.watchdog.timeout_error_rate_percent,
+                min_requests_per_window: resilience.watchdog.min_requests_per_window,
+                overload_inflight_percent: resilience.watchdog.overload_inflight_percent,
+                unhealthy_consecutive_windows: resilience
+                    .watchdog
+                    .unhealthy_consecutive_windows,
+                drain_grace: Duration::from_millis(resilience.watchdog.drain_grace_ms),
+                restart_cooldown: Duration::from_millis(
+                    resilience.watchdog.restart_cooldown_ms,
+                ),
+                restart_command: resilience.watchdog.restart_command.clone(),
+            },
             protocol: RuntimeProtocolPolicy(protocol),
         })
+    }
+
+    pub fn with_runtime_overrides(
+        &self,
+        default_route_cap_limit: usize,
+        global_route_cap_limit: usize,
+        adaptive_high_latency_limit: Duration,
+    ) -> Self {
+        let mut updated = self.clone();
+        updated.route_queue = updated
+            .route_queue
+            .clamped(default_route_cap_limit, global_route_cap_limit);
+        if updated.adaptive_admission.high_latency > adaptive_high_latency_limit {
+            updated.adaptive_admission.high_latency = adaptive_high_latency_limit;
+        }
+        updated
     }
 }
 
@@ -817,7 +1315,8 @@ impl RuntimePolicySet {
         let timeouts = RuntimeTimeoutPolicy::normalize(&config.performance)?;
         let transport = RuntimeTransportPolicy::normalize(&config.performance)?;
         let rate_limits = RuntimeRateLimitPolicy::normalize(&config.resilience)?;
-        let admission = RuntimeAdmissionPolicy::normalize(&config.resilience, &transport)?;
+        let admission =
+            RuntimeAdmissionPolicy::normalize(&config.resilience, transport.global_inflight_limit)?;
 
         Ok(Self {
             timeouts,

--- a/crates/config/src/runtime/policies.rs
+++ b/crates/config/src/runtime/policies.rs
@@ -186,7 +186,7 @@ pub struct RuntimeRouteMatchPolicy {
 }
 
 impl RuntimeRouteMatchPolicy {
-    pub fn normalize(
+    pub(crate) fn normalize(
         upstream_name: &str,
         route: &crate::config::RouteMatch,
     ) -> Result<Self, RuntimeConfigError> {
@@ -215,7 +215,8 @@ impl RuntimeRouteMatchPolicy {
         })
     }
 
-    pub fn as_config(&self) -> crate::config::RouteMatch {
+    #[cfg(test)]
+    pub(crate) fn as_config(&self) -> crate::config::RouteMatch {
         crate::config::RouteMatch {
             host: self.host.clone(),
             path_prefix: self.path_prefix.clone(),
@@ -240,7 +241,7 @@ pub enum RuntimeRequestKeySpec {
 }
 
 impl RuntimeRequestKeySpec {
-    pub fn normalize(raw: &str) -> Result<Self, RuntimeConfigError> {
+    pub(crate) fn normalize(raw: &str) -> Result<Self, RuntimeConfigError> {
         let normalized = raw.trim().to_ascii_lowercase();
         match normalized.as_str() {
             "path" => Ok(Self::Path),
@@ -277,21 +278,6 @@ impl RuntimeRequestKeySpec {
         }
     }
 
-    pub fn as_config(&self) -> String {
-        match self {
-            Self::Path => "path".to_string(),
-            Self::Authority => "authority".to_string(),
-            Self::Method => "method".to_string(),
-            Self::Cid => "cid".to_string(),
-            Self::StickyCid => "sticky-cid".to_string(),
-            Self::PeerIp => "peer_ip".to_string(),
-            Self::ClientIp => "client_ip".to_string(),
-            Self::BearerToken => "bearer_token".to_string(),
-            Self::Header(name) => format!("header:{name}"),
-            Self::Cookie(name) => format!("cookie:{name}"),
-            Self::Query(name) => format!("query:{name}"),
-        }
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -307,7 +293,7 @@ pub struct RuntimeApiKeyAuth {
 }
 
 impl RuntimeApiKeyAuth {
-    pub fn normalize(
+    pub(crate) fn normalize(
         api_key: &crate::config::ApiKeyAuth,
         upstream_name: &str,
     ) -> Result<Self, RuntimeConfigError> {
@@ -327,7 +313,8 @@ impl RuntimeApiKeyAuth {
         })
     }
 
-    pub fn as_config(&self) -> crate::config::ApiKeyAuth {
+    #[cfg(test)]
+    pub(crate) fn as_config(&self) -> crate::config::ApiKeyAuth {
         crate::config::ApiKeyAuth {
             header_name: self.header_name.clone(),
             keys: self.keys.clone(),
@@ -344,7 +331,7 @@ pub struct RuntimeJwtAuth {
 }
 
 impl RuntimeJwtAuth {
-    pub fn normalize(
+    pub(crate) fn normalize(
         jwt: &crate::config::JwtAuth,
         upstream_name: &str,
     ) -> Result<Self, RuntimeConfigError> {
@@ -363,7 +350,8 @@ impl RuntimeJwtAuth {
         })
     }
 
-    pub fn as_config(&self) -> crate::config::JwtAuth {
+    #[cfg(test)]
+    pub(crate) fn as_config(&self) -> crate::config::JwtAuth {
         crate::config::JwtAuth {
             secret: self.secret.clone(),
             issuer: self.issuer.clone(),
@@ -381,14 +369,15 @@ pub enum RuntimeExternalAuthFailureMode {
 }
 
 impl RuntimeExternalAuthFailureMode {
-    pub fn from_config(mode: crate::config::ExternalAuthFailureMode) -> Self {
+    pub(crate) fn from_config(mode: crate::config::ExternalAuthFailureMode) -> Self {
         match mode {
             crate::config::ExternalAuthFailureMode::FailOpen => Self::FailOpen,
             crate::config::ExternalAuthFailureMode::FailClosed => Self::FailClosed,
         }
     }
 
-    pub fn as_config(self) -> crate::config::ExternalAuthFailureMode {
+    #[cfg(test)]
+    pub(crate) fn as_config(self) -> crate::config::ExternalAuthFailureMode {
         match self {
             Self::FailOpen => crate::config::ExternalAuthFailureMode::FailOpen,
             Self::FailClosed => crate::config::ExternalAuthFailureMode::FailClosed,
@@ -432,6 +421,7 @@ impl RuntimeExternalAuthRequestHeader {
             .collect()
     }
 
+    #[cfg(test)]
     fn as_config(&self) -> crate::config::ExternalAuthRequestHeader {
         crate::config::ExternalAuthRequestHeader {
             name: self.name.clone(),
@@ -547,6 +537,7 @@ impl RuntimeExternalAuth {
         }
     }
 
+    #[cfg(test)]
     fn as_config(&self) -> crate::config::ExternalAuth {
         match self {
             Self::Http {
@@ -588,6 +579,7 @@ impl RuntimeExternalAuth {
         }
     }
 
+    #[cfg(test)]
     fn header_as_config(
         header: &RuntimeExternalAuthRequestHeader,
     ) -> crate::config::ExternalAuthRequestHeader {
@@ -605,7 +597,7 @@ pub struct RuntimeAuthPolicy {
 }
 
 impl RuntimeAuthPolicy {
-    pub fn normalize(
+    pub(crate) fn normalize(
         auth: &crate::config::RouteAuth,
         upstream_name: &str,
     ) -> Result<Self, RuntimeConfigError> {
@@ -636,7 +628,8 @@ impl RuntimeAuthPolicy {
         })
     }
 
-    pub fn as_config(&self) -> crate::config::RouteAuth {
+    #[cfg(test)]
+    pub(crate) fn as_config(&self) -> crate::config::RouteAuth {
         crate::config::RouteAuth {
             api_key: self.api_key.as_ref().map(RuntimeApiKeyAuth::as_config),
             jwt: self.jwt.as_ref().map(RuntimeJwtAuth::as_config),
@@ -663,7 +656,7 @@ pub struct RuntimeTimeoutPolicy {
 }
 
 impl RuntimeTimeoutPolicy {
-    pub fn normalize(performance: &Performance) -> Result<Self, RuntimeConfigError> {
+    pub(crate) fn normalize(performance: &Performance) -> Result<Self, RuntimeConfigError> {
         require_nonzero_u64("performance.backend_timeout_ms", performance.backend_timeout_ms)?;
         require_nonzero_u64(
             "performance.backend_connect_timeout_ms",
@@ -801,7 +794,7 @@ pub struct RuntimeBackendDnsPolicy {
 }
 
 impl RuntimeTransportPolicy {
-    pub fn normalize(performance: &Performance) -> Result<Self, RuntimeConfigError> {
+    pub(crate) fn normalize(performance: &Performance) -> Result<Self, RuntimeConfigError> {
         require_nonzero_usize("performance.worker_threads", performance.worker_threads)?;
         if performance.worker_threads > 1024 {
             return Err(config_invalid(format!(
@@ -1021,7 +1014,7 @@ pub struct RuntimeBackendEndpoint {
 }
 
 impl RuntimeBackendEndpoint {
-    pub fn normalize(
+    pub(crate) fn normalize(
         upstream_name: &str,
         backend_id: &str,
         address: &str,
@@ -1069,7 +1062,7 @@ pub struct RuntimeBackendHealthCheck {
 }
 
 impl RuntimeBackendHealthCheck {
-    pub fn normalize(
+    pub(crate) fn normalize(
         upstream_name: &str,
         backend_id: &str,
         health_check: &crate::config::HealthCheck,
@@ -1109,7 +1102,8 @@ impl RuntimeBackendHealthCheck {
         })
     }
 
-    pub fn as_config(&self) -> crate::config::HealthCheck {
+    #[cfg(test)]
+    pub(crate) fn as_config(&self) -> crate::config::HealthCheck {
         crate::config::HealthCheck {
             path: self.path.clone(),
             interval: self.interval.as_millis().try_into().unwrap_or(u64::MAX),
@@ -1158,7 +1152,7 @@ pub struct RuntimeLoadBalancingPolicy {
 }
 
 impl RuntimeLoadBalancingPolicy {
-    pub fn normalize(load_balancing: &LoadBalancing) -> Result<Self, RuntimeConfigError> {
+    pub(crate) fn normalize(load_balancing: &LoadBalancing) -> Result<Self, RuntimeConfigError> {
         let strategy = RuntimeLoadBalancingStrategy::from_lb_type(&load_balancing.lb_type);
         if matches!(strategy, RuntimeLoadBalancingStrategy::Other) {
             return Err(config_invalid(format!(
@@ -1182,7 +1176,8 @@ impl RuntimeLoadBalancingPolicy {
         })
     }
 
-    pub fn as_config(&self) -> LoadBalancing {
+    #[cfg(test)]
+    pub(crate) fn as_config(&self) -> LoadBalancing {
         LoadBalancing {
             lb_type: self.strategy.canonical_name().to_string(),
             key: self.key.clone(),
@@ -1202,7 +1197,9 @@ pub struct RuntimeScopedRateLimitPolicy {
 }
 
 impl RuntimeScopedRateLimitPolicy {
-    pub fn normalize(rule: &crate::config::ScopedRateLimit) -> Result<Self, RuntimeConfigError> {
+    pub(crate) fn normalize(
+        rule: &crate::config::ScopedRateLimit,
+    ) -> Result<Self, RuntimeConfigError> {
         let rule_name = rule.name.trim();
         if rule_name.is_empty() {
             return Err(config_invalid(
@@ -1363,7 +1360,7 @@ pub struct RuntimeRateLimitPolicy {
 }
 
 impl RuntimeRateLimitPolicy {
-    pub fn normalize(resilience: &Resilience) -> Result<Self, RuntimeConfigError> {
+    pub(crate) fn normalize(resilience: &Resilience) -> Result<Self, RuntimeConfigError> {
         let mut seen_names = std::collections::HashSet::new();
         let mut scoped_limits = Vec::with_capacity(resilience.scoped_rate_limits.len());
         for rule in &resilience.scoped_rate_limits {
@@ -1394,7 +1391,7 @@ pub struct RuntimeAdmissionPolicy {
 }
 
 impl RuntimeAdmissionPolicy {
-    pub fn normalize(
+    pub(crate) fn normalize(
         resilience: &Resilience,
         global_inflight_limit: usize,
     ) -> Result<Self, RuntimeConfigError> {
@@ -1725,7 +1722,7 @@ pub struct RuntimePolicySet {
 }
 
 impl RuntimePolicySet {
-    pub fn from_config(config: &Config) -> Result<Self, RuntimeConfigError> {
+    pub(crate) fn from_config(config: &Config) -> Result<Self, RuntimeConfigError> {
         let timeouts = RuntimeTimeoutPolicy::normalize(&config.performance)?;
         let transport = RuntimeTransportPolicy::normalize(&config.performance)?;
         let rate_limits = RuntimeRateLimitPolicy::normalize(&config.resilience)?;
@@ -1769,26 +1766,4 @@ pub struct RuntimeUpstreamPolicySet {
     pub host: RuntimeHostPolicy,
     pub forwarded_headers: RuntimeForwardedHeaderPolicy,
     pub protocol: RuntimeProtocolPolicy,
-}
-
-impl RuntimeUpstreamPolicySet {
-    pub fn normalize(
-        upstream: &RuntimeUpstream,
-        base: &RuntimePolicySet,
-    ) -> Result<Self, RuntimeConfigError> {
-        Ok(Self {
-            timeouts: base.timeouts.clone(),
-            auth: upstream.policy.upstream_auth.clone(),
-            rate_limits: base.rate_limits.clone(),
-            load_balancing: upstream.load_balancing.clone(),
-            admission: base.admission.clone(),
-            transport: RuntimeUpstreamTransportPolicy::from_effective_tls(
-                &upstream.effective_tls,
-                &base.transport,
-            ),
-            host: upstream.policy.host.clone(),
-            forwarded_headers: upstream.policy.forwarded_headers.clone(),
-            protocol: upstream.policy.protocol.clone(),
-        })
-    }
 }

--- a/crates/config/src/runtime/policies.rs
+++ b/crates/config/src/runtime/policies.rs
@@ -1,0 +1,293 @@
+use std::time::Duration;
+
+use super::*;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeLoadBalancingStrategy {
+    RoundRobin,
+    ConsistentHash,
+    Random,
+    LeastConnections,
+    LatencyAware,
+    StickyCid,
+    Other,
+}
+
+impl RuntimeLoadBalancingStrategy {
+    pub fn from_lb_type(lb_type: &str) -> Self {
+        match lb_type.trim().to_ascii_lowercase().as_str() {
+            "round-robin" => Self::RoundRobin,
+            "consistent-hash" => Self::ConsistentHash,
+            "random" => Self::Random,
+            "least-connections" => Self::LeastConnections,
+            "latency-aware" => Self::LatencyAware,
+            "sticky-cid" => Self::StickyCid,
+            _ => Self::Other,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeTimeoutPolicy {
+    pub inflight_acquire_wait: Duration,
+    pub backend_request: Duration,
+    pub backend_connect: Duration,
+    pub backend_body_idle: Duration,
+    pub backend_body_total: Duration,
+    pub backend_total_request: Duration,
+    pub shutdown_drain: Duration,
+    pub client_body_idle: Duration,
+    pub h2_pool_idle: Duration,
+    pub backend_dns_refresh_interval: Duration,
+    pub quic_max_idle: Duration,
+}
+
+impl RuntimeTimeoutPolicy {
+    pub fn from_performance(performance: &Performance) -> Self {
+        Self {
+            inflight_acquire_wait: Duration::from_millis(performance.inflight_acquire_wait_ms),
+            backend_request: Duration::from_millis(performance.backend_timeout_ms),
+            backend_connect: Duration::from_millis(performance.backend_connect_timeout_ms),
+            backend_body_idle: Duration::from_millis(performance.backend_body_idle_timeout_ms),
+            backend_body_total: Duration::from_millis(performance.backend_body_total_timeout_ms),
+            backend_total_request: Duration::from_millis(
+                performance.backend_total_request_timeout_ms,
+            ),
+            shutdown_drain: Duration::from_millis(performance.shutdown_drain_timeout_ms),
+            client_body_idle: Duration::from_millis(performance.client_body_idle_timeout_ms),
+            h2_pool_idle: Duration::from_millis(performance.h2_pool_idle_timeout_ms),
+            backend_dns_refresh_interval: Duration::from_millis(
+                performance.backend_dns_refresh_interval_ms,
+            ),
+            quic_max_idle: Duration::from_millis(performance.quic_max_idle_timeout_ms),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeTransportPolicy {
+    pub worker_threads: usize,
+    pub control_plane_threads: usize,
+    pub packet_shards_per_worker: usize,
+    pub packet_shard_queue_capacity: usize,
+    pub packet_shard_queue_max_bytes: usize,
+    pub reuseport: bool,
+    pub pin_workers: bool,
+    pub global_inflight_limit: usize,
+    pub per_upstream_inflight_limit: usize,
+    pub per_backend_inflight_limit: usize,
+    pub udp_recv_buffer_bytes: usize,
+    pub udp_send_buffer_bytes: usize,
+    pub h2_pool_max_idle_per_backend: usize,
+    pub backend_dns_refresh_enabled: bool,
+    pub new_connections_per_sec: u32,
+    pub new_connections_burst: u32,
+    pub max_active_connections: usize,
+    pub quic_initial_max_data: u64,
+    pub quic_initial_max_stream_data: u64,
+    pub quic_initial_max_streams_bidi: u64,
+    pub quic_initial_max_streams_uni: u64,
+    pub max_response_body_bytes: usize,
+    pub max_request_body_bytes: usize,
+    pub request_buffer_global_cap_bytes: usize,
+    pub unknown_length_response_prebuffer_bytes: usize,
+}
+
+impl RuntimeTransportPolicy {
+    pub fn from_performance(performance: &Performance) -> Self {
+        Self {
+            worker_threads: performance.worker_threads,
+            control_plane_threads: performance.control_plane_threads,
+            packet_shards_per_worker: performance.packet_shards_per_worker,
+            packet_shard_queue_capacity: performance.packet_shard_queue_capacity,
+            packet_shard_queue_max_bytes: performance.packet_shard_queue_max_bytes,
+            reuseport: performance.reuseport,
+            pin_workers: performance.pin_workers,
+            global_inflight_limit: performance.global_inflight_limit,
+            per_upstream_inflight_limit: performance.per_upstream_inflight_limit,
+            per_backend_inflight_limit: performance.per_backend_inflight_limit,
+            udp_recv_buffer_bytes: performance.udp_recv_buffer_bytes,
+            udp_send_buffer_bytes: performance.udp_send_buffer_bytes,
+            h2_pool_max_idle_per_backend: performance.h2_pool_max_idle_per_backend,
+            backend_dns_refresh_enabled: performance.backend_dns_refresh_enabled,
+            new_connections_per_sec: performance.new_connections_per_sec,
+            new_connections_burst: performance.new_connections_burst,
+            max_active_connections: performance.max_active_connections,
+            quic_initial_max_data: performance.quic_initial_max_data,
+            quic_initial_max_stream_data: performance.quic_initial_max_stream_data,
+            quic_initial_max_streams_bidi: performance.quic_initial_max_streams_bidi,
+            quic_initial_max_streams_uni: performance.quic_initial_max_streams_uni,
+            max_response_body_bytes: performance.max_response_body_bytes,
+            max_request_body_bytes: performance.max_request_body_bytes,
+            request_buffer_global_cap_bytes: performance.request_buffer_global_cap_bytes,
+            unknown_length_response_prebuffer_bytes:
+                performance.unknown_length_response_prebuffer_bytes,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeLoadBalancingPolicy {
+    pub strategy: RuntimeLoadBalancingStrategy,
+    pub key: Option<String>,
+}
+
+impl RuntimeLoadBalancingPolicy {
+    pub fn from_config(load_balancing: &LoadBalancing) -> Self {
+        Self {
+            strategy: RuntimeLoadBalancingStrategy::from_lb_type(&load_balancing.lb_type),
+            key: load_balancing.key.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeScopedRateLimitPolicy {
+    pub name: String,
+    pub scope: crate::config::ScopedRateLimitScope,
+    pub requests_per_sec: u32,
+    pub burst: u32,
+    pub key: Option<String>,
+    pub route_allowlist: Vec<String>,
+    pub idle_ttl: Duration,
+}
+
+impl RuntimeScopedRateLimitPolicy {
+    pub fn from_config(rule: &crate::config::ScopedRateLimit) -> Self {
+        Self {
+            name: rule.name.clone(),
+            scope: rule.scope,
+            requests_per_sec: rule.requests_per_sec,
+            burst: rule.burst,
+            key: rule.key.clone(),
+            route_allowlist: rule.route_allowlist.clone(),
+            idle_ttl: Duration::from_secs(rule.idle_ttl_secs),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RuntimeRateLimitPolicy {
+    pub scoped_limits: Vec<RuntimeScopedRateLimitPolicy>,
+}
+
+impl RuntimeRateLimitPolicy {
+    pub fn from_resilience(resilience: &Resilience) -> Self {
+        Self {
+            scoped_limits: resilience
+                .scoped_rate_limits
+                .iter()
+                .map(RuntimeScopedRateLimitPolicy::from_config)
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeAdmissionPolicy {
+    pub adaptive_admission: crate::config::AdaptiveAdmission,
+    pub route_queue: crate::config::RouteQueue,
+    pub circuit_breaker: crate::config::CircuitBreaker,
+    pub hedging: crate::config::Hedging,
+    pub retry_budget: crate::config::RetryBudget,
+    pub brownout: crate::config::Brownout,
+    pub watchdog: crate::config::Watchdog,
+    pub protocol: RuntimeProtocolPolicy,
+}
+
+impl RuntimeAdmissionPolicy {
+    pub fn from_resilience(resilience: &Resilience) -> Self {
+        Self {
+            adaptive_admission: resilience.adaptive_admission.clone(),
+            route_queue: resilience.route_queue.clone(),
+            circuit_breaker: resilience.circuit_breaker.clone(),
+            hedging: resilience.hedging.clone(),
+            retry_budget: resilience.retry_budget.clone(),
+            brownout: resilience.brownout.clone(),
+            watchdog: resilience.watchdog.clone(),
+            protocol: RuntimeProtocolPolicy(resilience.protocol.clone()),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeUpstreamTransportPolicy {
+    pub effective_tls: UpstreamTls,
+}
+
+impl RuntimeUpstreamTransportPolicy {
+    pub fn from_effective_tls(effective_tls: &UpstreamTls) -> Self {
+        Self {
+            effective_tls: effective_tls.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimePolicySet {
+    pub timeouts: RuntimeTimeoutPolicy,
+    pub admission: RuntimeAdmissionPolicy,
+    pub rate_limits: RuntimeRateLimitPolicy,
+    pub transport: RuntimeTransportPolicy,
+}
+
+impl RuntimePolicySet {
+    pub fn from_runtime_config(config: &RuntimeConfig) -> Self {
+        Self {
+            timeouts: RuntimeTimeoutPolicy::from_performance(&config.performance),
+            admission: RuntimeAdmissionPolicy::from_resilience(&config.resilience),
+            rate_limits: RuntimeRateLimitPolicy::from_resilience(&config.resilience),
+            transport: RuntimeTransportPolicy::from_performance(&config.performance),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeListenerPolicySet {
+    pub timeouts: RuntimeTimeoutPolicy,
+    pub transport: RuntimeTransportPolicy,
+    pub tls: RuntimeListenerTls,
+}
+
+impl RuntimeListenerPolicySet {
+    pub fn from_listener_runtime_config(config: &ListenerRuntimeConfig) -> Self {
+        Self {
+            timeouts: RuntimeTimeoutPolicy::from_performance(&config.performance),
+            transport: RuntimeTransportPolicy::from_performance(&config.performance),
+            tls: config.listen.tls.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeUpstreamPolicySet {
+    pub timeouts: RuntimeTimeoutPolicy,
+    pub auth: RuntimeAuthPolicy,
+    pub rate_limits: RuntimeRateLimitPolicy,
+    pub load_balancing: RuntimeLoadBalancingPolicy,
+    pub admission: RuntimeAdmissionPolicy,
+    pub transport: RuntimeUpstreamTransportPolicy,
+    pub host: RuntimeHostPolicy,
+    pub forwarded_headers: RuntimeForwardedHeaderPolicy,
+    pub protocol: RuntimeProtocolPolicy,
+}
+
+impl RuntimeUpstreamPolicySet {
+    pub fn from_runtime_parts(
+        upstream: &RuntimeUpstream,
+        performance: &Performance,
+        resilience: &Resilience,
+    ) -> Self {
+        Self {
+            timeouts: RuntimeTimeoutPolicy::from_performance(performance),
+            auth: upstream.policy.upstream_auth.clone(),
+            rate_limits: RuntimeRateLimitPolicy::from_resilience(resilience),
+            load_balancing: RuntimeLoadBalancingPolicy::from_config(&upstream.load_balancing),
+            admission: RuntimeAdmissionPolicy::from_resilience(resilience),
+            transport: RuntimeUpstreamTransportPolicy::from_effective_tls(&upstream.effective_tls),
+            host: upstream.policy.host.clone(),
+            forwarded_headers: upstream.policy.forwarded_headers.clone(),
+            protocol: upstream.policy.protocol.clone(),
+        }
+    }
+}

--- a/crates/config/src/runtime/policies.rs
+++ b/crates/config/src/runtime/policies.rs
@@ -586,6 +586,32 @@ pub struct RuntimeTransportPolicy {
     pub max_request_body_bytes: usize,
     pub request_buffer_global_cap_bytes: usize,
     pub unknown_length_response_prebuffer_bytes: usize,
+    pub connection_limits: RuntimeConnectionLimits,
+    pub backend_connections: RuntimeBackendConnectionPolicy,
+    pub backend_dns: RuntimeBackendDnsPolicy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeConnectionLimits {
+    pub global_inflight: usize,
+    pub per_upstream_inflight: usize,
+    pub per_backend: usize,
+    pub backend_pool_max_inflight: usize,
+    pub max_active_connections: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeBackendConnectionPolicy {
+    pub max_inflight: usize,
+    pub max_idle_per_backend: usize,
+    pub pool_idle_timeout: Duration,
+    pub connect_timeout: Duration,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeBackendDnsPolicy {
+    pub refresh_enabled: bool,
+    pub refresh_interval: Duration,
 }
 
 impl RuntimeTransportPolicy {
@@ -756,7 +782,184 @@ impl RuntimeTransportPolicy {
             request_buffer_global_cap_bytes: performance.request_buffer_global_cap_bytes,
             unknown_length_response_prebuffer_bytes:
                 performance.unknown_length_response_prebuffer_bytes,
+            connection_limits: RuntimeConnectionLimits {
+                global_inflight: performance.global_inflight_limit,
+                per_upstream_inflight: performance.per_upstream_inflight_limit,
+                per_backend: performance.per_backend_inflight_limit,
+                backend_pool_max_inflight: performance
+                    .per_backend_inflight_limit
+                    .saturating_mul(performance.worker_threads.max(1)),
+                max_active_connections: performance.max_active_connections,
+            },
+            backend_connections: RuntimeBackendConnectionPolicy {
+                max_inflight: performance
+                    .per_backend_inflight_limit
+                    .saturating_mul(performance.worker_threads.max(1)),
+                max_idle_per_backend: performance.h2_pool_max_idle_per_backend,
+                pool_idle_timeout: Duration::from_millis(performance.h2_pool_idle_timeout_ms),
+                connect_timeout: Duration::from_millis(
+                    performance.backend_connect_timeout_ms,
+                ),
+            },
+            backend_dns: RuntimeBackendDnsPolicy {
+                refresh_enabled: performance.backend_dns_refresh_enabled,
+                refresh_interval: Duration::from_millis(
+                    performance.backend_dns_refresh_interval_ms,
+                ),
+            },
         })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeBackendTransportKind {
+    Http1,
+    H2,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeBackendAddressKind {
+    Hostname,
+    IpLiteral,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeBackendEndpoint {
+    pub configured_address: String,
+    pub canonical: BackendEndpoint,
+    pub origin: String,
+    pub authority_host: String,
+    pub authority_port: u16,
+    pub address_kind: RuntimeBackendAddressKind,
+    pub transport_kind: RuntimeBackendTransportKind,
+}
+
+impl RuntimeBackendEndpoint {
+    pub fn normalize(
+        upstream_name: &str,
+        backend_id: &str,
+        address: &str,
+    ) -> Result<Self, RuntimeConfigError> {
+        let canonical =
+            BackendEndpoint::parse(address).map_err(|reason| RuntimeConfigError::BackendAddressInvalid {
+                upstream: upstream_name.to_string(),
+                backend: backend_id.to_string(),
+                address: address.to_string(),
+                reason,
+            })?;
+        let authority_host = canonical.authority_host().to_string();
+        let authority_port = canonical.authority_port();
+        let address_kind = if canonical.authority_is_ip_literal() {
+            RuntimeBackendAddressKind::IpLiteral
+        } else {
+            RuntimeBackendAddressKind::Hostname
+        };
+        let transport_kind = match canonical.scheme() {
+            crate::backend_endpoint::BackendScheme::Http => RuntimeBackendTransportKind::Http1,
+            crate::backend_endpoint::BackendScheme::Https => RuntimeBackendTransportKind::H2,
+        };
+        let origin = canonical.origin();
+
+        Ok(Self {
+            configured_address: address.to_string(),
+            canonical,
+            origin,
+            authority_host,
+            authority_port,
+            address_kind,
+            transport_kind,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeBackendHealthCheck {
+    pub path: String,
+    pub interval: Duration,
+    pub timeout: Duration,
+    pub failure_threshold: u32,
+    pub success_threshold: u32,
+    pub cooldown: Duration,
+}
+
+impl RuntimeBackendHealthCheck {
+    pub fn normalize(
+        upstream_name: &str,
+        backend_id: &str,
+        health_check: &crate::config::HealthCheck,
+    ) -> Result<Self, RuntimeConfigError> {
+        if health_check.interval == 0 {
+            return Err(config_invalid(format!(
+                "health check interval is invalid (0) for backend '{backend_id}' in upstream '{upstream_name}'"
+            )));
+        }
+        if health_check.timeout_ms == 0 {
+            return Err(config_invalid(format!(
+                "health check timeout is invalid (0) for backend '{backend_id}' in upstream '{upstream_name}'"
+            )));
+        }
+        if health_check.failure_threshold == 0 {
+            return Err(config_invalid(format!(
+                "health check failure threshold is invalid (0) for backend '{backend_id}' in upstream '{upstream_name}'"
+            )));
+        }
+        if health_check.success_threshold == 0 {
+            return Err(config_invalid(format!(
+                "health check success threshold is invalid (0) for backend '{backend_id}' in upstream '{upstream_name}'"
+            )));
+        }
+
+        Ok(Self {
+            path: if health_check.path.trim().is_empty() {
+                "/".to_string()
+            } else {
+                health_check.path.clone()
+            },
+            interval: Duration::from_millis(health_check.interval),
+            timeout: Duration::from_millis(health_check.timeout_ms),
+            failure_threshold: health_check.failure_threshold,
+            success_threshold: health_check.success_threshold,
+            cooldown: Duration::from_millis(health_check.cooldown_ms),
+        })
+    }
+
+    pub fn as_config(&self) -> crate::config::HealthCheck {
+        crate::config::HealthCheck {
+            path: self.path.clone(),
+            interval: self.interval.as_millis().try_into().unwrap_or(u64::MAX),
+            timeout_ms: self.timeout.as_millis().try_into().unwrap_or(u64::MAX),
+            failure_threshold: self.failure_threshold,
+            success_threshold: self.success_threshold,
+            cooldown_ms: self.cooldown.as_millis().try_into().unwrap_or(u64::MAX),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeBackendTlsPolicy {
+    pub verify_certificates: bool,
+    pub strict_sni: bool,
+    pub ca_file: Option<String>,
+    pub ca_dir: Option<String>,
+}
+
+impl RuntimeBackendTlsPolicy {
+    pub fn from_effective_tls(effective_tls: &UpstreamTls) -> Self {
+        Self {
+            verify_certificates: effective_tls.verify_certificates,
+            strict_sni: effective_tls.strict_sni,
+            ca_file: effective_tls.ca_file.clone(),
+            ca_dir: effective_tls.ca_dir.clone(),
+        }
+    }
+
+    pub fn as_upstream_tls(&self) -> UpstreamTls {
+        UpstreamTls {
+            verify_certificates: self.verify_certificates,
+            strict_sni: self.strict_sni,
+            ca_file: self.ca_file.clone(),
+            ca_dir: self.ca_dir.clone(),
+        }
     }
 }
 
@@ -1291,13 +1494,20 @@ impl RuntimeAdmissionPolicy {
 
 #[derive(Debug, Clone)]
 pub struct RuntimeUpstreamTransportPolicy {
-    pub effective_tls: UpstreamTls,
+    pub tls: RuntimeBackendTlsPolicy,
+    pub connection: RuntimeBackendConnectionPolicy,
+    pub dns: RuntimeBackendDnsPolicy,
 }
 
 impl RuntimeUpstreamTransportPolicy {
-    pub fn from_effective_tls(effective_tls: &UpstreamTls) -> Self {
+    pub fn from_effective_tls(
+        effective_tls: &UpstreamTls,
+        transport: &RuntimeTransportPolicy,
+    ) -> Self {
         Self {
-            effective_tls: effective_tls.clone(),
+            tls: RuntimeBackendTlsPolicy::from_effective_tls(effective_tls),
+            connection: transport.backend_connections.clone(),
+            dns: transport.backend_dns.clone(),
         }
     }
 }
@@ -1368,7 +1578,10 @@ impl RuntimeUpstreamPolicySet {
             rate_limits: base.rate_limits.clone(),
             load_balancing: RuntimeLoadBalancingPolicy::normalize(&upstream.load_balancing)?,
             admission: base.admission.clone(),
-            transport: RuntimeUpstreamTransportPolicy::from_effective_tls(&upstream.effective_tls),
+            transport: RuntimeUpstreamTransportPolicy::from_effective_tls(
+                &upstream.effective_tls,
+                &base.transport,
+            ),
             host: upstream.policy.host.clone(),
             forwarded_headers: upstream.policy.forwarded_headers.clone(),
             protocol: upstream.policy.protocol.clone(),

--- a/crates/config/src/runtime/policies.rs
+++ b/crates/config/src/runtime/policies.rs
@@ -71,21 +71,23 @@ fn is_valid_connect_authority(authority: &str) -> bool {
     let Some((host, port)) = authority.rsplit_once(':') else {
         return false;
     };
-    !host.trim().is_empty()
-        && port
-            .parse::<u16>()
-            .ok()
-            .is_some_and(|parsed| parsed > 0)
+    !host.trim().is_empty() && port.parse::<u16>().ok().is_some_and(|parsed| parsed > 0)
 }
 
 fn is_valid_request_key_spec(key_spec: &str) -> bool {
     let key_spec = key_spec.trim().to_ascii_lowercase();
     matches!(
         key_spec.as_str(),
-        "path" | "authority" | "method" | "cid" | "sticky-cid" | "peer_ip" | "client_ip" | "bearer_token"
+        "path"
+            | "authority"
+            | "method"
+            | "cid"
+            | "sticky-cid"
+            | "peer_ip"
+            | "client_ip"
+            | "bearer_token"
     ) || key_spec.split_once(':').is_some_and(|(source, key_name)| {
-        !key_name.trim().is_empty()
-            && matches!(source.trim(), "header" | "cookie" | "query")
+        !key_name.trim().is_empty() && matches!(source.trim(), "header" | "cookie" | "query")
     })
 }
 
@@ -200,7 +202,8 @@ impl RuntimeRouteMatchPolicy {
             )));
         }
 
-        let host = normalize_optional_string(route.host.as_deref()).map(|host| normalize_route_host(&host));
+        let host = normalize_optional_string(route.host.as_deref())
+            .map(|host| normalize_route_host(&host));
         let host_pattern = host.as_deref().map(parse_runtime_route_host_pattern);
         let method = normalized_route_method(route.method.as_deref());
 
@@ -277,7 +280,6 @@ impl RuntimeRequestKeySpec {
             }
         }
     }
-
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -398,10 +400,14 @@ impl RuntimeExternalAuthRequestHeader {
     ) -> Result<Self, RuntimeConfigError> {
         let name = header.name.trim();
         if name.is_empty() {
-            return Err(config_invalid(format!("{field_name}.name must be non-empty")));
+            return Err(config_invalid(format!(
+                "{field_name}.name must be non-empty"
+            )));
         }
         http::header::HeaderName::from_bytes(name.as_bytes()).map_err(|_| {
-            config_invalid(format!("{field_name}.name must be a valid HTTP header name"))
+            config_invalid(format!(
+                "{field_name}.name must be a valid HTTP header name"
+            ))
         })?;
 
         Ok(Self {
@@ -475,7 +481,9 @@ impl RuntimeExternalAuth {
                     endpoint: endpoint.clone(),
                     request_headers: RuntimeExternalAuthRequestHeader::normalize_many(
                         request_headers,
-                        &format!("upstream '{upstream_name}' auth.external_auth.http.request_headers"),
+                        &format!(
+                            "upstream '{upstream_name}' auth.external_auth.http.request_headers"
+                        ),
                     )?,
                     response_header_allowlist: normalize_nonempty_string_vec(
                         &format!(
@@ -522,7 +530,9 @@ impl RuntimeExternalAuth {
                     )?,
                     request_headers: RuntimeExternalAuthRequestHeader::normalize_many(
                         request_headers,
-                        &format!("upstream '{upstream_name}' auth.external_auth.oidc.request_headers"),
+                        &format!(
+                            "upstream '{upstream_name}' auth.external_auth.oidc.request_headers"
+                        ),
                     )?,
                     response_header_allowlist: normalize_nonempty_string_vec(
                         &format!(
@@ -633,7 +643,10 @@ impl RuntimeAuthPolicy {
         crate::config::RouteAuth {
             api_key: self.api_key.as_ref().map(RuntimeApiKeyAuth::as_config),
             jwt: self.jwt.as_ref().map(RuntimeJwtAuth::as_config),
-            external_auth: self.external_auth.as_ref().map(RuntimeExternalAuth::as_config),
+            external_auth: self
+                .external_auth
+                .as_ref()
+                .map(RuntimeExternalAuth::as_config),
             required_scopes: self.required_scopes.clone(),
             required_roles: self.required_roles.clone(),
         }
@@ -657,7 +670,10 @@ pub struct RuntimeTimeoutPolicy {
 
 impl RuntimeTimeoutPolicy {
     pub(crate) fn normalize(performance: &Performance) -> Result<Self, RuntimeConfigError> {
-        require_nonzero_u64("performance.backend_timeout_ms", performance.backend_timeout_ms)?;
+        require_nonzero_u64(
+            "performance.backend_timeout_ms",
+            performance.backend_timeout_ms,
+        )?;
         require_nonzero_u64(
             "performance.backend_connect_timeout_ms",
             performance.backend_connect_timeout_ms,
@@ -710,8 +726,7 @@ impl RuntimeTimeoutPolicy {
                 "performance.backend_body_idle_timeout_ms must be <= backend_body_total_timeout_ms",
             ));
         }
-        if performance.backend_body_total_timeout_ms
-            > performance.backend_total_request_timeout_ms
+        if performance.backend_body_total_timeout_ms > performance.backend_total_request_timeout_ms
         {
             return Err(config_invalid(
                 "performance.backend_body_total_timeout_ms must be <= backend_total_request_timeout_ms",
@@ -882,8 +897,7 @@ impl RuntimeTransportPolicy {
         if performance.quic_initial_max_stream_data > performance.quic_initial_max_data {
             return Err(config_invalid(format!(
                 "performance.quic_initial_max_stream_data ({}) must be <= quic_initial_max_data ({})",
-                performance.quic_initial_max_stream_data,
-                performance.quic_initial_max_data
+                performance.quic_initial_max_stream_data, performance.quic_initial_max_data
             )));
         }
         require_nonzero_u64(
@@ -913,19 +927,16 @@ impl RuntimeTransportPolicy {
         if performance.max_request_body_bytes > performance.quic_initial_max_stream_data as usize {
             return Err(config_invalid(format!(
                 "performance.max_request_body_bytes ({}) must be <= quic_initial_max_stream_data ({})",
-                performance.max_request_body_bytes,
-                performance.quic_initial_max_stream_data
+                performance.max_request_body_bytes, performance.quic_initial_max_stream_data
             )));
         }
         if performance.request_buffer_global_cap_bytes < performance.max_request_body_bytes {
             return Err(config_invalid(format!(
                 "performance.request_buffer_global_cap_bytes ({}) must be >= max_request_body_bytes ({})",
-                performance.request_buffer_global_cap_bytes,
-                performance.max_request_body_bytes
+                performance.request_buffer_global_cap_bytes, performance.max_request_body_bytes
             )));
         }
-        if performance.unknown_length_response_prebuffer_bytes
-            > performance.max_response_body_bytes
+        if performance.unknown_length_response_prebuffer_bytes > performance.max_response_body_bytes
         {
             return Err(config_invalid(format!(
                 "performance.unknown_length_response_prebuffer_bytes ({}) must be <= max_response_body_bytes ({})",
@@ -959,8 +970,8 @@ impl RuntimeTransportPolicy {
             max_response_body_bytes: performance.max_response_body_bytes,
             max_request_body_bytes: performance.max_request_body_bytes,
             request_buffer_global_cap_bytes: performance.request_buffer_global_cap_bytes,
-            unknown_length_response_prebuffer_bytes:
-                performance.unknown_length_response_prebuffer_bytes,
+            unknown_length_response_prebuffer_bytes: performance
+                .unknown_length_response_prebuffer_bytes,
             connection_limits: RuntimeConnectionLimits {
                 global_inflight: performance.global_inflight_limit,
                 per_upstream_inflight: performance.per_upstream_inflight_limit,
@@ -976,9 +987,7 @@ impl RuntimeTransportPolicy {
                     .saturating_mul(performance.worker_threads.max(1)),
                 max_idle_per_backend: performance.h2_pool_max_idle_per_backend,
                 pool_idle_timeout: Duration::from_millis(performance.h2_pool_idle_timeout_ms),
-                connect_timeout: Duration::from_millis(
-                    performance.backend_connect_timeout_ms,
-                ),
+                connect_timeout: Duration::from_millis(performance.backend_connect_timeout_ms),
             },
             backend_dns: RuntimeBackendDnsPolicy {
                 refresh_enabled: performance.backend_dns_refresh_enabled,
@@ -1019,13 +1028,14 @@ impl RuntimeBackendEndpoint {
         backend_id: &str,
         address: &str,
     ) -> Result<Self, RuntimeConfigError> {
-        let canonical =
-            BackendEndpoint::parse(address).map_err(|reason| RuntimeConfigError::BackendAddressInvalid {
+        let canonical = BackendEndpoint::parse(address).map_err(|reason| {
+            RuntimeConfigError::BackendAddressInvalid {
                 upstream: upstream_name.to_string(),
                 backend: backend_id.to_string(),
                 address: address.to_string(),
                 reason,
-            })?;
+            }
+        })?;
         let authority_host = canonical.authority_host().to_string();
         let authority_port = canonical.authority_port();
         let address_kind = if canonical.authority_is_ip_literal() {
@@ -1258,7 +1268,9 @@ impl RuntimeScopedRateLimitPolicy {
             }
             crate::config::ScopedRateLimitScope::Client
             | crate::config::ScopedRateLimitScope::Token => {
-                if let Some(key_spec) = key.as_deref() && !is_valid_request_key_spec(key_spec) {
+                if let Some(key_spec) = key.as_deref()
+                    && !is_valid_request_key_spec(key_spec)
+                {
                     return Err(config_invalid(format!(
                         "resilience.scoped_rate_limits['{}'].key must be a supported request key spec",
                         rule_name
@@ -1455,7 +1467,10 @@ impl RuntimeAdmissionPolicy {
             "resilience.protocol.allowed_methods",
             &resilience.protocol.allowed_methods,
         )?;
-        if allowed_methods.iter().any(|method| !is_valid_http_token(method)) {
+        if allowed_methods
+            .iter()
+            .any(|method| !is_valid_http_token(method))
+        {
             return Err(config_invalid(
                 "resilience.protocol.allowed_methods must contain valid HTTP method tokens",
             ));
@@ -1464,7 +1479,10 @@ impl RuntimeAdmissionPolicy {
             "resilience.protocol.denied_path_prefixes",
             &resilience.protocol.denied_path_prefixes,
         )?;
-        if denied_path_prefixes.iter().any(|prefix| !prefix.starts_with('/')) {
+        if denied_path_prefixes
+            .iter()
+            .any(|prefix| !prefix.starts_with('/'))
+        {
             return Err(config_invalid(
                 "resilience.protocol.denied_path_prefixes must contain '/'-prefixed paths",
             ));
@@ -1663,13 +1681,9 @@ impl RuntimeAdmissionPolicy {
                 timeout_error_rate_percent: resilience.watchdog.timeout_error_rate_percent,
                 min_requests_per_window: resilience.watchdog.min_requests_per_window,
                 overload_inflight_percent: resilience.watchdog.overload_inflight_percent,
-                unhealthy_consecutive_windows: resilience
-                    .watchdog
-                    .unhealthy_consecutive_windows,
+                unhealthy_consecutive_windows: resilience.watchdog.unhealthy_consecutive_windows,
                 drain_grace: Duration::from_millis(resilience.watchdog.drain_grace_ms),
-                restart_cooldown: Duration::from_millis(
-                    resilience.watchdog.restart_cooldown_ms,
-                ),
+                restart_cooldown: Duration::from_millis(resilience.watchdog.restart_cooldown_ms),
                 restart_command: resilience.watchdog.restart_command.clone(),
             },
             protocol: RuntimeProtocolPolicy(protocol),

--- a/crates/config/src/runtime/policies.rs
+++ b/crates/config/src/runtime/policies.rs
@@ -2,6 +2,80 @@ use std::time::Duration;
 
 use super::*;
 
+fn config_invalid(message: impl Into<String>) -> RuntimeConfigError {
+    RuntimeConfigError::ConfigInvalid(message.into())
+}
+
+fn unsupported_policy(message: impl Into<String>) -> RuntimeConfigError {
+    RuntimeConfigError::UnsupportedPolicyCombination(message.into())
+}
+
+fn require_nonzero_u64(name: &str, value: u64) -> Result<(), RuntimeConfigError> {
+    if value == 0 {
+        return Err(config_invalid(format!("{name} must be greater than 0")));
+    }
+    Ok(())
+}
+
+fn require_nonzero_usize(name: &str, value: usize) -> Result<(), RuntimeConfigError> {
+    if value == 0 {
+        return Err(config_invalid(format!("{name} must be greater than 0")));
+    }
+    Ok(())
+}
+
+fn require_nonzero_u32(name: &str, value: u32) -> Result<(), RuntimeConfigError> {
+    if value == 0 {
+        return Err(config_invalid(format!("{name} must be greater than 0")));
+    }
+    Ok(())
+}
+
+fn normalize_optional_string(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn normalize_string_vec(values: &[String]) -> Vec<String> {
+    values
+        .iter()
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn is_valid_http_token(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .bytes()
+            .all(|byte| matches!(byte, b'!' | b'#'..=b'\'' | b'*' | b'+' | b'-' | b'.' | b'0'..=b'9' | b'A'..=b'Z' | b'^' | b'_' | b'`' | b'a'..=b'z' | b'|' | b'~'))
+}
+
+fn is_valid_connect_authority(authority: &str) -> bool {
+    let Some((host, port)) = authority.rsplit_once(':') else {
+        return false;
+    };
+    !host.trim().is_empty()
+        && port
+            .parse::<u16>()
+            .ok()
+            .is_some_and(|parsed| parsed > 0)
+}
+
+fn is_valid_request_key_spec(key_spec: &str) -> bool {
+    let key_spec = key_spec.trim().to_ascii_lowercase();
+    matches!(
+        key_spec.as_str(),
+        "path" | "authority" | "method" | "cid" | "sticky-cid" | "peer_ip" | "client_ip" | "bearer_token"
+    ) || key_spec.split_once(':').is_some_and(|(source, key_name)| {
+        !key_name.trim().is_empty()
+            && matches!(source.trim(), "header" | "cookie" | "query")
+    })
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RuntimeLoadBalancingStrategy {
     RoundRobin,
@@ -43,8 +117,69 @@ pub struct RuntimeTimeoutPolicy {
 }
 
 impl RuntimeTimeoutPolicy {
-    pub fn from_performance(performance: &Performance) -> Self {
-        Self {
+    pub fn normalize(performance: &Performance) -> Result<Self, RuntimeConfigError> {
+        require_nonzero_u64("performance.backend_timeout_ms", performance.backend_timeout_ms)?;
+        require_nonzero_u64(
+            "performance.backend_connect_timeout_ms",
+            performance.backend_connect_timeout_ms,
+        )?;
+        require_nonzero_u64(
+            "performance.backend_body_idle_timeout_ms",
+            performance.backend_body_idle_timeout_ms,
+        )?;
+        require_nonzero_u64(
+            "performance.backend_body_total_timeout_ms",
+            performance.backend_body_total_timeout_ms,
+        )?;
+        require_nonzero_u64(
+            "performance.backend_total_request_timeout_ms",
+            performance.backend_total_request_timeout_ms,
+        )?;
+        require_nonzero_u64(
+            "performance.shutdown_drain_timeout_ms",
+            performance.shutdown_drain_timeout_ms,
+        )?;
+        require_nonzero_u64(
+            "performance.client_body_idle_timeout_ms",
+            performance.client_body_idle_timeout_ms,
+        )?;
+        require_nonzero_u64(
+            "performance.h2_pool_idle_timeout_ms",
+            performance.h2_pool_idle_timeout_ms,
+        )?;
+        require_nonzero_u64(
+            "performance.backend_dns_refresh_interval_ms",
+            performance.backend_dns_refresh_interval_ms,
+        )?;
+        require_nonzero_u64(
+            "performance.quic_max_idle_timeout_ms",
+            performance.quic_max_idle_timeout_ms,
+        )?;
+
+        if performance.backend_connect_timeout_ms > performance.backend_timeout_ms {
+            return Err(config_invalid(
+                "performance.backend_connect_timeout_ms must be <= backend_timeout_ms",
+            ));
+        }
+        if performance.backend_timeout_ms > performance.backend_body_idle_timeout_ms {
+            return Err(config_invalid(
+                "performance.backend_timeout_ms must be <= backend_body_idle_timeout_ms",
+            ));
+        }
+        if performance.backend_body_idle_timeout_ms > performance.backend_body_total_timeout_ms {
+            return Err(config_invalid(
+                "performance.backend_body_idle_timeout_ms must be <= backend_body_total_timeout_ms",
+            ));
+        }
+        if performance.backend_body_total_timeout_ms
+            > performance.backend_total_request_timeout_ms
+        {
+            return Err(config_invalid(
+                "performance.backend_body_total_timeout_ms must be <= backend_total_request_timeout_ms",
+            ));
+        }
+
+        Ok(Self {
             inflight_acquire_wait: Duration::from_millis(performance.inflight_acquire_wait_ms),
             backend_request: Duration::from_millis(performance.backend_timeout_ms),
             backend_connect: Duration::from_millis(performance.backend_connect_timeout_ms),
@@ -60,7 +195,7 @@ impl RuntimeTimeoutPolicy {
                 performance.backend_dns_refresh_interval_ms,
             ),
             quic_max_idle: Duration::from_millis(performance.quic_max_idle_timeout_ms),
-        }
+        })
     }
 }
 
@@ -94,8 +229,147 @@ pub struct RuntimeTransportPolicy {
 }
 
 impl RuntimeTransportPolicy {
-    pub fn from_performance(performance: &Performance) -> Self {
-        Self {
+    pub fn normalize(performance: &Performance) -> Result<Self, RuntimeConfigError> {
+        require_nonzero_usize("performance.worker_threads", performance.worker_threads)?;
+        if performance.worker_threads > 1024 {
+            return Err(config_invalid(format!(
+                "performance.worker_threads={} exceeds the maximum of 1024",
+                performance.worker_threads
+            )));
+        }
+        require_nonzero_usize(
+            "performance.control_plane_threads",
+            performance.control_plane_threads,
+        )?;
+        if performance.control_plane_threads > 1024 {
+            return Err(config_invalid(format!(
+                "performance.control_plane_threads={} exceeds the maximum of 1024",
+                performance.control_plane_threads
+            )));
+        }
+        require_nonzero_usize(
+            "performance.packet_shards_per_worker",
+            performance.packet_shards_per_worker,
+        )?;
+        if performance.packet_shards_per_worker > 256 {
+            return Err(config_invalid(format!(
+                "performance.packet_shards_per_worker={} exceeds the maximum of 256",
+                performance.packet_shards_per_worker
+            )));
+        }
+        require_nonzero_usize(
+            "performance.packet_shard_queue_capacity",
+            performance.packet_shard_queue_capacity,
+        )?;
+        require_nonzero_usize(
+            "performance.packet_shard_queue_max_bytes",
+            performance.packet_shard_queue_max_bytes,
+        )?;
+        if performance.worker_threads > 1 && !performance.reuseport {
+            return Err(config_invalid(
+                "performance.reuseport must be true when performance.worker_threads > 1",
+            ));
+        }
+        require_nonzero_usize(
+            "performance.global_inflight_limit",
+            performance.global_inflight_limit,
+        )?;
+        require_nonzero_usize(
+            "performance.per_upstream_inflight_limit",
+            performance.per_upstream_inflight_limit,
+        )?;
+        require_nonzero_usize(
+            "performance.per_backend_inflight_limit",
+            performance.per_backend_inflight_limit,
+        )?;
+        require_nonzero_usize(
+            "performance.udp_recv_buffer_bytes",
+            performance.udp_recv_buffer_bytes,
+        )?;
+        require_nonzero_usize(
+            "performance.udp_send_buffer_bytes",
+            performance.udp_send_buffer_bytes,
+        )?;
+        require_nonzero_usize(
+            "performance.h2_pool_max_idle_per_backend",
+            performance.h2_pool_max_idle_per_backend,
+        )?;
+        require_nonzero_u32(
+            "performance.new_connections_per_sec",
+            performance.new_connections_per_sec,
+        )?;
+        require_nonzero_u32(
+            "performance.new_connections_burst",
+            performance.new_connections_burst,
+        )?;
+        require_nonzero_usize(
+            "performance.max_active_connections",
+            performance.max_active_connections,
+        )?;
+        require_nonzero_u64(
+            "performance.quic_initial_max_data",
+            performance.quic_initial_max_data,
+        )?;
+        require_nonzero_u64(
+            "performance.quic_initial_max_stream_data",
+            performance.quic_initial_max_stream_data,
+        )?;
+        if performance.quic_initial_max_stream_data > performance.quic_initial_max_data {
+            return Err(config_invalid(format!(
+                "performance.quic_initial_max_stream_data ({}) must be <= quic_initial_max_data ({})",
+                performance.quic_initial_max_stream_data,
+                performance.quic_initial_max_data
+            )));
+        }
+        require_nonzero_u64(
+            "performance.quic_initial_max_streams_bidi",
+            performance.quic_initial_max_streams_bidi,
+        )?;
+        require_nonzero_u64(
+            "performance.quic_initial_max_streams_uni",
+            performance.quic_initial_max_streams_uni,
+        )?;
+        require_nonzero_usize(
+            "performance.max_response_body_bytes",
+            performance.max_response_body_bytes,
+        )?;
+        require_nonzero_usize(
+            "performance.max_request_body_bytes",
+            performance.max_request_body_bytes,
+        )?;
+        require_nonzero_usize(
+            "performance.request_buffer_global_cap_bytes",
+            performance.request_buffer_global_cap_bytes,
+        )?;
+        require_nonzero_usize(
+            "performance.unknown_length_response_prebuffer_bytes",
+            performance.unknown_length_response_prebuffer_bytes,
+        )?;
+        if performance.max_request_body_bytes > performance.quic_initial_max_stream_data as usize {
+            return Err(config_invalid(format!(
+                "performance.max_request_body_bytes ({}) must be <= quic_initial_max_stream_data ({})",
+                performance.max_request_body_bytes,
+                performance.quic_initial_max_stream_data
+            )));
+        }
+        if performance.request_buffer_global_cap_bytes < performance.max_request_body_bytes {
+            return Err(config_invalid(format!(
+                "performance.request_buffer_global_cap_bytes ({}) must be >= max_request_body_bytes ({})",
+                performance.request_buffer_global_cap_bytes,
+                performance.max_request_body_bytes
+            )));
+        }
+        if performance.unknown_length_response_prebuffer_bytes
+            > performance.max_response_body_bytes
+        {
+            return Err(config_invalid(format!(
+                "performance.unknown_length_response_prebuffer_bytes ({}) must be <= max_response_body_bytes ({})",
+                performance.unknown_length_response_prebuffer_bytes,
+                performance.max_response_body_bytes
+            )));
+        }
+
+        Ok(Self {
             worker_threads: performance.worker_threads,
             control_plane_threads: performance.control_plane_threads,
             packet_shards_per_worker: performance.packet_shards_per_worker,
@@ -122,7 +396,7 @@ impl RuntimeTransportPolicy {
             request_buffer_global_cap_bytes: performance.request_buffer_global_cap_bytes,
             unknown_length_response_prebuffer_bytes:
                 performance.unknown_length_response_prebuffer_bytes,
-        }
+        })
     }
 }
 
@@ -133,11 +407,19 @@ pub struct RuntimeLoadBalancingPolicy {
 }
 
 impl RuntimeLoadBalancingPolicy {
-    pub fn from_config(load_balancing: &LoadBalancing) -> Self {
-        Self {
-            strategy: RuntimeLoadBalancingStrategy::from_lb_type(&load_balancing.lb_type),
-            key: load_balancing.key.clone(),
+    pub fn normalize(load_balancing: &LoadBalancing) -> Result<Self, RuntimeConfigError> {
+        let strategy = RuntimeLoadBalancingStrategy::from_lb_type(&load_balancing.lb_type);
+        if matches!(strategy, RuntimeLoadBalancingStrategy::Other) {
+            return Err(config_invalid(format!(
+                "unsupported load balancing type '{}'",
+                load_balancing.lb_type
+            )));
         }
+
+        Ok(Self {
+            strategy,
+            key: normalize_optional_string(load_balancing.key.as_deref()),
+        })
     }
 }
 
@@ -153,16 +435,83 @@ pub struct RuntimeScopedRateLimitPolicy {
 }
 
 impl RuntimeScopedRateLimitPolicy {
-    pub fn from_config(rule: &crate::config::ScopedRateLimit) -> Self {
-        Self {
+    pub fn normalize(rule: &crate::config::ScopedRateLimit) -> Result<Self, RuntimeConfigError> {
+        let rule_name = rule.name.trim();
+        if rule_name.is_empty() {
+            return Err(config_invalid(
+                "resilience.scoped_rate_limits[].name must be non-empty",
+            ));
+        }
+        if rule.requests_per_sec == 0 {
+            return Err(config_invalid(format!(
+                "resilience.scoped_rate_limits['{}'].requests_per_sec must be greater than 0",
+                rule_name
+            )));
+        }
+        if rule.burst == 0 {
+            return Err(config_invalid(format!(
+                "resilience.scoped_rate_limits['{}'].burst must be greater than 0",
+                rule_name
+            )));
+        }
+        if rule.idle_ttl_secs == 0 {
+            return Err(config_invalid(format!(
+                "resilience.scoped_rate_limits['{}'].idle_ttl_secs must be greater than 0",
+                rule_name
+            )));
+        }
+        let route_allowlist = normalize_string_vec(&rule.route_allowlist);
+        if route_allowlist.len() != rule.route_allowlist.len() {
+            return Err(config_invalid(format!(
+                "resilience.scoped_rate_limits['{}'].route_allowlist must not contain empty values",
+                rule_name
+            )));
+        }
+
+        let key = normalize_optional_string(rule.key.as_deref());
+        match rule.scope {
+            crate::config::ScopedRateLimitScope::Route => {
+                if key.is_some() {
+                    return Err(config_invalid(format!(
+                        "resilience.scoped_rate_limits['{}'].key is invalid for scope=route",
+                        rule_name
+                    )));
+                }
+            }
+            crate::config::ScopedRateLimitScope::Tenant => {
+                let Some(key_spec) = key.as_deref() else {
+                    return Err(config_invalid(format!(
+                        "resilience.scoped_rate_limits['{}'].key is required for scope=tenant",
+                        rule_name
+                    )));
+                };
+                if !is_valid_request_key_spec(key_spec) {
+                    return Err(config_invalid(format!(
+                        "resilience.scoped_rate_limits['{}'].key must be a supported request key spec",
+                        rule_name
+                    )));
+                }
+            }
+            crate::config::ScopedRateLimitScope::Client
+            | crate::config::ScopedRateLimitScope::Token => {
+                if let Some(key_spec) = key.as_deref() && !is_valid_request_key_spec(key_spec) {
+                    return Err(config_invalid(format!(
+                        "resilience.scoped_rate_limits['{}'].key must be a supported request key spec",
+                        rule_name
+                    )));
+                }
+            }
+        }
+
+        Ok(Self {
             name: rule.name.clone(),
             scope: rule.scope,
             requests_per_sec: rule.requests_per_sec,
             burst: rule.burst,
-            key: rule.key.clone(),
-            route_allowlist: rule.route_allowlist.clone(),
+            key,
+            route_allowlist,
             idle_ttl: Duration::from_secs(rule.idle_ttl_secs),
-        }
+        })
     }
 }
 
@@ -172,14 +521,21 @@ pub struct RuntimeRateLimitPolicy {
 }
 
 impl RuntimeRateLimitPolicy {
-    pub fn from_resilience(resilience: &Resilience) -> Self {
-        Self {
-            scoped_limits: resilience
-                .scoped_rate_limits
-                .iter()
-                .map(RuntimeScopedRateLimitPolicy::from_config)
-                .collect(),
+    pub fn normalize(resilience: &Resilience) -> Result<Self, RuntimeConfigError> {
+        let mut seen_names = std::collections::HashSet::new();
+        let mut scoped_limits = Vec::with_capacity(resilience.scoped_rate_limits.len());
+        for rule in &resilience.scoped_rate_limits {
+            let normalized = RuntimeScopedRateLimitPolicy::normalize(rule)?;
+            if !seen_names.insert(normalized.name.clone()) {
+                return Err(config_invalid(format!(
+                    "resilience.scoped_rate_limits contains duplicate rule name '{}'",
+                    normalized.name
+                )));
+            }
+            scoped_limits.push(normalized);
         }
+
+        Ok(Self { scoped_limits })
     }
 }
 
@@ -196,8 +552,233 @@ pub struct RuntimeAdmissionPolicy {
 }
 
 impl RuntimeAdmissionPolicy {
-    pub fn from_resilience(resilience: &Resilience) -> Self {
-        Self {
+    pub fn normalize(
+        resilience: &Resilience,
+        transport: &RuntimeTransportPolicy,
+    ) -> Result<Self, RuntimeConfigError> {
+        if resilience.adaptive_admission.min_limit == 0 {
+            return Err(config_invalid(
+                "resilience.adaptive_admission.min_limit must be greater than 0",
+            ));
+        }
+        if let Some(max_limit) = resilience.adaptive_admission.max_limit {
+            if max_limit == 0 {
+                return Err(config_invalid(
+                    "resilience.adaptive_admission.max_limit must be greater than 0",
+                ));
+            }
+            if max_limit < resilience.adaptive_admission.min_limit {
+                return Err(config_invalid(format!(
+                    "resilience.adaptive_admission.max_limit ({}) must be >= min_limit ({})",
+                    max_limit, resilience.adaptive_admission.min_limit
+                )));
+            }
+            if max_limit > transport.global_inflight_limit {
+                return Err(config_invalid(format!(
+                    "resilience.adaptive_admission.max_limit ({}) must be <= performance.global_inflight_limit ({})",
+                    max_limit, transport.global_inflight_limit
+                )));
+            }
+        }
+        require_nonzero_usize(
+            "resilience.adaptive_admission.decrease_step",
+            resilience.adaptive_admission.decrease_step,
+        )?;
+        require_nonzero_usize(
+            "resilience.adaptive_admission.increase_step",
+            resilience.adaptive_admission.increase_step,
+        )?;
+
+        require_nonzero_usize(
+            "resilience.route_queue.default_cap",
+            resilience.route_queue.default_cap,
+        )?;
+        require_nonzero_usize(
+            "resilience.route_queue.global_cap",
+            resilience.route_queue.global_cap,
+        )?;
+        if resilience.route_queue.shed_retry_after_seconds == 0 {
+            return Err(config_invalid(
+                "resilience.route_queue.shed_retry_after_seconds must be greater than 0",
+            ));
+        }
+        if resilience.route_queue.caps.values().any(|cap| *cap == 0) {
+            return Err(config_invalid(
+                "resilience.route_queue.caps values must be greater than 0",
+            ));
+        }
+
+        let early_data_safe_methods = normalize_string_vec(&resilience.protocol.early_data_safe_methods);
+        if early_data_safe_methods.len() != resilience.protocol.early_data_safe_methods.len() {
+            return Err(config_invalid(
+                "resilience.protocol.early_data_safe_methods must not contain empty values",
+            ));
+        }
+        let allowed_methods = normalize_string_vec(&resilience.protocol.allowed_methods);
+        if allowed_methods.len() != resilience.protocol.allowed_methods.len() {
+            return Err(config_invalid(
+                "resilience.protocol.allowed_methods must not contain empty values",
+            ));
+        }
+        if allowed_methods.iter().any(|method| !is_valid_http_token(method)) {
+            return Err(config_invalid(
+                "resilience.protocol.allowed_methods must contain valid HTTP method tokens",
+            ));
+        }
+        let denied_path_prefixes = normalize_string_vec(&resilience.protocol.denied_path_prefixes);
+        if denied_path_prefixes.len() != resilience.protocol.denied_path_prefixes.len()
+            || denied_path_prefixes
+                .iter()
+                .any(|prefix| !prefix.starts_with('/'))
+        {
+            return Err(config_invalid(
+                "resilience.protocol.denied_path_prefixes must contain '/'-prefixed paths",
+            ));
+        }
+        require_nonzero_usize(
+            "resilience.protocol.max_headers_count",
+            resilience.protocol.max_headers_count,
+        )?;
+        require_nonzero_usize(
+            "resilience.protocol.max_headers_bytes",
+            resilience.protocol.max_headers_bytes,
+        )?;
+        if !resilience.protocol.allow_connect
+            && (!resilience.protocol.connect_allowed_ports.is_empty()
+                || !resilience.protocol.connect_allowed_authorities.is_empty())
+        {
+            return Err(config_invalid(
+                "resilience.protocol.connect_allowed_ports/connect_allowed_authorities require allow_connect=true",
+            ));
+        }
+        if resilience.protocol.connect_allowed_ports.contains(&0) {
+            return Err(config_invalid(
+                "resilience.protocol.connect_allowed_ports must contain ports in range 1-65535",
+            ));
+        }
+        if resilience
+            .protocol
+            .connect_allowed_authorities
+            .iter()
+            .any(|authority| !is_valid_connect_authority(authority))
+        {
+            return Err(config_invalid(
+                "resilience.protocol.connect_allowed_authorities must contain authority-form host:port targets",
+            ));
+        }
+        if resilience.protocol.allow_0rtt && early_data_safe_methods.is_empty() {
+            return Err(config_invalid(
+                "resilience.protocol.early_data_safe_methods must be non-empty when allow_0rtt=true",
+            ));
+        }
+
+        if resilience.circuit_breaker.failure_threshold == 0 {
+            return Err(config_invalid(
+                "resilience.circuit_breaker.failure_threshold must be greater than 0",
+            ));
+        }
+        if resilience.circuit_breaker.open_ms == 0 {
+            return Err(config_invalid(
+                "resilience.circuit_breaker.open_ms must be greater than 0",
+            ));
+        }
+        if resilience.circuit_breaker.half_open_max_probes == 0 {
+            return Err(config_invalid(
+                "resilience.circuit_breaker.half_open_max_probes must be greater than 0",
+            ));
+        }
+
+        if resilience.hedging.enabled && resilience.hedging.delay_ms == 0 {
+            return Err(config_invalid(
+                "resilience.hedging: delay_ms must be > 0 when hedging is enabled",
+            ));
+        }
+
+        if resilience.retry_budget.ratio_percent > 100 {
+            return Err(config_invalid(
+                "resilience.retry_budget.ratio_percent must be <= 100",
+            ));
+        }
+        if resilience
+            .retry_budget
+            .per_route_ratio_percent
+            .values()
+            .any(|ratio| *ratio > 100)
+        {
+            return Err(config_invalid(
+                "resilience.retry_budget.per_route_ratio_percent values must be <= 100",
+            ));
+        }
+
+        if resilience.brownout.trigger_inflight_percent > 100
+            || resilience.brownout.recover_inflight_percent > 100
+        {
+            return Err(config_invalid(
+                "resilience.brownout inflight percentages must be <= 100",
+            ));
+        }
+        if resilience.brownout.recover_inflight_percent
+            >= resilience.brownout.trigger_inflight_percent
+        {
+            return Err(config_invalid(
+                "resilience.brownout.recover_inflight_percent must be < trigger_inflight_percent",
+            ));
+        }
+
+        require_nonzero_u64(
+            "resilience.watchdog.check_interval_ms",
+            resilience.watchdog.check_interval_ms,
+        )?;
+        require_nonzero_u64(
+            "resilience.watchdog.poll_stall_timeout_ms",
+            resilience.watchdog.poll_stall_timeout_ms,
+        )?;
+        if resilience.watchdog.timeout_error_rate_percent > 100 {
+            return Err(config_invalid(
+                "resilience.watchdog.timeout_error_rate_percent must be <= 100",
+            ));
+        }
+        require_nonzero_u64(
+            "resilience.watchdog.min_requests_per_window",
+            resilience.watchdog.min_requests_per_window,
+        )?;
+        if resilience.watchdog.overload_inflight_percent > 100 {
+            return Err(config_invalid(
+                "resilience.watchdog.overload_inflight_percent must be <= 100",
+            ));
+        }
+        if resilience.watchdog.unhealthy_consecutive_windows == 0 {
+            return Err(config_invalid(
+                "resilience.watchdog.unhealthy_consecutive_windows must be greater than 0",
+            ));
+        }
+        require_nonzero_u64(
+            "resilience.watchdog.drain_grace_ms",
+            resilience.watchdog.drain_grace_ms,
+        )?;
+        require_nonzero_u64(
+            "resilience.watchdog.restart_cooldown_ms",
+            resilience.watchdog.restart_cooldown_ms,
+        )?;
+        if !resilience.watchdog.restart_command.is_empty()
+            && resilience.watchdog.restart_command[0].trim().is_empty()
+        {
+            return Err(config_invalid(
+                "resilience.watchdog.restart_command[0] must be a non-empty executable path",
+            ));
+        }
+        if resilience.watchdog.restart_hook.is_some() {
+            return Err(unsupported_policy(
+                "resilience.watchdog.restart_hook is deprecated and unsupported; use restart_command instead",
+            ));
+        }
+
+        let mut protocol = resilience.protocol.clone();
+        protocol.early_data_safe_methods = early_data_safe_methods;
+        protocol.allowed_methods = allowed_methods;
+        protocol.denied_path_prefixes = denied_path_prefixes;
+
+        Ok(Self {
             adaptive_admission: resilience.adaptive_admission.clone(),
             route_queue: resilience.route_queue.clone(),
             circuit_breaker: resilience.circuit_breaker.clone(),
@@ -205,8 +786,8 @@ impl RuntimeAdmissionPolicy {
             retry_budget: resilience.retry_budget.clone(),
             brownout: resilience.brownout.clone(),
             watchdog: resilience.watchdog.clone(),
-            protocol: RuntimeProtocolPolicy(resilience.protocol.clone()),
-        }
+            protocol: RuntimeProtocolPolicy(protocol),
+        })
     }
 }
 
@@ -232,13 +813,18 @@ pub struct RuntimePolicySet {
 }
 
 impl RuntimePolicySet {
-    pub fn from_runtime_config(config: &RuntimeConfig) -> Self {
-        Self {
-            timeouts: RuntimeTimeoutPolicy::from_performance(&config.performance),
-            admission: RuntimeAdmissionPolicy::from_resilience(&config.resilience),
-            rate_limits: RuntimeRateLimitPolicy::from_resilience(&config.resilience),
-            transport: RuntimeTransportPolicy::from_performance(&config.performance),
-        }
+    pub fn from_config(config: &Config) -> Result<Self, RuntimeConfigError> {
+        let timeouts = RuntimeTimeoutPolicy::normalize(&config.performance)?;
+        let transport = RuntimeTransportPolicy::normalize(&config.performance)?;
+        let rate_limits = RuntimeRateLimitPolicy::normalize(&config.resilience)?;
+        let admission = RuntimeAdmissionPolicy::normalize(&config.resilience, &transport)?;
+
+        Ok(Self {
+            timeouts,
+            admission,
+            rate_limits,
+            transport,
+        })
     }
 }
 
@@ -252,8 +838,8 @@ pub struct RuntimeListenerPolicySet {
 impl RuntimeListenerPolicySet {
     pub fn from_listener_runtime_config(config: &ListenerRuntimeConfig) -> Self {
         Self {
-            timeouts: RuntimeTimeoutPolicy::from_performance(&config.performance),
-            transport: RuntimeTransportPolicy::from_performance(&config.performance),
+            timeouts: config.policies.timeouts.clone(),
+            transport: config.policies.transport.clone(),
             tls: config.listen.tls.clone(),
         }
     }
@@ -273,21 +859,20 @@ pub struct RuntimeUpstreamPolicySet {
 }
 
 impl RuntimeUpstreamPolicySet {
-    pub fn from_runtime_parts(
+    pub fn normalize(
         upstream: &RuntimeUpstream,
-        performance: &Performance,
-        resilience: &Resilience,
-    ) -> Self {
-        Self {
-            timeouts: RuntimeTimeoutPolicy::from_performance(performance),
+        base: &RuntimePolicySet,
+    ) -> Result<Self, RuntimeConfigError> {
+        Ok(Self {
+            timeouts: base.timeouts.clone(),
             auth: upstream.policy.upstream_auth.clone(),
-            rate_limits: RuntimeRateLimitPolicy::from_resilience(resilience),
-            load_balancing: RuntimeLoadBalancingPolicy::from_config(&upstream.load_balancing),
-            admission: RuntimeAdmissionPolicy::from_resilience(resilience),
+            rate_limits: base.rate_limits.clone(),
+            load_balancing: RuntimeLoadBalancingPolicy::normalize(&upstream.load_balancing)?,
+            admission: base.admission.clone(),
             transport: RuntimeUpstreamTransportPolicy::from_effective_tls(&upstream.effective_tls),
             host: upstream.policy.host.clone(),
             forwarded_headers: upstream.policy.forwarded_headers.clone(),
             protocol: upstream.policy.protocol.clone(),
-        }
+        })
     }
 }

--- a/crates/config/src/runtime/policies.rs
+++ b/crates/config/src/runtime/policies.rs
@@ -89,6 +89,44 @@ fn is_valid_request_key_spec(key_spec: &str) -> bool {
     })
 }
 
+fn normalize_route_host(raw: &str) -> String {
+    let trimmed = raw.trim();
+    let host = if let Some(rest) = trimmed.strip_prefix('[') {
+        if let Some(end) = rest.find(']') {
+            &rest[..end]
+        } else {
+            trimmed
+        }
+    } else if let Some((candidate_host, candidate_port)) = trimmed.rsplit_once(':') {
+        if !candidate_host.contains(':') && candidate_port.chars().all(|c| c.is_ascii_digit()) {
+            candidate_host
+        } else {
+            trimmed
+        }
+    } else {
+        trimmed
+    };
+    host.trim_end_matches('.').to_ascii_lowercase()
+}
+
+fn normalized_route_method(method: Option<&str>) -> Option<String> {
+    method
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| value.to_ascii_uppercase())
+}
+
+fn parse_runtime_route_host_pattern(raw: &str) -> RuntimeRouteHostPattern {
+    let normalized = normalize_route_host(raw);
+    let Some(wildcard_suffix) = normalized.strip_prefix("*.") else {
+        return RuntimeRouteHostPattern::Exact(normalized);
+    };
+    if wildcard_suffix.is_empty() || wildcard_suffix.contains('*') {
+        return RuntimeRouteHostPattern::Exact(normalized);
+    }
+    RuntimeRouteHostPattern::WildcardSuffix(wildcard_suffix.to_string())
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RuntimeLoadBalancingStrategy {
     RoundRobin,
@@ -103,15 +141,163 @@ pub enum RuntimeLoadBalancingStrategy {
 impl RuntimeLoadBalancingStrategy {
     pub fn from_lb_type(lb_type: &str) -> Self {
         match lb_type.trim().to_ascii_lowercase().as_str() {
-            "round-robin" => Self::RoundRobin,
-            "consistent-hash" => Self::ConsistentHash,
+            "round-robin" | "round_robin" | "rr" => Self::RoundRobin,
+            "consistent-hash" | "consistent_hash" | "ch" => Self::ConsistentHash,
             "random" => Self::Random,
-            "least-connections" => Self::LeastConnections,
-            "latency-aware" => Self::LatencyAware,
-            "sticky-cid" => Self::StickyCid,
+            "least-connections" | "least_connections" | "lc" => Self::LeastConnections,
+            "latency-aware" | "latency_aware" | "la" => Self::LatencyAware,
+            "sticky-cid" | "sticky_cid" | "cid-sticky" | "cid_sticky" => Self::StickyCid,
             _ => Self::Other,
         }
     }
+
+    pub fn canonical_name(self) -> &'static str {
+        match self {
+            Self::RoundRobin => "round-robin",
+            Self::ConsistentHash => "consistent-hash",
+            Self::Random => "random",
+            Self::LeastConnections => "least-connections",
+            Self::LatencyAware => "latency-aware",
+            Self::StickyCid => "sticky-cid",
+            Self::Other => "unsupported",
+        }
+    }
+
+    pub fn supports_readonly_alternate_pick(self) -> bool {
+        !matches!(self, Self::ConsistentHash | Self::StickyCid | Self::Other)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum RuntimeRouteHostPattern {
+    Exact(String),
+    WildcardSuffix(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RuntimeRouteMatchPolicy {
+    pub host: Option<String>,
+    pub host_pattern: Option<RuntimeRouteHostPattern>,
+    pub path_prefix: Option<String>,
+    pub method: Option<String>,
+    pub path_len: usize,
+    pub host_specific: bool,
+    pub method_specific: bool,
+}
+
+impl RuntimeRouteMatchPolicy {
+    pub fn normalize(
+        upstream_name: &str,
+        route: &crate::config::RouteMatch,
+    ) -> Result<Self, RuntimeConfigError> {
+        let path_prefix = normalize_optional_string(route.path_prefix.as_deref());
+        if let Some(path_prefix) = path_prefix.as_deref()
+            && !path_prefix.starts_with('/')
+        {
+            return Err(config_invalid(format!(
+                "upstream '{upstream_name}' has an invalid route.path_prefix '{}'",
+                path_prefix
+            )));
+        }
+
+        let host = normalize_optional_string(route.host.as_deref()).map(|host| normalize_route_host(&host));
+        let host_pattern = host.as_deref().map(parse_runtime_route_host_pattern);
+        let method = normalized_route_method(route.method.as_deref());
+
+        Ok(Self {
+            path_len: path_prefix.as_ref().map(|value| value.len()).unwrap_or(0),
+            host_specific: host.is_some(),
+            method_specific: method.is_some(),
+            host,
+            host_pattern,
+            path_prefix,
+            method,
+        })
+    }
+
+    pub fn as_config(&self) -> crate::config::RouteMatch {
+        crate::config::RouteMatch {
+            host: self.host.clone(),
+            path_prefix: self.path_prefix.clone(),
+            method: self.method.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RuntimeRequestKeySpec {
+    Path,
+    Authority,
+    Method,
+    Cid,
+    StickyCid,
+    PeerIp,
+    ClientIp,
+    BearerToken,
+    Header(String),
+    Cookie(String),
+    Query(String),
+}
+
+impl RuntimeRequestKeySpec {
+    pub fn normalize(raw: &str) -> Result<Self, RuntimeConfigError> {
+        let normalized = raw.trim().to_ascii_lowercase();
+        match normalized.as_str() {
+            "path" => Ok(Self::Path),
+            "authority" => Ok(Self::Authority),
+            "method" => Ok(Self::Method),
+            "cid" => Ok(Self::Cid),
+            "sticky-cid" => Ok(Self::StickyCid),
+            "peer_ip" => Ok(Self::PeerIp),
+            "client_ip" => Ok(Self::ClientIp),
+            "bearer_token" => Ok(Self::BearerToken),
+            _ => {
+                let Some((source, key_name)) = normalized.split_once(':') else {
+                    return Err(config_invalid(format!(
+                        "unsupported request key spec '{}'",
+                        raw
+                    )));
+                };
+                if key_name.trim().is_empty() {
+                    return Err(config_invalid(format!(
+                        "unsupported request key spec '{}'",
+                        raw
+                    )));
+                }
+                match source {
+                    "header" => Ok(Self::Header(key_name.to_string())),
+                    "cookie" => Ok(Self::Cookie(key_name.to_string())),
+                    "query" => Ok(Self::Query(key_name.to_string())),
+                    _ => Err(config_invalid(format!(
+                        "unsupported request key spec '{}'",
+                        raw
+                    ))),
+                }
+            }
+        }
+    }
+
+    pub fn as_config(&self) -> String {
+        match self {
+            Self::Path => "path".to_string(),
+            Self::Authority => "authority".to_string(),
+            Self::Method => "method".to_string(),
+            Self::Cid => "cid".to_string(),
+            Self::StickyCid => "sticky-cid".to_string(),
+            Self::PeerIp => "peer_ip".to_string(),
+            Self::ClientIp => "client_ip".to_string(),
+            Self::BearerToken => "bearer_token".to_string(),
+            Self::Header(name) => format!("header:{name}"),
+            Self::Cookie(name) => format!("cookie:{name}"),
+            Self::Query(name) => format!("query:{name}"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RuntimeAlternateBackendPolicy {
+    pub readonly_lb_pick: bool,
+    pub healthy_fallback: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -967,6 +1153,8 @@ impl RuntimeBackendTlsPolicy {
 pub struct RuntimeLoadBalancingPolicy {
     pub strategy: RuntimeLoadBalancingStrategy,
     pub key: Option<String>,
+    pub key_spec: Option<RuntimeRequestKeySpec>,
+    pub alternate_backend: RuntimeAlternateBackendPolicy,
 }
 
 impl RuntimeLoadBalancingPolicy {
@@ -982,7 +1170,23 @@ impl RuntimeLoadBalancingPolicy {
         Ok(Self {
             strategy,
             key: normalize_optional_string(load_balancing.key.as_deref()),
+            key_spec: load_balancing
+                .key
+                .as_deref()
+                .map(RuntimeRequestKeySpec::normalize)
+                .transpose()?,
+            alternate_backend: RuntimeAlternateBackendPolicy {
+                readonly_lb_pick: strategy.supports_readonly_alternate_pick(),
+                healthy_fallback: true,
+            },
         })
+    }
+
+    pub fn as_config(&self) -> LoadBalancing {
+        LoadBalancing {
+            lb_type: self.strategy.canonical_name().to_string(),
+            key: self.key.clone(),
+        }
     }
 }
 
@@ -1576,7 +1780,7 @@ impl RuntimeUpstreamPolicySet {
             timeouts: base.timeouts.clone(),
             auth: upstream.policy.upstream_auth.clone(),
             rate_limits: base.rate_limits.clone(),
-            load_balancing: RuntimeLoadBalancingPolicy::normalize(&upstream.load_balancing)?,
+            load_balancing: upstream.load_balancing.clone(),
             admission: base.admission.clone(),
             transport: RuntimeUpstreamTransportPolicy::from_effective_tls(
                 &upstream.effective_tls,

--- a/crates/config/src/runtime/upstreams.rs
+++ b/crates/config/src/runtime/upstreams.rs
@@ -51,7 +51,8 @@ impl RuntimeUpstream {
         Ok(runtime_upstream)
     }
 
-    pub fn as_config_upstream(&self) -> Upstream {
+    #[cfg(test)]
+    pub(crate) fn as_config_upstream(&self) -> Upstream {
         Upstream {
             load_balancing: self.load_balancing.as_config(),
             auth: self.policy.upstream_auth.as_config(),

--- a/crates/config/src/runtime/upstreams.rs
+++ b/crates/config/src/runtime/upstreams.rs
@@ -2,183 +2,6 @@ use super::*;
 
 type RouteMatcherKey = (Option<String>, Option<String>, Option<String>);
 
-fn runtime_external_auth_request_headers(
-    headers: &[crate::config::ExternalAuthRequestHeader],
-) -> Vec<RuntimeExternalAuthRequestHeader> {
-    headers
-        .iter()
-        .map(|header| RuntimeExternalAuthRequestHeader {
-            name: header.name.clone(),
-            value: header.value.clone(),
-        })
-        .collect()
-}
-
-fn runtime_external_auth_failure_mode(
-    mode: crate::config::ExternalAuthFailureMode,
-) -> RuntimeExternalAuthFailureMode {
-    match mode {
-        crate::config::ExternalAuthFailureMode::FailOpen => {
-            RuntimeExternalAuthFailureMode::FailOpen
-        }
-        crate::config::ExternalAuthFailureMode::FailClosed => {
-            RuntimeExternalAuthFailureMode::FailClosed
-        }
-    }
-}
-
-fn config_external_auth_failure_mode(
-    mode: RuntimeExternalAuthFailureMode,
-) -> crate::config::ExternalAuthFailureMode {
-    match mode {
-        RuntimeExternalAuthFailureMode::FailOpen => {
-            crate::config::ExternalAuthFailureMode::FailOpen
-        }
-        RuntimeExternalAuthFailureMode::FailClosed => {
-            crate::config::ExternalAuthFailureMode::FailClosed
-        }
-    }
-}
-
-fn runtime_auth_policy(auth: &crate::config::RouteAuth) -> RuntimeAuthPolicy {
-    let api_key = auth.api_key.as_ref().map(|api_key| RuntimeApiKeyAuth {
-        header_name: api_key.header_name.clone(),
-        keys: api_key.keys.clone(),
-    });
-    let jwt = auth.jwt.as_ref().map(|jwt| RuntimeJwtAuth {
-        secret: jwt.secret.clone(),
-        issuer: jwt.issuer.clone(),
-        audience: jwt.audience.clone(),
-        clock_skew_secs: jwt.clock_skew_secs,
-    });
-    let external_auth = auth
-        .external_auth
-        .as_ref()
-        .map(|external_auth| match external_auth {
-            crate::config::ExternalAuth::Http {
-                endpoint,
-                request_headers,
-                response_header_allowlist,
-                timeout_ms,
-                failure_mode,
-            } => RuntimeExternalAuth::Http {
-                endpoint: endpoint.clone(),
-                request_headers: runtime_external_auth_request_headers(request_headers),
-                response_header_allowlist: response_header_allowlist.clone(),
-                timeout_ms: *timeout_ms,
-                failure_mode: runtime_external_auth_failure_mode(*failure_mode),
-            },
-            crate::config::ExternalAuth::Oidc {
-                discovery_url,
-                issuer_url,
-                client_id,
-                client_secret,
-                audience,
-                scopes,
-                request_headers,
-                response_header_allowlist,
-                timeout_ms,
-                failure_mode,
-            } => RuntimeExternalAuth::Oidc {
-                discovery_url: discovery_url.clone(),
-                issuer_url: issuer_url.clone(),
-                client_id: client_id.clone(),
-                client_secret: client_secret.clone(),
-                audience: audience.clone(),
-                scopes: scopes.clone(),
-                request_headers: runtime_external_auth_request_headers(request_headers),
-                response_header_allowlist: response_header_allowlist.clone(),
-                timeout_ms: *timeout_ms,
-                failure_mode: runtime_external_auth_failure_mode(*failure_mode),
-            },
-        });
-
-    RuntimeAuthPolicy {
-        api_key,
-        jwt,
-        external_auth,
-        required_scopes: auth.required_scopes.clone(),
-        required_roles: auth.required_roles.clone(),
-    }
-}
-
-fn config_external_auth_request_headers(
-    headers: &[RuntimeExternalAuthRequestHeader],
-) -> Vec<crate::config::ExternalAuthRequestHeader> {
-    headers
-        .iter()
-        .map(|header| crate::config::ExternalAuthRequestHeader {
-            name: header.name.clone(),
-            value: header.value.clone(),
-        })
-        .collect()
-}
-
-fn config_route_auth(auth: &RuntimeAuthPolicy) -> crate::config::RouteAuth {
-    let api_key = auth
-        .api_key
-        .as_ref()
-        .map(|api_key| crate::config::ApiKeyAuth {
-            header_name: api_key.header_name.clone(),
-            keys: api_key.keys.clone(),
-        });
-    let jwt = auth.jwt.as_ref().map(|jwt| crate::config::JwtAuth {
-        secret: jwt.secret.clone(),
-        issuer: jwt.issuer.clone(),
-        audience: jwt.audience.clone(),
-        clock_skew_secs: jwt.clock_skew_secs,
-    });
-    let external_auth = auth
-        .external_auth
-        .as_ref()
-        .map(|external_auth| match external_auth {
-            RuntimeExternalAuth::Http {
-                endpoint,
-                request_headers,
-                response_header_allowlist,
-                timeout_ms,
-                failure_mode,
-            } => crate::config::ExternalAuth::Http {
-                endpoint: endpoint.clone(),
-                request_headers: config_external_auth_request_headers(request_headers),
-                response_header_allowlist: response_header_allowlist.clone(),
-                timeout_ms: *timeout_ms,
-                failure_mode: config_external_auth_failure_mode(*failure_mode),
-            },
-            RuntimeExternalAuth::Oidc {
-                discovery_url,
-                issuer_url,
-                client_id,
-                client_secret,
-                audience,
-                scopes,
-                request_headers,
-                response_header_allowlist,
-                timeout_ms,
-                failure_mode,
-            } => crate::config::ExternalAuth::Oidc {
-                discovery_url: discovery_url.clone(),
-                issuer_url: issuer_url.clone(),
-                client_id: client_id.clone(),
-                client_secret: client_secret.clone(),
-                audience: audience.clone(),
-                scopes: scopes.clone(),
-                request_headers: config_external_auth_request_headers(request_headers),
-                response_header_allowlist: response_header_allowlist.clone(),
-                timeout_ms: *timeout_ms,
-                failure_mode: config_external_auth_failure_mode(*failure_mode),
-            },
-        });
-
-    crate::config::RouteAuth {
-        api_key,
-        jwt,
-        external_auth,
-        required_scopes: auth.required_scopes.clone(),
-        required_roles: auth.required_roles.clone(),
-    }
-}
-
 impl RuntimeUpstream {
     pub(super) fn from_config(
         config: &Config,
@@ -191,7 +14,7 @@ impl RuntimeUpstream {
             .clone()
             .unwrap_or_else(|| config.upstream_tls.clone());
         let policy = RuntimeUpstreamPolicy {
-            upstream_auth: runtime_auth_policy(&upstream.auth),
+            upstream_auth: RuntimeAuthPolicy::normalize(&upstream.auth, name)?,
             host: RuntimeHostPolicy(upstream.host_policy.clone()),
             forwarded_headers: RuntimeForwardedHeaderPolicy(upstream.forwarded_headers.clone()),
             protocol: base_policies.admission.protocol.clone(),
@@ -231,7 +54,7 @@ impl RuntimeUpstream {
     pub fn as_config_upstream(&self) -> Upstream {
         Upstream {
             load_balancing: self.load_balancing.clone(),
-            auth: config_route_auth(&self.policy.upstream_auth),
+            auth: self.policy.upstream_auth.as_config(),
             host_policy: self.policy.host.0.clone(),
             forwarded_headers: self.policy.forwarded_headers.0.clone(),
             tls: Some(self.effective_tls.clone()),

--- a/crates/config/src/runtime/upstreams.rs
+++ b/crates/config/src/runtime/upstreams.rs
@@ -13,6 +13,8 @@ impl RuntimeUpstream {
             .tls
             .clone()
             .unwrap_or_else(|| config.upstream_tls.clone());
+        let upstream_transport =
+            RuntimeUpstreamTransportPolicy::from_effective_tls(&effective_tls, &base_policies.transport);
         let policy = RuntimeUpstreamPolicy {
             upstream_auth: RuntimeAuthPolicy::normalize(&upstream.auth, name)?,
             host: RuntimeHostPolicy(upstream.host_policy.clone()),
@@ -30,7 +32,7 @@ impl RuntimeUpstream {
                 rate_limits: base_policies.rate_limits.clone(),
                 load_balancing: RuntimeLoadBalancingPolicy::normalize(&upstream.load_balancing)?,
                 admission: base_policies.admission.clone(),
-                transport: RuntimeUpstreamTransportPolicy::from_effective_tls(&effective_tls),
+                transport: upstream_transport,
                 host: RuntimeHostPolicy(upstream.host_policy.clone()),
                 forwarded_headers: RuntimeForwardedHeaderPolicy(upstream.forwarded_headers.clone()),
                 protocol: base_policies.admission.protocol.clone(),
@@ -39,12 +41,8 @@ impl RuntimeUpstream {
             backends: upstream
                 .backends
                 .iter()
-                .cloned()
-                .map(|backend| RuntimeBackend {
-                    backend,
-                    effective_tls: effective_tls.clone(),
-                })
-                .collect(),
+                .map(|backend| RuntimeBackend::normalize(name, backend))
+                .collect::<Result<Vec<_>, _>>()?,
         };
         runtime_upstream.policy_set.auth = runtime_upstream.policy.upstream_auth.clone();
 
@@ -62,7 +60,14 @@ impl RuntimeUpstream {
             backends: self
                 .backends
                 .iter()
-                .map(|backend| backend.backend.clone())
+                .map(|backend| {
+                    let mut config_backend = backend.backend.clone();
+                    config_backend.health_check = backend
+                        .health_check
+                        .as_ref()
+                        .map(RuntimeBackendHealthCheck::as_config);
+                    config_backend
+                })
                 .collect(),
         }
     }
@@ -108,39 +113,18 @@ pub(super) fn normalize_upstreams(
         let mut upstream_uses_https_backends = false;
 
         for backend in &runtime_upstream.backends {
-            if backend.backend.id.trim().is_empty() {
-                return Err(RuntimeConfigError::ConfigInvalid(format!(
-                    "upstream '{upstream_name}' contains an empty backend id"
-                )));
-            }
-            if backend.backend.address.trim().is_empty() {
-                return Err(RuntimeConfigError::ConfigInvalid(format!(
-                    "backend '{}' in upstream '{}' has an empty address",
-                    backend.backend.id, upstream_name
-                )));
-            }
-
-            let endpoint = BackendEndpoint::parse(&backend.backend.address).map_err(|err| {
-                RuntimeConfigError::BackendAddressInvalid {
-                    upstream: upstream_name.clone(),
-                    backend: backend.backend.id.clone(),
-                    address: backend.backend.address.clone(),
-                    reason: err,
-                }
-            })?;
-            if endpoint.scheme() == crate::backend_endpoint::BackendScheme::Https {
+            if matches!(backend.endpoint.transport_kind, RuntimeBackendTransportKind::H2) {
                 upstream_uses_https_backends = true;
             }
 
-            let origin = endpoint.origin();
             if let Some((existing_upstream, existing_backend)) = seen_backend_origins.insert(
-                origin.clone(),
+                backend.endpoint.origin.clone(),
                 (upstream_name.clone(), backend.backend.id.clone()),
             ) {
                 return Err(RuntimeConfigError::BackendAddressInvalid {
                     upstream: upstream_name.clone(),
                     backend: backend.backend.id.clone(),
-                    address: origin,
+                    address: backend.endpoint.origin.clone(),
                     reason: format!(
                         "conflicts with upstream '{}' backend '{}'",
                         existing_upstream, existing_backend
@@ -150,13 +134,55 @@ pub(super) fn normalize_upstreams(
         }
 
         if upstream_uses_https_backends {
-            validate_runtime_upstream_tls(upstream_name, &runtime_upstream.effective_tls)?;
+            validate_runtime_upstream_tls(
+                upstream_name,
+                &runtime_upstream.policy_set.transport.tls.as_upstream_tls(),
+            )?;
         }
 
         normalized.insert(upstream_name.clone(), runtime_upstream);
     }
 
     Ok(normalized)
+}
+
+impl RuntimeBackend {
+    pub(super) fn normalize(
+        upstream_name: &str,
+        backend: &Backend,
+    ) -> Result<Self, RuntimeConfigError> {
+        if backend.id.trim().is_empty() {
+            return Err(RuntimeConfigError::ConfigInvalid(format!(
+                "upstream '{upstream_name}' contains an empty backend id"
+            )));
+        }
+        if backend.address.trim().is_empty() {
+            return Err(RuntimeConfigError::ConfigInvalid(format!(
+                "backend '{}' in upstream '{}' has an empty address",
+                backend.id, upstream_name
+            )));
+        }
+
+        Ok(Self {
+            backend: backend.clone(),
+            endpoint: RuntimeBackendEndpoint::normalize(
+                upstream_name,
+                backend.id.as_str(),
+                backend.address.as_str(),
+            )?,
+            health_check: backend
+                .health_check
+                .as_ref()
+                .map(|health_check| {
+                    RuntimeBackendHealthCheck::normalize(
+                        upstream_name,
+                        backend.id.as_str(),
+                        health_check,
+                    )
+                })
+                .transpose()?,
+        })
+    }
 }
 
 fn validate_protocol_policy(policy: &ProtocolPolicy) -> Result<(), RuntimeConfigError> {

--- a/crates/config/src/runtime/upstreams.rs
+++ b/crates/config/src/runtime/upstreams.rs
@@ -13,8 +13,10 @@ impl RuntimeUpstream {
             .tls
             .clone()
             .unwrap_or_else(|| config.upstream_tls.clone());
-        let upstream_transport =
-            RuntimeUpstreamTransportPolicy::from_effective_tls(&effective_tls, &base_policies.transport);
+        let upstream_transport = RuntimeUpstreamTransportPolicy::from_effective_tls(
+            &effective_tls,
+            &base_policies.transport,
+        );
         let load_balancing = RuntimeLoadBalancingPolicy::normalize(&upstream.load_balancing)?;
         let route = RuntimeRouteMatchPolicy::normalize(name, &upstream.route)?;
         let policy = RuntimeUpstreamPolicy {
@@ -112,7 +114,10 @@ pub(super) fn normalize_upstreams(
         let mut upstream_uses_https_backends = false;
 
         for backend in &runtime_upstream.backends {
-            if matches!(backend.endpoint.transport_kind, RuntimeBackendTransportKind::H2) {
+            if matches!(
+                backend.endpoint.transport_kind,
+                RuntimeBackendTransportKind::H2
+            ) {
                 upstream_uses_https_backends = true;
             }
 

--- a/crates/config/src/runtime/upstreams.rs
+++ b/crates/config/src/runtime/upstreams.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-type RouteMatcherKey = (Option<String>, Option<String>, Option<String>);
+type RouteMatcherKey = RuntimeRouteMatchPolicy;
 
 impl RuntimeUpstream {
     pub(super) fn from_config(
@@ -15,6 +15,8 @@ impl RuntimeUpstream {
             .unwrap_or_else(|| config.upstream_tls.clone());
         let upstream_transport =
             RuntimeUpstreamTransportPolicy::from_effective_tls(&effective_tls, &base_policies.transport);
+        let load_balancing = RuntimeLoadBalancingPolicy::normalize(&upstream.load_balancing)?;
+        let route = RuntimeRouteMatchPolicy::normalize(name, &upstream.route)?;
         let policy = RuntimeUpstreamPolicy {
             upstream_auth: RuntimeAuthPolicy::normalize(&upstream.auth, name)?,
             host: RuntimeHostPolicy(upstream.host_policy.clone()),
@@ -23,14 +25,14 @@ impl RuntimeUpstream {
         };
         let mut runtime_upstream = Self {
             name: name.to_string(),
-            load_balancing: upstream.load_balancing.clone(),
-            route: upstream.route.clone(),
+            load_balancing: load_balancing.clone(),
+            route: route.clone(),
             policy,
             policy_set: RuntimeUpstreamPolicySet {
                 timeouts: base_policies.timeouts.clone(),
                 auth: RuntimeAuthPolicy::default(),
                 rate_limits: base_policies.rate_limits.clone(),
-                load_balancing: RuntimeLoadBalancingPolicy::normalize(&upstream.load_balancing)?,
+                load_balancing,
                 admission: base_policies.admission.clone(),
                 transport: upstream_transport,
                 host: RuntimeHostPolicy(upstream.host_policy.clone()),
@@ -51,12 +53,12 @@ impl RuntimeUpstream {
 
     pub fn as_config_upstream(&self) -> Upstream {
         Upstream {
-            load_balancing: self.load_balancing.clone(),
+            load_balancing: self.load_balancing.as_config(),
             auth: self.policy.upstream_auth.as_config(),
             host_policy: self.policy.host.0.clone(),
             forwarded_headers: self.policy.forwarded_headers.0.clone(),
             tls: Some(self.effective_tls.clone()),
-            route: self.route.clone(),
+            route: self.route.as_config(),
             backends: self
                 .backends
                 .iter()
@@ -92,19 +94,15 @@ pub(super) fn normalize_upstreams(
     for (upstream_name, upstream) in &config.upstream {
         validate_upstream_policy(config, upstream_name, upstream)?;
 
-        let route_key = (
-            upstream.route.host.as_deref().map(normalize_route_host),
-            upstream.route.path_prefix.clone(),
-            normalized_route_method(upstream.route.method.as_deref()),
-        );
+        let route_key = RuntimeRouteMatchPolicy::normalize(upstream_name, &upstream.route)?;
         if let Some(existing) = seen_route_matchers.insert(route_key.clone(), upstream_name.clone())
         {
             return Err(RuntimeConfigError::DuplicateRouteAmbiguity {
                 upstream: upstream_name.clone(),
                 existing_upstream: existing,
-                host: route_key.0.clone(),
-                path_prefix: route_key.1.clone(),
-                method: route_key.2.clone(),
+                host: route_key.host.clone(),
+                path_prefix: route_key.path_prefix.clone(),
+                method: route_key.method.clone(),
             });
         }
 
@@ -587,26 +585,6 @@ fn validate_runtime_upstream_tls(
         )));
     }
     Ok(())
-}
-
-fn normalize_route_host(raw: &str) -> String {
-    let trimmed = raw.trim();
-    let host = if let Some(rest) = trimmed.strip_prefix('[') {
-        if let Some(end) = rest.find(']') {
-            &rest[..end]
-        } else {
-            trimmed
-        }
-    } else if let Some((candidate_host, candidate_port)) = trimmed.rsplit_once(':') {
-        if !candidate_host.contains(':') && candidate_port.chars().all(|c| c.is_ascii_digit()) {
-            candidate_host
-        } else {
-            trimmed
-        }
-    } else {
-        trimmed
-    };
-    host.trim_end_matches('.').to_ascii_lowercase()
 }
 
 fn normalized_route_method(method: Option<&str>) -> Option<String> {

--- a/crates/config/src/runtime/upstreams.rs
+++ b/crates/config/src/runtime/upstreams.rs
@@ -180,21 +180,37 @@ fn config_route_auth(auth: &RuntimeAuthPolicy) -> crate::config::RouteAuth {
 }
 
 impl RuntimeUpstream {
-    pub(super) fn from_config(config: &Config, name: &str, upstream: &Upstream) -> Self {
+    pub(super) fn from_config(
+        config: &Config,
+        name: &str,
+        upstream: &Upstream,
+        base_policies: &RuntimePolicySet,
+    ) -> Result<Self, RuntimeConfigError> {
         let effective_tls = upstream
             .tls
             .clone()
             .unwrap_or_else(|| config.upstream_tls.clone());
-
-        Self {
+        let policy = RuntimeUpstreamPolicy {
+            upstream_auth: runtime_auth_policy(&upstream.auth),
+            host: RuntimeHostPolicy(upstream.host_policy.clone()),
+            forwarded_headers: RuntimeForwardedHeaderPolicy(upstream.forwarded_headers.clone()),
+            protocol: base_policies.admission.protocol.clone(),
+        };
+        let mut runtime_upstream = Self {
             name: name.to_string(),
             load_balancing: upstream.load_balancing.clone(),
             route: upstream.route.clone(),
-            policy: RuntimeUpstreamPolicy {
-                upstream_auth: runtime_auth_policy(&upstream.auth),
+            policy,
+            policy_set: RuntimeUpstreamPolicySet {
+                timeouts: base_policies.timeouts.clone(),
+                auth: RuntimeAuthPolicy::default(),
+                rate_limits: base_policies.rate_limits.clone(),
+                load_balancing: RuntimeLoadBalancingPolicy::normalize(&upstream.load_balancing)?,
+                admission: base_policies.admission.clone(),
+                transport: RuntimeUpstreamTransportPolicy::from_effective_tls(&effective_tls),
                 host: RuntimeHostPolicy(upstream.host_policy.clone()),
                 forwarded_headers: RuntimeForwardedHeaderPolicy(upstream.forwarded_headers.clone()),
-                protocol: RuntimeProtocolPolicy(config.resilience.protocol.clone()),
+                protocol: base_policies.admission.protocol.clone(),
             },
             effective_tls: effective_tls.clone(),
             backends: upstream
@@ -206,7 +222,10 @@ impl RuntimeUpstream {
                     effective_tls: effective_tls.clone(),
                 })
                 .collect(),
-        }
+        };
+        runtime_upstream.policy_set.auth = runtime_upstream.policy.upstream_auth.clone();
+
+        Ok(runtime_upstream)
     }
 
     pub fn as_config_upstream(&self) -> Upstream {
@@ -228,6 +247,7 @@ impl RuntimeUpstream {
 
 pub(super) fn normalize_upstreams(
     config: &Config,
+    base_policies: &RuntimePolicySet,
 ) -> Result<HashMap<String, RuntimeUpstream>, RuntimeConfigError> {
     if config.upstream.is_empty() {
         return Err(RuntimeConfigError::ConfigInvalid(
@@ -261,7 +281,7 @@ pub(super) fn normalize_upstreams(
         }
 
         let runtime_upstream =
-            RuntimeUpstream::from_config(config, upstream_name.as_str(), upstream);
+            RuntimeUpstream::from_config(config, upstream_name.as_str(), upstream, base_policies)?;
         let mut upstream_uses_https_backends = false;
 
         for backend in &runtime_upstream.backends {

--- a/crates/edge/src/quic_listener/admission.rs
+++ b/crates/edge/src/quic_listener/admission.rs
@@ -487,21 +487,22 @@ pub(super) fn validated_hs256_jwt_claims(
     let Ok(now_secs) = now.duration_since(UNIX_EPOCH).map(|value| value.as_secs()) else {
         return None;
     };
+    let clock_skew_secs = jwt.clock_skew.as_secs();
     let exp = claims.get("exp").and_then(Value::as_u64)?;
-    if now_secs > exp.saturating_add(jwt.clock_skew_secs) {
+    if now_secs > exp.saturating_add(clock_skew_secs) {
         return None;
     }
     if claims
         .get("nbf")
         .and_then(Value::as_u64)
-        .is_some_and(|nbf| now_secs.saturating_add(jwt.clock_skew_secs) < nbf)
+        .is_some_and(|nbf| now_secs.saturating_add(clock_skew_secs) < nbf)
     {
         return None;
     }
     if claims
         .get("iat")
         .and_then(Value::as_u64)
-        .is_some_and(|iat| now_secs.saturating_add(jwt.clock_skew_secs) < iat)
+        .is_some_and(|iat| now_secs.saturating_add(clock_skew_secs) < iat)
     {
         return None;
     }

--- a/crates/edge/src/quic_listener/backend_resolution.rs
+++ b/crates/edge/src/quic_listener/backend_resolution.rs
@@ -47,7 +47,7 @@ impl QUICListener {
         metrics: Arc<Metrics>,
         task_registry: Arc<RuntimeTaskRegistry>,
     ) {
-        if !config.performance.backend_dns_refresh_enabled {
+        if !config.policies.transport.backend_dns.refresh_enabled {
             return;
         }
 
@@ -56,7 +56,15 @@ impl QUICListener {
             return;
         }
 
-        let interval_ms = config.performance.backend_dns_refresh_interval_ms.max(1);
+        let interval_ms: u64 = config
+            .policies
+            .transport
+            .backend_dns
+            .refresh_interval
+            .as_millis()
+            .try_into()
+            .unwrap_or(u64::MAX)
+            .max(1);
         let handle = match runtime_handle() {
             Some(handle) => handle,
             None => {

--- a/crates/edge/src/quic_listener/bootstrap_tls.rs
+++ b/crates/edge/src/quic_listener/bootstrap_tls.rs
@@ -188,7 +188,10 @@ impl QUICListener {
             config.listen.listen.address, config.listen.listen.port
         );
         let alt_svc_value = format!("h3=\":{}\"; ma=86400", config.listen.listen.port);
-        let max_connections = transport_policy.connection_limits.max_active_connections.max(1);
+        let max_connections = transport_policy
+            .connection_limits
+            .max_active_connections
+            .max(1);
         let connection_timeout = timeout_policy.client_body_idle;
         let listener_label = Self::listener_label(config);
         shared_state

--- a/crates/edge/src/quic_listener/bootstrap_tls.rs
+++ b/crates/edge/src/quic_listener/bootstrap_tls.rs
@@ -181,14 +181,15 @@ impl QUICListener {
         runtime_bundle: Option<Arc<RuntimeBundleHandle>>,
         shutdown_signal: Option<Arc<AtomicBool>>,
     ) -> Result<(), ProxyError> {
+        let transport_policy = &config.policies.transport;
+        let timeout_policy = &config.policies.timeouts;
         let bind = format!(
             "{}:{}",
             config.listen.listen.address, config.listen.listen.port
         );
         let alt_svc_value = format!("h3=\":{}\"; ma=86400", config.listen.listen.port);
-        let max_connections = config.performance.max_active_connections.max(1);
-        let connection_timeout =
-            Duration::from_millis(config.performance.client_body_idle_timeout_ms.max(1));
+        let max_connections = transport_policy.connection_limits.max_active_connections.max(1);
+        let connection_timeout = timeout_policy.client_body_idle;
         let listener_label = Self::listener_label(config);
         shared_state
             .listener_tls_store
@@ -1569,16 +1570,16 @@ impl QUICListener {
 
         Some(BootstrapConnectionState {
             alt_svc_value: format!("h3=\":{}\"; ma=86400", listener_config.listen.listen.port),
-            backend_timeout: Duration::from_millis(listener_config.performance.backend_timeout_ms),
-            max_request_body_bytes: listener_config.performance.max_request_body_bytes,
-            max_response_body_bytes: listener_config.performance.max_response_body_bytes,
-            max_connections: listener_config.performance.max_active_connections.max(1),
-            connection_timeout: Duration::from_millis(
-                listener_config
-                    .performance
-                    .client_body_idle_timeout_ms
-                    .max(1),
-            ),
+            backend_timeout: listener_config.policies.timeouts.backend_request,
+            max_request_body_bytes: listener_config.policies.transport.max_request_body_bytes,
+            max_response_body_bytes: listener_config.policies.transport.max_response_body_bytes,
+            max_connections: listener_config
+                .policies
+                .transport
+                .connection_limits
+                .max_active_connections
+                .max(1),
+            connection_timeout: listener_config.policies.timeouts.client_body_idle,
             listener_tls_store,
             transport_pool,
             backend_endpoints,

--- a/crates/edge/src/quic_listener/control_api/watchdog.rs
+++ b/crates/edge/src/quic_listener/control_api/watchdog.rs
@@ -23,7 +23,7 @@ impl QUICListener {
         watchdog: Arc<WatchdogCoordinator>,
         task_registry: Arc<RuntimeTaskRegistry>,
     ) {
-        let watchdog_config = WatchdogRuntimeConfig::from(&config.resilience.watchdog);
+        let watchdog_config = WatchdogRuntimeConfig::from(&config.policies.admission.watchdog);
         if !watchdog_config.enabled || !watchdog.enabled() {
             return;
         }

--- a/crates/edge/src/quic_listener/forwarding/lb_key.rs
+++ b/crates/edge/src/quic_listener/forwarding/lb_key.rs
@@ -1,4 +1,5 @@
 use super::*;
+use spooky_config::runtime::{RuntimeLoadBalancingStrategy, RuntimeRequestKeySpec};
 
 struct LbKeyRequestParts<'a> {
     method: &'a str,
@@ -91,6 +92,22 @@ fn extract_query_param(path: &str, param: &str) -> Option<String> {
 }
 
 impl QUICListener {
+    pub(in crate::quic_listener::forwarding) fn resolve_lb_key_for_runtime_request(
+        lb_strategy: RuntimeLoadBalancingStrategy,
+        lb_key_spec: Option<&RuntimeRequestKeySpec>,
+        request: &super::resolve::RouteResolutionRequest<'_>,
+    ) -> ResolvedLbKey {
+        let request = LbKeyRequestParts::new(
+            request.method,
+            request.path,
+            request.authority,
+            request.cid_key,
+            None,
+            request.header_lookup,
+        );
+        Self::resolve_lb_key_for_runtime_input(lb_strategy, lb_key_spec, &request)
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub(in crate::quic_listener::forwarding) fn resolve_lb_key(
         lb_type: &str,
@@ -107,21 +124,44 @@ impl QUICListener {
         Self::resolve_lb_key_for_input(&LbKeyResolutionInput::new(lb_type, lb_key_spec, request))
     }
 
-    pub(in crate::quic_listener::forwarding) fn resolve_lb_key_for_route_request(
-        lb_type: &str,
-        lb_key_spec: Option<&str>,
-        request: &super::resolve::RouteResolutionRequest<'_>,
-    ) -> ResolvedLbKey {
-        Self::resolve_lb_key(
-            lb_type,
-            lb_key_spec,
-            request.method,
-            request.path,
-            request.authority,
-            request.cid_key,
-            None,
-            request.header_lookup,
-        )
+    fn resolve_lb_key_from_runtime_parts(
+        lb_key_spec: &RuntimeRequestKeySpec,
+        request: &LbKeyRequestParts<'_>,
+    ) -> Option<String> {
+        match lb_key_spec {
+            RuntimeRequestKeySpec::Path => {
+                let path_only = request
+                    .path
+                    .split_once('?')
+                    .map(|(p, _)| p)
+                    .unwrap_or(request.path);
+                Some(path_only.to_string())
+            }
+            RuntimeRequestKeySpec::Authority => request.authority.map(str::to_string),
+            RuntimeRequestKeySpec::Method => Some(request.method.to_string()),
+            RuntimeRequestKeySpec::Cid | RuntimeRequestKeySpec::StickyCid => {
+                request.cid_key.map(str::to_string)
+            }
+            RuntimeRequestKeySpec::PeerIp | RuntimeRequestKeySpec::ClientIp => {
+                request.client_addr.map(|addr| addr.ip().to_string())
+            }
+            RuntimeRequestKeySpec::BearerToken => {
+                let raw = request
+                    .header_lookup
+                    .and_then(|lookup| lookup(http::header::AUTHORIZATION.as_str()))?;
+                Self::bearer_token_from_authorization_value(&raw)
+            }
+            RuntimeRequestKeySpec::Header(key_name) => {
+                request.header_lookup.and_then(|lookup| lookup(key_name))
+            }
+            RuntimeRequestKeySpec::Cookie(cookie_name) => {
+                let cookie_header = request
+                    .header_lookup
+                    .and_then(|lookup| lookup(http::header::COOKIE.as_str()))?;
+                extract_cookie_value(cookie_header.as_str(), cookie_name)
+            }
+            RuntimeRequestKeySpec::Query(param) => extract_query_param(request.path, param),
+        }
     }
 
     fn resolve_lb_key_from_parts(
@@ -210,6 +250,38 @@ impl QUICListener {
 
         if input.lb_type == "sticky-cid"
             && let Some(cid_key) = input.request.cid_key
+        {
+            return ResolvedLbKey {
+                value: cid_key.to_string(),
+                source: LbKeySource::StickyCidFallback,
+            };
+        }
+
+        ResolvedLbKey {
+            value: default_key,
+            source: LbKeySource::DefaultFallback,
+        }
+    }
+
+    fn resolve_lb_key_for_runtime_input(
+        lb_strategy: RuntimeLoadBalancingStrategy,
+        lb_key_spec: Option<&RuntimeRequestKeySpec>,
+        request: &LbKeyRequestParts<'_>,
+    ) -> ResolvedLbKey {
+        let default_key = Self::default_lb_request_key_for_parts(request);
+
+        if let Some(spec) = lb_key_spec
+            && let Some(value) = Self::resolve_lb_key_from_runtime_parts(spec, request)
+            && !value.is_empty()
+        {
+            return ResolvedLbKey {
+                value,
+                source: LbKeySource::ConfiguredSpec,
+            };
+        }
+
+        if matches!(lb_strategy, RuntimeLoadBalancingStrategy::StickyCid)
+            && let Some(cid_key) = request.cid_key
         {
             return ResolvedLbKey {
                 value: cid_key.to_string(),

--- a/crates/edge/src/quic_listener/forwarding/lb_key.rs
+++ b/crates/edge/src/quic_listener/forwarding/lb_key.rs
@@ -1,5 +1,6 @@
-use super::*;
 use spooky_config::runtime::{RuntimeLoadBalancingStrategy, RuntimeRequestKeySpec};
+
+use super::*;
 
 struct LbKeyRequestParts<'a> {
     method: &'a str,

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -1422,7 +1422,7 @@ mod tests {
                     secret: "jwt-secret".to_string(),
                     issuer: Some("issuer-1".to_string()),
                     audience: Some("aud-1".to_string()),
-                    clock_skew_secs: 30,
+                    clock_skew: Duration::from_secs(30),
                 }),
                 external_auth: None,
                 required_scopes: Vec::new(),
@@ -1454,7 +1454,7 @@ mod tests {
             secret: "wrong".to_string(),
             issuer: Some("issuer-1".to_string()),
             audience: Some("aud-1".to_string()),
-            clock_skew_secs: 30,
+            clock_skew: Duration::from_secs(30),
         };
         assert!(
             super::super::admission::validated_hs256_jwt_claims(token.as_str(), &wrong_secret, now)
@@ -1473,7 +1473,7 @@ mod tests {
                     secret: "jwt-secret".to_string(),
                     issuer: None,
                     audience: None,
-                    clock_skew_secs: 0,
+                    clock_skew: Duration::ZERO,
                 },
                 now
             )

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -1683,9 +1683,11 @@ mod tests {
             None,
             Some(&lookup),
         );
-        let routed_header = QUICListener::resolve_lb_key_for_route_request(
-            "",
-            Some("header:x-user-id"),
+        let routed_header = QUICListener::resolve_lb_key_for_runtime_request(
+            spooky_config::runtime::RuntimeLoadBalancingStrategy::RoundRobin,
+            Some(&spooky_config::runtime::RuntimeRequestKeySpec::Header(
+                "x-user-id".to_string(),
+            )),
             &route_request,
         );
         assert_eq!(direct_header.value, routed_header.value);
@@ -1704,9 +1706,11 @@ mod tests {
             None,
             Some(&lookup),
         );
-        let routed_sticky = QUICListener::resolve_lb_key_for_route_request(
-            "sticky-cid",
-            Some("header:x-missing"),
+        let routed_sticky = QUICListener::resolve_lb_key_for_runtime_request(
+            spooky_config::runtime::RuntimeLoadBalancingStrategy::StickyCid,
+            Some(&spooky_config::runtime::RuntimeRequestKeySpec::Header(
+                "x-missing".to_string(),
+            )),
             &route_request,
         );
         assert_eq!(direct_sticky.value, routed_sticky.value);

--- a/crates/edge/src/quic_listener/forwarding/resolve.rs
+++ b/crates/edge/src/quic_listener/forwarding/resolve.rs
@@ -335,12 +335,18 @@ impl QUICListener {
         request: &RouteResolutionRequest<'_>,
         pool: &UpstreamPool,
     ) -> BackendSelectionPlan {
-        let lb_type = pool.lb_name().to_string();
         let ResolvedLbKey {
             value: lb_key,
             source: _lb_key_source,
-        } = Self::resolve_lb_key_for_route_request(&lb_type, pool.lb_key(), request);
-        BackendSelectionPlan { lb_type, lb_key }
+        } = Self::resolve_lb_key_for_runtime_request(
+            pool.lb_strategy(),
+            pool.lb_key_spec(),
+            request,
+        );
+        BackendSelectionPlan {
+            lb_type: pool.lb_strategy().canonical_name().to_string(),
+            lb_key,
+        }
     }
 
     fn no_servers_in_upstream_error() -> ProxyError {

--- a/crates/edge/src/quic_listener/health_check.rs
+++ b/crates/edge/src/quic_listener/health_check.rs
@@ -7,6 +7,7 @@ impl QUICListener {
         upstream_pools: HashMap<String, Arc<RwLock<UpstreamPool>>>,
         transport_pool: Arc<UpstreamTransportPool>,
         backend_endpoints: Arc<HashMap<String, BackendEndpoint>>,
+        backend_health_checks: Arc<HashMap<String, spooky_config::runtime::RuntimeBackendHealthCheck>>,
         _backend_resolution_store: Arc<RuntimeBackendResolutionStore>,
         metrics: Arc<Metrics>,
         task_registry: Arc<RuntimeTaskRegistry>,
@@ -32,15 +33,11 @@ impl QUICListener {
                 Err(_) => continue,
             };
             for index in pool.pool.all_indices() {
-                let (address, health) =
-                    match (pool.pool.address(index), pool.pool.health_check(index)) {
-                        (Some(address), Some(health)) => (address.to_string(), health),
-                        _ => continue,
-                    };
-                let path: &str = if health.path.is_empty() {
-                    "/"
-                } else {
-                    &health.path
+                let Some(address) = pool.pool.address(index).map(str::to_string) else {
+                    continue;
+                };
+                let Some(health) = backend_health_checks.get(&address) else {
+                    continue;
                 };
                 let endpoint = match backend_endpoints.get(&address) {
                     Some(endpoint) => endpoint,
@@ -52,7 +49,8 @@ impl QUICListener {
                         continue;
                     }
                 };
-                let base_interval_ms = health.interval.max(1);
+                let base_interval_ms: u64 =
+                    health.interval.as_millis().try_into().unwrap_or(u64::MAX).max(1);
                 let initial_jitter_ms = if base_interval_ms > 1 {
                     crate::stable_hash64(address.as_bytes()) % base_interval_ms
                 } else {
@@ -63,8 +61,8 @@ impl QUICListener {
                     upstream_pool: Arc::clone(upstream_pool),
                     index,
                     backend_identity: address,
-                    health_uri: endpoint.uri_for_path(path),
-                    timeout: Duration::from_millis(health.timeout_ms.max(1)),
+                    health_uri: endpoint.uri_for_path(&health.path),
+                    timeout: health.timeout,
                     base_interval_ms,
                     consecutive_failures: 0,
                     next_due_at,

--- a/crates/edge/src/quic_listener/health_check.rs
+++ b/crates/edge/src/quic_listener/health_check.rs
@@ -7,7 +7,9 @@ impl QUICListener {
         upstream_pools: HashMap<String, Arc<RwLock<UpstreamPool>>>,
         transport_pool: Arc<UpstreamTransportPool>,
         backend_endpoints: Arc<HashMap<String, BackendEndpoint>>,
-        backend_health_checks: Arc<HashMap<String, spooky_config::runtime::RuntimeBackendHealthCheck>>,
+        backend_health_checks: Arc<
+            HashMap<String, spooky_config::runtime::RuntimeBackendHealthCheck>,
+        >,
         _backend_resolution_store: Arc<RuntimeBackendResolutionStore>,
         metrics: Arc<Metrics>,
         task_registry: Arc<RuntimeTaskRegistry>,
@@ -49,8 +51,12 @@ impl QUICListener {
                         continue;
                     }
                 };
-                let base_interval_ms: u64 =
-                    health.interval.as_millis().try_into().unwrap_or(u64::MAX).max(1);
+                let base_interval_ms: u64 = health
+                    .interval
+                    .as_millis()
+                    .try_into()
+                    .unwrap_or(u64::MAX)
+                    .max(1);
                 let initial_jitter_ms = if base_interval_ms > 1 {
                     crate::stable_hash64(address.as_bytes()) % base_interval_ms
                 } else {

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -51,15 +51,14 @@ use spooky_config::{
     config::ClientAuth,
     runtime::{
         ListenerRuntimeConfig, RuntimeConfig, RuntimeListenerTls, RuntimeTlsIdentity,
-        RuntimeBackendAddressKind, RuntimeBackendTlsPolicy, RuntimeBackendTransportKind,
-        RuntimeUpstreamPolicy,
+        RuntimeBackendAddressKind, RuntimeUpstreamPolicy,
     },
 };
 use spooky_errors::{PoolError, ProxyError};
 use spooky_lb::{health::HealthFailureReason, upstream_pool::UpstreamPool};
 use spooky_transport::{
-    h2_client::{SharedDnsResolver, TlsClientConfig},
-    transport_pool::{BackendTransportKind, UpstreamTransportPool},
+    h2_client::SharedDnsResolver,
+    transport_pool::UpstreamTransportPool,
 };
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
@@ -541,15 +540,6 @@ impl QUICListener {
         Self::new_with_socket_and_shared_state(listener_config, socket, shared_state)
     }
 
-    fn upstream_tls_client_config(tls: &RuntimeBackendTlsPolicy) -> TlsClientConfig {
-        TlsClientConfig {
-            verify_certificates: tls.verify_certificates,
-            strict_sni: tls.strict_sni,
-            ca_file: tls.ca_file.clone(),
-            ca_dir: tls.ca_dir.clone(),
-        }
-    }
-
     fn record_backend_connect(
         metrics: &Metrics,
         backend: &str,
@@ -572,8 +562,6 @@ impl QUICListener {
         let worker_slots = active_worker_threads.saturating_mul(shard_count).max(1);
         let per_upstream_limit = transport_policy.connection_limits.per_upstream_inflight.max(1);
         let global_inflight_limit = transport_policy.connection_limits.global_inflight.max(1);
-        let max_inflight_per_backend = transport_policy.backend_connections.max_inflight.max(1);
-
         info!(
             "Runtime performance concurrency worker_threads={} control_plane_threads={} packet_shards_per_worker={} reuseport={} pin_workers={}",
             worker_threads,
@@ -620,16 +608,11 @@ impl QUICListener {
             .collect::<HashMap<_, _>>();
         let listener_tls_store = Arc::new(Self::build_listener_tls_reload_store(config)?);
 
-        let mut backend_transports = Vec::new();
         let mut backend_resolutions = Vec::new();
         let mut seen_backend_origins: HashMap<String, (String, String)> = HashMap::new();
-        let mut backend_tls_configs: HashMap<String, TlsClientConfig> = HashMap::new();
         let mut backend_endpoints: HashMap<String, BackendEndpoint> = HashMap::new();
         let mut backend_health_checks = HashMap::new();
         for (upstream_name, upstream) in &config.upstreams {
-            let upstream_tls_client =
-                Self::upstream_tls_client_config(&upstream.policy_set.transport.tls);
-
             for backend in &upstream.backends {
                 let endpoint = backend.endpoint.canonical.clone();
                 let origin = backend.endpoint.origin.clone();
@@ -646,13 +629,6 @@ impl QUICListener {
                         existing_backend
                     )));
                 }
-                backend_transports.push((
-                    backend.backend.address.clone(),
-                    match backend.endpoint.transport_kind {
-                        RuntimeBackendTransportKind::Http1 => BackendTransportKind::Http1,
-                        RuntimeBackendTransportKind::H2 => BackendTransportKind::H2,
-                    },
-                ));
                 let authority_host = backend.endpoint.authority_host.clone();
                 let authority_port = backend.endpoint.authority_port;
                 let resolution = if matches!(backend.endpoint.address_kind, RuntimeBackendAddressKind::IpLiteral) {
@@ -684,19 +660,15 @@ impl QUICListener {
                     "Configured upstream TLS policy backend={} upstream={} verify_certificates={} strict_sni={} ca_file={:?} ca_dir={:?} authority_kind={}",
                     backend.backend.address,
                     upstream_name,
-                    upstream_tls_client.verify_certificates,
-                    upstream_tls_client.strict_sni,
-                    upstream_tls_client.ca_file,
-                    upstream_tls_client.ca_dir,
+                    upstream.policy_set.transport.tls.verify_certificates,
+                    upstream.policy_set.transport.tls.strict_sni,
+                    upstream.policy_set.transport.tls.ca_file,
+                    upstream.policy_set.transport.tls.ca_dir,
                     authority_kind
                 );
                 backend_endpoints.insert(backend.backend.address.clone(), endpoint);
                 if let Some(health_check) = backend.health_check.clone() {
                     backend_health_checks.insert(backend.backend.address.clone(), health_check);
-                }
-                if matches!(backend.endpoint.transport_kind, RuntimeBackendTransportKind::H2) {
-                    backend_tls_configs
-                        .insert(backend.backend.address.clone(), upstream_tls_client.clone());
                 }
             }
         }
@@ -720,13 +692,9 @@ impl QUICListener {
             },
         );
         let transport_pool = Arc::new(
-            UpstreamTransportPool::new_with_observer(
-                backend_transports,
-                backend_tls_configs,
-                max_inflight_per_backend,
-                transport_policy.backend_connections.max_idle_per_backend,
-                transport_policy.backend_connections.pool_idle_timeout,
-                transport_policy.backend_connections.connect_timeout,
+            UpstreamTransportPool::from_runtime_upstreams(
+                config.upstreams.values(),
+                &transport_policy.backend_connections,
                 backend_dns_resolver.clone(),
                 Some(connect_observer),
             )

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -708,38 +708,40 @@ impl QUICListener {
             .resilience
             .validate()
             .map_err(|e| ProxyError::Transport(format!("invalid resilience config: {e}")))?;
-        let mut effective_resilience = config.resilience.clone();
+        let mut effective_admission = config.policies.admission.clone();
         let default_route_cap_limit = per_upstream_limit.saturating_mul(2).max(1);
-        if effective_resilience.route_queue.default_cap > default_route_cap_limit {
+        if effective_admission.route_queue.default_cap > default_route_cap_limit {
             warn!(
                 "resilience.route_queue.default_cap={} is above tuned limit {}; clamping for steadier timeout/admission behavior",
-                effective_resilience.route_queue.default_cap, default_route_cap_limit
+                effective_admission.route_queue.default_cap, default_route_cap_limit
             );
-            effective_resilience.route_queue.default_cap = default_route_cap_limit;
         }
         let global_route_cap_limit = global_inflight_limit.saturating_mul(2).max(1);
-        if effective_resilience.route_queue.global_cap > global_route_cap_limit {
+        if effective_admission.route_queue.global_cap > global_route_cap_limit {
             warn!(
                 "resilience.route_queue.global_cap={} is above tuned limit {}; clamping for steadier timeout/admission behavior",
-                effective_resilience.route_queue.global_cap, global_route_cap_limit
+                effective_admission.route_queue.global_cap, global_route_cap_limit
             );
-            effective_resilience.route_queue.global_cap = global_route_cap_limit;
-        }
-        for cap in effective_resilience.route_queue.caps.values_mut() {
-            *cap = (*cap).min(default_route_cap_limit).max(1);
         }
         let tuned_high_latency =
             (config.performance.backend_timeout_ms.saturating_mul(7) / 10).max(50);
-        if effective_resilience.adaptive_admission.high_latency_ms > tuned_high_latency {
+        if effective_admission.adaptive_admission.high_latency
+            > Duration::from_millis(tuned_high_latency)
+        {
             warn!(
                 "resilience.adaptive_admission.high_latency_ms={} is above tuned limit {}; clamping for faster overload reaction",
-                effective_resilience.adaptive_admission.high_latency_ms, tuned_high_latency
+                effective_admission.adaptive_admission.high_latency.as_millis(),
+                tuned_high_latency
             );
-            effective_resilience.adaptive_admission.high_latency_ms = tuned_high_latency;
         }
-        let resilience = Arc::new(RuntimeResilience::from_config(
-            &effective_resilience,
-            global_inflight_limit,
+        effective_admission = effective_admission.with_runtime_overrides(
+            default_route_cap_limit,
+            global_route_cap_limit,
+            Duration::from_millis(tuned_high_latency),
+        );
+        let resilience = Arc::new(RuntimeResilience::from_policies(
+            &effective_admission,
+            &config.policies.rate_limits,
         ));
         let watchdog = Arc::new(WatchdogCoordinator::new(&config.resilience.watchdog));
         for (listener_label, inventory) in listener_tls_store.snapshot() {

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -658,7 +658,7 @@ impl QUICListener {
 
         let mut route_labels = config.upstreams.keys().cloned().collect::<Vec<_>>();
         route_labels.push("unrouted".to_string());
-        let routing_index = Arc::new(RouteIndex::from_upstreams(&config.upstreams_as_config()));
+        let routing_index = Arc::new(RouteIndex::from_runtime_upstreams(&config.upstreams));
         let metrics = Arc::new(Metrics::new(worker_slots, route_labels));
         let backend_dns_resolver = SharedDnsResolver::new();
         let backend_resolution_store =
@@ -690,8 +690,8 @@ impl QUICListener {
         let mut upstream_pools = HashMap::new();
         let mut upstream_inflight = HashMap::new();
         for (name, runtime_upstream) in &config.upstreams {
-            let upstream_pool = UpstreamPool::from_upstream(&runtime_upstream.as_config_upstream())
-                .map_err(|err| {
+            let upstream_pool =
+                UpstreamPool::from_runtime_upstream(runtime_upstream).map_err(|err| {
                     ProxyError::Transport(format!(
                         "failed to create upstream pool '{}': {}",
                         name, err

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -48,9 +48,10 @@ use spooky_bridge::response::{
 };
 use spooky_config::{
     backend_endpoint::{BackendEndpoint, BackendScheme},
-    config::{ClientAuth, UpstreamTls},
+    config::ClientAuth,
     runtime::{
         ListenerRuntimeConfig, RuntimeConfig, RuntimeListenerTls, RuntimeTlsIdentity,
+        RuntimeBackendAddressKind, RuntimeBackendTlsPolicy, RuntimeBackendTransportKind,
         RuntimeUpstreamPolicy,
     },
 };
@@ -495,7 +496,7 @@ impl QUICListener {
         Self::new_with_socket_and_shared_state(listener_config, socket, shared_state)
     }
 
-    fn upstream_tls_client_config(tls: &UpstreamTls) -> TlsClientConfig {
+    fn upstream_tls_client_config(tls: &RuntimeBackendTlsPolicy) -> TlsClientConfig {
         TlsClientConfig {
             verify_certificates: tls.verify_certificates,
             strict_sni: tls.strict_sni,
@@ -514,58 +515,57 @@ impl QUICListener {
     }
 
     pub fn build_shared_state(config: &RuntimeConfig) -> Result<SharedRuntimeState, ProxyError> {
-        let worker_threads = config.performance.worker_threads.max(1);
-        let shard_count = config.performance.packet_shards_per_worker.max(1);
-        let active_worker_threads = if worker_threads > 1 && !config.performance.reuseport {
+        let transport_policy = &config.policies.transport;
+        let timeout_policy = &config.policies.timeouts;
+        let worker_threads = transport_policy.worker_threads.max(1);
+        let shard_count = transport_policy.packet_shards_per_worker.max(1);
+        let active_worker_threads = if worker_threads > 1 && !transport_policy.reuseport {
             1
         } else {
             worker_threads
         };
         let worker_slots = active_worker_threads.saturating_mul(shard_count).max(1);
-        let per_upstream_limit = config.performance.per_upstream_inflight_limit.max(1);
-        let global_inflight_limit = config.performance.global_inflight_limit.max(1);
-        let max_inflight_per_backend = config
-            .performance
-            .per_backend_inflight_limit
-            .saturating_mul(worker_threads);
+        let per_upstream_limit = transport_policy.connection_limits.per_upstream_inflight.max(1);
+        let global_inflight_limit = transport_policy.connection_limits.global_inflight.max(1);
+        let max_inflight_per_backend = transport_policy.backend_connections.max_inflight.max(1);
 
         info!(
             "Runtime performance concurrency worker_threads={} control_plane_threads={} packet_shards_per_worker={} reuseport={} pin_workers={}",
             worker_threads,
-            config.performance.control_plane_threads.max(1),
+            transport_policy.control_plane_threads.max(1),
             shard_count,
-            config.performance.reuseport,
-            config.performance.pin_workers,
+            transport_policy.reuseport,
+            transport_policy.pin_workers,
         );
         info!(
             "Runtime performance inflight_limits global_inflight_limit={} per_upstream_inflight_limit={} per_backend_inflight_limit={} max_active_connections={}",
             global_inflight_limit,
             per_upstream_limit,
-            config.performance.per_backend_inflight_limit,
-            config.performance.max_active_connections,
+            transport_policy.connection_limits.per_backend,
+            transport_policy.connection_limits.max_active_connections,
         );
         info!(
             "Runtime performance upstream_timeouts backend_connect_timeout_ms={} backend_timeout_ms={} backend_body_idle_timeout_ms={} backend_body_total_timeout_ms={} backend_total_request_timeout_ms={}",
-            config.performance.backend_connect_timeout_ms,
-            config.performance.backend_timeout_ms,
-            config.performance.backend_body_idle_timeout_ms,
-            config.performance.backend_body_total_timeout_ms,
-            config.performance.backend_total_request_timeout_ms,
+            timeout_policy.backend_connect.as_millis(),
+            timeout_policy.backend_request.as_millis(),
+            timeout_policy.backend_body_idle.as_millis(),
+            timeout_policy.backend_body_total.as_millis(),
+            timeout_policy.backend_total_request.as_millis(),
         );
         info!(
             "Runtime performance request_limits client_body_idle_timeout_ms={} max_request_body_bytes={} max_response_body_bytes={} request_buffer_global_cap_bytes={} unknown_length_response_prebuffer_bytes={}",
-            config.performance.client_body_idle_timeout_ms,
-            config.performance.max_request_body_bytes,
-            config.performance.max_response_body_bytes,
-            config.performance.request_buffer_global_cap_bytes,
-            config.performance.unknown_length_response_prebuffer_bytes,
+            timeout_policy.client_body_idle.as_millis(),
+            transport_policy.max_request_body_bytes,
+            transport_policy.max_response_body_bytes,
+            transport_policy.request_buffer_global_cap_bytes,
+            transport_policy.unknown_length_response_prebuffer_bytes,
         );
         info!(
             "Runtime performance transport_buffers udp_recv_buffer_bytes={} udp_send_buffer_bytes={} h2_pool_max_idle_per_backend={} h2_pool_idle_timeout_ms={}",
-            config.performance.udp_recv_buffer_bytes,
-            config.performance.udp_send_buffer_bytes,
-            config.performance.h2_pool_max_idle_per_backend,
-            config.performance.h2_pool_idle_timeout_ms,
+            transport_policy.udp_recv_buffer_bytes,
+            transport_policy.udp_send_buffer_bytes,
+            transport_policy.backend_connections.max_idle_per_backend,
+            transport_policy.backend_connections.pool_idle_timeout.as_millis(),
         );
 
         let listener_runtime_configs = config
@@ -579,21 +579,15 @@ impl QUICListener {
         let mut backend_resolutions = Vec::new();
         let mut seen_backend_origins: HashMap<String, (String, String)> = HashMap::new();
         let mut backend_tls_configs: HashMap<String, TlsClientConfig> = HashMap::new();
+        let mut backend_endpoints: HashMap<String, BackendEndpoint> = HashMap::new();
+        let mut backend_health_checks = HashMap::new();
         for (upstream_name, upstream) in &config.upstreams {
-            let upstream_tls_client = Self::upstream_tls_client_config(&upstream.effective_tls);
+            let upstream_tls_client =
+                Self::upstream_tls_client_config(&upstream.policy_set.transport.tls);
 
             for backend in &upstream.backends {
-                let endpoint = match BackendEndpoint::parse(&backend.backend.address) {
-                    Ok(endpoint) => endpoint,
-                    Err(err) => {
-                        return Err(ProxyError::Transport(format!(
-                            "invalid backend address '{}' in upstream '{}' (backend '{}'): {}",
-                            backend.backend.address, upstream_name, backend.backend.id, err
-                        )));
-                    }
-                };
-
-                let origin = endpoint.origin();
+                let endpoint = backend.endpoint.canonical.clone();
+                let origin = backend.endpoint.origin.clone();
                 if let Some((existing_upstream, existing_backend)) = seen_backend_origins.insert(
                     origin.clone(),
                     (upstream_name.clone(), backend.backend.id.clone()),
@@ -609,14 +603,14 @@ impl QUICListener {
                 }
                 backend_transports.push((
                     backend.backend.address.clone(),
-                    match endpoint.scheme() {
-                        BackendScheme::Http => BackendTransportKind::Http1,
-                        BackendScheme::Https => BackendTransportKind::H2,
+                    match backend.endpoint.transport_kind {
+                        RuntimeBackendTransportKind::Http1 => BackendTransportKind::Http1,
+                        RuntimeBackendTransportKind::H2 => BackendTransportKind::H2,
                     },
                 ));
-                let authority_host = endpoint.authority_host().to_string();
-                let authority_port = endpoint.authority_port();
-                let resolution = if endpoint.authority_is_ip_literal() {
+                let authority_host = backend.endpoint.authority_host.clone();
+                let authority_port = backend.endpoint.authority_port;
+                let resolution = if matches!(backend.endpoint.address_kind, RuntimeBackendAddressKind::IpLiteral) {
                     let ip_addr = authority_host.parse::<IpAddr>().map_err(|err| {
                         ProxyError::Transport(format!(
                             "failed to parse IP literal backend '{}' in upstream '{}' (backend '{}'): {}",
@@ -637,10 +631,9 @@ impl QUICListener {
                     )
                 };
                 backend_resolutions.push(resolution);
-                let authority_kind = if endpoint.authority_is_ip_literal() {
-                    "ip_literal"
-                } else {
-                    "hostname"
+                let authority_kind = match backend.endpoint.address_kind {
+                    RuntimeBackendAddressKind::IpLiteral => "ip_literal",
+                    RuntimeBackendAddressKind::Hostname => "hostname",
                 };
                 debug!(
                     "Configured upstream TLS policy backend={} upstream={} verify_certificates={} strict_sni={} ca_file={:?} ca_dir={:?} authority_kind={}",
@@ -652,7 +645,11 @@ impl QUICListener {
                     upstream_tls_client.ca_dir,
                     authority_kind
                 );
-                if endpoint.scheme() == BackendScheme::Https {
+                backend_endpoints.insert(backend.backend.address.clone(), endpoint);
+                if let Some(health_check) = backend.health_check.clone() {
+                    backend_health_checks.insert(backend.backend.address.clone(), health_check);
+                }
+                if matches!(backend.endpoint.transport_kind, RuntimeBackendTransportKind::H2) {
                     backend_tls_configs
                         .insert(backend.backend.address.clone(), upstream_tls_client.clone());
                 }
@@ -682,9 +679,9 @@ impl QUICListener {
                 backend_transports,
                 backend_tls_configs,
                 max_inflight_per_backend,
-                config.performance.h2_pool_max_idle_per_backend,
-                Duration::from_millis(config.performance.h2_pool_idle_timeout_ms),
-                Duration::from_millis(config.performance.backend_connect_timeout_ms),
+                transport_policy.backend_connections.max_idle_per_backend,
+                transport_policy.backend_connections.pool_idle_timeout,
+                transport_policy.backend_connections.connect_timeout,
                 backend_dns_resolver.clone(),
                 Some(connect_observer),
             )
@@ -752,18 +749,8 @@ impl QUICListener {
             listener_runtime_configs: Arc::new(listener_runtime_configs),
             listener_tls_store,
             transport_pool,
-            backend_endpoints: Arc::new(
-                config
-                    .upstreams
-                    .values()
-                    .flat_map(|upstream| upstream.backends.iter())
-                    .filter_map(|backend| {
-                        BackendEndpoint::parse(&backend.backend.address)
-                            .ok()
-                            .map(|endpoint| (backend.backend.address.clone(), endpoint))
-                    })
-                    .collect(),
-            ),
+            backend_endpoints: Arc::new(backend_endpoints),
+            backend_health_checks: Arc::new(backend_health_checks),
             backend_resolution_store,
             backend_dns_resolver,
             upstream_policies: Arc::new(
@@ -857,6 +844,7 @@ impl QUICListener {
             shared_state.upstream_pools.clone(),
             Arc::clone(&shared_state.transport_pool),
             Arc::clone(&shared_state.backend_endpoints),
+            Arc::clone(&shared_state.backend_health_checks),
             Arc::clone(&shared_state.backend_resolution_store),
             Arc::clone(&shared_state.metrics),
             Arc::clone(&task_registry),

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -50,16 +50,13 @@ use spooky_config::{
     backend_endpoint::{BackendEndpoint, BackendScheme},
     config::ClientAuth,
     runtime::{
-        ListenerRuntimeConfig, RuntimeConfig, RuntimeListenerTls, RuntimeTlsIdentity,
-        RuntimeBackendAddressKind, RuntimeUpstreamPolicy,
+        ListenerRuntimeConfig, RuntimeBackendAddressKind, RuntimeConfig, RuntimeListenerTls,
+        RuntimeTlsIdentity, RuntimeUpstreamPolicy,
     },
 };
 use spooky_errors::{PoolError, ProxyError};
 use spooky_lb::{health::HealthFailureReason, upstream_pool::UpstreamPool};
-use spooky_transport::{
-    h2_client::SharedDnsResolver,
-    transport_pool::UpstreamTransportPool,
-};
+use spooky_transport::{h2_client::SharedDnsResolver, transport_pool::UpstreamTransportPool};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     runtime::Handle,
@@ -508,7 +505,10 @@ impl QUICListener {
             backend_total_request_timeout: timeout_policy.backend_total_request,
             inflight_acquire_wait: timeout_policy.inflight_acquire_wait,
             drain_timeout: timeout_policy.shutdown_drain,
-            max_active_connections: transport_policy.connection_limits.max_active_connections.max(1),
+            max_active_connections: transport_policy
+                .connection_limits
+                .max_active_connections
+                .max(1),
             max_streams_per_connection: usize::try_from(
                 transport_policy.quic_initial_max_streams_bidi,
             )
@@ -560,7 +560,10 @@ impl QUICListener {
             worker_threads
         };
         let worker_slots = active_worker_threads.saturating_mul(shard_count).max(1);
-        let per_upstream_limit = transport_policy.connection_limits.per_upstream_inflight.max(1);
+        let per_upstream_limit = transport_policy
+            .connection_limits
+            .per_upstream_inflight
+            .max(1);
         let global_inflight_limit = transport_policy.connection_limits.global_inflight.max(1);
         info!(
             "Runtime performance concurrency worker_threads={} control_plane_threads={} packet_shards_per_worker={} reuseport={} pin_workers={}",
@@ -598,7 +601,10 @@ impl QUICListener {
             transport_policy.udp_recv_buffer_bytes,
             transport_policy.udp_send_buffer_bytes,
             transport_policy.backend_connections.max_idle_per_backend,
-            transport_policy.backend_connections.pool_idle_timeout.as_millis(),
+            transport_policy
+                .backend_connections
+                .pool_idle_timeout
+                .as_millis(),
         );
 
         let listener_runtime_configs = config
@@ -631,7 +637,10 @@ impl QUICListener {
                 }
                 let authority_host = backend.endpoint.authority_host.clone();
                 let authority_port = backend.endpoint.authority_port;
-                let resolution = if matches!(backend.endpoint.address_kind, RuntimeBackendAddressKind::IpLiteral) {
+                let resolution = if matches!(
+                    backend.endpoint.address_kind,
+                    RuntimeBackendAddressKind::IpLiteral
+                ) {
                     let ip_addr = authority_host.parse::<IpAddr>().map_err(|err| {
                         ProxyError::Transport(format!(
                             "failed to parse IP literal backend '{}' in upstream '{}' (backend '{}'): {}",
@@ -737,7 +746,10 @@ impl QUICListener {
         {
             warn!(
                 "resilience.adaptive_admission.high_latency_ms={} is above tuned limit {}; clamping for faster overload reaction",
-                effective_admission.adaptive_admission.high_latency.as_millis(),
+                effective_admission
+                    .adaptive_admission
+                    .high_latency
+                    .as_millis(),
                 tuned_high_latency
             );
         }

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -138,6 +138,24 @@ use validation::{
 };
 use x509_parser::{extensions::GeneralName, parse_x509_certificate};
 
+struct ListenerRuntimeSettings {
+    backend_timeout: Duration,
+    backend_body_idle_timeout: Duration,
+    backend_body_total_timeout: Duration,
+    client_body_idle_timeout: Duration,
+    backend_total_request_timeout: Duration,
+    inflight_acquire_wait: Duration,
+    drain_timeout: Duration,
+    max_active_connections: usize,
+    max_streams_per_connection: usize,
+    max_request_body_bytes: usize,
+    max_response_body_bytes: usize,
+    request_buffer_global_cap_bytes: usize,
+    unknown_length_response_prebuffer_bytes: usize,
+    new_connections_per_sec: u32,
+    new_connections_burst: u32,
+}
+
 #[cfg(test)]
 fn connection_header_tokens(headers: &http::HeaderMap) -> HashSet<String> {
     let mut tokens = HashSet::new();
@@ -480,6 +498,33 @@ fn boxed_full(body: Bytes) -> http_body_util::combinators::BoxBody<Bytes, Infall
 }
 
 impl QUICListener {
+    fn listener_runtime_settings(config: &ListenerRuntimeConfig) -> ListenerRuntimeSettings {
+        let transport_policy = &config.policies.transport;
+        let timeout_policy = &config.policies.timeouts;
+        ListenerRuntimeSettings {
+            backend_timeout: timeout_policy.backend_request,
+            backend_body_idle_timeout: timeout_policy.backend_body_idle,
+            backend_body_total_timeout: timeout_policy.backend_body_total,
+            client_body_idle_timeout: timeout_policy.client_body_idle,
+            backend_total_request_timeout: timeout_policy.backend_total_request,
+            inflight_acquire_wait: timeout_policy.inflight_acquire_wait,
+            drain_timeout: timeout_policy.shutdown_drain,
+            max_active_connections: transport_policy.connection_limits.max_active_connections.max(1),
+            max_streams_per_connection: usize::try_from(
+                transport_policy.quic_initial_max_streams_bidi,
+            )
+            .unwrap_or(usize::MAX)
+            .max(1),
+            max_request_body_bytes: transport_policy.max_request_body_bytes,
+            max_response_body_bytes: transport_policy.max_response_body_bytes,
+            request_buffer_global_cap_bytes: transport_policy.request_buffer_global_cap_bytes,
+            unknown_length_response_prebuffer_bytes: transport_policy
+                .unknown_length_response_prebuffer_bytes,
+            new_connections_per_sec: transport_policy.new_connections_per_sec,
+            new_connections_burst: transport_policy.new_connections_burst,
+        }
+    }
+
     pub fn new(config: spooky_config::config::Config) -> Result<Self, ProxyError> {
         let runtime_config = RuntimeConfig::from_config(&config)
             .map_err(|err| ProxyError::Transport(err.to_string()))?;
@@ -701,10 +746,6 @@ impl QUICListener {
             upstream_inflight.insert(name.clone(), Arc::new(Semaphore::new(per_upstream_limit)));
         }
 
-        config
-            .resilience
-            .validate()
-            .map_err(|e| ProxyError::Transport(format!("invalid resilience config: {e}")))?;
         let mut effective_admission = config.policies.admission.clone();
         let default_route_cap_limit = per_upstream_limit.saturating_mul(2).max(1);
         if effective_admission.route_queue.default_cap > default_route_cap_limit {
@@ -720,8 +761,9 @@ impl QUICListener {
                 effective_admission.route_queue.global_cap, global_route_cap_limit
             );
         }
-        let tuned_high_latency =
-            (config.performance.backend_timeout_ms.saturating_mul(7) / 10).max(50);
+        let backend_timeout_ms =
+            u64::try_from(timeout_policy.backend_request.as_millis()).unwrap_or(u64::MAX);
+        let tuned_high_latency = (backend_timeout_ms.saturating_mul(7) / 10).max(50);
         if effective_admission.adaptive_admission.high_latency
             > Duration::from_millis(tuned_high_latency)
         {
@@ -740,7 +782,9 @@ impl QUICListener {
             &effective_admission,
             &config.policies.rate_limits,
         ));
-        let watchdog = Arc::new(WatchdogCoordinator::new(&config.resilience.watchdog));
+        let watchdog = Arc::new(WatchdogCoordinator::from_runtime_config(
+            &WatchdogRuntimeConfig::from(&config.policies.admission.watchdog),
+        ));
         for (listener_label, inventory) in listener_tls_store.snapshot() {
             Self::update_listener_tls_expiry_metrics(&metrics, &listener_label, &inventory);
         }
@@ -825,10 +869,11 @@ impl QUICListener {
     ) {
         shared_state.watchdog.set_expected_workers(
             config
-                .performance
+                .policies
+                .transport
                 .worker_threads
                 .max(1)
-                .saturating_mul(config.performance.packet_shards_per_worker.max(1))
+                .saturating_mul(config.policies.transport.packet_shards_per_worker.max(1))
                 .max(1),
         );
         let task_registry = Arc::clone(&shared_state.generation_tasks);
@@ -875,11 +920,12 @@ impl QUICListener {
         reuse_port: bool,
     ) -> Result<UdpSocket, ProxyError> {
         let bind_addr = Self::resolve_bind_addr(config)?;
+        let transport_policy = &config.policies.transport;
         let socket = Self::create_udp_socket(
             bind_addr,
             reuse_port,
-            config.performance.udp_recv_buffer_bytes,
-            config.performance.udp_send_buffer_bytes,
+            transport_policy.udp_recv_buffer_bytes,
+            transport_policy.udp_send_buffer_bytes,
         )?;
         socket
             .set_read_timeout(Some(Duration::from_millis(UDP_READ_TIMEOUT_MS)))
@@ -919,34 +965,13 @@ impl QUICListener {
             config.enable_extended_connect(true);
             config
         });
-        let backend_timeout = Duration::from_millis(config.performance.backend_timeout_ms);
-        let backend_body_idle_timeout =
-            Duration::from_millis(config.performance.backend_body_idle_timeout_ms);
-        let backend_body_total_timeout =
-            Duration::from_millis(config.performance.backend_body_total_timeout_ms);
-        let client_body_idle_timeout =
-            Duration::from_millis(config.performance.client_body_idle_timeout_ms);
-        let backend_total_request_timeout =
-            Duration::from_millis(config.performance.backend_total_request_timeout_ms);
-        let inflight_acquire_wait =
-            Duration::from_millis(config.performance.inflight_acquire_wait_ms);
-        let drain_timeout = Duration::from_millis(config.performance.shutdown_drain_timeout_ms);
-        let max_active_connections = config.performance.max_active_connections.max(1);
-        let max_streams_per_connection =
-            usize::try_from(config.performance.quic_initial_max_streams_bidi)
-                .unwrap_or(usize::MAX)
-                .max(1);
-        let max_request_body_bytes = config.performance.max_request_body_bytes;
-        let max_response_body_bytes = config.performance.max_response_body_bytes;
-        let request_buffer_global_cap_bytes = config.performance.request_buffer_global_cap_bytes;
-        let unknown_length_response_prebuffer_bytes =
-            config.performance.unknown_length_response_prebuffer_bytes;
+        let settings = Self::listener_runtime_settings(&config);
         let require_client_cert = Self::runtime_listener_tls(&config)?
             .client_auth
             .require_client_cert;
         let conn_rate_limiter = TokenBucket::new(
-            config.performance.new_connections_per_sec,
-            config.performance.new_connections_burst,
+            settings.new_connections_per_sec,
+            settings.new_connections_burst,
         );
 
         Ok(Self {
@@ -973,19 +998,20 @@ impl QUICListener {
             draining: false,
             drain_start: None,
             watchdog_worker_drained: false,
-            drain_timeout,
-            backend_timeout,
-            backend_body_idle_timeout,
-            backend_body_total_timeout,
-            client_body_idle_timeout,
-            backend_total_request_timeout,
-            inflight_acquire_wait,
-            max_active_connections,
-            max_streams_per_connection,
-            max_request_body_bytes,
-            max_response_body_bytes,
-            request_buffer_global_cap_bytes,
-            unknown_length_response_prebuffer_bytes,
+            drain_timeout: settings.drain_timeout,
+            backend_timeout: settings.backend_timeout,
+            backend_body_idle_timeout: settings.backend_body_idle_timeout,
+            backend_body_total_timeout: settings.backend_body_total_timeout,
+            client_body_idle_timeout: settings.client_body_idle_timeout,
+            backend_total_request_timeout: settings.backend_total_request_timeout,
+            inflight_acquire_wait: settings.inflight_acquire_wait,
+            max_active_connections: settings.max_active_connections,
+            max_streams_per_connection: settings.max_streams_per_connection,
+            max_request_body_bytes: settings.max_request_body_bytes,
+            max_response_body_bytes: settings.max_response_body_bytes,
+            request_buffer_global_cap_bytes: settings.request_buffer_global_cap_bytes,
+            unknown_length_response_prebuffer_bytes: settings
+                .unknown_length_response_prebuffer_bytes,
             require_client_cert,
             runtime_bundle: None,
             runtime_generation: 0,

--- a/crates/edge/src/quic_listener/tests.rs
+++ b/crates/edge/src/quic_listener/tests.rs
@@ -87,6 +87,31 @@ fn test_upstream_with(lb_type: &str, lb_key: Option<&str>, method: Option<&str>)
     }
 }
 
+fn runtime_config_with_upstreams(upstreams: HashMap<String, Upstream>) -> RuntimeConfig {
+    RuntimeConfig::from_config(&SpookyConfigConfig {
+        version: 1,
+        listen: Listen {
+            protocol: "http1".to_string(),
+            tls: Tls {
+                cert: "/tmp/test-cert.pem".to_string(),
+                key: "/tmp/test-key.pem".to_string(),
+                ..Tls::default()
+            },
+            ..Listen::default()
+        },
+        listeners: Vec::new(),
+        upstream: upstreams,
+        load_balancing: None,
+        upstream_tls: UpstreamTls::default(),
+        log: Log::default(),
+        performance: Performance::default(),
+        observability: Observability::default(),
+        resilience: Resilience::default(),
+        security: Security::default(),
+    })
+    .expect("runtime config")
+}
+
 fn write_test_cert_for_name(dir: &Path, cert_name: &str, dns_name: &str) -> (String, String) {
     let mut params = CertificateParams::new(vec![dns_name.to_string()]);
     params
@@ -761,16 +786,24 @@ type TestRoutingContext = (
 fn test_routing_context(lb_type: &str) -> TestRoutingContext {
     let mut upstreams = HashMap::new();
     upstreams.insert("api_pool".to_string(), test_upstream(lb_type));
-    let routing_index = super::RouteIndex::from_upstreams(&upstreams);
-    let pool = super::UpstreamPool::from_upstream(upstreams.get("api_pool").expect("upstream"))
-        .expect("pool");
+    let runtime = runtime_config_with_upstreams(upstreams);
+    let routing_index = super::RouteIndex::from_runtime_upstreams(&runtime.upstreams);
+    let pool = super::UpstreamPool::from_runtime_upstream(
+        runtime.upstreams.get("api_pool").expect("upstream"),
+    )
+    .expect("pool");
     let pool = Arc::new(RwLock::new(pool));
     let mut upstream_pools = HashMap::new();
     upstream_pools.insert("api_pool".to_string(), Arc::clone(&pool));
     let mut upstream_policies = HashMap::new();
     upstream_policies.insert(
         "api_pool".to_string(),
-        spooky_config::runtime::RuntimeUpstreamPolicy::default(),
+        runtime
+            .upstreams
+            .get("api_pool")
+            .expect("upstream")
+            .policy
+            .clone(),
     );
     (upstream_pools, upstream_policies, routing_index, pool)
 }
@@ -876,16 +909,14 @@ fn resolve_backend_prefers_method_specific_route() {
     }];
     upstreams.insert("post_only".to_string(), post_only);
 
-    let routing_index = super::RouteIndex::from_upstreams(&upstreams);
+    let runtime = runtime_config_with_upstreams(upstreams);
+    let routing_index = super::RouteIndex::from_runtime_upstreams(&runtime.upstreams);
     let mut upstream_pools = HashMap::new();
     let mut upstream_policies = HashMap::new();
-    for (name, upstream) in &upstreams {
-        let pool = super::UpstreamPool::from_upstream(upstream).expect("pool");
+    for (name, upstream) in &runtime.upstreams {
+        let pool = super::UpstreamPool::from_runtime_upstream(upstream).expect("pool");
         upstream_pools.insert(name.clone(), Arc::new(RwLock::new(pool)));
-        upstream_policies.insert(
-            name.clone(),
-            spooky_config::runtime::RuntimeUpstreamPolicy::default(),
-        );
+        upstream_policies.insert(name.clone(), upstream.policy.clone());
     }
 
     let request =
@@ -920,16 +951,24 @@ fn resolve_backend_uses_configured_header_lb_key() {
             "api_pool".to_string(),
             test_upstream_with("consistent-hash", Some("header:x-user-id"), None),
         );
-        let routing_index = super::RouteIndex::from_upstreams(&upstreams);
-        let pool = super::UpstreamPool::from_upstream(upstreams.get("api_pool").expect("upstream"))
-            .expect("pool");
+        let runtime = runtime_config_with_upstreams(upstreams);
+        let routing_index = super::RouteIndex::from_runtime_upstreams(&runtime.upstreams);
+        let pool = super::UpstreamPool::from_runtime_upstream(
+            runtime.upstreams.get("api_pool").expect("upstream"),
+        )
+        .expect("pool");
         let pool = Arc::new(RwLock::new(pool));
         let mut upstream_pools = HashMap::new();
         upstream_pools.insert("api_pool".to_string(), Arc::clone(&pool));
         let mut upstream_policies = HashMap::new();
         upstream_policies.insert(
             "api_pool".to_string(),
-            spooky_config::runtime::RuntimeUpstreamPolicy::default(),
+            runtime
+                .upstreams
+                .get("api_pool")
+                .expect("upstream")
+                .policy
+                .clone(),
         );
         (upstream_pools, upstream_policies, routing_index, pool)
     };

--- a/crates/edge/src/quic_listener/tests.rs
+++ b/crates/edge/src/quic_listener/tests.rs
@@ -443,8 +443,12 @@ fn bootstrap_connection_state_prefers_reloaded_runtime_settings() {
 
     let mut reloaded = startup.clone();
     reloaded.performance.backend_timeout_ms = 4321;
+    reloaded.performance.backend_body_idle_timeout_ms = 5321;
+    reloaded.performance.backend_body_total_timeout_ms = 6321;
+    reloaded.performance.backend_total_request_timeout_ms = 7321;
     reloaded.performance.max_request_body_bytes = 65_537;
     reloaded.performance.max_response_body_bytes = 98_765;
+    reloaded.performance.unknown_length_response_prebuffer_bytes = 98_765;
     reloaded.performance.max_active_connections = 37;
     reloaded.performance.client_body_idle_timeout_ms = 7654;
 

--- a/crates/edge/src/quic_listener/tls_runtime.rs
+++ b/crates/edge/src/quic_listener/tls_runtime.rs
@@ -83,12 +83,10 @@ impl QUICListener {
         quic_config.set_max_recv_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
         quic_config.set_max_send_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
         quic_config.set_initial_max_data(transport_policy.quic_initial_max_data);
-        quic_config.set_initial_max_stream_data_bidi_local(
-            transport_policy.quic_initial_max_stream_data,
-        );
-        quic_config.set_initial_max_stream_data_bidi_remote(
-            transport_policy.quic_initial_max_stream_data,
-        );
+        quic_config
+            .set_initial_max_stream_data_bidi_local(transport_policy.quic_initial_max_stream_data);
+        quic_config
+            .set_initial_max_stream_data_bidi_remote(transport_policy.quic_initial_max_stream_data);
         quic_config.set_initial_max_stream_data_uni(transport_policy.quic_initial_max_stream_data);
         quic_config.set_initial_max_streams_bidi(transport_policy.quic_initial_max_streams_bidi);
         quic_config.set_initial_max_streams_uni(transport_policy.quic_initial_max_streams_uni);

--- a/crates/edge/src/quic_listener/tls_runtime.rs
+++ b/crates/edge/src/quic_listener/tls_runtime.rs
@@ -51,6 +51,8 @@ impl QUICListener {
 
     pub(super) fn build_quic_config(config: &ListenerRuntimeConfig) -> Result<Config, ProxyError> {
         let loaded_tls = Self::load_listener_tls_material(config)?;
+        let transport_policy = &config.policies.transport;
+        let timeout_policy = &config.policies.timeouts;
         debug!(
             "Loaded downstream default TLS identity cert='{}' serial={} san_dns={:?} sni_identities={}",
             loaded_tls.default_identity.identity.cert_path,
@@ -71,20 +73,25 @@ impl QUICListener {
             .map_err(|err| {
                 ProxyError::Transport(format!("failed to set ALPN protocols: {:?}", err))
             })?;
-        quic_config.set_max_idle_timeout(config.performance.quic_max_idle_timeout_ms);
+        quic_config.set_max_idle_timeout(
+            timeout_policy
+                .quic_max_idle
+                .as_millis()
+                .try_into()
+                .unwrap_or(u64::MAX),
+        );
         quic_config.set_max_recv_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
         quic_config.set_max_send_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
-        quic_config.set_initial_max_data(config.performance.quic_initial_max_data);
+        quic_config.set_initial_max_data(transport_policy.quic_initial_max_data);
         quic_config.set_initial_max_stream_data_bidi_local(
-            config.performance.quic_initial_max_stream_data,
+            transport_policy.quic_initial_max_stream_data,
         );
         quic_config.set_initial_max_stream_data_bidi_remote(
-            config.performance.quic_initial_max_stream_data,
+            transport_policy.quic_initial_max_stream_data,
         );
-        quic_config
-            .set_initial_max_stream_data_uni(config.performance.quic_initial_max_stream_data);
-        quic_config.set_initial_max_streams_bidi(config.performance.quic_initial_max_streams_bidi);
-        quic_config.set_initial_max_streams_uni(config.performance.quic_initial_max_streams_uni);
+        quic_config.set_initial_max_stream_data_uni(transport_policy.quic_initial_max_stream_data);
+        quic_config.set_initial_max_streams_bidi(transport_policy.quic_initial_max_streams_bidi);
+        quic_config.set_initial_max_streams_uni(transport_policy.quic_initial_max_streams_uni);
         quic_config.set_disable_active_migration(true);
 
         if loaded_tls.client_auth.enabled {
@@ -337,38 +344,27 @@ impl QUICListener {
         self.metrics = Arc::clone(&runtime.shared_state.metrics);
         self.resilience = Arc::clone(&runtime.shared_state.resilience);
         self.watchdog = Arc::clone(&runtime.shared_state.watchdog);
-        self.backend_timeout = Duration::from_millis(self.config.performance.backend_timeout_ms);
-        self.backend_body_idle_timeout =
-            Duration::from_millis(self.config.performance.backend_body_idle_timeout_ms);
-        self.backend_body_total_timeout =
-            Duration::from_millis(self.config.performance.backend_body_total_timeout_ms);
-        self.client_body_idle_timeout =
-            Duration::from_millis(self.config.performance.client_body_idle_timeout_ms);
-        self.backend_total_request_timeout =
-            Duration::from_millis(self.config.performance.backend_total_request_timeout_ms);
-        self.inflight_acquire_wait =
-            Duration::from_millis(self.config.performance.inflight_acquire_wait_ms);
-        self.drain_timeout =
-            Duration::from_millis(self.config.performance.shutdown_drain_timeout_ms);
-        self.max_active_connections = self.config.performance.max_active_connections.max(1);
-        self.max_streams_per_connection =
-            usize::try_from(self.config.performance.quic_initial_max_streams_bidi)
-                .unwrap_or(usize::MAX)
-                .max(1);
-        self.max_request_body_bytes = self.config.performance.max_request_body_bytes;
-        self.max_response_body_bytes = self.config.performance.max_response_body_bytes;
-        self.request_buffer_global_cap_bytes =
-            self.config.performance.request_buffer_global_cap_bytes;
-        self.unknown_length_response_prebuffer_bytes = self
-            .config
-            .performance
-            .unknown_length_response_prebuffer_bytes;
+        let settings = Self::listener_runtime_settings(&self.config);
+        self.backend_timeout = settings.backend_timeout;
+        self.backend_body_idle_timeout = settings.backend_body_idle_timeout;
+        self.backend_body_total_timeout = settings.backend_body_total_timeout;
+        self.client_body_idle_timeout = settings.client_body_idle_timeout;
+        self.backend_total_request_timeout = settings.backend_total_request_timeout;
+        self.inflight_acquire_wait = settings.inflight_acquire_wait;
+        self.drain_timeout = settings.drain_timeout;
+        self.max_active_connections = settings.max_active_connections;
+        self.max_streams_per_connection = settings.max_streams_per_connection;
+        self.max_request_body_bytes = settings.max_request_body_bytes;
+        self.max_response_body_bytes = settings.max_response_body_bytes;
+        self.request_buffer_global_cap_bytes = settings.request_buffer_global_cap_bytes;
+        self.unknown_length_response_prebuffer_bytes =
+            settings.unknown_length_response_prebuffer_bytes;
         self.require_client_cert = Self::runtime_listener_tls(&self.config)?
             .client_auth
             .require_client_cert;
         self.conn_rate_limiter.reconfigure(
-            self.config.performance.new_connections_per_sec,
-            self.config.performance.new_connections_burst,
+            settings.new_connections_per_sec,
+            settings.new_connections_burst,
         );
         self.quic_config = Self::build_quic_config(&self.config)?;
         self.runtime_generation = runtime.generation;

--- a/crates/edge/src/resilience/runtime.rs
+++ b/crates/edge/src/resilience/runtime.rs
@@ -1,6 +1,9 @@
 use std::{collections::HashSet, sync::Arc, time::Duration};
 
-use spooky_config::config::Resilience as ResilienceConfig;
+use spooky_config::{
+    config::Resilience as ResilienceConfig,
+    runtime::{RuntimeAdmissionPolicy, RuntimeRateLimitPolicy},
+};
 
 use crate::resilience::{
     adaptive_admission::AdaptiveAdmission,
@@ -39,11 +42,10 @@ pub struct RuntimeResilience {
 impl RuntimeResilience {
     pub fn from_config(config: &ResilienceConfig, global_limit: usize) -> Self {
         let adaptive = &config.adaptive_admission;
-        let adaptive_max_limit = adaptive.max_limit.unwrap_or(global_limit);
         let admission = Arc::new(AdaptiveAdmission::new(
             adaptive.enabled,
             adaptive.min_limit,
-            adaptive_max_limit.max(adaptive.min_limit),
+            adaptive.max_limit.unwrap_or(global_limit).max(adaptive.min_limit),
             adaptive.increase_step,
             adaptive.decrease_step,
             adaptive.high_latency_ms,
@@ -72,7 +74,6 @@ impl RuntimeResilience {
             config.brownout.recover_inflight_percent,
             config.brownout.core_routes.clone(),
         ));
-
         let hedge_safe_methods = config
             .hedging
             .safe_methods
@@ -129,6 +130,125 @@ impl RuntimeResilience {
             early_data_safe_methods,
             allowed_methods,
             denied_path_prefixes: config.protocol.denied_path_prefixes.clone(),
+            connect_allowed_ports,
+            connect_allowed_authorities,
+            route_allowlist,
+        }
+    }
+
+    pub fn from_policies(
+        admission_policy: &RuntimeAdmissionPolicy,
+        rate_limit_policy: &RuntimeRateLimitPolicy,
+    ) -> Self {
+        let adaptive = &admission_policy.adaptive_admission;
+        let admission = Arc::new(AdaptiveAdmission::new(
+            adaptive.enabled,
+            adaptive.min_limit,
+            adaptive.max_limit.max(adaptive.min_limit),
+            adaptive.increase_step,
+            adaptive.decrease_step,
+            adaptive.high_latency.as_millis().try_into().unwrap_or(u64::MAX),
+        ));
+        let route_queue = Arc::new(RouteQueueLimiter::new(
+            admission_policy.route_queue.default_cap,
+            admission_policy.route_queue.global_cap,
+            admission_policy.route_queue.caps.clone(),
+        ));
+        let scoped_rate_limits = Arc::new(ScopedRateLimiters::new(
+            &rate_limit_policy
+                .scoped_limits
+                .iter()
+                .map(|rule| spooky_config::config::ScopedRateLimit {
+                    name: rule.name.clone(),
+                    scope: rule.scope,
+                    requests_per_sec: rule.requests_per_sec,
+                    burst: rule.burst,
+                    key: rule.key.clone(),
+                    route_allowlist: rule.route_allowlist.clone(),
+                    idle_ttl_secs: rule.idle_ttl.as_secs(),
+                })
+                .collect::<Vec<_>>(),
+        ));
+        let circuit_breakers = Arc::new(CircuitBreakers::new(
+            admission_policy.circuit_breaker.enabled,
+            admission_policy.circuit_breaker.failure_threshold,
+            admission_policy.circuit_breaker.open,
+            admission_policy.circuit_breaker.half_open_max_probes,
+        ));
+        let retry_budget = Arc::new(RetryBudget::new(
+            admission_policy.retry_budget.enabled,
+            admission_policy.retry_budget.ratio_percent,
+            admission_policy.retry_budget.per_route_ratio_percent.clone(),
+        ));
+        let brownout = Arc::new(BrownoutController::new(
+            admission_policy.brownout.enabled,
+            admission_policy.brownout.trigger_inflight_percent,
+            admission_policy.brownout.recover_inflight_percent,
+            admission_policy.brownout.core_routes.clone(),
+        ));
+        let hedge_safe_methods = admission_policy
+            .hedging
+            .safe_methods
+            .iter()
+            .map(|method| method.to_ascii_uppercase())
+            .collect::<HashSet<_>>();
+        let early_data_safe_methods = admission_policy
+            .protocol
+            .0
+            .early_data_safe_methods
+            .iter()
+            .map(|method| method.to_ascii_uppercase())
+            .collect::<HashSet<_>>();
+        let allowed_methods = admission_policy
+            .protocol
+            .0
+            .allowed_methods
+            .iter()
+            .map(|method| method.to_ascii_uppercase())
+            .collect::<HashSet<_>>();
+        let route_allowlist = admission_policy
+            .hedging
+            .route_allowlist
+            .iter()
+            .cloned()
+            .collect::<HashSet<_>>();
+        let connect_allowed_ports = admission_policy
+            .protocol
+            .0
+            .connect_allowed_ports
+            .iter()
+            .copied()
+            .collect::<HashSet<_>>();
+        let connect_allowed_authorities = admission_policy
+            .protocol
+            .0
+            .connect_allowed_authorities
+            .iter()
+            .filter_map(|authority| normalize_connect_authority(authority))
+            .collect::<HashSet<_>>();
+
+        Self {
+            adaptive_admission: admission,
+            route_queue,
+            scoped_rate_limits,
+            circuit_breakers,
+            retry_budget,
+            brownout,
+            shed_retry_after_seconds: admission_policy.route_queue.shed_retry_after_seconds,
+            allow_0rtt: admission_policy.protocol.0.allow_0rtt,
+            max_headers_count: admission_policy.protocol.0.max_headers_count.max(1),
+            max_headers_bytes: admission_policy.protocol.0.max_headers_bytes.max(1),
+            enforce_authority_host_match: admission_policy
+                .protocol
+                .0
+                .enforce_authority_host_match,
+            allow_connect: admission_policy.protocol.0.allow_connect,
+            hedging_enabled: admission_policy.hedging.enabled,
+            hedging_delay: admission_policy.hedging.delay,
+            hedge_safe_methods,
+            early_data_safe_methods,
+            allowed_methods,
+            denied_path_prefixes: admission_policy.protocol.0.denied_path_prefixes.clone(),
             connect_allowed_ports,
             connect_allowed_authorities,
             route_allowlist,

--- a/crates/edge/src/resilience/runtime.rs
+++ b/crates/edge/src/resilience/runtime.rs
@@ -45,7 +45,10 @@ impl RuntimeResilience {
         let admission = Arc::new(AdaptiveAdmission::new(
             adaptive.enabled,
             adaptive.min_limit,
-            adaptive.max_limit.unwrap_or(global_limit).max(adaptive.min_limit),
+            adaptive
+                .max_limit
+                .unwrap_or(global_limit)
+                .max(adaptive.min_limit),
             adaptive.increase_step,
             adaptive.decrease_step,
             adaptive.high_latency_ms,
@@ -147,7 +150,11 @@ impl RuntimeResilience {
             adaptive.max_limit.max(adaptive.min_limit),
             adaptive.increase_step,
             adaptive.decrease_step,
-            adaptive.high_latency.as_millis().try_into().unwrap_or(u64::MAX),
+            adaptive
+                .high_latency
+                .as_millis()
+                .try_into()
+                .unwrap_or(u64::MAX),
         ));
         let route_queue = Arc::new(RouteQueueLimiter::new(
             admission_policy.route_queue.default_cap,
@@ -178,7 +185,10 @@ impl RuntimeResilience {
         let retry_budget = Arc::new(RetryBudget::new(
             admission_policy.retry_budget.enabled,
             admission_policy.retry_budget.ratio_percent,
-            admission_policy.retry_budget.per_route_ratio_percent.clone(),
+            admission_policy
+                .retry_budget
+                .per_route_ratio_percent
+                .clone(),
         ));
         let brownout = Arc::new(BrownoutController::new(
             admission_policy.brownout.enabled,
@@ -238,10 +248,7 @@ impl RuntimeResilience {
             allow_0rtt: admission_policy.protocol.0.allow_0rtt,
             max_headers_count: admission_policy.protocol.0.max_headers_count.max(1),
             max_headers_bytes: admission_policy.protocol.0.max_headers_bytes.max(1),
-            enforce_authority_host_match: admission_policy
-                .protocol
-                .0
-                .enforce_authority_host_match,
+            enforce_authority_host_match: admission_policy.protocol.0.enforce_authority_host_match,
             allow_connect: admission_policy.protocol.0.allow_connect,
             hedging_enabled: admission_policy.hedging.enabled,
             hedging_delay: admission_policy.hedging.delay,

--- a/crates/edge/src/routing/index.rs
+++ b/crates/edge/src/routing/index.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 
-use spooky_config::config::Upstream;
+use spooky_config::{
+    config::Upstream,
+    runtime::{RuntimeRouteHostPattern, RuntimeUpstream},
+};
 
 use crate::routing::{
     decision::{RouteDecision, RouteDecisionReason, RoutePreference},
@@ -20,59 +23,88 @@ pub struct RouteIndex {
 
 impl RouteIndex {
     pub fn from_upstreams(upstreams: &HashMap<String, Upstream>) -> Self {
-        let mut host_tries = HashMap::new();
-        let mut wildcard_host_tries = HashMap::new();
-        let mut default_trie = RouteTrie::default();
-        let mut default_max_path_len = 0usize;
-        let mut upstream_names = Vec::with_capacity(upstreams.len());
-        let mut upstream_methods = Vec::with_capacity(upstreams.len());
-        // Build a stable route list first. This keeps tie-breaking deterministic even if
-        // upstreams came from a map with non-deterministic iteration order.
         let mut ordered: Vec<(&String, &Upstream)> = upstreams.iter().collect();
         ordered.sort_by_key(|(left, _)| *left);
-
-        for (order, (name, upstream)) in ordered.into_iter().enumerate() {
-            let upstream_idx = upstream_names.len();
-            upstream_names.push(name.clone());
-            upstream_methods.push(
-                upstream
+        Self::from_ordered_routes(ordered.into_iter().enumerate().map(
+            |(order, (name, upstream))| IndexedRouteSource {
+                name: name.clone(),
+                method: upstream
                     .route
                     .method
                     .as_deref()
                     .map(str::trim)
                     .filter(|value| !value.is_empty())
                     .map(|value| value.to_ascii_uppercase()),
-            );
-            let path_len = upstream
-                .route
-                .path_prefix
-                .as_ref()
-                .map(|prefix| prefix.len())
-                .unwrap_or(0);
+                path_prefix: upstream.route.path_prefix.clone(),
+                path_len: upstream
+                    .route
+                    .path_prefix
+                    .as_ref()
+                    .map(|prefix| prefix.len())
+                    .unwrap_or(0),
+                host_specific: upstream.route.host.is_some(),
+                method_specific: upstream.route.method.is_some(),
+                host_pattern: upstream
+                    .route
+                    .host
+                    .as_deref()
+                    .and_then(parse_configured_host_pattern)
+                    .map(RuntimeRouteHostPattern::from),
+                order,
+            },
+        ))
+    }
+
+    pub fn from_runtime_upstreams(upstreams: &HashMap<String, RuntimeUpstream>) -> Self {
+        let mut ordered: Vec<(&String, &RuntimeUpstream)> = upstreams.iter().collect();
+        ordered.sort_by_key(|(left, _)| *left);
+        Self::from_ordered_routes(ordered.into_iter().enumerate().map(
+            |(order, (name, upstream))| IndexedRouteSource {
+                name: name.clone(),
+                method: upstream.route.method.clone(),
+                path_prefix: upstream.route.path_prefix.clone(),
+                path_len: upstream.route.path_len,
+                host_specific: upstream.route.host_specific,
+                method_specific: upstream.route.method_specific,
+                host_pattern: upstream.route.host_pattern.clone(),
+                order,
+            },
+        ))
+    }
+
+    fn from_ordered_routes(routes: impl IntoIterator<Item = IndexedRouteSource>) -> Self {
+        let mut host_tries = HashMap::new();
+        let mut wildcard_host_tries = HashMap::new();
+        let mut default_trie = RouteTrie::default();
+        let mut default_max_path_len = 0usize;
+        let mut upstream_names = Vec::new();
+        let mut upstream_methods = Vec::new();
+        for route_source in routes {
+            let path_prefix = route_source.path_prefix.as_deref();
+            let upstream_idx = upstream_names.len();
+            upstream_names.push(route_source.name);
+            upstream_methods.push(route_source.method);
 
             let route = IndexedRoute {
                 upstream_idx,
-                path_len,
-                host_specific: upstream.route.host.is_some(),
-                method_specific: upstream.route.method.is_some(),
-                order,
+                path_len: route_source.path_len,
+                host_specific: route_source.host_specific,
+                method_specific: route_source.method_specific,
+                order: route_source.order,
             };
 
-            match upstream.route.host.as_deref() {
-                Some(host) => match parse_configured_host_pattern(host) {
-                    Some(ConfiguredHostPattern::WildcardSuffix(suffix)) => wildcard_host_tries
-                        .entry(suffix)
-                        .or_insert_with(RouteTrie::default)
-                        .insert(upstream.route.path_prefix.as_deref(), route),
-                    Some(ConfiguredHostPattern::Exact(normalized_host)) => host_tries
-                        .entry(normalized_host)
-                        .or_insert_with(RouteTrie::default)
-                        .insert(upstream.route.path_prefix.as_deref(), route),
-                    None => {}
-                },
+            match route_source.host_pattern {
+                Some(RuntimeRouteHostPattern::WildcardSuffix(suffix)) => wildcard_host_tries
+                    .entry(suffix)
+                    .or_insert_with(RouteTrie::default)
+                    .insert(path_prefix, route),
+                Some(RuntimeRouteHostPattern::Exact(normalized_host)) => host_tries
+                    .entry(normalized_host)
+                    .or_insert_with(RouteTrie::default)
+                    .insert(path_prefix, route),
                 None => {
-                    default_max_path_len = default_max_path_len.max(path_len);
-                    default_trie.insert(upstream.route.path_prefix.as_deref(), route);
+                    default_max_path_len = default_max_path_len.max(route_source.path_len);
+                    default_trie.insert(path_prefix, route);
                 }
             }
         }
@@ -288,5 +320,25 @@ impl RouteIndex {
         }
 
         prefer_host_lookup_result(wildcard_best, exact_best)
+    }
+}
+
+struct IndexedRouteSource {
+    name: String,
+    method: Option<String>,
+    path_prefix: Option<String>,
+    path_len: usize,
+    host_specific: bool,
+    method_specific: bool,
+    host_pattern: Option<RuntimeRouteHostPattern>,
+    order: usize,
+}
+
+impl From<ConfiguredHostPattern> for RuntimeRouteHostPattern {
+    fn from(value: ConfiguredHostPattern) -> Self {
+        match value {
+            ConfiguredHostPattern::Exact(host) => Self::Exact(host),
+            ConfiguredHostPattern::WildcardSuffix(suffix) => Self::WildcardSuffix(suffix),
+        }
     }
 }

--- a/crates/edge/src/routing/index.rs
+++ b/crates/edge/src/routing/index.rs
@@ -26,31 +26,33 @@ impl RouteIndex {
         let mut ordered: Vec<(&String, &Upstream)> = upstreams.iter().collect();
         ordered.sort_by_key(|(left, _)| *left);
         Self::from_ordered_routes(ordered.into_iter().enumerate().map(
-            |(order, (name, upstream))| IndexedRouteSource {
-                name: name.clone(),
-                method: upstream
-                    .route
-                    .method
-                    .as_deref()
-                    .map(str::trim)
-                    .filter(|value| !value.is_empty())
-                    .map(|value| value.to_ascii_uppercase()),
-                path_prefix: upstream.route.path_prefix.clone(),
-                path_len: upstream
-                    .route
-                    .path_prefix
-                    .as_ref()
-                    .map(|prefix| prefix.len())
-                    .unwrap_or(0),
-                host_specific: upstream.route.host.is_some(),
-                method_specific: upstream.route.method.is_some(),
-                host_pattern: upstream
-                    .route
-                    .host
-                    .as_deref()
-                    .and_then(parse_configured_host_pattern)
-                    .map(RuntimeRouteHostPattern::from),
-                order,
+            |(order, (name, upstream))| {
+                IndexedRouteSource {
+                    name: name.clone(),
+                    method: upstream
+                        .route
+                        .method
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|value| !value.is_empty())
+                        .map(|value| value.to_ascii_uppercase()),
+                    path_prefix: upstream.route.path_prefix.clone(),
+                    path_len: upstream
+                        .route
+                        .path_prefix
+                        .as_ref()
+                        .map(|prefix| prefix.len())
+                        .unwrap_or(0),
+                    host_specific: upstream.route.host.is_some(),
+                    method_specific: upstream.route.method.is_some(),
+                    host_pattern: upstream
+                        .route
+                        .host
+                        .as_deref()
+                        .and_then(parse_configured_host_pattern)
+                        .map(RuntimeRouteHostPattern::from),
+                    order,
+                }
             },
         ))
     }

--- a/crates/edge/src/runtime/connection/auth.rs
+++ b/crates/edge/src/runtime/connection/auth.rs
@@ -41,16 +41,16 @@ impl ExternalAuthExecutionPolicy {
     pub(crate) fn from_external_auth(value: &RuntimeExternalAuth) -> Self {
         match value {
             RuntimeExternalAuth::Http {
-                timeout_ms,
+                timeout,
                 failure_mode,
                 ..
             }
             | RuntimeExternalAuth::Oidc {
-                timeout_ms,
+                timeout,
                 failure_mode,
                 ..
             } => Self {
-                timeout: Duration::from_millis((*timeout_ms).max(1)),
+                timeout: *timeout,
                 failure_mode: *failure_mode,
             },
         }
@@ -1014,7 +1014,7 @@ mod tests {
             endpoint: "http://127.0.0.1:9000/auth".to_string(),
             request_headers: Vec::new(),
             response_header_allowlist: Vec::new(),
-            timeout_ms: 250,
+            timeout: Duration::from_millis(250),
             failure_mode: RuntimeExternalAuthFailureMode::FailOpen,
         };
 

--- a/crates/edge/src/runtime/connection/outcome.rs
+++ b/crates/edge/src/runtime/connection/outcome.rs
@@ -457,12 +457,14 @@ pub(crate) fn log_backend_health_transition(addr: &str, transition: HealthTransi
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::time::Duration;
 
     use spooky_config::config::{
-        Backend, ForwardedHeaderPolicy, HealthCheck, LoadBalancing, RouteAuth, RouteMatch,
-        Upstream, UpstreamHostPolicy,
+        Backend, Config, ForwardedHeaderPolicy, HealthCheck, Listen, LoadBalancing, RouteAuth,
+        RouteMatch, Tls, Upstream, UpstreamHostPolicy,
     };
+    use spooky_config::runtime::RuntimeConfig;
 
     use super::*;
 
@@ -471,8 +473,10 @@ mod tests {
     }
 
     fn test_upstream_pool() -> Arc<RwLock<UpstreamPool>> {
-        Arc::new(RwLock::new(
-            UpstreamPool::from_upstream(&Upstream {
+        let mut upstreams = HashMap::new();
+        upstreams.insert(
+            "api".to_string(),
+            Upstream {
                 load_balancing: LoadBalancing {
                     lb_type: "round-robin".to_string(),
                     key: None,
@@ -492,16 +496,51 @@ mod tests {
                     weight: 1,
                     health_check: Some(HealthCheck {
                         path: "/health".to_string(),
-                        interval: 0,
+                        interval: 1,
                         timeout_ms: 1000,
                         failure_threshold: 1,
                         success_threshold: 1,
                         cooldown_ms: 0,
                     }),
                 }],
-            })
-            .expect("pool"),
-        ))
+            },
+        );
+        let runtime = RuntimeConfig::from_config(&Config {
+            version: 1,
+            listen: Listen {
+                protocol: "http1".to_string(),
+                tls: Tls {
+                    cert: "/tmp/test-cert.pem".to_string(),
+                    key: "/tmp/test-key.pem".to_string(),
+                    ..Tls::default()
+                },
+                ..Listen::default()
+            },
+            listeners: Vec::new(),
+            upstream: upstreams,
+            load_balancing: None,
+            upstream_tls: Default::default(),
+            log: Default::default(),
+            performance: Default::default(),
+            observability: Default::default(),
+            resilience: Default::default(),
+            security: Default::default(),
+        })
+        .expect("runtime config");
+
+        let mut pool =
+            UpstreamPool::from_runtime_upstream(runtime.upstreams.get("api").expect("upstream"))
+                .expect("pool");
+        pool.pool.backends[0].health_check = Some(HealthCheck {
+            path: "/health".to_string(),
+            interval: 0,
+            timeout_ms: 1000,
+            failure_threshold: 1,
+            success_threshold: 1,
+            cooldown_ms: 0,
+        });
+
+        Arc::new(RwLock::new(pool))
     }
 
     fn upstream_request_count(

--- a/crates/edge/src/runtime/connection/outcome.rs
+++ b/crates/edge/src/runtime/connection/outcome.rs
@@ -457,14 +457,15 @@ pub(crate) fn log_backend_health_transition(addr: &str, transition: HealthTransi
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-    use std::time::Duration;
+    use std::{collections::HashMap, time::Duration};
 
-    use spooky_config::config::{
-        Backend, Config, ForwardedHeaderPolicy, HealthCheck, Listen, LoadBalancing, RouteAuth,
-        RouteMatch, Tls, Upstream, UpstreamHostPolicy,
+    use spooky_config::{
+        config::{
+            Backend, Config, ForwardedHeaderPolicy, HealthCheck, Listen, LoadBalancing, RouteAuth,
+            RouteMatch, Tls, Upstream, UpstreamHostPolicy,
+        },
+        runtime::RuntimeConfig,
     };
-    use spooky_config::runtime::RuntimeConfig;
 
     use super::*;
 

--- a/crates/edge/src/runtime/shared_state.rs
+++ b/crates/edge/src/runtime/shared_state.rs
@@ -5,7 +5,7 @@ use std::{
 
 use spooky_config::{
     backend_endpoint::BackendEndpoint,
-    runtime::{ListenerRuntimeConfig, RuntimeUpstreamPolicy},
+    runtime::{ListenerRuntimeConfig, RuntimeBackendHealthCheck, RuntimeUpstreamPolicy},
 };
 use spooky_lb::upstream_pool::UpstreamPool;
 use spooky_transport::{h2_client::SharedDnsResolver, transport_pool::UpstreamTransportPool};
@@ -27,6 +27,7 @@ pub struct SharedRuntimeState {
     pub(crate) listener_tls_store: Arc<ListenerTlsReloadStore>,
     pub(crate) transport_pool: Arc<UpstreamTransportPool>,
     pub(crate) backend_endpoints: Arc<HashMap<String, BackendEndpoint>>,
+    pub(crate) backend_health_checks: Arc<HashMap<String, RuntimeBackendHealthCheck>>,
     pub(crate) backend_resolution_store: Arc<RuntimeBackendResolutionStore>,
     pub(crate) backend_dns_resolver: SharedDnsResolver,
     pub(crate) upstream_policies: Arc<HashMap<String, RuntimeUpstreamPolicy>>,

--- a/crates/edge/src/watchdog/config.rs
+++ b/crates/edge/src/watchdog/config.rs
@@ -1,5 +1,4 @@
-use spooky_config::config::Watchdog as WatchdogConfig;
-use spooky_config::runtime::RuntimeWatchdogPolicy;
+use spooky_config::{config::Watchdog as WatchdogConfig, runtime::RuntimeWatchdogPolicy};
 
 #[derive(Debug, Clone)]
 pub struct WatchdogRuntimeConfig {
@@ -38,7 +37,11 @@ impl From<&RuntimeWatchdogPolicy> for WatchdogRuntimeConfig {
     fn from(value: &RuntimeWatchdogPolicy) -> Self {
         Self {
             enabled: value.enabled,
-            check_interval_ms: value.check_interval.as_millis().try_into().unwrap_or(u64::MAX),
+            check_interval_ms: value
+                .check_interval
+                .as_millis()
+                .try_into()
+                .unwrap_or(u64::MAX),
             poll_stall_timeout_ms: value
                 .poll_stall_timeout
                 .as_millis()

--- a/crates/edge/src/watchdog/config.rs
+++ b/crates/edge/src/watchdog/config.rs
@@ -1,4 +1,5 @@
 use spooky_config::config::Watchdog as WatchdogConfig;
+use spooky_config::runtime::RuntimeWatchdogPolicy;
 
 #[derive(Debug, Clone)]
 pub struct WatchdogRuntimeConfig {
@@ -29,6 +30,32 @@ impl From<&WatchdogConfig> for WatchdogRuntimeConfig {
             restart_cooldown_ms: value.restart_cooldown_ms.max(1),
             restart_command: value.restart_command.clone(),
             restart_hook: value.restart_hook.clone(),
+        }
+    }
+}
+
+impl From<&RuntimeWatchdogPolicy> for WatchdogRuntimeConfig {
+    fn from(value: &RuntimeWatchdogPolicy) -> Self {
+        Self {
+            enabled: value.enabled,
+            check_interval_ms: value.check_interval.as_millis().try_into().unwrap_or(u64::MAX),
+            poll_stall_timeout_ms: value
+                .poll_stall_timeout
+                .as_millis()
+                .try_into()
+                .unwrap_or(u64::MAX),
+            timeout_error_rate_percent: value.timeout_error_rate_percent,
+            min_requests_per_window: value.min_requests_per_window,
+            overload_inflight_percent: value.overload_inflight_percent,
+            unhealthy_consecutive_windows: value.unhealthy_consecutive_windows,
+            drain_grace_ms: value.drain_grace.as_millis().try_into().unwrap_or(u64::MAX),
+            restart_cooldown_ms: value
+                .restart_cooldown
+                .as_millis()
+                .try_into()
+                .unwrap_or(u64::MAX),
+            restart_command: value.restart_command.clone(),
+            restart_hook: None,
         }
     }
 }

--- a/crates/edge/src/watchdog/coordinator.rs
+++ b/crates/edge/src/watchdog/coordinator.rs
@@ -9,6 +9,7 @@ use std::{
 use log::warn;
 use spooky_config::config::Watchdog as WatchdogConfig;
 
+use crate::watchdog::config::WatchdogRuntimeConfig;
 use crate::watchdog::time::now_millis;
 
 pub struct WatchdogCoordinator {
@@ -27,6 +28,10 @@ pub struct WatchdogCoordinator {
 
 impl WatchdogCoordinator {
     pub fn new(config: &WatchdogConfig) -> Self {
+        Self::from_runtime_config(&WatchdogRuntimeConfig::from(config))
+    }
+
+    pub fn from_runtime_config(config: &WatchdogRuntimeConfig) -> Self {
         let now_ms = now_millis();
         Self {
             enabled: config.enabled,

--- a/crates/edge/src/watchdog/coordinator.rs
+++ b/crates/edge/src/watchdog/coordinator.rs
@@ -9,8 +9,7 @@ use std::{
 use log::warn;
 use spooky_config::config::Watchdog as WatchdogConfig;
 
-use crate::watchdog::config::WatchdogRuntimeConfig;
-use crate::watchdog::time::now_millis;
+use crate::watchdog::{config::WatchdogRuntimeConfig, time::now_millis};
 
 pub struct WatchdogCoordinator {
     enabled: bool,

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -2934,6 +2934,7 @@ fn request_body_idle_timeout_returns_408() {
     let backend_addr = rt.block_on(start_h2_backend());
     let mut config = make_config(0, backend_addr.to_string(), cert, key);
     config.performance.client_body_idle_timeout_ms = 120;
+    config.performance.backend_body_total_timeout_ms = 10_000;
     config.performance.backend_total_request_timeout_ms = 10_000;
 
     let listener = QUICListener::new(config).expect("failed to create listener");
@@ -3209,8 +3210,10 @@ fn long_stream_survives_body_total_timeout_after_progress() {
     let rt = tokio::runtime::Runtime::new().expect("runtime");
     let backend_addr = rt.block_on(start_h2_backend_with_regression_routes());
     let mut config = make_config(0, backend_addr.to_string(), cert, key);
+    config.performance.backend_timeout_ms = 240;
+    config.performance.backend_connect_timeout_ms = 240;
     config.performance.backend_body_total_timeout_ms = 250;
-    config.performance.backend_body_idle_timeout_ms = 500;
+    config.performance.backend_body_idle_timeout_ms = 240;
     config.performance.backend_total_request_timeout_ms = 5_000;
     let listener = QUICListener::new(config).expect("failed to create listener");
     let listen_addr = listener.socket.local_addr().unwrap();
@@ -3765,6 +3768,7 @@ fn backend_timeout_respects_configured_performance_value() {
     let backend_addr = rt.block_on(start_h2_backend_with_regression_routes());
     let mut config = make_config(0, backend_addr.to_string(), cert, key);
     config.performance.backend_timeout_ms = 150;
+    config.performance.backend_connect_timeout_ms = 150;
 
     let listener = QUICListener::new(config).expect("failed to create listener");
     let listen_addr = listener.socket.local_addr().unwrap();
@@ -3841,6 +3845,7 @@ fn chaos_packet_loss_like_timeout_maps_to_recoverable_response() {
     let backend_addr = rt.block_on(start_h2_backend_with_chaos_routes());
     let mut config = make_config(0, backend_addr.to_string(), cert, key);
     config.performance.backend_timeout_ms = 120;
+    config.performance.backend_connect_timeout_ms = 120;
 
     let listener = QUICListener::new(config).expect("failed to create listener");
     let listen_addr = listener.socket.local_addr().unwrap();
@@ -3953,6 +3958,7 @@ fn chaos_partial_outage_preserves_some_availability() {
     ];
     let mut config = make_config_with_backends(0, backends, "round-robin", cert, key);
     config.performance.backend_timeout_ms = 250;
+    config.performance.backend_connect_timeout_ms = 250;
 
     let listener = QUICListener::new(config).expect("failed to create listener");
     let listen_addr = listener.socket.local_addr().unwrap();
@@ -4088,6 +4094,7 @@ fn response_body_cap_returns_503_on_declared_length_breach() {
     // Cap at 1 KiB — far below the 8 KiB the backend will send.
     let mut config = make_config(0, backend_addr.to_string(), cert, key);
     config.performance.max_response_body_bytes = 1024;
+    config.performance.unknown_length_response_prebuffer_bytes = 1024;
 
     let listener = QUICListener::new(config).expect("failed to create listener");
     let listen_addr = listener.socket.local_addr().unwrap();
@@ -4276,6 +4283,7 @@ fn response_body_cap_returns_503_on_unknown_length_breach() {
 
     let mut config = make_config(0, backend_addr.to_string(), cert, key);
     config.performance.max_response_body_bytes = 1024;
+    config.performance.unknown_length_response_prebuffer_bytes = 1024;
 
     let listener = QUICListener::new(config).expect("failed to create listener");
     let listen_addr = listener.socket.local_addr().unwrap();
@@ -4858,6 +4866,7 @@ fn teardown_upstream_timeout_cleans_up_stream() {
     let mut config = make_config(0, backend_addr.to_string(), cert, key);
     // Use a short timeout so the test doesn't wait long.
     config.performance.backend_timeout_ms = 200;
+    config.performance.backend_connect_timeout_ms = 200;
 
     let listener = QUICListener::new(config).expect("listener");
     let listen_addr = listener.socket.local_addr().unwrap();

--- a/crates/edge/tests/h3_bridge/protocol.rs
+++ b/crates/edge/tests/h3_bridge/protocol.rs
@@ -670,6 +670,7 @@ fn grpc_timeout_returns_recoverable_proxy_error() {
     let backend_addr = rt.block_on(start_h2_backend_with_grpc_routes());
     let mut config = make_config(0, backend_addr.to_string(), cert, key);
     config.performance.backend_timeout_ms = 150;
+    config.performance.backend_connect_timeout_ms = 150;
     let listener = QUICListener::new(config).expect("failed to create listener");
     let listen_addr = listener.socket.local_addr().unwrap();
     let _listener_task = ListenerTaskGuard::spawn(&rt, listener);

--- a/crates/lb/src/alternate_backend.rs
+++ b/crates/lb/src/alternate_backend.rs
@@ -37,25 +37,31 @@ pub fn choose_alternate_backend(
     excluded_indices: &[usize],
     lb_key: Option<&str>,
 ) -> AlternateBackendDecision {
-    let readonly_candidate = pool
-        .pick_readonly(lb_key.unwrap_or_default())
-        .filter(|index| !is_excluded(*index, excluded_indices));
-    if let Some(index) = readonly_candidate {
-        return AlternateBackendDecision::Select(AlternateBackendChoice {
-            index,
-            mode: AlternateBackendSelectionMode::LoadBalancerReadonly,
-        });
+    let policy = pool.alternate_backend_policy();
+
+    if policy.readonly_lb_pick {
+        let readonly_candidate = pool
+            .pick_readonly(lb_key.unwrap_or_default())
+            .filter(|index| !is_excluded(*index, excluded_indices));
+        if let Some(index) = readonly_candidate {
+            return AlternateBackendDecision::Select(AlternateBackendChoice {
+                index,
+                mode: AlternateBackendSelectionMode::LoadBalancerReadonly,
+            });
+        }
     }
 
-    let fallback_candidate = pool
-        .pool
-        .healthy_indices_iter()
-        .find(|index| !is_excluded(*index, excluded_indices));
-    if let Some(index) = fallback_candidate {
-        return AlternateBackendDecision::Select(AlternateBackendChoice {
-            index,
-            mode: AlternateBackendSelectionMode::HealthyFallback,
-        });
+    if policy.healthy_fallback {
+        let fallback_candidate = pool
+            .pool
+            .healthy_indices_iter()
+            .find(|index| !is_excluded(*index, excluded_indices));
+        if let Some(index) = fallback_candidate {
+            return AlternateBackendDecision::Select(AlternateBackendChoice {
+                index,
+                mode: AlternateBackendSelectionMode::HealthyFallback,
+            });
+        }
     }
 
     if pool.pool.healthy_len() == 0 {
@@ -72,6 +78,7 @@ pub fn choose_alternate_backend(
 #[cfg(test)]
 mod tests {
     use spooky_config::config::{Backend, HealthCheck, LoadBalancing, RouteMatch, Upstream};
+    use spooky_config::runtime::RuntimeAlternateBackendPolicy;
 
     use super::*;
     use crate::health::HealthFailureReason;
@@ -191,6 +198,47 @@ mod tests {
             decision,
             AlternateBackendDecision::DoNotSelect {
                 denial: AlternateBackendFailureReason::NoHealthyBackends,
+            }
+        );
+    }
+
+    #[test]
+    fn suppresses_readonly_pick_when_policy_disables_it() {
+        let mut pool = UpstreamPool::from_upstream(&upstream(
+            "round-robin",
+            &["http://a", "http://b", "http://c"],
+        ))
+        .expect("pool");
+        pool.set_alternate_backend_policy(RuntimeAlternateBackendPolicy {
+            readonly_lb_pick: false,
+            healthy_fallback: true,
+        });
+
+        let decision = choose_alternate_backend(&pool, &[0], None);
+        assert_eq!(
+            decision,
+            AlternateBackendDecision::Select(AlternateBackendChoice {
+                index: 1,
+                mode: AlternateBackendSelectionMode::HealthyFallback,
+            })
+        );
+    }
+
+    #[test]
+    fn reports_excluded_backends_when_all_failover_modes_are_disabled() {
+        let mut pool =
+            UpstreamPool::from_upstream(&upstream("round-robin", &["http://a", "http://b"]))
+                .expect("pool");
+        pool.set_alternate_backend_policy(RuntimeAlternateBackendPolicy {
+            readonly_lb_pick: false,
+            healthy_fallback: false,
+        });
+
+        let decision = choose_alternate_backend(&pool, &[0], None);
+        assert_eq!(
+            decision,
+            AlternateBackendDecision::DoNotSelect {
+                denial: AlternateBackendFailureReason::OnlyExcludedBackendsHealthy,
             }
         );
     }

--- a/crates/lb/src/alternate_backend.rs
+++ b/crates/lb/src/alternate_backend.rs
@@ -77,8 +77,12 @@ pub fn choose_alternate_backend(
 
 #[cfg(test)]
 mod tests {
-    use spooky_config::config::{Backend, HealthCheck, LoadBalancing, RouteMatch, Upstream};
-    use spooky_config::runtime::RuntimeAlternateBackendPolicy;
+    use std::collections::HashMap;
+
+    use spooky_config::{
+        config::{Backend, Config, HealthCheck, Listen, LoadBalancing, RouteMatch, Tls, Upstream},
+        runtime::{RuntimeAlternateBackendPolicy, RuntimeConfig, RuntimeUpstream},
+    };
 
     use super::*;
     use crate::health::HealthFailureReason;
@@ -103,7 +107,7 @@ mod tests {
                     weight: 1,
                     health_check: Some(HealthCheck {
                         path: "/health".to_string(),
-                        interval: 0,
+                        interval: 1,
                         timeout_ms: 1000,
                         failure_threshold: 1,
                         success_threshold: 1,
@@ -114,12 +118,43 @@ mod tests {
         }
     }
 
+    fn runtime_upstream(upstream: Upstream) -> RuntimeUpstream {
+        let mut upstreams = HashMap::new();
+        upstreams.insert("api".to_string(), upstream);
+
+        RuntimeConfig::from_config(&Config {
+            version: 1,
+            listen: Listen {
+                protocol: "http1".to_string(),
+                tls: Tls {
+                    cert: "/tmp/test-cert.pem".to_string(),
+                    key: "/tmp/test-key.pem".to_string(),
+                    ..Tls::default()
+                },
+                ..Listen::default()
+            },
+            listeners: Vec::new(),
+            upstream: upstreams,
+            load_balancing: None,
+            upstream_tls: Default::default(),
+            log: Default::default(),
+            performance: Default::default(),
+            observability: Default::default(),
+            resilience: Default::default(),
+            security: Default::default(),
+        })
+        .expect("runtime config")
+        .upstreams
+        .remove("api")
+        .expect("runtime upstream")
+    }
+
     #[test]
     fn chooses_non_excluded_backend_from_readonly_lb_pick() {
-        let pool = UpstreamPool::from_upstream(&upstream(
+        let pool = UpstreamPool::from_runtime_upstream(&runtime_upstream(upstream(
             "round-robin",
             &["http://a", "http://b", "http://c"],
-        ))
+        )))
         .expect("pool");
 
         let decision = choose_alternate_backend(&pool, &[2], None);
@@ -134,10 +169,10 @@ mod tests {
 
     #[test]
     fn falls_back_when_readonly_pick_hits_excluded_backend() {
-        let pool = UpstreamPool::from_upstream(&upstream(
+        let pool = UpstreamPool::from_runtime_upstream(&runtime_upstream(upstream(
             "round-robin",
             &["http://a", "http://b", "http://c"],
-        ))
+        )))
         .expect("pool");
 
         let decision = choose_alternate_backend(&pool, &[0], None);
@@ -152,9 +187,11 @@ mod tests {
 
     #[test]
     fn falls_back_to_healthy_scan_when_readonly_strategy_is_unavailable() {
-        let pool =
-            UpstreamPool::from_upstream(&upstream("consistent-hash", &["http://a", "http://b"]))
-                .expect("pool");
+        let pool = UpstreamPool::from_runtime_upstream(&runtime_upstream(upstream(
+            "consistent-hash",
+            &["http://a", "http://b"],
+        )))
+        .expect("pool");
 
         let decision = choose_alternate_backend(&pool, &[0], None);
         assert_eq!(
@@ -168,8 +205,11 @@ mod tests {
 
     #[test]
     fn reports_when_only_excluded_backends_are_healthy() {
-        let pool =
-            UpstreamPool::from_upstream(&upstream("round-robin", &["http://a"])).expect("pool");
+        let pool = UpstreamPool::from_runtime_upstream(&runtime_upstream(upstream(
+            "round-robin",
+            &["http://a"],
+        )))
+        .expect("pool");
 
         let decision = choose_alternate_backend(&pool, &[0], None);
         assert_eq!(
@@ -182,9 +222,11 @@ mod tests {
 
     #[test]
     fn reports_when_no_backends_are_healthy() {
-        let mut pool =
-            UpstreamPool::from_upstream(&upstream("round-robin", &["http://a", "http://b"]))
-                .expect("pool");
+        let mut pool = UpstreamPool::from_runtime_upstream(&runtime_upstream(upstream(
+            "round-robin",
+            &["http://a", "http://b"],
+        )))
+        .expect("pool");
 
         let _ = pool
             .pool
@@ -204,10 +246,10 @@ mod tests {
 
     #[test]
     fn suppresses_readonly_pick_when_policy_disables_it() {
-        let mut pool = UpstreamPool::from_upstream(&upstream(
+        let mut pool = UpstreamPool::from_runtime_upstream(&runtime_upstream(upstream(
             "round-robin",
             &["http://a", "http://b", "http://c"],
-        ))
+        )))
         .expect("pool");
         pool.set_alternate_backend_policy(RuntimeAlternateBackendPolicy {
             readonly_lb_pick: false,
@@ -226,9 +268,11 @@ mod tests {
 
     #[test]
     fn reports_excluded_backends_when_all_failover_modes_are_disabled() {
-        let mut pool =
-            UpstreamPool::from_upstream(&upstream("round-robin", &["http://a", "http://b"]))
-                .expect("pool");
+        let mut pool = UpstreamPool::from_runtime_upstream(&runtime_upstream(upstream(
+            "round-robin",
+            &["http://a", "http://b"],
+        )))
+        .expect("pool");
         pool.set_alternate_backend_policy(RuntimeAlternateBackendPolicy {
             readonly_lb_pick: false,
             healthy_fallback: false,

--- a/crates/lb/src/load_balancing.rs
+++ b/crates/lb/src/load_balancing.rs
@@ -69,4 +69,10 @@ impl LoadBalancing {
             LoadBalancing::StickyCid(_) => "sticky-cid",
         }
     }
+
+    pub fn from_runtime_strategy(
+        strategy: spooky_config::runtime::RuntimeLoadBalancingStrategy,
+    ) -> Result<Self, String> {
+        Self::from_config(strategy.canonical_name())
+    }
 }

--- a/crates/lb/src/upstream_pool.rs
+++ b/crates/lb/src/upstream_pool.rs
@@ -14,19 +14,6 @@ pub struct UpstreamPool {
 }
 
 impl UpstreamPool {
-    pub fn from_upstream(upstream: &spooky_config::config::Upstream) -> Result<Self, String> {
-        let backends = upstream.backends.iter().map(BackendState::new).collect();
-        let lb_policy = RuntimeLoadBalancingPolicy::normalize(&upstream.load_balancing)
-            .map_err(|err| err.to_string())?;
-        let load_balancer = LoadBalancing::from_runtime_strategy(lb_policy.strategy)?;
-
-        Ok(Self {
-            pool: BackendPool::new_from_states(backends),
-            load_balancer,
-            lb_policy,
-        })
-    }
-
     pub fn from_runtime_upstream(upstream: &RuntimeUpstream) -> Result<Self, String> {
         let backends = upstream
             .backends

--- a/crates/lb/src/upstream_pool.rs
+++ b/crates/lb/src/upstream_pool.rs
@@ -1,32 +1,29 @@
 use std::time::Duration;
 
-use spooky_config::runtime::RuntimeUpstream;
+use spooky_config::runtime::{
+    RuntimeAlternateBackendPolicy, RuntimeLoadBalancingPolicy, RuntimeLoadBalancingStrategy,
+    RuntimeRequestKeySpec, RuntimeUpstream,
+};
 
 use crate::{backend::BackendState, backend_pool::BackendPool, load_balancing::LoadBalancing};
 
 pub struct UpstreamPool {
     pub pool: BackendPool,
     pub load_balancer: LoadBalancing,
-    lb_key: Option<String>,
+    lb_policy: RuntimeLoadBalancingPolicy,
 }
 
 impl UpstreamPool {
     pub fn from_upstream(upstream: &spooky_config::config::Upstream) -> Result<Self, String> {
         let backends = upstream.backends.iter().map(BackendState::new).collect();
-
-        let load_balancer = LoadBalancing::from_config(&upstream.load_balancing.lb_type)?;
-        let lb_key = upstream
-            .load_balancing
-            .key
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(str::to_string);
+        let lb_policy = RuntimeLoadBalancingPolicy::normalize(&upstream.load_balancing)
+            .map_err(|err| err.to_string())?;
+        let load_balancer = LoadBalancing::from_runtime_strategy(lb_policy.strategy)?;
 
         Ok(Self {
             pool: BackendPool::new_from_states(backends),
             load_balancer,
-            lb_key,
+            lb_policy,
         })
     }
 
@@ -37,13 +34,13 @@ impl UpstreamPool {
             .map(|backend| BackendState::new(&backend.backend))
             .collect();
 
-        let load_balancer = LoadBalancing::from_runtime_strategy(upstream.load_balancing.strategy)?;
-        let lb_key = upstream.load_balancing.key.clone();
+        let lb_policy = upstream.load_balancing.clone();
+        let load_balancer = LoadBalancing::from_runtime_strategy(lb_policy.strategy)?;
 
         Ok(Self {
             pool: BackendPool::new_from_states(backends),
             load_balancer,
-            lb_key,
+            lb_policy,
         })
     }
 
@@ -76,11 +73,24 @@ impl UpstreamPool {
         self.pool.finish_request(index, latency, status);
     }
 
-    pub fn lb_name(&self) -> &'static str {
-        self.load_balancer.name()
+    pub fn lb_policy(&self) -> &RuntimeLoadBalancingPolicy {
+        &self.lb_policy
     }
 
-    pub fn lb_key(&self) -> Option<&str> {
-        self.lb_key.as_deref()
+    pub fn lb_strategy(&self) -> RuntimeLoadBalancingStrategy {
+        self.lb_policy.strategy
+    }
+
+    pub fn lb_key_spec(&self) -> Option<&RuntimeRequestKeySpec> {
+        self.lb_policy.key_spec.as_ref()
+    }
+
+    pub fn alternate_backend_policy(&self) -> RuntimeAlternateBackendPolicy {
+        self.lb_policy.alternate_backend
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_alternate_backend_policy(&mut self, policy: RuntimeAlternateBackendPolicy) {
+        self.lb_policy.alternate_backend = policy;
     }
 }

--- a/crates/lb/src/upstream_pool.rs
+++ b/crates/lb/src/upstream_pool.rs
@@ -1,5 +1,7 @@
 use std::time::Duration;
 
+use spooky_config::runtime::RuntimeUpstream;
+
 use crate::{backend::BackendState, backend_pool::BackendPool, load_balancing::LoadBalancing};
 
 pub struct UpstreamPool {
@@ -20,6 +22,23 @@ impl UpstreamPool {
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .map(str::to_string);
+
+        Ok(Self {
+            pool: BackendPool::new_from_states(backends),
+            load_balancer,
+            lb_key,
+        })
+    }
+
+    pub fn from_runtime_upstream(upstream: &RuntimeUpstream) -> Result<Self, String> {
+        let backends = upstream
+            .backends
+            .iter()
+            .map(|backend| BackendState::new(&backend.backend))
+            .collect();
+
+        let load_balancer = LoadBalancing::from_runtime_strategy(upstream.load_balancing.strategy)?;
+        let lb_key = upstream.load_balancing.key.clone();
 
         Ok(Self {
             pool: BackendPool::new_from_states(backends),

--- a/crates/lb/tests/upstream_pool.rs
+++ b/crates/lb/tests/upstream_pool.rs
@@ -1,4 +1,9 @@
-use spooky_config::config::{Backend, HealthCheck, RouteMatch};
+use std::collections::HashMap;
+
+use spooky_config::{
+    config::{Backend, Config, HealthCheck, Listen, RouteMatch, Tls},
+    runtime::RuntimeConfig,
+};
 use spooky_lb::{load_balancing::LoadBalancing, upstream_pool::UpstreamPool};
 
 #[test]
@@ -46,7 +51,32 @@ fn upstream_pool_from_config() {
         ],
     };
 
-    let upstream_pool = UpstreamPool::from_upstream(&upstream).unwrap();
+    let mut upstreams = HashMap::new();
+    upstreams.insert("api".to_string(), upstream);
+    let runtime = RuntimeConfig::from_config(&Config {
+        version: 1,
+        listen: Listen {
+            protocol: "http1".to_string(),
+            tls: Tls {
+                cert: "/tmp/test-cert.pem".to_string(),
+                key: "/tmp/test-key.pem".to_string(),
+                ..Tls::default()
+            },
+            ..Listen::default()
+        },
+        listeners: Vec::new(),
+        upstream: upstreams,
+        load_balancing: None,
+        upstream_tls: Default::default(),
+        log: Default::default(),
+        performance: Default::default(),
+        observability: Default::default(),
+        resilience: Default::default(),
+        security: Default::default(),
+    })
+    .unwrap();
+
+    let upstream_pool = UpstreamPool::from_runtime_upstream(runtime.upstreams.get("api").unwrap()).unwrap();
     assert!(matches!(
         upstream_pool.load_balancer,
         LoadBalancing::RoundRobin(_)

--- a/crates/lb/tests/upstream_pool.rs
+++ b/crates/lb/tests/upstream_pool.rs
@@ -76,7 +76,8 @@ fn upstream_pool_from_config() {
     })
     .unwrap();
 
-    let upstream_pool = UpstreamPool::from_runtime_upstream(runtime.upstreams.get("api").unwrap()).unwrap();
+    let upstream_pool =
+        UpstreamPool::from_runtime_upstream(runtime.upstreams.get("api").unwrap()).unwrap();
     assert!(matches!(
         upstream_pool.load_balancer,
         LoadBalancing::RoundRobin(_)

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -17,3 +17,4 @@ tokio.workspace = true
 tower-service = "0.3"
 webpki-roots.workspace = true
 spooky-errors = { path = "../errors" }
+spooky-config = { path = "../config" }

--- a/crates/transport/src/h2_client.rs
+++ b/crates/transport/src/h2_client.rs
@@ -32,6 +32,7 @@ use rustls::{
     pki_types::{CertificateDer, ServerName, UnixTime},
 };
 use rustls_pki_types::pem::PemObject;
+use spooky_config::runtime::RuntimeBackendTlsPolicy;
 use tower_service::Service;
 
 #[derive(Debug, Clone)]
@@ -49,6 +50,17 @@ impl Default for TlsClientConfig {
             strict_sni: true,
             ca_file: None,
             ca_dir: None,
+        }
+    }
+}
+
+impl From<&RuntimeBackendTlsPolicy> for TlsClientConfig {
+    fn from(value: &RuntimeBackendTlsPolicy) -> Self {
+        Self {
+            verify_certificates: value.verify_certificates,
+            strict_sni: value.strict_sni,
+            ca_file: value.ca_file.clone(),
+            ca_dir: value.ca_dir.clone(),
         }
     }
 }

--- a/crates/transport/src/transport_pool.rs
+++ b/crates/transport/src/transport_pool.rs
@@ -6,6 +6,9 @@ use hyper::{
     body::{Bytes, Incoming},
 };
 pub use spooky_errors::PoolError;
+use spooky_config::runtime::{
+    RuntimeBackendConnectionPolicy, RuntimeBackendTransportKind, RuntimeUpstream,
+};
 
 use crate::{
     h1_pool::H1Pool,
@@ -101,6 +104,47 @@ impl UpstreamTransportPool {
             h1_pool,
             h2_pool,
         })
+    }
+
+    pub fn from_runtime_upstreams<'a, I>(
+        upstreams: I,
+        connection_policy: &RuntimeBackendConnectionPolicy,
+        dns_resolver: SharedDnsResolver,
+        connect_observer: Option<ConnectObserver>,
+    ) -> Result<Self, String>
+    where
+        I: IntoIterator<Item = &'a RuntimeUpstream>,
+    {
+        let mut backends = Vec::new();
+        let mut backend_tls = HashMap::new();
+
+        for upstream in upstreams {
+            for backend in &upstream.backends {
+                let backend_addr = backend.backend.address.clone();
+                let kind = match backend.endpoint.transport_kind {
+                    RuntimeBackendTransportKind::Http1 => BackendTransportKind::Http1,
+                    RuntimeBackendTransportKind::H2 => BackendTransportKind::H2,
+                };
+                backends.push((backend_addr.clone(), kind));
+                if matches!(kind, BackendTransportKind::H2) {
+                    backend_tls.insert(
+                        backend_addr,
+                        TlsClientConfig::from(&upstream.policy_set.transport.tls),
+                    );
+                }
+            }
+        }
+
+        Self::new_with_observer(
+            backends,
+            backend_tls,
+            connection_policy.max_inflight,
+            connection_policy.max_idle_per_backend,
+            connection_policy.pool_idle_timeout,
+            connection_policy.connect_timeout,
+            dns_resolver,
+            connect_observer,
+        )
     }
 
     pub async fn send(

--- a/crates/transport/src/transport_pool.rs
+++ b/crates/transport/src/transport_pool.rs
@@ -5,10 +5,10 @@ use hyper::{
     Request,
     body::{Bytes, Incoming},
 };
-pub use spooky_errors::PoolError;
 use spooky_config::runtime::{
     RuntimeBackendConnectionPolicy, RuntimeBackendTransportKind, RuntimeUpstream,
 };
+pub use spooky_errors::PoolError;
 
 use crate::{
     h1_pool::H1Pool,


### PR DESCRIPTION
## Summary

This PR finishes the runtime-config interpretation cleanup by making `config` the single canonical source of validated runtime policy objects, then moving downstream callers and benchmarks onto that contract.

It also removes the last raw `Upstream` compatibility path in `lb`, updates affected tests and benchmark helpers to build through `RuntimeConfig`, and fixes `h3_bridge` fixtures so they satisfy the now-centralized timeout and body-limit invariants.

## What Changed

- tightened `crates/config` runtime interpretation boundaries
- reduced config-side normalization/export helpers to internal or test-only usage
- removed `UpstreamPool::from_upstream` and kept `from_runtime_upstream` as the canonical entrypoint
- updated `lb` tests, `edge` tests, and benchmark setup to construct pools from normalized runtime upstreams
- aligned `h3_bridge` test fixtures with validated timeout ordering and body-cap/prebuffer rules

## Why

Before this change, downstream crates still had a few compatibility paths that reintroduced raw config-shaped inputs after runtime interpretation. That weakened the boundary and kept some config normalization APIs more public than necessary.

With this PR:
- runtime policy interpretation happens once in `config`
- downstream crates consume canonical runtime objects
- tests and benches exercise the same path production code uses
- validation failures surface earlier and more consistently

## Notes

One effect of centralizing runtime validation was that a few existing `h3_bridge` tests were relying on timeout/body-limit combinations that are now rejected during listener startup. Those fixtures were updated to preserve the intended behavior under the canonical validation rules.