### PR TITLE
docs: align documentation with current code (post-refactor accuracy pass)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -98,8 +98,8 @@ curl --http3-only -k \
 
 **Check health and readiness** (control API, default port 9902):
 ```bash
-curl http://127.0.0.1:9902/health
-curl http://127.0.0.1:9902/ready
+curl -k https://127.0.0.1:9902/health
+curl -k https://127.0.0.1:9902/ready
 ```
 
 ### Log levels

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -23,7 +23,7 @@ Core options:
 Spooky exposes two main operator-facing HTTP surfaces when configured:
 
 - a Prometheus metrics endpoint
-- a control API for liveness, readiness, runtime visibility, cert reload, and restart actions
+- a control API for liveness, readiness, runtime visibility, full config reload, cert reload, and restart actions
 
 Use:
 
@@ -40,10 +40,13 @@ The canonical configuration docs live in:
 
 ## Important Scope Note
 
-The control API is not a full dynamic configuration API today.
+The control API applies configuration through a file-reload model, not a granular per-object API.
 
-- it provides health, readiness, runtime inspection, restart hooks, and certificate reload
-- it does not provide full live route or upstream mutation
+- it provides health, readiness, runtime inspection, restart actions, certificate reload, and full
+  config reload (`POST /admin/runtime/reload`)
+- config reload re-reads the config file and applies it live via an atomic runtime swap, including
+  route, upstream, and backend changes — it is not a per-object mutation API (you edit the file and
+  reload), and startup-owned settings and listener bind/removal changes still require a restart
 
 ## Related Pages
 

--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -38,40 +38,55 @@ struct Cli {
 
 ### Main Flow
 
+The data plane is **multi-worker** (one `SO_REUSEPORT` socket + OS thread per worker, optionally
+sub-sharded into packet-shard threads). The primary thread does not run a `poll()` loop; it builds
+a shared runtime bundle, spawns one managed listener group per configured listener, and then runs a
+supervisory reconcile/collect loop.
+
 ```rust
-#[tokio::main]
-async fn main() {
-    // 1. Parse CLI arguments
-    let cli = Cli::parse();
+fn main() {
+    app::main_entry(); // parse CLI, load + validate config, init logger, drop-privilege prep
+}
 
-    // 2. Load configuration
-    let config = spooky_config::loader::read_config(&config_path)?;
+async fn run(runtime_config: RuntimeConfig, log: Log, uid: libc::uid_t, config_path: String) {
+    // 1. Build the shared runtime state + atomically-swappable RuntimeBundleHandle
+    let bundle = QUICListener::build_runtime_bundle(config_path, log, &runtime_config)?;
+    let shared_state = Arc::clone(&bundle.shared_state);
+    let runtime_bundle = Arc::new(RuntimeBundleHandle::new(bundle));
 
-    // 3. Initialize logger
-    spooky_utils::logger::init_logger(&config.log.level);
+    // 2. Spawn control-plane tasks (health checks, metrics/control API, watchdog, DNS refresh)
+    QUICListener::spawn_control_plane_tasks_with_runtime_bundle(&runtime_config, &shared_state,
+        Arc::clone(&runtime_bundle), effective_worker_count)?;
 
-    // 4. Validate configuration
-    spooky_config::validator::validate(&config);
-
-    // 5. Create QUIC listener
-    let mut listener = spooky_edge::QUICListener::new(config)?;
-
-    // 6. Setup shutdown handler
+    // 3. Install the shutdown signal handler
     let shutdown = Arc::new(AtomicBool::new(false));
-    tokio::spawn(signal_handler(shutdown.clone()));
+    tokio::spawn(/* wait_for_shutdown_signal → shutdown.store(true) */);
 
-    // 7. Main event loop
+    // 4. Spawn one managed listener group per configured listener
+    //    (each group owns its SO_REUSEPORT worker/shard threads)
+    let mut listener_groups = Vec::new();
+    for listener_config in runtime_config.listener_runtime_configs() {
+        listener_groups.push(spawn_managed_listener_group(
+            listener_config, Arc::clone(&shared_state), Arc::clone(&runtime_bundle), base)?);
+    }
+    apply_privilege_drop(uid, &runtime_config);
+
+    // 5. Supervisory loop on the primary thread: reap finished groups + reconcile
+    //    listener topology against hot-reloaded config (NOT a packet poll loop)
     while !shutdown.load(Ordering::Relaxed) {
-        listener.poll();
+        collect_finished_listener_groups(&mut listener_groups, &mut worker_failed);
+        reconcile_listener_groups(&runtime_bundle, &mut listener_groups);
+        if worker_failed { break; }
+        tokio::time::sleep(Duration::from_millis(100)).await;
     }
 
-    // 8. Graceful shutdown
-    listener.start_draining();
-    while !listener.drain_complete() {
-        listener.poll();
-    }
+    // 6. Graceful drain of all listener groups
+    shutdown_listener_groups(&mut listener_groups, &mut worker_failed).await;
 }
 ```
+
+Each worker/shard thread runs its own `recv_from` → feed-quiche → poll-HTTP/3-events loop
+internally; that per-worker loop is where packets are actually processed.
 
 ### Dependencies
 
@@ -95,21 +110,35 @@ async fn main() {
 
 ### Key Types
 
+The listener is constructed per worker/shard from shared runtime state (not one monolithic owner).
+Fields shown are abbreviated — the real struct (`crates/edge/src/runtime/listener.rs`) carries the
+full set of timeout/limit fields and connection-routing maps.
+
 ```rust
 pub struct QUICListener {
     pub socket: UdpSocket,
-    pub config: Config,
+    pub local_addr: SocketAddr,
+    pub config: ListenerRuntimeConfig,          // not the raw Config
+    pub runtime_bundle: Option<Arc<RuntimeBundleHandle>>, // atomically-swappable runtime (hot reload)
     pub quic_config: quiche::Config,
     pub h3_config: Arc<quiche::h3::Config>,
-    pub h2_pool: Arc<H2Pool>,
-    pub upstream_pools: HashMap<String, Arc<Mutex<UpstreamPool>>>,
-    pub load_balancer: LoadBalancing,
-    pub metrics: Metrics,
+    pub transport_pool: Arc<UpstreamTransportPool>,       // per-backend H1/H2 pools
+    pub upstream_pools: HashMap<String, Arc<RwLock<UpstreamPool>>>,
+    pub upstream_inflight: HashMap<String, Arc<Semaphore>>,
+    pub global_inflight: Arc<Semaphore>,
+    pub routing_index: Arc<RouteIndex>,          // deterministic trie router (no owned LoadBalancing field)
+    pub metrics: Arc<Metrics>,                   // shared across all workers
+    pub resilience: Arc<RuntimeResilience>,      // brownout, circuit breakers, admission, rate limits
+    pub watchdog: Arc<WatchdogCoordinator>,
     pub draining: bool,
     pub drain_start: Option<Instant>,
-    pub recv_buf: [u8; 65535],
-    pub send_buf: [u8; 65535],
-    pub connections: HashMap<Vec<u8>, QuicConnection>,
+    // … plus backend/client timeout + body/buffer limit fields …
+    recv_buf: Box<[u8; MAX_DATAGRAM_SIZE_BYTES]>, // heap-boxed, not inline [u8; 65535]
+    send_buf: Box<[u8; MAX_DATAGRAM_SIZE_BYTES]>,
+    connections: HashMap<Arc<[u8]>, QuicConnection>, // keyed by SCID (Arc<[u8]>)
+    cid_routes: HashMap<Arc<[u8]>, Arc<[u8]>>,
+    peer_routes: HashMap<SocketAddr, Arc<[u8]>>,
+    conn_rate_limiter: TokenBucket,              // new-connection admission
 }
 
 pub struct QuicConnection {
@@ -121,21 +150,39 @@ pub struct QuicConnection {
     pub last_activity: Instant,
 }
 
+// RequestEnvelope streams the body via an mpsc channel with a bounded overflow buffer —
+// it does NOT hold the whole body as a Vec<u8>. Abbreviated; the real struct also carries
+// tracing, routing-decision, admission-permit, and async-auth/handoff fields.
 pub struct RequestEnvelope {
+    pub request_id: u64,
     pub method: String,
     pub path: String,
     pub authority: Option<String>,
-    pub headers: Vec<(Vec<u8>, Vec<u8>)>,
-    pub body: Vec<u8>,
+    pub body_tx: Option<mpsc::Sender<Bytes>>,   // sender half; dropping it signals EOF to hyper
+    pub body_buf: VecDeque<Bytes>,              // bounded overflow before the channel has capacity
+    pub body_buf_bytes: usize,
+    pub body_bytes_received: usize,
+    pub bodyless_mode: bool,
     pub start: Instant,
+    // … routing decision, inflight/admission permits, async external-auth handoff, phase state …
 }
 
+// Metrics has ~70 AtomicU64 counters/gauges plus label-keyed maps and latency histograms —
+// far more than the five request counters. A representative subset:
 pub struct Metrics {
     pub requests_total: AtomicU64,
     pub requests_success: AtomicU64,
     pub requests_failure: AtomicU64,
+    pub request_validation_rejects: AtomicU64,
+    pub external_auth_allowed: AtomicU64,        // + denied/timeout/error
+    pub request_rate_limited: AtomicU64,
+    pub circuit_breaker_rejected_total: AtomicU64,
+    pub brownout_active: AtomicU64,
+    pub active_connections: AtomicU64,
     pub backend_timeouts: AtomicU64,
     pub backend_errors: AtomicU64,
+    // … overload-shed-by-reason, hedge, retry, health-check, DNS-refresh, ingress, watchdog
+    //   counters, plus per-route / per-worker label maps and latency histograms …
 }
 ```
 
@@ -156,12 +203,18 @@ impl QUICListener {
     pub fn drain_complete(&self) -> bool;
 }
 
+// Metrics exposes one increment/observe helper per counter/gauge/histogram (dozens total),
+// plus render_prometheus() to serialize the whole set in Prometheus text format. Examples:
 impl Metrics {
     pub fn inc_total(&self);
     pub fn inc_success(&self);
     pub fn inc_failure(&self);
     pub fn inc_timeout(&self);
     pub fn inc_backend_error(&self);
+    pub fn inc_circuit_breaker_rejected(&self);
+    pub fn inc_request_rate_limited(&self);
+    // … one per metric family; see crates/edge/src/metrics/ …
+    pub fn render_prometheus(&self) -> String;
 }
 ```
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -195,20 +195,25 @@ Spooky uses Tokio as its asynchronous runtime:
 ### State Management
 
 Shared state is managed carefully:
-- `Arc<T>` for shared ownership
-- `Mutex<T>` for mutable shared state (upstream pools)
+- `Arc<T>` for shared ownership (including `Arc<Metrics>` shared across all workers)
+- `RwLock<T>` for mutable shared state (upstream pools)
 - `AtomicU64` for lock-free counters (metrics)
-- Single-threaded UDP socket polling (no lock contention)
+- A `RuntimeBundleHandle` provides an atomically swappable snapshot of runtime state, enabling
+  config hot reload without restarting the process
 
 ### Task Structure
 
-The main event loop runs on the primary thread:
-- `poll()` processes UDP packets synchronously
-- QUIC connections are managed in-process
-- Backend requests spawn async tasks via Tokio
-- Graceful shutdown coordinated via AtomicBool
+The data plane is **multi-worker**, not a single primary-thread loop:
+- One UDP socket is bound per worker via `SO_REUSEPORT`, and one OS thread is spawned per socket
+  (`spooky-data-plane-{idx}`); worker count comes from `performance.worker_threads`.
+- Each worker can be further sub-sharded into `performance.packet_shards_per_worker` packet-shard
+  threads, fed via bounded `mpsc` channels. Packets are hashed by peer address so a given peer
+  always lands on the same shard/connection state.
+- Each worker/shard runs its own `recv_from` → QUIC-poll loop; connections are managed in-process.
+- Backend requests spawn async tasks via Tokio; graceful drain/shutdown is coordinated per group.
 
-This design avoids thread synchronization overhead on the packet processing path while leveraging Tokio's async capabilities for backend I/O.
+This design scales UDP ingress across cores while keeping each connection pinned to one thread's
+state, and leverages Tokio's async capabilities for backend I/O.
 
 ## Error Handling Strategy
 
@@ -291,7 +296,7 @@ Configuration validation occurs before runtime:
 Current configuration is immutable at runtime:
 - Loaded once at startup
 - Shared via Arc across components
-- Hot reload not yet implemented (requires atomic swap)
+- Hot reload implemented with atomic swap
 
 ## Security Considerations
 
@@ -305,7 +310,7 @@ Current configuration is immutable at runtime:
 ### Backend Communication
 
 - Currently plaintext HTTP/2
-- Mutual TLS to backends (planned)
+- upstream TLS shipped, verify-on by default (server-side; note true mTLS/client-cert to backends is the actual gap)
 - Connection reuse reduces handshake overhead
 
 ### Attack Surface
@@ -333,7 +338,7 @@ Atomic counters for key metrics:
 - `backend_timeouts`: timed out backend requests
 - `backend_errors`: backend error responses
 
-Metrics export via Prometheus format (planned).
+Metrics export via Prometheus format (shipped).
 
 ### Tracing
 
@@ -342,7 +347,7 @@ Request-level tracing:
 - Duration calculated on completion
 - Logged with request details
 
-Distributed tracing via OpenTelemetry (planned).
+Distributed tracing via OpenTelemetry (shipped).
 
 ## Performance Characteristics
 
@@ -371,14 +376,14 @@ Distributed tracing via OpenTelemetry (planned).
 
 ### Planned Features
 
-- Hot configuration reload without restart (planned)
-- Prometheus metrics endpoint
-- OpenTelemetry distributed tracing
-- Mutual TLS to backends
-- Active health check probes (TCP/HTTP)
-- Rate limiting per client
-- Circuit breaker pattern for failing backends
-- Admin API for runtime inspection
+- Mutual TLS (client certificates) **to backends** — upstream TLS with certificate verification is
+  already implemented; client-cert authentication toward backends is the remaining gap
+- Upstream HTTP/3 forwarding
+- Richer service-discovery integrations
+
+_Already shipped (previously listed here as planned): active HTTP health-check probes, per-client
+scoped rate limiting, per-backend circuit breakers, and the admin/control API for runtime
+inspection and hot reload._
 
 ### Architectural Improvements
 

--- a/docs/configuration/defaults.md
+++ b/docs/configuration/defaults.md
@@ -284,6 +284,7 @@ These apply when a backend provides a `health_check` object and omits individual
 | `observability.control_api.ready_path` | `"/ready"` | Readiness endpoint path |
 | `observability.control_api.runtime_path` | `"/admin/runtime"` | Runtime summary path |
 | `observability.control_api.restart_path` | `"/admin/runtime/restart"` | Restart control path |
+| `observability.control_api.reload_path` | `"/admin/runtime/reload"` | Full config hot-reload path |
 | `observability.control_api.reload_certs_path` | `"/admin/runtime/reload-certs"` | Certificate reload path |
 | `observability.control_api.auth_token` | `null` | Must be set when the control API is enabled |
 | `observability.control_api.max_connections` | `256` | Concurrent control API connections cap |

--- a/docs/configuration/examples.md
+++ b/docs/configuration/examples.md
@@ -229,10 +229,14 @@ upstream:
 
 ## Example 7: Current Reload Stance
 
-Spooky currently supports **certificate reload for new handshakes**, not full configuration hot reload. When planning operations:
+Spooky supports **full configuration hot reload** via `POST /admin/runtime/reload`, alongside
+certificate-only reload for new handshakes. When planning operations:
 
-- use cert reload for listener certificate replacement
-- plan a drain-and-restart workflow for route, upstream, and policy changes
+- use full config reload (`/admin/runtime/reload`) for route, upstream, backend, timeout, limit,
+  and resilience-policy changes — these apply live via an atomic runtime swap, no restart
+- use cert reload (`/admin/runtime/reload-certs`) for listener certificate replacement
+- plan a drain-and-restart workflow only for startup-owned settings (log, tracing, thread counts)
+  and listener removal or bind-address changes, which the reload endpoint rejects
 - keep rollback and staged rollout procedures ready
 
 ## Related Pages

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -20,10 +20,13 @@ This page covers:
 
 Default coverage now lives on [Configuration Defaults](defaults.md) so the full inventory can stay centralized and easier to audit against the code.
 
-This page does not change the current product limits:
+This page does not change the current product behavior:
 
-- full config hot reload is not implemented
-- certificate reload covers new handshakes only
+- configuration hot reload is supported via `POST /admin/runtime/reload`: the full config is
+  re-read, validated, and applied through an atomic runtime swap (routes, upstreams, backends,
+  timeouts, limits, and resilience policies). Only startup-owned settings (log, tracing, thread
+  counts) and listener removal / bind-address changes still require a restart.
+- certificate reload (`POST /admin/runtime/reload-certs`) covers new handshakes only
 - backend transport is scheme-driven: `https://` backends use HTTP/2, `http://` backends use HTTP/1.1
 
 ## Reading This Reference

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -1119,7 +1119,8 @@ Key fields:
 
 Key fields:
 
-- `observability.control_api.auth_token`: bearer token required for runtime, reload-certs, and restart endpoints (`Authorization: Bearer <token>`).
+- `observability.control_api.auth_token`: bearer token required for runtime, reload, reload-certs, and restart endpoints (`Authorization: Bearer <token>`).
+- `observability.control_api.reload_path` (default: `/admin/runtime/reload`): authenticated POST endpoint that re-reads the config file and applies the full configuration via an atomic runtime swap (routes, upstreams, backends, timeouts, limits, resilience policies). Startup-owned settings and listener bind/removal changes are rejected and still require a restart.
 - `observability.control_api.reload_certs_path`: authenticated POST endpoint that reloads listener certificate and client-auth CA material for new handshakes.
 - `observability.control_api.max_connections` (default: `256`): concurrent connection cap.
 - `observability.control_api.connection_timeout_ms` (default: `30000`): per-connection lifetime timeout.

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -1041,7 +1041,7 @@ Request-shape rules enforced by the runtime:
 
 ### watchdog
 
-Monitors worker health and triggers a restart hook when error rates or stall conditions exceed thresholds.
+Monitors worker health and triggers a restart command when error rates or stall conditions exceed thresholds.
 
 | Property | Type | Required | Default | Description |
 |----------|------|----------|---------|-------------|
@@ -1051,10 +1051,11 @@ Monitors worker health and triggers a restart hook when error rates or stall con
 | `timeout_error_rate_percent` | integer | No | `60` | Trigger if timeout errors exceed this % of requests in a window |
 | `min_requests_per_window` | integer | No | `20` | Minimum requests in a window before error-rate check applies |
 | `overload_inflight_percent` | integer | No | `95` | Trigger if in-flight % exceeds this threshold |
-| `unhealthy_consecutive_windows` | integer | No | `3` | Consecutive unhealthy windows before invoking the restart hook |
+| `unhealthy_consecutive_windows` | integer | No | `3` | Consecutive unhealthy windows before invoking the restart command |
 | `drain_grace_ms` | integer | No | `8000` | Grace period (ms) to drain connections before restarting |
-| `restart_cooldown_ms` | integer | No | `120000` | Minimum time (ms) between restart hook invocations |
-| `restart_hook` | string | No | `null` | Shell command invoked on restart trigger |
+| `restart_cooldown_ms` | integer | No | `120000` | Minimum time (ms) between restart command invocations |
+| `restart_command` | list of strings | No | `[]` | Command invoked on restart trigger; first element is the executable, the rest are args. Avoids shell evaluation. |
+| `restart_hook` | string | No | `null` | **Deprecated and rejected at startup** — setting it is a hard config error. Use `restart_command` instead. |
 
 ### Startup Validation Errors
 

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -841,9 +841,13 @@ Controls resource limits, tuning knobs, and connection-flood protection. All fie
 | `control_plane_threads` | integer | No | `2` | Tokio worker threads for the control-plane runtime (startup, health checks, metrics, and other async control tasks) |
 | `reuseport` | bool | No | `true` | Enable `SO_REUSEPORT`; required when `worker_threads > 1` |
 | `pin_workers` | bool | No | `false` | Pin each worker thread to a dedicated CPU core |
+| `packet_shards_per_worker` | integer | No | `1` | Packet-processing shards per bound UDP worker socket; `1` preserves single-loop behavior, values >1 enable parallel shard workers |
+| `packet_shard_queue_capacity` | integer | No | `2048` | Capacity of the bounded ingress queue per shard |
+| `packet_shard_queue_max_bytes` | integer | No | `67108864` | Memory-aware cap (bytes) for queued datagram bytes per ingress shard dispatch queue |
 | `global_inflight_limit` | integer | No | `4096` | Maximum concurrent in-flight requests across all upstreams |
 | `per_upstream_inflight_limit` | integer | No | `1024` | Maximum concurrent in-flight requests per upstream pool |
 | `per_backend_inflight_limit` | integer | No | `64` | Maximum concurrent in-flight requests per backend |
+| `inflight_acquire_wait_ms` | integer | No | `0` | Optional micro-wait (ms) before shedding on global/upstream inflight permit acquisition; `0` sheds immediately |
 | `backend_timeout_ms` | integer | No | `2000` | Initial backend response timeout (ms) |
 | `backend_connect_timeout_ms` | integer | No | `500` | Backend TCP/TLS handshake timeout (ms); must be ≤ `backend_timeout_ms` |
 | `backend_body_idle_timeout_ms` | integer | No | `2000` | Idle timeout while streaming response body (ms); must be ≥ `backend_timeout_ms` |
@@ -865,6 +869,10 @@ Controls resource limits, tuning knobs, and connection-flood protection. All fie
 | `quic_initial_max_streams_bidi` | integer | No | `100` | Maximum concurrent bidirectional QUIC streams per connection |
 | `quic_initial_max_streams_uni` | integer | No | `100` | Maximum concurrent unidirectional QUIC streams per connection |
 | `max_response_body_bytes` | integer | No | `104857600` | Hard cap on upstream response body bytes per stream; streams exceeding this return 503 (`upstream response body too large`) |
+| `max_request_body_bytes` | integer | No | `1000000` | Hard cap on request body bytes per stream; requests exceeding this are rejected with 413. Must be ≤ `quic_initial_max_stream_data` |
+| `request_buffer_global_cap_bytes` | integer | No | `67108864` | Global cap (bytes) for data buffered in request backpressure queues across a worker |
+| `unknown_length_response_prebuffer_bytes` | integer | No | `2097152` | Max bytes buffered for unknown-length upstream responses before headers are emitted; responses exceeding this are terminated with an overload response |
+| `client_body_idle_timeout_ms` | integer | No | `10000` | Idle timeout (ms) for request-body upload progress; the stream is failed if no body bytes arrive within this period |
 
 ### Connection flood protection
 

--- a/docs/deployment/migration.md
+++ b/docs/deployment/migration.md
@@ -6,7 +6,7 @@ This guide is for platform and SRE engineers who already operate NGINX or Envoy 
 
 ## Before You Start
 
-**What Spooky is and is not.** Spooky is a QUIC-native edge reverse proxy. It terminates HTTP/3 connections over QUIC, forwards to upstream backends over HTTP/2 (`https://` backends) or HTTP/1.1 (`http://` backends), and handles upstream pool management with named pools, path- and host-based routing, and per-upstream health checks. Mixed HTTP/1.1 and HTTP/2 backend deployments are supported in the same config. It is not a full API gateway: there is no built-in rate limiting by key, no JWT validation, no request transformation pipeline. It is not a service mesh control plane: it does not speak xDS, does not distribute config to sidecars, and does not manage mTLS between services. It is not a WAF: it has no request inspection, no ModSecurity integration, no bot detection. If your current NGINX or Envoy setup relies on any of those capabilities, read the "Things That Don't Translate Directly" section before proceeding — you will need to keep those concerns handled elsewhere in your stack.
+**What Spooky is and is not.** Spooky is a QUIC-native edge reverse proxy. It terminates HTTP/3 connections over QUIC, forwards to upstream backends over HTTP/2 (`https://` backends) or HTTP/1.1 (`http://` backends), and handles upstream pool management with named pools, path- and host-based routing, and per-upstream health checks. Mixed HTTP/1.1 and HTTP/2 backend deployments are supported in the same config. It is not a full API gateway, but it does include scoped rate limiting (by route/client/tenant/token), per-upstream API-key and local HS256-JWT auth (with scope/role checks), and external auth via HTTP subrequest or OIDC. What it lacks is a request/response transformation pipeline, JWKS/asymmetric-JWT validation, and a generic policy engine. It is not a service mesh control plane: it does not speak xDS, does not distribute config to sidecars, and does not manage mTLS between services. It is not a WAF: it has no request inspection, no ModSecurity integration, no bot detection. If your current NGINX or Envoy setup relies on any of those capabilities, read the "Things That Don't Translate Directly" section before proceeding — you will need to keep those concerns handled elsewhere in your stack.
 
 **Two migration patterns.** This document covers two approaches. Pattern A is additive: Spooky sits in front of your existing proxy and acts as an HTTP/3 ingress layer, while NGINX or Envoy continues to handle all the routing and backend logic it currently handles. This is the lowest-risk starting point and requires no changes to your existing proxy config or your backends. Pattern B is a replacement: Spooky takes over routing duties route by route, and you eventually decommission your old proxy entirely. Pattern B is recommended for teams who want to move fully to Spooky, but it should be done incrementally — one route at a time — never as a big-bang cutover.
 
@@ -31,41 +31,35 @@ The following is a complete working config for Pattern A, assuming your existing
 ```yaml
 # /etc/spooky/config.yaml — Pattern A: Spooky as HTTP/3 ingress in front of NGINX/Envoy
 
+# A single `listen` block defines the QUIC/HTTP-3 listener. Spooky automatically starts a
+# TCP+TLS bootstrap listener on the SAME address/port for HTTP/1.1 and HTTP/2 clients and
+# advertises `Alt-Svc: h3` so they upgrade to HTTP/3 — there is no separate TCP listener entry.
 listen:
-  - address: "0.0.0.0:9889"
-    protocol: quic          # HTTP/3 over QUIC (UDP)
-    tls:
-      cert: /etc/spooky/tls/fullchain.pem
-      key: /etc/spooky/tls/privkey.pem
+  protocol: http3           # the only valid value; QUIC (UDP) + auto TCP bootstrap
+  address: "0.0.0.0"        # host only — NOT combined with the port
+  port: 9889
+  tls:
+    cert: /etc/spooky/tls/fullchain.pem
+    key: /etc/spooky/tls/privkey.pem
 
-  - address: "0.0.0.0:9889"
-    protocol: tcp           # Bootstrap path for HTTP/1.1 and HTTP/2 clients
-    tls:
-      cert: /etc/spooky/tls/fullchain.pem
-      key: /etc/spooky/tls/privkey.pem
-
-upstreams:
-  - name: existing-proxy
-    backends:
-      - address: "127.0.0.1:443"
-        protocol: https
-        health_check:
-          path: /healthz
-          interval: 10s
-          timeout: 3s
-          healthy_threshold: 2
-          unhealthy_threshold: 3
+# `upstream` is a MAP keyed by pool name (not a `upstreams:` list, and no `name:` field).
+# The route match lives inside the pool entry — there is no top-level `routes:` list.
+upstream:
+  existing-proxy:
     load_balancing:
       type: round-robin
-
-routes:
-  - match:
-      host: "*.example.com"
-    upstream: existing-proxy
-
-  - match:
+    route:
+      host: "*.example.com" # host and/or path_prefix; matched to this pool
       path_prefix: "/"
-    upstream: existing-proxy
+    backends:
+      - id: existing-proxy-1
+        address: "https://127.0.0.1:443"  # scheme in the address: https:// = HTTP/2 upstream
+        health_check:
+          path: /healthz
+          interval: 10000     # milliseconds (integer), not "10s"
+          timeout_ms: 3000
+          failure_threshold: 3
+          success_threshold: 2
 ```
 
 > **TLS note.** Spooky must present a certificate that your clients trust. If your existing proxy terminates TLS with a cert from Let's Encrypt or your CA, use the same cert and key here — or provision a new one for the Spooky host. Spooky forwards to your existing proxy over HTTPS; if your existing proxy uses a self-signed cert on the loopback interface you may need to configure trust appropriately or use HTTP on the loopback leg.
@@ -127,61 +121,57 @@ The key principle is that every request must have a destination. Model your exis
 ```yaml
 # /etc/spooky/config.yaml — Pattern B: incremental route migration
 
+# Single QUIC/HTTP-3 listener; the TCP bootstrap listener is started automatically on the
+# same address/port (see Pattern A note above).
 listen:
-  - address: "0.0.0.0:9889"
-    protocol: quic
-    tls:
-      cert: /etc/spooky/tls/fullchain.pem
-      key: /etc/spooky/tls/privkey.pem
-  - address: "0.0.0.0:9889"
-    protocol: tcp
-    tls:
-      cert: /etc/spooky/tls/fullchain.pem
-      key: /etc/spooky/tls/privkey.pem
+  protocol: http3
+  address: "0.0.0.0"
+  port: 9889
+  tls:
+    cert: /etc/spooky/tls/fullchain.pem
+    key: /etc/spooky/tls/privkey.pem
 
-upstreams:
+# `upstream` is a map keyed by pool name. Routing is expressed by each pool's own `route:`
+# block; there is no separate top-level `routes:` list. Longest-prefix wins, so a pool with
+# `path_prefix: /static` takes precedence over the `path_prefix: /` catch-all pool.
+upstream:
   # The first route migrated to Spooky — static asset backend
-  - name: static-origin
-    backends:
-      - address: "10.0.1.20:8080"
-        protocol: http
-        health_check:
-          path: /healthz
-          interval: 10s
-          timeout: 3s
-          healthy_threshold: 2
-          unhealthy_threshold: 3
+  static-origin:
     load_balancing:
       type: round-robin
-
-  # Everything else still goes to your existing proxy
-  - name: legacy-proxy
+    route:
+      path_prefix: "/static"   # more specific → matched first
     backends:
-      - address: "127.0.0.1:443"
-        protocol: https
+      - id: static-origin-1
+        address: "http://10.0.1.20:8080"   # http:// = HTTP/1.1 upstream
         health_check:
           path: /healthz
-          interval: 15s
-          timeout: 5s
-          healthy_threshold: 1
-          unhealthy_threshold: 2
+          interval: 10000
+          timeout_ms: 3000
+          failure_threshold: 3
+          success_threshold: 2
+
+  # Everything else still goes to your existing proxy (catch-all via path_prefix "/")
+  legacy-proxy:
     load_balancing:
       type: round-robin
-
-routes:
-  # Migrated route — explicit path prefix match comes first
-  - match:
-      path_prefix: "/static"
-    upstream: static-origin
-
-  # Fallback — all unmatched traffic goes to the old proxy
-  # Add migrated routes above this line; shrink this as migration progresses
-  - match:
-      path_prefix: "/"
-    upstream: legacy-proxy
+    route:
+      path_prefix: "/"         # least specific → the fallback
+    backends:
+      - id: legacy-proxy-1
+        address: "https://127.0.0.1:443"   # https:// = HTTP/2 upstream
+        health_check:
+          path: /healthz
+          interval: 15000
+          timeout_ms: 5000
+          failure_threshold: 2
+          success_threshold: 1
 ```
 
-As you migrate each subsequent route, add a new upstream pool for its backend and insert a new route block above the `legacy-proxy` fallback. When the fallback pool has no traffic, remove it and decommission the old proxy.
+As you migrate each subsequent route, add a new upstream pool (with its own more-specific
+`route.path_prefix`) for its backend. Longest-prefix matching routes those paths to the new pool
+while everything else keeps falling through to the `legacy-proxy` pool. When the fallback pool has
+no traffic, remove it and decommission the old proxy.
 
 ---
 
@@ -189,13 +179,13 @@ As you migrate each subsequent route, add a new upstream pool for its backend an
 
 | NGINX directive | Spooky equivalent |
 |---|---|
-| `upstream mypool { server 10.0.0.1:8080; }` | An entry in `upstreams:` with `name: mypool` and a `backends:` list containing `address: "10.0.0.1:8080"` |
-| `proxy_pass http://mypool` | `upstream: mypool` on a route block; Spooky resolves the name to the upstream pool |
-| `location /api { ... }` | `routes: - match: path_prefix: "/api"` |
-| `proxy_next_upstream error timeout http_502` | Per-backend `health_check:` config with `unhealthy_threshold` controlling how many consecutive failures remove a backend from rotation; retries on connection error are automatic |
-| `least_conn` | `load_balancing: type: least-connections` inside the upstream pool |
-| `ip_hash` | `load_balancing: type: consistent-hash` (hashes on client address by default) |
-| `keepalive 32` | Spooky maintains a connection pool to upstream backends automatically; the pool size is not separately configurable in v0.1.x |
+| `upstream mypool { server 10.0.0.1:8080; }` | A `mypool:` key under the `upstream:` map with a `backends:` list containing `id:` + `address: "http://10.0.0.1:8080"` |
+| `proxy_pass http://mypool` | The `mypool:` pool's own `route:` block (`host`/`path_prefix`); there is no separate name reference — the match lives on the pool |
+| `location /api { ... }` | `route: { path_prefix: "/api" }` inside the relevant upstream pool |
+| `proxy_next_upstream error timeout http_502` | Per-backend `health_check:` config with `failure_threshold` controlling how many consecutive failures remove a backend from rotation; retries on connection error are automatic |
+| `least_conn` | `load_balancing: { type: least-connections }` inside the upstream pool |
+| `ip_hash` | `load_balancing: { type: consistent-hash }` (hashes on client address by default) |
+| `keepalive 32` | Spooky maintains a connection pool to upstream backends automatically; the pool size is not separately configurable |
 | `ssl_certificate /path/cert.pem` | `listen.tls.cert: /path/cert.pem` under the relevant listener |
 | `ssl_certificate_key /path/key.pem` | `listen.tls.key: /path/key.pem` under the relevant listener |
 
@@ -207,7 +197,7 @@ The following NGINX and Envoy features have no equivalent in Spooky v0.1.x. This
 
 **NGINX dynamic modules (ModSecurity, gzip, Brotli, etc.)** are not available. Spooky has no module system and no request/response body processing pipeline. If you rely on ModSecurity for WAF rules, you must keep a WAF in the chain — either in front of Spooky or as a sidecar on the backend. For gzip/Brotli: serve pre-compressed assets from your origin, or keep an NGINX instance in the chain for compression.
 
-**Envoy's xDS dynamic control plane** does not apply to Spooky. Spooky uses a static YAML config and currently requires a controlled restart workflow for non-certificate config changes. If your current setup relies on Envoy's ADS/EDS for dynamic backend discovery (e.g., service discovery via Consul or a service mesh), you cannot replicate that behavior with Spooky today. Alternatives: use a configuration management tool to render Spooky's config and restart on change, or continue using Envoy for the service mesh interior and put Spooky only at the edge.
+**Envoy's xDS dynamic control plane** does not apply to Spooky. Spooky uses a file-based YAML config; changes are applied by editing the file and calling `POST /admin/runtime/reload`, which hot-swaps routes, upstreams, backends, and policies live (only startup-owned settings and listener bind/removal changes need a restart). There is no push-based config distribution to sidecars. If your current setup relies on Envoy's ADS/EDS for dynamic backend discovery (e.g., service discovery via Consul or a service mesh), you cannot replicate that behavior with Spooky today. Alternatives: use a configuration management tool to render Spooky's config and restart on change, or continue using Envoy for the service mesh interior and put Spooky only at the edge.
 
 **Lua scripting and WASM filters** are not supported. Envoy's Lua filter and WASM extension model, and NGINX's `lua-nginx-module`, have no equivalent in Spooky. Any per-request logic (custom header inspection, A/B routing logic, request signing) must move to the application layer or to a middleware service in front of Spooky.
 
@@ -215,7 +205,7 @@ The following NGINX and Envoy features have no equivalent in Spooky v0.1.x. This
 
 **Response header manipulation** (`add_header`, `proxy_hide_header`, `more_set_headers` in NGINX; `response_headers_to_add` in Envoy) is not available. Spooky passes response headers from the upstream to the client unmodified. Workaround: set headers at the origin service, or use a thin middleware layer (e.g., a simple HTTP wrapper service) for routes where specific headers are required.
 
-**Per-IP rate limiting** (`limit_req_zone` / `limit_conn_zone` in NGINX; rate limit filter in Envoy) is not available in v0.1.x. Spooky supports admission control at the global level and per-upstream pool level, but not keyed by client IP or any request attribute. Workaround: place a dedicated rate-limiting layer (e.g., a Redis-backed rate limiter, or a cloud provider's WAF/shield service) in front of Spooky, or keep NGINX in the chain for routes that require per-IP throttling.
+**Per-IP rate limiting** (`limit_req_zone` / `limit_conn_zone` in NGINX; rate limit filter in Envoy). Spooky has scoped rate limiting (`resilience.scoped_rate_limits`) keyed by route, client, tenant, or token, plus global and per-upstream admission control — but not the full breadth of NGINX/Envoy rate-limit expressions, and no distributed/cross-instance rate limiting. For advanced or cross-instance throttling, place a dedicated rate-limiting layer (e.g., a Redis-backed rate limiter, or a cloud provider's WAF/shield service) in front of Spooky, or keep NGINX in the chain for routes that require per-IP throttling.
 
 ---
 

--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -492,11 +492,12 @@ For environments requiring mandatory access control, create appropriate policies
 Spooky exposes a Prometheus-compatible metrics endpoint. Configure it in `config.yaml`:
 
 ```yaml
-metrics:
-  enabled: true
-  address: "127.0.0.1"
-  port: 9090
-  path: "/metrics"
+observability:
+  metrics:
+    enabled: true
+    address: "127.0.0.1"
+    port: 9901
+    path: "/metrics"
 ```
 
 Scrape it with Prometheus:
@@ -509,7 +510,7 @@ scrape_configs:
     scrape_timeout: 10s
     metrics_path: '/metrics'
     static_configs:
-      - targets: ['spooky-01.internal:9090', 'spooky-02.internal:9090']
+      - targets: ['spooky-01.internal:9901', 'spooky-02.internal:9901']
         labels:
           environment: 'production'
           service: 'proxy'

--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -330,8 +330,11 @@ Group=spooky
 
 # Binary and configuration
 ExecStart=/usr/local/bin/spooky --config /etc/spooky/config.yaml
-# Note: Hot reload not currently supported, use restart instead
-# ExecReload=/bin/kill -HUP $MAINPID
+# Hot reload: config is reloaded via the control API, not a signal.
+# `systemctl reload spooky` POSTs to the reload endpoint (control API is HTTPS + bearer-auth).
+# Applies routes/upstreams/backends/limits/policies live; startup-owned settings and listener
+# bind/removal changes still require a full restart.
+ExecReload=/usr/bin/curl -sf -k -X POST -H "Authorization: Bearer ${SPOOKY_ADMIN_TOKEN}" https://127.0.0.1:9902/admin/runtime/reload
 
 # Restart policy
 Restart=always

--- a/docs/deployment/validation.md
+++ b/docs/deployment/validation.md
@@ -49,7 +49,7 @@ After starting Spooky against the new config (in a staging environment, or as a 
 The `/admin/runtime` endpoint returns the current runtime state of every upstream pool, including per-backend health status. Query it within the first 30 seconds of startup:
 
 ```bash
-curl -s http://127.0.0.1:9000/admin/runtime | jq .
+curl -sk https://127.0.0.1:9902/admin/runtime | jq .
 ```
 
 A healthy response looks like this:
@@ -97,10 +97,11 @@ A pool where `healthy_count` is less than `total_count` indicates partial degrad
 
 ### 2. Watch health check logs at debug level
 
-During the first 30 seconds after startup, run Spooky at debug log level (or tail its logs if already running with structured output) and watch for health probe results:
+During the first 30 seconds after startup, run Spooky at debug log level (or tail its logs if already running with structured output) and watch for health probe results. The log level is set in the config file via `log.level: debug` (there is no `SPOOKY_LOG`/`RUST_LOG` environment variable):
 
 ```bash
-SPOOKY_LOG=debug spooky --config /etc/spooky/config-new.yaml 2>&1 | grep -i "health\|probe\|backend"
+# set `log.level: debug` in config-new.yaml, then:
+spooky --config /etc/spooky/config-new.yaml 2>&1 | grep -i "health\|probe\|backend"
 ```
 
 You are looking for probe success messages for every backend. Any repeated probe failure for a backend that should be reachable is a signal to stop and investigate before the instance takes traffic.
@@ -216,8 +217,9 @@ Run the new-config instance on a different port from the production instance. Bo
 # Production instance (already running)
 # Config: /etc/spooky/config.yaml, port 443
 
-# Canary instance
-spooky --config /etc/spooky/config-new.yaml --listen 0.0.0.0:8443
+# Canary instance — the CLI only accepts --config/-c; set the bind address in the config file.
+# Use config-new.yaml with `listen.address`/`listen.port` set to the canary port (e.g. 8443).
+spooky --config /etc/spooky/config-new.yaml
 ```
 
 Alternatively, use a separate unit file if running under systemd:
@@ -254,19 +256,25 @@ Run the same query for the canary instance and compare. A lower success rate on 
 
 ```promql
 histogram_quantile(0.99,
-  rate(spooky_request_duration_seconds_bucket{instance="host:9090"}[5m])
+  rate(spooky_upstream_request_latency_ms_bucket{instance="host:9901"}[5m])
 )
 ```
 
-A p99 latency increase on the canary instance (but not the production instance) points to backend latency regression or a timeout misconfiguration in the new config.
+This histogram is in **milliseconds** (buckets are `_ms`), and carries `upstream`/`outcome`/`le`
+labels. A p99 latency increase on the canary instance (but not the production instance) points to
+backend latency regression or a timeout misconfiguration in the new config.
 
-**Backend health gauge (should be 1 for all backends on both instances):**
+**Backend health (compare health-check success/failure between instances):**
+
+Spooky does not export a per-backend boolean health gauge. Use the health-check counters instead:
 
 ```promql
-spooky_backend_healthy{instance="host:9090"}
+rate(spooky_health_checks_failure{instance="host:9901"}[5m])
 ```
 
-Any backend showing `0` on the canary but `1` on the production instance confirms a backend reachability or config problem specific to the new config.
+A rising health-check failure rate on the canary but not the production instance confirms a backend
+reachability or config problem specific to the new config. (Live per-backend health is also visible
+in the `/admin/runtime` snapshot.)
 
 ### 4. Promote or roll back
 
@@ -309,7 +317,7 @@ A timeout spike after restart is a strong signal that backend addresses changed 
 Poll this endpoint repeatedly in the first few minutes after restart:
 
 ```bash
-watch -n 5 'curl -s http://127.0.0.1:9000/admin/runtime | jq ".upstreams | to_entries[] | {pool: .key, healthy: .value.healthy_count, total: .value.total_count}"'
+watch -n 5 'curl -sk https://127.0.0.1:9902/admin/runtime | jq ".upstreams | to_entries[] | {pool: .key, healthy: .value.healthy_count, total: .value.total_count}"'
 ```
 
 Any pool where `healthy` is less than `total` after 60 seconds of uptime should be investigated. If a backend was healthy before the restart and is now unhealthy, the new config is likely pointing to a wrong address or using a different TLS mode that the backend does not expect.
@@ -400,7 +408,7 @@ Expected: `Active: active (running)`. If the service enters a failed state, chec
 
 ```bash
 for i in $(seq 1 10); do
-  STATUS=$(curl -o /dev/null -s -w "%{http_code}" http://127.0.0.1:9000/health)
+  STATUS=$(curl -o /dev/null -sk -w "%{http_code}" https://127.0.0.1:9902/health)
   echo "$(date +%T) /health: $STATUS"
   [ "$STATUS" = "200" ] && break
   sleep 0.5

--- a/docs/deployment/validation.md
+++ b/docs/deployment/validation.md
@@ -243,7 +243,7 @@ Use the Prometheus queries below to compare the two instances side by side. Subs
 **Request success rate (should be equal between instances):**
 
 ```promql
-rate(spooky_requests_success_total{instance="host:9090"}[5m])
+rate(spooky_requests_success{instance="host:9090"}[5m])
 /
 rate(spooky_requests_total{instance="host:9090"}[5m])
 ```
@@ -280,26 +280,26 @@ If any metric diverges unfavorably, route all traffic back to the production ins
 
 After restarting Spooky with a new config or new binary, watch the following five signals for the first 30 minutes. Set up dashboard panels or alert inhibitions before the restart so you can observe cleanly.
 
-**1. `spooky_requests_success_total` rate**
+**1. `spooky_requests_success` rate**
 
 ```promql
-rate(spooky_requests_success_total[2m])
+rate(spooky_requests_success[2m])
 ```
 
 This should match the pre-deploy baseline within 1-2 minutes of restart (after QUIC connections re-establish). A sustained drop below baseline indicates requests are failing. Compare against the same window from yesterday or the previous week to account for traffic volume changes.
 
-**2. `spooky_backend_errors_total` rate**
+**2. `spooky_backend_errors` rate**
 
 ```promql
-rate(spooky_backend_errors_total[2m])
+rate(spooky_backend_errors[2m])
 ```
 
 Any sudden increase after restart indicates Spooky is reaching backends but backends are returning errors. This points to a routing misconfiguration (requests sent to wrong backend), a backend environment mismatch, or an application-level problem triggered by the new routing.
 
-**3. `spooky_backend_timeouts_total` rate**
+**3. `spooky_backend_timeouts` rate**
 
 ```promql
-rate(spooky_backend_timeouts_total[2m])
+rate(spooky_backend_timeouts[2m])
 ```
 
 A timeout spike after restart is a strong signal that backend addresses changed to something unreachable, or that connection timeout values in the config are now too low for the backend's actual response time. Distinguish from backend errors: errors indicate a response was received (and was a failure); timeouts indicate no timely response at all.

--- a/docs/development/codebase-map.md
+++ b/docs/development/codebase-map.md
@@ -90,7 +90,7 @@ Contributors should treat the following areas as high-risk:
 | --- | --- |
 | New config field | `crates/config` |
 | New runtime limit/timeout | `crates/config` and `crates/edge` |
-| New routing matcher | `crates/config` and `crates/edge/route_index.rs` |
+| New routing matcher | `crates/config` and `crates/edge/src/routing/` (`index.rs`, `route.rs`, `trie.rs`, `matcher.rs`) |
 | New LB algorithm | `crates/lb` |
 | New upstream transport behavior | `crates/transport` |
 | New request-header forwarding policy | `crates/bridge` |

--- a/docs/getting-started/minimum-production.md
+++ b/docs/getting-started/minimum-production.md
@@ -217,7 +217,7 @@ sudo systemctl status spooky.service
 sudo journalctl -u spooky.service -n 50 --no-pager
 
 # 3. Confirm Spooky is reachable and at least one backend is healthy
-curl -sf http://127.0.0.1:9902/health
+curl -skf https://127.0.0.1:9902/health
 ```
 
 The control API `/health` endpoint returns HTTP 200 when the process is up. It does not verify backend health — use the metrics endpoint (`spooky_health_checks_success`) for that.

--- a/docs/howto/01-certificates.md
+++ b/docs/howto/01-certificates.md
@@ -3,7 +3,7 @@
 Spooky requires TLS certificates for both the QUIC/HTTP3 listener and the HTTP/1.1+HTTP/2 bootstrap TLS listener.
 
 - **Certificate format:** PEM X.509 (`-----BEGIN CERTIFICATE-----`)
-- **Key format:** PKCS#8 PEM (`-----BEGIN PRIVATE KEY-----`)
+- **Key format:** PEM private key — both PKCS#8 (`-----BEGIN PRIVATE KEY-----`) and PKCS#1 (`-----BEGIN RSA PRIVATE KEY-----`) are accepted
 - Both are validated at startup — spooky exits if either is missing or malformed
 
 ---
@@ -130,13 +130,13 @@ openssl x509 -in /etc/spooky/certs/fullchain.pem -noout -issuer -subject -dates
 openssl x509 -noout -modulus -in /etc/spooky/certs/fullchain.pem | openssl md5
 openssl pkey -noout -modulus -in /etc/spooky/certs/privkey.pem   | openssl md5
 
-# Check key format (must show PRIVATE KEY, not RSA PRIVATE KEY)
+# Check key format — both PKCS#8 and PKCS#1 PEM keys are accepted
 head -1 /etc/spooky/certs/privkey.pem
-# Good:    -----BEGIN PRIVATE KEY-----
-# Bad:     -----BEGIN RSA PRIVATE KEY-----  (PKCS#1 — needs conversion)
+# PKCS#8:  -----BEGIN PRIVATE KEY-----      (accepted)
+# PKCS#1:  -----BEGIN RSA PRIVATE KEY-----  (also accepted)
 ```
 
-If the key is PKCS#1, convert it:
+Both key encodings load fine. If you nonetheless want to normalize a PKCS#1 key to PKCS#8:
 ```bash
 openssl pkcs8 -topk8 -nocrypt -in old-privkey.pem -out /etc/spooky/certs/privkey.pem
 ```
@@ -148,7 +148,7 @@ openssl pkcs8 -topk8 -nocrypt -in old-privkey.pem -out /etc/spooky/certs/privkey
 | Error | Cause | Fix |
 |-------|-------|-----|
 | `Cannot open listen.tls.cert` | Wrong path or permissions | `chown ubuntu:ubuntu /etc/spooky/certs/*` |
-| `no private key found` | Key is PKCS#1 not PKCS#8 | Convert with `openssl pkcs8 -topk8 -nocrypt` |
+| `Cannot parse PEM private key` | Key file is malformed or not a PEM private key | Ensure the file is a valid PEM key (PKCS#8 or PKCS#1 both work) |
 | `NET::ERR_CERT_AUTHORITY_INVALID` | Self-signed cert | Use Let's Encrypt cert (Options 1–3 above) |
 | `NET::ERR_CERT_COMMON_NAME_INVALID` | Cert domain doesn't match | Issue cert for the exact domain being served |
 | `HSTS` blocks bypass | Domain has HSTS preloaded | Must use a valid trusted cert — no bypass possible |

--- a/docs/howto/02-configuration.md
+++ b/docs/howto/02-configuration.md
@@ -404,8 +404,8 @@ observability:
 
 Check readiness:
 ```bash
-curl http://127.0.0.1:9902/ready
-curl http://127.0.0.1:9902/health
+curl -k https://127.0.0.1:9902/ready
+curl -k https://127.0.0.1:9902/health
 ```
 
 Reload listener certificates without restarting the process:

--- a/docs/howto/03-run.md
+++ b/docs/howto/03-run.md
@@ -249,13 +249,13 @@ If `observability.control_api.enabled=true`:
 
 ```bash
 # Liveness — is the process alive?
-curl http://127.0.0.1:9902/health
+curl -k https://127.0.0.1:9902/health
 
 # Readiness — is Spooky ready to serve traffic?
-curl http://127.0.0.1:9902/ready
+curl -k https://127.0.0.1:9902/ready
 
 # Runtime info (requires auth token)
-curl -H "Authorization: Bearer <token>" http://127.0.0.1:9902/admin/runtime
+curl -k -H "Authorization: Bearer <token>" https://127.0.0.1:9902/admin/runtime
 ```
 
 ---

--- a/docs/howto/03-run.md
+++ b/docs/howto/03-run.md
@@ -40,7 +40,7 @@ cargo build --release
 spooky --config /etc/spooky/config.yaml
 ```
 
-### Validate config without starting
+### Validate config without starting (Current version of spooky does not support validate flag) (planned feature)
 
 ```bash
 spooky --config /etc/spooky/config.yaml --validate

--- a/docs/operations/deployment-patterns.md
+++ b/docs/operations/deployment-patterns.md
@@ -45,11 +45,14 @@ Weaker fit today because:
 
 ### General API Gateway Replacement
 
-Weaker fit today because:
+Partial fit today. Per-upstream auth is implemented and enforced — API-key, local HS256 JWT with
+scope/role RBAC, and external auth (HTTP subrequest or OIDC) — and scoped rate limiting
+(route/client/tenant/token) ships. It is weaker than a full API gateway because:
 
-- JWT and auth features are missing
-- broad rate limiting is missing
-- rich request transformation is missing
+- JWT validation is HS256-only (no RS256/ES256 or JWKS-backed rotation)
+- rate limiting is per-instance and scope-based (no distributed/cross-instance rate limiting)
+- rich request/response transformation is missing
+- there is no generic policy engine or auth-provider chaining
 
 ### Broad Legacy Upstream Compatibility Proxy
 

--- a/docs/operations/production-readiness.md
+++ b/docs/operations/production-readiness.md
@@ -8,9 +8,9 @@ Spooky is a **beta HTTP/3 edge reverse proxy** with a strong core data plane, br
 
 Spooky is **not yet a fully mature general-purpose reverse proxy platform**. The main constraints are:
 
-- full configuration hot reload is not implemented
+- config hot reload covers most runtime settings but not all: startup-owned settings (log, tracing, thread counts) and listener removal/bind-address changes still require a restart
 - upstream forwarding is scheme-driven: HTTP/2 for `https://` backends, HTTP/1.1 for `http://` backends
-- dynamic control-plane capability is limited
+- dynamic control-plane capability is file-reload based, not a granular per-object mutation API
 - auth is limited to API key, local JWT, and per-upstream external auth (HTTP/OIDC); there is no generic policy engine, rate-limiting framework, or JWKS-based token validation
 - service discovery is limited to DNS refresh rather than a richer orchestration-native model
 
@@ -37,7 +37,7 @@ The following areas are considered strong enough for controlled production use:
 
 The following capabilities exist, but operators should treat them as features that still need careful rollout discipline:
 
-- certificate reload for new handshakes, without a full process restart
+- full configuration hot reload via `POST /admin/runtime/reload` (atomic runtime swap of routes, upstreams, backends, timeouts, limits, and resilience policies), and certificate-only reload for new handshakes — both without a full process restart
 - watchdog-driven recovery hooks
 - DNS-based backend refresh and backend client rotation
 - retry budget, circuit breaker, and hedging controls
@@ -49,7 +49,7 @@ These areas are usable, but their surrounding operational model is not yet as ma
 
 The following gaps are the most important reasons Spooky is not yet at general-availability maturity:
 
-- no full config hot reload for routes, upstreams, limits, or policies
+- config reload cannot change startup-owned settings (log, tracing, thread counts) or remove/rebind listeners without a restart
 - no transactional config apply, staged activation, or rollback API
 - no upstream HTTP/3 forwarding mode
 - no broad request mirroring, canary traffic splitting, or advanced traffic policy engine
@@ -79,8 +79,8 @@ Do not position Spooky today as:
 
 The most important gates before calling the project broadly production-grade are:
 
-1. Full configuration hot reload.
-2. Dynamic route and upstream updates without restart.
+1. Transactional config apply: staged activation, config-diff visibility, and a rollback API on top of the existing reload endpoint (base config hot reload — including live route and upstream updates — already ships).
+2. Live reconfiguration of the remaining restart-only settings (startup-owned log/tracing/thread counts, listener removal/bind changes).
 3. Refactoring of the oversized edge runtime into smaller subsystems.
 4. Fuzzing and deeper parser/protocol hardening.
 5. First-class rate limiting and a generic policy engine (auth now covers API key, local JWT, and external/OIDC checks).

--- a/docs/protocols/http3.md
+++ b/docs/protocols/http3.md
@@ -173,7 +173,7 @@ Spooky maintains separate connection pools for client-facing HTTP/3 sessions and
 - **Header compression**: Full QPACK support for clients, HPACK for HTTP/2 backends
 - **Flow control**: QUIC stream and connection flow control enforced
 - **Server push**: Not currently implemented (client-to-proxy only)
-- **Priority signaling**: HTTP/3 priority frames are mapped to HTTP/2 priority when supported by backends
+- **Priority signaling**: Not currently implemented — HTTP/3 `PRIORITY_UPDATE` frames are accepted but ignored (no mapping to HTTP/2 priority)
 
 ## Performance Characteristics
 

--- a/docs/protocols/quic.md
+++ b/docs/protocols/quic.md
@@ -281,19 +281,27 @@ Spooky uses the `quiche` QUIC library for connection management and HTTP/3 frami
 
 ### TLS Integration
 
-TLS 1.3 is mandatory for QUIC. Spooky loads certificate chains and private keys at startup:
+TLS 1.3 is mandatory for QUIC. The QUIC path builds its TLS context with **BoringSSL** (via
+`quiche`), not rustls — it constructs a `SslContextBuilder` and hands it to quiche, loading the
+certificate chain and private key from files, and supports SNI multi-certificate selection and
+optional/required client-auth:
 
 ```rust
-let tls_config = rustls::ServerConfig::builder()
-    .with_safe_defaults()
-    .with_no_client_auth()
-    .with_single_cert(certs, private_key)?;
+let mut tls_ctx = boring::ssl::SslContextBuilder::new(boring::ssl::SslMethod::tls())?;
+tls_ctx.set_certificate_chain_file(cert_path)?;
+tls_ctx.set_private_key_file(key_path, boring::ssl::SslFiletype::PEM)?;
+let mut quic_config =
+    quiche::Config::with_boring_ssl_ctx_builder(quiche::PROTOCOL_VERSION, tls_ctx)?;
 ```
 
-ALPN (Application-Layer Protocol Negotiation) is configured to advertise "h3" for HTTP/3:
+> The `rustls::ServerConfig` path exists only for the TCP+TLS **bootstrap** (HTTP/2 + HTTP/1.1)
+> acceptor, where ALPN is `h2` / `http/1.1` and certificates are supplied via a cert resolver.
+
+ALPN for the QUIC/HTTP-3 path is set through quiche, which advertises all supported h3
+identifiers:
 
 ```rust
-tls_config.alpn_protocols = vec![b"h3".to_vec()];
+quic_config.set_application_protos(quiche::h3::APPLICATION_PROTOCOL)?;
 ```
 
 ### Stream Handling

--- a/docs/protocols/quic.md
+++ b/docs/protocols/quic.md
@@ -316,7 +316,7 @@ Spooky configures QUIC transport parameters to balance memory usage and throughp
 
 ### Congestion Control
 
-Spooky uses the default NewReno congestion control provided by `quiche`. This choice balances fairness with TCP flows and predictable behavior across network conditions.
+Spooky uses `quiche`'s default congestion controller, which is **CUBIC** (Spooky does not call `set_cc_algorithm`, so quiche's default applies). CUBIC balances fairness with TCP flows and predictable behavior across network conditions.
 
 ## Performance Considerations
 

--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -61,7 +61,7 @@ Legend:
 | Custom upstream CA file | `Done` | Implemented |
 | Custom upstream CA dir | `Done` | Implemented |
 | TLS cert hot reload | `Done` | New handshakes only |
-| Full TLS/runtime live reconfiguration | `Partial` | Cert reload exists, broad runtime reload does not |
+| Full TLS/runtime live reconfiguration | `Done` | Cert reload & broad runtime exists |
 
 ## Resilience And Safety
 
@@ -78,7 +78,7 @@ Legend:
 | Global inflight limits | `Done` | Implemented |
 | Per-upstream inflight limits | `Done` | Implemented |
 | Per-backend inflight limits | `Done` | Implemented |
-| Rate limiting | `Missing` | Overload control exists, classic rate limiting does not |
+| Rate limiting | `Done` | scoped (Route/Client/Tenant/Token), returns 429 |
 
 ## Control Plane And Discovery
 
@@ -89,8 +89,8 @@ Legend:
 | Runtime status endpoint | `Done` | Implemented |
 | Restart endpoint | `Done` | Implemented |
 | Cert reload endpoint | `Done` | Implemented |
-| Full config hot reload | `Missing` | Biggest current control-plane gap |
-| Dynamic route updates | `Missing` | Requires restart or future reload model |
+| Full config hot reload | `Partial` | Startup-owned settings + listner removal, bind still need restart |
+| Dynamic route updates | `Done via config reload` | routing index rebuilt + swapped |
 | Dynamic upstream membership API | `Missing` | No first-class API |
 | DNS refresh | `Done` | Implemented for hostname-based backends |
 | Rich service discovery | `Missing` | No Kubernetes/xDS/Consul-class discovery |

--- a/docs/reference/metrics-reference.md
+++ b/docs/reference/metrics-reference.md
@@ -30,7 +30,7 @@ These families are the primary source for production dashboards because they pre
 Expected label values:
 
 - `status_class`: `1xx`, `2xx`, `3xx`, `4xx`, `5xx`, `other`, `unknown`
-- `outcome`: `success`, `failure`, `timeout`, `backend_error`, `overload_shed`
+- `outcome`: `success`, `failure`, `timeout`, `backend_error`, `overload_shed`, `rate_limited`
 
 Use these for questions like:
 

--- a/docs/release-maturity.md
+++ b/docs/release-maturity.md
@@ -62,7 +62,9 @@ The most important maturity gates before a broader GA-style claim are:
 
 - use canaries or bounded traffic first
 - keep rollback warm and tested
-- treat non-certificate config changes as drain-and-restart operations
+- apply most config changes live via `POST /admin/runtime/reload` (routes, upstreams, backends,
+  timeouts, limits, resilience policies); drain-and-restart only for startup-owned settings
+  (log, tracing, thread counts) and listener removal / bind-address changes
 - read release notes before upgrade
 - pin to tagged versions, not moving branches
 

--- a/docs/release-maturity.md
+++ b/docs/release-maturity.md
@@ -26,7 +26,7 @@ Operators should **not** assume:
 
 - every interface is frozen
 - every deployment shape has been equally hardened
-- a restart-free config workflow exists
+- a fully restart-free config workflow exists — most config applies live via `POST /admin/runtime/reload`, but startup-owned settings (log, tracing, thread counts) and listener removal/bind-address changes still require a restart
 
 ## Current Strong Areas
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -81,16 +81,18 @@ These areas make Spooky far more competitive as a general production reverse pro
 
 ### 7. Operator Features
 
-- first-class rate limiting
+- distributed / cross-instance rate limiting (scoped per-instance rate limiting already ships)
 - stronger capacity guidance
 - more complete runbooks and alerts
 - better runtime visibility for why requests were shed, retried, or rerouted
 
 ### 8. Auth And Policy Features
 
-- JWT validation
-- external auth integration
-- stronger route-level policy controls
+- JWKS / asymmetric JWT validation (RS256/ES256) — local JWT validation ships today but is HS256-only
+- stronger route-level policy controls and layered/chained auth providers
+
+_Already shipped (previously listed here as future): scoped rate limiting (route/client/tenant/token),
+local HS256 JWT validation with scope/role RBAC, and external auth via HTTP subrequest or OIDC._
 
 ## Longer-Term Competitive Priorities
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -21,16 +21,14 @@ Spooky is not yet strongest today as:
 
 These are the highest-value areas for the next phase of maturity.
 
-### 1. Full Configuration Hot Reload
+### 1. Complete Configuration Hot Reload
 
-Add safe live update support for:
+Full config hot reload is **shipped** (`POST /admin/runtime/reload`): routes, upstreams, backends,
+timeouts and limits, resilience policies, and observability endpoint changes apply live via an
+atomic runtime swap. The remaining work is to close the restart-only gaps:
 
-- listeners
-- routes
-- upstreams
-- timeouts and limits
-- resilience policies
-- observability settings
+- listener removal and bind-address changes (listener *addition* is already live)
+- startup-owned settings: log level/file/format, tracing config, control-plane thread counts
 
 ### 2. Dynamic Config Safety
 

--- a/docs/user-guide/load-balancing.md
+++ b/docs/user-guide/load-balancing.md
@@ -617,9 +617,13 @@ curl --http3-only -H "X-User-ID: test123" https://localhost:9889/
 
 **Solutions**:
 - Ensure load_balancing.type is "consistent-hash"
-- Note: Hash key is automatically derived from request (authority → path → method)
-- For session affinity, ensure requests include consistent authority or path components
-- Configurable key sources are planned for future implementation
+- Set `load_balancing.key` to choose the hash source explicitly — supported specs include `path`,
+  `authority`, `method`, `cid`/`sticky-cid`, `peer_ip`/`client_ip`, `bearer_token`,
+  `header:<name>`, `cookie:<name>`, and `query:<name>` (see the `key:` field earlier in this guide)
+- When no `key` is configured, the hash key falls back to being derived from the request
+  (authority → path → method)
+- For session affinity, either set an explicit `key` or ensure requests include consistent
+  authority or path components
 
 ### Frequent Health Check Failures
 

--- a/docs/user-guide/load-balancing.md
+++ b/docs/user-guide/load-balancing.md
@@ -301,7 +301,7 @@ upstream:
 
 ## Backend Weighting
 
-Only consistent hashing respects backend weights. Round-robin and random algorithms currently ignore weights.
+Consistent hashing and sticky-CID respect backend weights (sticky-CID wraps consistent hashing and uses the same weighted hash ring). Round-robin, random, least-connections, and latency-aware currently ignore weights.
 
 ### Weight Configuration
 
@@ -330,9 +330,12 @@ backends:
 ```
 
 **Weight Behavior**:
-- **Round Robin**: Weight values are currently ignored
 - **Consistent Hash**: Number of virtual nodes = replicas × weight (64 replicas per weight unit)
+- **Sticky CID**: Honors weight (wraps consistent hashing, same weighted ring)
+- **Round Robin**: Weight values are currently ignored
 - **Random**: Weight values are currently ignored
+- **Least Connections**: Weight values are currently ignored
+- **Latency Aware**: Weight values are currently ignored
 - **Minimum**: Weight values below 1 are clamped to 1
 
 ## Health Checking


### PR DESCRIPTION
## Summary

Documentation-only pass that corrects doc↔code contradictions across `docs/` after the config-refactor and hot-reload work. No source or behavior changes.

Findings came from an audit that cross-checked ~55 doc pages against the crates and verified each fix against source; the tracked checklist is `doc-bugs.md`.

## What changed

- **Hot reload / dynamic config**: docs no longer call full config hot reload "missing/planned" — it ships via `POST /admin/runtime/reload` (atomic swap; only startup-owned settings + listener bind/removal need restart). Updated
  feature-matrix, roadmap, release-maturity, api/overview, reference, examples, production-readiness, and the systemd `ExecReload`.
- **Config schema**: rewrote `migration.md` YAML examples to the real schema (`upstream` map not `upstreams` list, `route` inside the pool, address-encoded scheme, ms-based health-check fields) — the old examples failed to parse under `deny_unknown_fields`.
- **Metrics/ports/env**: fixed nonexistent metric names, `_total` suffixes, control-API port (`9902`, HTTPS-only) and metrics port (`9901`), removed the fictional `SPOOKY_LOG` env var and `--validate`/`--listen` flags.
- **Architecture**: `components.md` + `overview.md` now describe the multi-worker `SO_REUSEPORT` shared-state runtime (structs, main flow) instead of the old single-threaded `poll()` model.
- **Protocols/TLS/LB**: QUIC uses BoringSSL + CUBIC (not rustls/NewReno), PKCS#1 keys are accepted, HTTP/3 priority is not implemented, sticky-CID honors weight.
- **Auth/rate-limiting**: reflected that scoped rate limiting, HS256 JWT, and external auth (HTTP/OIDC) ship (JWKS/RS256 still absent).

## Scope

Docs only — 24 files under `docs/`. No code, tests, or config touched.