### PR TITLE
test: add unit tests for config, routing, and fundamental blocks

### DIFF
--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -1292,3 +1292,65 @@ impl Default for RoutingTransparency {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Config;
+
+    #[test]
+    fn minimal_yaml_applies_documented_defaults() {
+        let yaml = r#"
+listen:
+  tls: {}
+upstream:
+  api:
+    route: {}
+    backends:
+      - id: backend1
+        address: "http://127.0.0.1:7001"
+"#;
+
+        let config: Config = serde_yaml::from_str(yaml).expect("minimal config should parse");
+        let upstream = config.upstream.get("api").expect("missing api upstream");
+        let backend = upstream
+            .backends
+            .first()
+            .expect("missing backend in minimal config");
+
+        assert_eq!(config.version, 1);
+        assert_eq!(config.listen.protocol, "http3");
+        assert_eq!(config.listen.port, 9889);
+        assert_eq!(config.listen.address, "0.0.0.0");
+        assert_eq!(config.log.level, "info");
+        assert_eq!(backend.weight, 100);
+    }
+
+    #[test]
+    fn backend_health_check_defaults_are_filled_by_serde() {
+        let yaml = r#"
+listen:
+  tls: {}
+upstream:
+  api:
+    route: {}
+    backends:
+      - id: backend1
+        address: "http://127.0.0.1:7001"
+        health_check: {}
+"#;
+
+        let config: Config =
+            serde_yaml::from_str(yaml).expect("config with empty health_check should parse");
+        let health_check = config.upstream["api"].backends[0]
+            .health_check
+            .as_ref()
+            .expect("missing defaulted health check");
+
+        assert_eq!(health_check.path, "/health");
+        assert_eq!(health_check.interval, 5_000);
+        assert_eq!(health_check.timeout_ms, 1_000);
+        assert_eq!(health_check.failure_threshold, 3);
+        assert_eq!(health_check.success_threshold, 2);
+        assert_eq!(health_check.cooldown_ms, 5_000);
+    }
+}

--- a/crates/config/src/default.rs
+++ b/crates/config/src/default.rs
@@ -219,40 +219,6 @@ pub fn perf_default_quic_initial_max_streams_bidi() -> u64 {
     100
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::config::LogFormat;
-
-    #[test]
-    fn documented_scalar_defaults_match_contract() {
-        assert_eq!(get_default_version(), 1);
-        assert_eq!(get_default_protocol(), "http3");
-        assert_eq!(get_default_port(), 9889);
-        assert_eq!(get_default_address(), "0.0.0.0");
-        assert_eq!(get_default_weight(), 100);
-        assert_eq!(get_default_path(), "/health");
-        assert_eq!(get_default_interval(), 5_000);
-        assert_eq!(get_default_health_timeout(), 1_000);
-        assert_eq!(get_default_failure_threshold(), 3);
-        assert_eq!(get_default_success_threshold(), 2);
-        assert_eq!(get_default_log_level(), "info");
-    }
-
-    #[test]
-    fn documented_composite_defaults_match_contract() {
-        let load_balancing = get_default_load_balancing();
-        assert_eq!(load_balancing.lb_type, "round-robin");
-        assert_eq!(load_balancing.key, None);
-
-        let log = get_default_log();
-        assert_eq!(log.level, "info");
-        assert!(!log.file.enabled);
-        assert_eq!(log.file.path, "/var/log/spooky/spooky.log");
-        assert_eq!(log.format, LogFormat::Plain);
-    }
-}
-
 pub fn perf_default_quic_initial_max_streams_uni() -> u64 {
     100
 }
@@ -504,3 +470,40 @@ pub fn upstream_tls_default_verify_certificates() -> bool {
 pub fn upstream_tls_default_strict_sni() -> bool {
     true
 }
+
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::LogFormat;
+
+    #[test]
+    fn documented_scalar_defaults_match_contract() {
+        assert_eq!(get_default_version(), 1);
+        assert_eq!(get_default_protocol(), "http3");
+        assert_eq!(get_default_port(), 9889);
+        assert_eq!(get_default_address(), "0.0.0.0");
+        assert_eq!(get_default_weight(), 100);
+        assert_eq!(get_default_path(), "/health");
+        assert_eq!(get_default_interval(), 5_000);
+        assert_eq!(get_default_health_timeout(), 1_000);
+        assert_eq!(get_default_failure_threshold(), 3);
+        assert_eq!(get_default_success_threshold(), 2);
+        assert_eq!(get_default_log_level(), "info");
+    }
+
+    #[test]
+    fn documented_composite_defaults_match_contract() {
+        let load_balancing = get_default_load_balancing();
+        assert_eq!(load_balancing.lb_type, "round-robin");
+        assert_eq!(load_balancing.key, None);
+
+        let log = get_default_log();
+        assert_eq!(log.level, "info");
+        assert!(!log.file.enabled);
+        assert_eq!(log.file.path, "/var/log/spooky/spooky.log");
+        assert_eq!(log.format, LogFormat::Plain);
+    }
+}
+

--- a/crates/config/src/default.rs
+++ b/crates/config/src/default.rs
@@ -219,6 +219,40 @@ pub fn perf_default_quic_initial_max_streams_bidi() -> u64 {
     100
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::LogFormat;
+
+    #[test]
+    fn documented_scalar_defaults_match_contract() {
+        assert_eq!(get_default_version(), 1);
+        assert_eq!(get_default_protocol(), "http3");
+        assert_eq!(get_default_port(), 9889);
+        assert_eq!(get_default_address(), "0.0.0.0");
+        assert_eq!(get_default_weight(), 100);
+        assert_eq!(get_default_path(), "/health");
+        assert_eq!(get_default_interval(), 5_000);
+        assert_eq!(get_default_health_timeout(), 1_000);
+        assert_eq!(get_default_failure_threshold(), 3);
+        assert_eq!(get_default_success_threshold(), 2);
+        assert_eq!(get_default_log_level(), "info");
+    }
+
+    #[test]
+    fn documented_composite_defaults_match_contract() {
+        let load_balancing = get_default_load_balancing();
+        assert_eq!(load_balancing.lb_type, "round-robin");
+        assert_eq!(load_balancing.key, None);
+
+        let log = get_default_log();
+        assert_eq!(log.level, "info");
+        assert!(!log.file.enabled);
+        assert_eq!(log.file.path, "/var/log/spooky/spooky.log");
+        assert_eq!(log.format, LogFormat::Plain);
+    }
+}
+
 pub fn perf_default_quic_initial_max_streams_uni() -> u64 {
     100
 }

--- a/crates/config/src/default.rs
+++ b/crates/config/src/default.rs
@@ -471,8 +471,6 @@ pub fn upstream_tls_default_strict_sni() -> bool {
     true
 }
 
-
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -506,4 +504,3 @@ mod tests {
         assert_eq!(log.format, LogFormat::Plain);
     }
 }
-

--- a/crates/edge/src/body.rs
+++ b/crates/edge/src/body.rs
@@ -90,14 +90,8 @@ mod tests {
 
     #[test]
     fn channel_body_error_type_is_infallible() {
+        // Compile-time proof that ChannelBody implements the expected Body associated types.
         fn assert_body_error_type<B: Body<Data = Bytes, Error = Infallible>>() {}
         assert_body_error_type::<ChannelBody>();
-
-        let (_tx, mut body) = ChannelBody::channel(1);
-        let _typed: fn(
-            Pin<&mut ChannelBody>,
-            &mut std::task::Context<'_>,
-        ) -> std::task::Poll<Option<Result<Frame<Bytes>, Infallible>>> = ChannelBody::poll_frame;
-        let _ = &mut body;
     }
 }

--- a/crates/edge/src/body.rs
+++ b/crates/edge/src/body.rs
@@ -40,11 +40,11 @@ impl Body for ChannelBody {
 
 #[cfg(test)]
 mod tests {
-    use std::{convert::Infallible, pin::Pin};
+    use std::convert::Infallible;
 
     use bytes::Bytes;
     use http_body_util::BodyExt;
-    use hyper::body::{Body, Frame};
+    use hyper::body::Body;
 
     use super::ChannelBody;
 

--- a/crates/edge/src/body.rs
+++ b/crates/edge/src/body.rs
@@ -37,3 +37,67 @@ impl Body for ChannelBody {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{convert::Infallible, pin::Pin};
+
+    use bytes::Bytes;
+    use http_body_util::BodyExt;
+    use hyper::body::{Body, Frame};
+
+    use super::ChannelBody;
+
+    #[tokio::test]
+    async fn channel_body_yields_chunks_in_send_order() {
+        let (tx, mut body) = ChannelBody::channel(4);
+        tx.send(Bytes::from_static(b"first"))
+            .await
+            .expect("send first chunk");
+        tx.send(Bytes::from_static(b"second"))
+            .await
+            .expect("send second chunk");
+        drop(tx);
+
+        let first = body
+            .frame()
+            .await
+            .expect("first frame should exist")
+            .expect("first frame should be ok");
+        assert_eq!(
+            first.into_data().expect("first data frame"),
+            Bytes::from("first")
+        );
+
+        let second = body
+            .frame()
+            .await
+            .expect("second frame should exist")
+            .expect("second frame should be ok");
+        assert_eq!(
+            second.into_data().expect("second data frame"),
+            Bytes::from("second")
+        );
+    }
+
+    #[tokio::test]
+    async fn dropping_sender_yields_eof() {
+        let (tx, mut body) = ChannelBody::channel(1);
+        drop(tx);
+
+        assert!(body.frame().await.is_none());
+    }
+
+    #[test]
+    fn channel_body_error_type_is_infallible() {
+        fn assert_body_error_type<B: Body<Data = Bytes, Error = Infallible>>() {}
+        assert_body_error_type::<ChannelBody>();
+
+        let (_tx, mut body) = ChannelBody::channel(1);
+        let _typed: fn(
+            Pin<&mut ChannelBody>,
+            &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Option<Result<Frame<Bytes>, Infallible>>> = ChannelBody::poll_frame;
+        let _ = &mut body;
+    }
+}

--- a/crates/edge/src/hash.rs
+++ b/crates/edge/src/hash.rs
@@ -34,3 +34,60 @@ pub fn stable_hash_socket_addr(addr: &SocketAddr) -> u64 {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+
+    use super::{stable_hash_socket_addr, stable_hash64};
+
+    #[test]
+    fn stable_hash64_matches_known_fnv1a_vectors() {
+        let cases = [
+            (b"" as &[u8], 0xcbf2_9ce4_8422_2325u64),
+            (b"a" as &[u8], 0xaf63_dc4c_8601_ec8cu64),
+            (b"foobar" as &[u8], 0x8594_4171_f739_67e8u64),
+            (b"hello world" as &[u8], 0x779a_65e7_023c_d2e7u64),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(
+                stable_hash64(input),
+                expected,
+                "FNV-1a mismatch for {:?}",
+                input
+            );
+        }
+    }
+
+    #[test]
+    fn stable_hash_socket_addr_is_deterministic_for_ipv4_and_ipv6() {
+        let ipv4 = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8443));
+        let ipv6 = SocketAddr::V6(SocketAddrV6::new(
+            Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1),
+            8443,
+            7,
+            3,
+        ));
+
+        assert_eq!(
+            stable_hash_socket_addr(&ipv4),
+            stable_hash_socket_addr(&ipv4)
+        );
+        assert_eq!(
+            stable_hash_socket_addr(&ipv6),
+            stable_hash_socket_addr(&ipv6)
+        );
+    }
+
+    #[test]
+    fn stable_hash_socket_addr_distinguishes_ipv4_from_ipv6() {
+        let ipv4 = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8443));
+        let ipv6 = SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::LOCALHOST, 8443, 0, 0));
+
+        assert_ne!(
+            stable_hash_socket_addr(&ipv4),
+            stable_hash_socket_addr(&ipv6)
+        );
+    }
+}

--- a/crates/edge/src/quic_listener/forwarding/stream_progress.rs
+++ b/crates/edge/src/quic_listener/forwarding/stream_progress.rs
@@ -547,110 +547,106 @@ impl QUICListener {
                                 req.response_headers_sent = true;
                                 req.phase = StreamPhase::SendingResponse;
                                 req.response_status = Some(status.as_u16());
-                            } else {
-                                let (chunk_tx, chunk_rx) =
-                                    mpsc::channel::<ResponseChunk>(RESPONSE_CHUNK_CHANNEL_CAPACITY);
-                                let fail_tx = chunk_tx.clone();
-                                let deferred_status = status;
-                                let deferred_headers = owned_h3_headers.clone();
-                                let tunnel_mode = tunnel_response;
-                                let progressive_emission_allowed =
-                                    progressive_body_emission_allowed;
-                                let fut = async move {
-                                    use http_body_util::BodyExt;
-                                    let Some(mut body) = response_body else {
-                                        let _ = chunk_tx
-                                            .send(ResponseChunk::Error(ProxyError::Transport(
-                                                "non-tunnel responses must carry an HTTP body stream"
-                                                    .into(),
-                                            )))
-                                            .await;
-                                        return;
+                            }
+                        } else {
+                            let (chunk_tx, chunk_rx) =
+                                mpsc::channel::<ResponseChunk>(RESPONSE_CHUNK_CHANNEL_CAPACITY);
+                            let fail_tx = chunk_tx.clone();
+                            let deferred_status = status;
+                            let deferred_headers = owned_h3_headers.clone();
+                            let tunnel_mode = tunnel_response;
+                            let progressive_emission_allowed = progressive_body_emission_allowed;
+                            let fut = async move {
+                                use http_body_util::BodyExt;
+                                let Some(mut body) = response_body else {
+                                    let _ = chunk_tx
+                                        .send(ResponseChunk::Error(ProxyError::Transport(
+                                            "non-tunnel responses must carry an HTTP body stream"
+                                                .into(),
+                                        )))
+                                        .await;
+                                    return;
+                                };
+                                let body_started_at = tokio::time::Instant::now();
+                                let mut last_body_progress_at = body_started_at;
+                                let mut response_bytes_received: usize = 0;
+                                let mut prebuffered_bytes: usize = 0;
+                                let mut buffered_chunks: Vec<Bytes> = Vec::new();
+                                let mut buffered_trailers: Option<Vec<(Vec<u8>, Vec<u8>)>> = None;
+                                loop {
+                                    let wait_decision = checked_response_body_guardrails(
+                                        response_guardrails,
+                                        ResponseBodyGuardrailInput {
+                                            elapsed: body_started_at.elapsed(),
+                                            idle_for: last_body_progress_at.elapsed(),
+                                            bytes_received: response_bytes_received,
+                                            prebuffered_bytes,
+                                            next_chunk_bytes: 0,
+                                            declared_content_length: upstream_content_length,
+                                            headers_emitted: !defer_headers_until_body_validated,
+                                            progressive_emission_allowed,
+                                            body_forwarding_enabled,
+                                            exempt_from_body_size_cap: tunnel_mode,
+                                        },
+                                    );
+                                    let streaming = match wait_decision {
+                                        Ok(evaluated) => evaluated.streaming,
+                                        other => {
+                                            if let Err(other) = other
+                                                && let Some(err) =
+                                                    response_body_guardrail_error(other)
+                                            {
+                                                let _ =
+                                                    chunk_tx.send(ResponseChunk::Error(err)).await;
+                                            }
+                                            return;
+                                        }
                                     };
-                                    let body_started_at = tokio::time::Instant::now();
-                                    let mut last_body_progress_at = body_started_at;
-                                    let mut response_bytes_received: usize = 0;
-                                    let mut prebuffered_bytes: usize = 0;
-                                    let mut buffered_chunks: Vec<Bytes> = Vec::new();
-                                    let mut buffered_trailers: Option<Vec<(Vec<u8>, Vec<u8>)>> =
-                                        None;
-                                    loop {
-                                        let wait_decision = checked_response_body_guardrails(
-                                            response_guardrails,
-                                            ResponseBodyGuardrailInput {
-                                                elapsed: body_started_at.elapsed(),
-                                                idle_for: last_body_progress_at.elapsed(),
-                                                bytes_received: response_bytes_received,
-                                                prebuffered_bytes,
-                                                next_chunk_bytes: 0,
-                                                declared_content_length: upstream_content_length,
-                                                headers_emitted:
-                                                    !defer_headers_until_body_validated,
-                                                progressive_emission_allowed,
-                                                body_forwarding_enabled,
-                                                exempt_from_body_size_cap: tunnel_mode,
-                                            },
-                                        );
-                                        let streaming = match wait_decision {
-                                            Ok(evaluated) => evaluated.streaming,
-                                            other => {
-                                                if let Err(other) = other
-                                                    && let Some(err) =
-                                                        response_body_guardrail_error(other)
-                                                {
-                                                    let _ = chunk_tx
-                                                        .send(ResponseChunk::Error(err))
-                                                        .await;
-                                                }
-                                                return;
-                                            }
-                                        };
-                                        let frame_fut = BodyExt::frame(&mut body);
-                                        let result =
-                                            tokio::time::timeout(streaming.wait_timeout, frame_fut)
+                                    let frame_fut = BodyExt::frame(&mut body);
+                                    let result =
+                                        tokio::time::timeout(streaming.wait_timeout, frame_fut)
+                                            .await;
+                                    match result {
+                                        Err(_elapsed) => {
+                                            let _ = chunk_tx
+                                                .send(ResponseChunk::Error(ProxyError::Timeout))
                                                 .await;
-                                        match result {
-                                            Err(_elapsed) => {
-                                                let _ = chunk_tx
-                                                    .send(ResponseChunk::Error(ProxyError::Timeout))
-                                                    .await;
-                                                return;
-                                            }
-                                            Ok(Some(Ok(f))) => match f.into_data() {
+                                            return;
+                                        }
+                                        Ok(Some(Ok(f))) => {
+                                            match f.into_data() {
                                                 Ok(data) => {
                                                     if !data.is_empty() {
                                                         last_body_progress_at =
                                                             tokio::time::Instant::now();
                                                     }
-                                                    let data_decision =
-                                                        checked_response_body_guardrails(
-                                                            response_guardrails,
-                                                            ResponseBodyGuardrailInput {
-                                                                elapsed: body_started_at.elapsed(),
-                                                                idle_for: last_body_progress_at
-                                                                    .elapsed(),
-                                                                bytes_received: response_bytes_received,
-                                                                prebuffered_bytes,
-                                                                next_chunk_bytes: data.len(),
-                                                                declared_content_length: upstream_content_length,
-                                                                headers_emitted: !defer_headers_until_body_validated,
-                                                                progressive_emission_allowed,
-                                                                body_forwarding_enabled,
-                                                                exempt_from_body_size_cap: tunnel_mode,
-                                                            },
-                                                        );
+                                                    let data_decision = checked_response_body_guardrails(
+                                                    response_guardrails,
+                                                    ResponseBodyGuardrailInput {
+                                                        elapsed: body_started_at.elapsed(),
+                                                        idle_for: last_body_progress_at.elapsed(),
+                                                        bytes_received: response_bytes_received,
+                                                        prebuffered_bytes,
+                                                        next_chunk_bytes: data.len(),
+                                                        declared_content_length: upstream_content_length,
+                                                        headers_emitted: !defer_headers_until_body_validated,
+                                                        progressive_emission_allowed,
+                                                        body_forwarding_enabled,
+                                                        exempt_from_body_size_cap: tunnel_mode,
+                                                    },
+                                                );
                                                     let evaluated =
                                                         match data_decision {
                                                             Ok(evaluated) => evaluated,
                                                             other => {
                                                                 if let Err(other) = other
-                                                                && let Some(err) =
+                                                            && let Some(err) =
                                                                 response_body_guardrail_error(other)
-                                                            {
-                                                                let _ = chunk_tx
-                                                                    .send(ResponseChunk::Error(err))
-                                                                    .await;
-                                                            }
+                                                        {
+                                                            let _ = chunk_tx
+                                                                .send(ResponseChunk::Error(err))
+                                                                .await;
+                                                        }
                                                                 return;
                                                             }
                                                         };
@@ -665,20 +661,20 @@ impl QUICListener {
                                                     ) {
                                                         let chunk = data.slice(start..end);
                                                         match streaming.emission {
-                                                            ProgressiveEmissionPolicy::PrebufferUntilValidated => {
-                                                                buffered_chunks.push(chunk);
-                                                            }
-                                                            ProgressiveEmissionPolicy::StreamProgressively => {
-                                                                if chunk_tx
-                                                                    .send(ResponseChunk::Data(chunk))
-                                                                    .await
-                                                                    .is_err()
-                                                                {
-                                                                    return;
-                                                                }
-                                                            }
-                                                            ProgressiveEmissionPolicy::SuppressBody => {}
+                                                        ProgressiveEmissionPolicy::PrebufferUntilValidated => {
+                                                            buffered_chunks.push(chunk);
                                                         }
+                                                        ProgressiveEmissionPolicy::StreamProgressively => {
+                                                            if chunk_tx
+                                                                .send(ResponseChunk::Data(chunk))
+                                                                .await
+                                                                .is_err()
+                                                            {
+                                                                return;
+                                                            }
+                                                        }
+                                                        ProgressiveEmissionPolicy::SuppressBody => {}
+                                                    }
                                                     }
                                                 }
                                                 Err(frame) => {
@@ -701,74 +697,70 @@ impl QUICListener {
                                                         }
                                                     }
                                                 }
-                                            },
-                                            Ok(Some(Err(_))) => {
-                                                let _ = chunk_tx
-                                                    .send(ResponseChunk::Error(
-                                                        ProxyError::Transport(
-                                                            "upstream body error".into(),
-                                                        ),
-                                                    ))
-                                                    .await;
-                                                return;
                                             }
-                                            Ok(None) => {
-                                                if defer_headers_until_body_validated {
+                                        }
+                                        Ok(Some(Err(_))) => {
+                                            let _ = chunk_tx
+                                                .send(ResponseChunk::Error(ProxyError::Transport(
+                                                    "upstream body error".into(),
+                                                )))
+                                                .await;
+                                            return;
+                                        }
+                                        Ok(None) => {
+                                            if defer_headers_until_body_validated {
+                                                if chunk_tx
+                                                    .send(ResponseChunk::Start {
+                                                        status: deferred_status,
+                                                        headers: deferred_headers,
+                                                    })
+                                                    .await
+                                                    .is_err()
+                                                {
+                                                    return;
+                                                }
+                                                for chunk in buffered_chunks {
                                                     if chunk_tx
-                                                        .send(ResponseChunk::Start {
-                                                            status: deferred_status,
-                                                            headers: deferred_headers,
-                                                        })
+                                                        .send(ResponseChunk::Data(chunk))
                                                         .await
                                                         .is_err()
                                                     {
                                                         return;
                                                     }
-                                                    for chunk in buffered_chunks {
-                                                        if chunk_tx
-                                                            .send(ResponseChunk::Data(chunk))
-                                                            .await
-                                                            .is_err()
-                                                        {
-                                                            return;
-                                                        }
-                                                    }
                                                 }
-                                                if let Some(headers) = buffered_trailers
-                                                    && chunk_tx
-                                                        .send(ResponseChunk::Trailers { headers })
-                                                        .await
-                                                        .is_err()
-                                                {
-                                                    return;
-                                                }
-                                                let _ = chunk_tx.send(ResponseChunk::End).await;
+                                            }
+                                            if let Some(headers) = buffered_trailers
+                                                && chunk_tx
+                                                    .send(ResponseChunk::Trailers { headers })
+                                                    .await
+                                                    .is_err()
+                                            {
                                                 return;
                                             }
+                                            let _ = chunk_tx.send(ResponseChunk::End).await;
+                                            return;
                                         }
                                     }
-                                };
-                                let request_span = streams
-                                    .get(&stream_id)
-                                    .and_then(|req| req.trace_span.clone());
-                                let spawned = match request_span {
-                                    Some(span) => {
-                                        spawn_async_task(fut.instrument(span), "body-pump")
-                                    }
-                                    None => spawn_async_task(fut, "body-pump"),
-                                };
-                                if !spawned {
-                                    let _ = fail_tx.try_send(ResponseChunk::Error(
-                                        ProxyError::Transport("runtime unavailable".into()),
-                                    ));
                                 }
+                            };
+                            let request_span = streams
+                                .get(&stream_id)
+                                .and_then(|req| req.trace_span.clone());
+                            let spawned = match request_span {
+                                Some(span) => spawn_async_task(fut.instrument(span), "body-pump"),
+                                None => spawn_async_task(fut, "body-pump"),
+                            };
+                            if !spawned {
+                                let _ = fail_tx.try_send(ResponseChunk::Error(
+                                    ProxyError::Transport("runtime unavailable".into()),
+                                ));
+                            }
 
-                                if let Some(req) = streams.get_mut(&stream_id) {
-                                    req.response_chunk_rx = Some(chunk_rx);
-                                    req.response_headers_sent = !defer_headers_until_body_validated;
-                                    req.phase = StreamPhase::SendingResponse;
-                                    req.response_status = Some(status.as_u16());
-                                }
+                            if let Some(req) = streams.get_mut(&stream_id) {
+                                req.response_chunk_rx = Some(chunk_rx);
+                                req.response_headers_sent = !defer_headers_until_body_validated;
+                                req.phase = StreamPhase::SendingResponse;
+                                req.response_status = Some(status.as_u16());
                             }
                         }
 

--- a/crates/edge/src/quic_listener/forwarding/stream_progress.rs
+++ b/crates/edge/src/quic_listener/forwarding/stream_progress.rs
@@ -541,14 +541,12 @@ impl QUICListener {
                                 req.response_status = Some(status.as_u16());
                             }
                             immediate_terminal = true;
-                        } else {
-                            if let Some(chunk_rx) = prebuilt_response_chunk_rx {
-                                if let Some(req) = streams.get_mut(&stream_id) {
-                                    req.response_chunk_rx = Some(chunk_rx);
-                                    req.response_headers_sent = true;
-                                    req.phase = StreamPhase::SendingResponse;
-                                    req.response_status = Some(status.as_u16());
-                                }
+                        } else if let Some(chunk_rx) = prebuilt_response_chunk_rx {
+                            if let Some(req) = streams.get_mut(&stream_id) {
+                                req.response_chunk_rx = Some(chunk_rx);
+                                req.response_headers_sent = true;
+                                req.phase = StreamPhase::SendingResponse;
+                                req.response_status = Some(status.as_u16());
                             } else {
                                 let (chunk_tx, chunk_rx) =
                                     mpsc::channel::<ResponseChunk>(RESPONSE_CHUNK_CHANNEL_CAPACITY);

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -1739,9 +1739,45 @@ impl QUICListener {
                 .close(true, 0x1, b"http3 protocol handling error");
         }
 
-        Self::maybe_rotate_scid(&mut connection, &self.metrics);
-
         let mut send_buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
+
+        let shared_ctx = ForwardingSharedCtx {
+            metrics: Arc::clone(&self.metrics),
+            resilience: &self.resilience,
+            routing_index: &self.routing_index,
+            upstream_pools: &self.upstream_pools,
+        };
+        let exec_ctx = ForwardingExecutionCtx {
+            transport_pool: Arc::clone(&self.transport_pool),
+            backend_endpoints: Arc::clone(&self.backend_endpoints),
+            backend_resolution_store: Arc::clone(&self.backend_resolution_store),
+            upstream_inflight: &self.upstream_inflight,
+            global_inflight: Arc::clone(&self.global_inflight),
+            backend_timeout: self.backend_timeout,
+            inflight_acquire_wait: self.inflight_acquire_wait,
+        };
+        let progress_config = StreamProgressConfig {
+            backend_body_idle_timeout: self.backend_body_idle_timeout,
+            backend_body_total_timeout: self.backend_body_total_timeout,
+            max_response_body_bytes: self.max_response_body_bytes,
+            unknown_length_response_prebuffer_bytes: self.unknown_length_response_prebuffer_bytes,
+            client_body_idle_timeout: self.client_body_idle_timeout,
+            listen_port: self.config.listen.listen.port,
+        };
+
+        if !connection.quic.is_closed() {
+            Self::advance_connection_streams(
+                &self.socket,
+                &mut connection,
+                &mut send_buf,
+                &shared_ctx,
+                &exec_ctx,
+                &progress_config,
+                "packet path",
+            );
+        }
+
+        Self::maybe_rotate_scid(&mut connection, &self.metrics);
 
         Self::flush_send(&self.socket, &mut send_buf, &mut connection);
         Self::handle_timeout(&self.socket, &mut send_buf, &mut connection);
@@ -1772,6 +1808,29 @@ impl QUICListener {
 
         let mut send_buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
         let mut to_remove = Vec::new();
+        let shared_ctx = ForwardingSharedCtx {
+            metrics: Arc::clone(&self.metrics),
+            resilience: &self.resilience,
+            routing_index: &self.routing_index,
+            upstream_pools: &self.upstream_pools,
+        };
+        let exec_ctx = ForwardingExecutionCtx {
+            transport_pool: Arc::clone(&self.transport_pool),
+            backend_endpoints: Arc::clone(&self.backend_endpoints),
+            backend_resolution_store: Arc::clone(&self.backend_resolution_store),
+            upstream_inflight: &self.upstream_inflight,
+            global_inflight: Arc::clone(&self.global_inflight),
+            backend_timeout: self.backend_timeout,
+            inflight_acquire_wait: self.inflight_acquire_wait,
+        };
+        let progress_config = StreamProgressConfig {
+            backend_body_idle_timeout: self.backend_body_idle_timeout,
+            backend_body_total_timeout: self.backend_body_total_timeout,
+            max_response_body_bytes: self.max_response_body_bytes,
+            unknown_length_response_prebuffer_bytes: self.unknown_length_response_prebuffer_bytes,
+            client_body_idle_timeout: self.client_body_idle_timeout,
+            listen_port: self.config.listen.listen.port,
+        };
 
         for (scid, connection) in self.connections.iter_mut() {
             let timeout = match connection.quic.timeout() {
@@ -1801,44 +1860,15 @@ impl QUICListener {
             }
 
             // Advance in-flight streams independent of inbound packets.
-            if let Some(mut h3) = connection.h3.take() {
-                let shared_ctx = ForwardingSharedCtx {
-                    metrics: Arc::clone(&self.metrics),
-                    resilience: &self.resilience,
-                    routing_index: &self.routing_index,
-                    upstream_pools: &self.upstream_pools,
-                };
-                let exec_ctx = ForwardingExecutionCtx {
-                    transport_pool: Arc::clone(&self.transport_pool),
-                    backend_endpoints: Arc::clone(&self.backend_endpoints),
-                    backend_resolution_store: Arc::clone(&self.backend_resolution_store),
-                    upstream_inflight: &self.upstream_inflight,
-                    global_inflight: Arc::clone(&self.global_inflight),
-                    backend_timeout: self.backend_timeout,
-                    inflight_acquire_wait: self.inflight_acquire_wait,
-                };
-                let progress_config = StreamProgressConfig {
-                    backend_body_idle_timeout: self.backend_body_idle_timeout,
-                    backend_body_total_timeout: self.backend_body_total_timeout,
-                    max_response_body_bytes: self.max_response_body_bytes,
-                    unknown_length_response_prebuffer_bytes: self
-                        .unknown_length_response_prebuffer_bytes,
-                    client_body_idle_timeout: self.client_body_idle_timeout,
-                    listen_port: self.config.listen.listen.port,
-                };
-                if let Err(e) = Self::advance_streams_non_blocking(
-                    &mut connection.streams,
-                    &mut connection.quic,
-                    &mut h3,
-                    &exec_ctx,
-                    &shared_ctx,
-                    &progress_config,
-                ) {
-                    error!("advance_streams_non_blocking in timeout path: {:?}", e);
-                }
-                connection.h3 = Some(h3);
-                Self::flush_send(&self.socket, &mut send_buf, connection);
-            }
+            Self::advance_connection_streams(
+                &self.socket,
+                connection,
+                &mut send_buf,
+                &shared_ctx,
+                &exec_ctx,
+                &progress_config,
+                "timeout path",
+            );
         }
 
         sweep_closed_connections(
@@ -1863,6 +1893,33 @@ impl QUICListener {
             connection.last_activity = Instant::now();
             Self::flush_send(socket, send_buf, connection);
         }
+    }
+
+    fn advance_connection_streams(
+        socket: &UdpSocket,
+        connection: &mut QuicConnection,
+        send_buf: &mut [u8],
+        shared_ctx: &ForwardingSharedCtx<'_>,
+        exec_ctx: &ForwardingExecutionCtx<'_>,
+        progress_config: &StreamProgressConfig,
+        context: &str,
+    ) {
+        let Some(mut h3) = connection.h3.take() else {
+            return;
+        };
+
+        if let Err(e) = Self::advance_streams_non_blocking(
+            &mut connection.streams,
+            &mut connection.quic,
+            &mut h3,
+            exec_ctx,
+            shared_ctx,
+            progress_config,
+        ) {
+            error!("advance_streams_non_blocking in {}: {:?}", context, e);
+        }
+        connection.h3 = Some(h3);
+        Self::flush_send(socket, send_buf, connection);
     }
 
     fn refresh_active_connection_metric(&self) {

--- a/crates/edge/src/routing/decision.rs
+++ b/crates/edge/src/routing/decision.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RoutePreference {
     KeepCurrent,
@@ -46,5 +48,92 @@ pub fn route_preference_reason(preference: RoutePreference) -> Option<RouteDecis
             Some(RouteDecisionReason::MethodSpecificTieBreak)
         }
         RoutePreference::TakeCandidateLexicalOrder => Some(RouteDecisionReason::LexicalTieBreak),
+    }
+}
+
+impl fmt::Display for RouteDecisionReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value = match self {
+            Self::HostTrieNoDefault => "host-trie-no-default",
+            Self::HostPathLongerOrEqual => "host-path-longer-or-equal",
+            Self::DefaultPathLonger => "default-path-longer",
+            Self::HostSpecificTieBreak => "host-specific-tie-break",
+            Self::ExactHostTieBreak => "exact-host-tie-break",
+            Self::WildcardSpecificityTieBreak => "wildcard-specificity-tie-break",
+            Self::MethodSpecificTieBreak => "method-specific-tie-break",
+            Self::LexicalTieBreak => "lexical-tie-break",
+        };
+
+        f.write_str(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RouteDecisionReason, RoutePreference, route_preference_reason};
+
+    #[test]
+    fn route_preference_reason_maps_each_preference() {
+        assert_eq!(route_preference_reason(RoutePreference::KeepCurrent), None);
+        assert_eq!(
+            route_preference_reason(RoutePreference::TakeCandidatePathLen),
+            Some(RouteDecisionReason::HostPathLongerOrEqual)
+        );
+        assert_eq!(
+            route_preference_reason(RoutePreference::TakeCandidateHostSpecific),
+            Some(RouteDecisionReason::HostSpecificTieBreak)
+        );
+        assert_eq!(
+            route_preference_reason(RoutePreference::TakeCandidateExactHost),
+            Some(RouteDecisionReason::ExactHostTieBreak)
+        );
+        assert_eq!(
+            route_preference_reason(RoutePreference::TakeCandidateWildcardSpecificity),
+            Some(RouteDecisionReason::WildcardSpecificityTieBreak)
+        );
+        assert_eq!(
+            route_preference_reason(RoutePreference::TakeCandidateMethodSpecific),
+            Some(RouteDecisionReason::MethodSpecificTieBreak)
+        );
+        assert_eq!(
+            route_preference_reason(RoutePreference::TakeCandidateLexicalOrder),
+            Some(RouteDecisionReason::LexicalTieBreak)
+        );
+    }
+
+    #[test]
+    fn route_decision_reason_display_uses_lowercase_hyphenated_tokens() {
+        assert_eq!(
+            format!("{}", RouteDecisionReason::HostTrieNoDefault),
+            "host-trie-no-default"
+        );
+        assert_eq!(
+            format!("{}", RouteDecisionReason::HostPathLongerOrEqual),
+            "host-path-longer-or-equal"
+        );
+        assert_eq!(
+            format!("{}", RouteDecisionReason::DefaultPathLonger),
+            "default-path-longer"
+        );
+        assert_eq!(
+            format!("{}", RouteDecisionReason::HostSpecificTieBreak),
+            "host-specific-tie-break"
+        );
+        assert_eq!(
+            format!("{}", RouteDecisionReason::ExactHostTieBreak),
+            "exact-host-tie-break"
+        );
+        assert_eq!(
+            format!("{}", RouteDecisionReason::WildcardSpecificityTieBreak),
+            "wildcard-specificity-tie-break"
+        );
+        assert_eq!(
+            format!("{}", RouteDecisionReason::MethodSpecificTieBreak),
+            "method-specific-tie-break"
+        );
+        assert_eq!(
+            format!("{}", RouteDecisionReason::LexicalTieBreak),
+            "lexical-tie-break"
+        );
     }
 }

--- a/crates/edge/src/routing/host.rs
+++ b/crates/edge/src/routing/host.rs
@@ -73,3 +73,82 @@ pub fn parse_configured_host_pattern_ref(raw: &str) -> Option<ConfiguredHostPatt
     }
     Some(ConfiguredHostPatternRef::WildcardSuffix(wildcard_suffix))
 }
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use super::{
+        ConfiguredHostPattern, ConfiguredHostPatternRef, normalize_host_for_routing,
+        parse_configured_host_pattern, parse_configured_host_pattern_ref,
+    };
+
+    #[test]
+    fn normalize_host_for_routing_lowercases_and_strips_port_and_trailing_dot() {
+        assert_eq!(
+            normalize_host_for_routing(" Example.COM.:443 "),
+            Some(Cow::Owned("example.com".to_string()))
+        );
+    }
+
+    #[test]
+    fn normalize_host_for_routing_preserves_already_normalized_host() {
+        assert_eq!(
+            normalize_host_for_routing("api.example.com"),
+            Some(Cow::Borrowed("api.example.com"))
+        );
+    }
+
+    #[test]
+    fn normalize_host_for_routing_parses_ipv6_authority() {
+        assert_eq!(
+            normalize_host_for_routing("[2001:db8::1]:443"),
+            Some(Cow::Borrowed("2001:db8::1"))
+        );
+    }
+
+    #[test]
+    fn normalize_host_for_routing_rejects_invalid_input() {
+        assert_eq!(normalize_host_for_routing(""), None);
+        assert_eq!(normalize_host_for_routing("   "), None);
+        assert_eq!(normalize_host_for_routing("[missing-end"), None);
+    }
+
+    #[test]
+    fn parse_configured_host_pattern_distinguishes_exact_and_wildcard_hosts() {
+        assert_eq!(
+            parse_configured_host_pattern("Api.Example.com."),
+            Some(ConfiguredHostPattern::Exact("api.example.com".to_string()))
+        );
+        assert_eq!(
+            parse_configured_host_pattern("*.Example.com"),
+            Some(ConfiguredHostPattern::WildcardSuffix(
+                "example.com".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_configured_host_pattern_rejects_invalid_input() {
+        assert_eq!(parse_configured_host_pattern(""), None);
+        assert_eq!(parse_configured_host_pattern("[missing-end"), None);
+    }
+
+    #[test]
+    fn parse_configured_host_pattern_ref_distinguishes_exact_and_wildcard_hosts() {
+        assert_eq!(
+            parse_configured_host_pattern_ref("api.example.com"),
+            Some(ConfiguredHostPatternRef::Exact("api.example.com"))
+        );
+        assert_eq!(
+            parse_configured_host_pattern_ref("*.example.com"),
+            Some(ConfiguredHostPatternRef::WildcardSuffix("example.com"))
+        );
+    }
+
+    #[test]
+    fn parse_configured_host_pattern_ref_rejects_invalid_input() {
+        assert_eq!(parse_configured_host_pattern_ref(""), None);
+        assert_eq!(parse_configured_host_pattern_ref("[missing-end"), None);
+    }
+}

--- a/crates/edge/src/routing/index.rs
+++ b/crates/edge/src/routing/index.rs
@@ -179,11 +179,14 @@ impl RouteIndex {
 
         let default_best = self
             .default_trie
-            .longest_prefix(path, method, &self.upstream_methods)
-            .map(|route| RouteCandidate {
-                route,
-                host_match_kind: HostMatchKind::Default,
-                wildcard_suffix_len: 0,
+            .longest_prefix_with_reason(path, method, &self.upstream_methods)
+            .map(|(route, decision_reason)| HostLookupResult {
+                candidate: RouteCandidate {
+                    route,
+                    host_match_kind: HostMatchKind::Default,
+                    wildcard_suffix_len: 0,
+                },
+                decision_reason,
             });
         if let Some(best) = host_best
             && best.candidate.route.path_len >= self.default_max_path_len
@@ -191,7 +194,7 @@ impl RouteIndex {
             let fallback_reason = match default_best {
                 None => RouteDecisionReason::HostTrieNoDefault,
                 Some(default_route) => {
-                    match compare_route_candidate(default_route, best.candidate) {
+                    match compare_route_candidate(default_route.candidate, best.candidate) {
                         RoutePreference::TakeCandidateHostSpecific => {
                             RouteDecisionReason::HostSpecificTieBreak
                         }
@@ -221,10 +224,12 @@ impl RouteIndex {
 
         match (default_best, host_best) {
             (Some(default_route), None) => Some(RouteDecision {
-                upstream: self.upstream_names[default_route.route.upstream_idx].as_str(),
-                matched_path_len: default_route.route.path_len,
-                host_specific: default_route.route.host_specific,
-                reason: RouteDecisionReason::DefaultPathLonger,
+                upstream: self.upstream_names[default_route.candidate.route.upstream_idx].as_str(),
+                matched_path_len: default_route.candidate.route.path_len,
+                host_specific: default_route.candidate.route.host_specific,
+                reason: default_route
+                    .decision_reason
+                    .unwrap_or(RouteDecisionReason::DefaultPathLonger),
             }),
             (None, Some(host_route)) => Some(RouteDecision {
                 upstream: self.upstream_names[host_route.candidate.route.upstream_idx].as_str(),
@@ -235,7 +240,7 @@ impl RouteIndex {
                     .unwrap_or(RouteDecisionReason::HostTrieNoDefault),
             }),
             (Some(current), Some(candidate)) => {
-                let preference = compare_route_candidate(current, candidate.candidate);
+                let preference = compare_route_candidate(current.candidate, candidate.candidate);
                 let fallback_reason = match preference {
                     RoutePreference::TakeCandidatePathLen => {
                         RouteDecisionReason::HostPathLongerOrEqual
@@ -258,7 +263,7 @@ impl RouteIndex {
                     RoutePreference::KeepCurrent => RouteDecisionReason::DefaultPathLonger,
                 };
                 let selected = match preference {
-                    RoutePreference::KeepCurrent => current,
+                    RoutePreference::KeepCurrent => current.candidate,
                     _ => candidate.candidate,
                 };
                 Some(RouteDecision {
@@ -268,7 +273,7 @@ impl RouteIndex {
                     reason: if selected == candidate.candidate {
                         candidate.decision_reason.unwrap_or(fallback_reason)
                     } else {
-                        fallback_reason
+                        current.decision_reason.unwrap_or(fallback_reason)
                     },
                 })
             }
@@ -342,5 +347,162 @@ impl From<ConfiguredHostPattern> for RuntimeRouteHostPattern {
             ConfiguredHostPattern::Exact(host) => Self::Exact(host),
             ConfiguredHostPattern::WildcardSuffix(suffix) => Self::WildcardSuffix(suffix),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use spooky_config::config::{Backend, LoadBalancing, RouteMatch, Upstream};
+
+    use crate::routing::{decision::RouteDecisionReason, index::RouteIndex};
+
+    fn upstream(path_prefix: &str, host: Option<&str>, method: Option<&str>) -> Upstream {
+        Upstream {
+            load_balancing: LoadBalancing {
+                lb_type: "round-robin".to_string(),
+                key: None,
+            },
+            auth: Default::default(),
+            host_policy: Default::default(),
+            forwarded_headers: Default::default(),
+            tls: None,
+            route: RouteMatch {
+                path_prefix: Some(path_prefix.to_string()),
+                host: host.map(str::to_string),
+                method: method.map(str::to_string),
+            },
+            backends: vec![Backend {
+                id: "b1".to_string(),
+                address: "http://127.0.0.1:7001".to_string(),
+                weight: 1,
+                health_check: None,
+            }],
+        }
+    }
+
+    #[test]
+    fn lookup_prefers_host_specific_route_over_default() {
+        let upstreams = HashMap::from([
+            ("default".to_string(), upstream("/api", None, None)),
+            (
+                "payments".to_string(),
+                upstream("/api", Some("pay.example.com"), None),
+            ),
+        ]);
+        let index = RouteIndex::from_upstreams(&upstreams);
+
+        assert_eq!(
+            index.lookup("/api", Some("pay.example.com")),
+            Some("payments")
+        );
+
+        let decision = index
+            .lookup_with_decision("/api", Some("pay.example.com"))
+            .expect("route decision");
+        assert_eq!(decision.upstream, "payments");
+        assert_eq!(decision.reason, RouteDecisionReason::HostSpecificTieBreak);
+    }
+
+    #[test]
+    fn lookup_prefers_exact_host_over_wildcard() {
+        let upstreams = HashMap::from([
+            (
+                "wildcard".to_string(),
+                upstream("/api", Some("*.example.com"), None),
+            ),
+            (
+                "exact".to_string(),
+                upstream("/api", Some("api.example.com"), None),
+            ),
+        ]);
+        let index = RouteIndex::from_upstreams(&upstreams);
+
+        assert_eq!(index.lookup("/api", Some("api.example.com")), Some("exact"));
+
+        let decision = index
+            .lookup_with_decision("/api", Some("api.example.com"))
+            .expect("route decision");
+        assert_eq!(decision.upstream, "exact");
+        assert_eq!(decision.reason, RouteDecisionReason::ExactHostTieBreak);
+    }
+
+    #[test]
+    fn lookup_prefers_more_specific_wildcard_suffix() {
+        let upstreams = HashMap::from([
+            (
+                "broad".to_string(),
+                upstream("/api", Some("*.example.com"), None),
+            ),
+            (
+                "narrow".to_string(),
+                upstream("/api", Some("*.svc.example.com"), None),
+            ),
+        ]);
+        let index = RouteIndex::from_upstreams(&upstreams);
+
+        assert_eq!(
+            index.lookup("/api", Some("edge.svc.example.com")),
+            Some("narrow")
+        );
+
+        let decision = index
+            .lookup_with_decision("/api", Some("edge.svc.example.com"))
+            .expect("route decision");
+        assert_eq!(decision.upstream, "narrow");
+        assert_eq!(
+            decision.reason,
+            RouteDecisionReason::WildcardSpecificityTieBreak
+        );
+    }
+
+    #[test]
+    fn lookup_for_method_prefers_method_specific_route() {
+        let upstreams = HashMap::from([
+            ("generic".to_string(), upstream("/transfer", None, None)),
+            (
+                "post_only".to_string(),
+                upstream("/transfer", None, Some("POST")),
+            ),
+        ]);
+        let index = RouteIndex::from_upstreams(&upstreams);
+
+        assert_eq!(
+            index.lookup_for_method("/transfer", None, Some("POST")),
+            Some("post_only")
+        );
+
+        let decision = index
+            .lookup_with_decision_for_method("/transfer", None, Some("POST"))
+            .expect("route decision");
+        assert_eq!(decision.upstream, "post_only");
+        assert_eq!(decision.reason, RouteDecisionReason::MethodSpecificTieBreak);
+    }
+
+    #[test]
+    fn lookup_with_decision_prefers_longer_default_path_when_host_route_is_shorter() {
+        let upstreams = HashMap::from([
+            (
+                "host_short".to_string(),
+                upstream("/api", Some("pay.example.com"), None),
+            ),
+            (
+                "default_long".to_string(),
+                upstream("/api/v1/payments", None, None),
+            ),
+        ]);
+        let index = RouteIndex::from_upstreams(&upstreams);
+
+        assert_eq!(
+            index.lookup("/api/v1/payments", Some("pay.example.com")),
+            Some("default_long")
+        );
+
+        let decision = index
+            .lookup_with_decision("/api/v1/payments", Some("pay.example.com"))
+            .expect("route decision");
+        assert_eq!(decision.upstream, "default_long");
+        assert_eq!(decision.reason, RouteDecisionReason::DefaultPathLonger);
     }
 }

--- a/crates/edge/src/routing/matcher.rs
+++ b/crates/edge/src/routing/matcher.rs
@@ -35,6 +35,10 @@ pub fn compare_route_candidate(
     current: RouteCandidate,
     candidate: RouteCandidate,
 ) -> RoutePreference {
+    let wildcard_specificity_equal = candidate.host_match_kind != HostMatchKind::Wildcard
+        || current.host_match_kind != HostMatchKind::Wildcard
+        || candidate.wildcard_suffix_len == current.wildcard_suffix_len;
+
     if candidate.route.path_len > current.route.path_len {
         RoutePreference::TakeCandidatePathLen
     } else if candidate.route.path_len == current.route.path_len
@@ -54,12 +58,14 @@ pub fn compare_route_candidate(
         RoutePreference::TakeCandidateWildcardSpecificity
     } else if candidate.route.path_len == current.route.path_len
         && candidate.host_match_kind == current.host_match_kind
+        && wildcard_specificity_equal
         && candidate.route.method_specific
         && !current.route.method_specific
     {
         RoutePreference::TakeCandidateMethodSpecific
     } else if candidate.route.path_len == current.route.path_len
         && candidate.host_match_kind == current.host_match_kind
+        && wildcard_specificity_equal
         && candidate.route.method_specific == current.route.method_specific
         && candidate.route.order < current.route.order
     {
@@ -171,4 +177,148 @@ pub fn best_matching_route_with_reason(
         };
     }
     best
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::routing::{
+        decision::{RouteDecisionReason, RoutePreference},
+        matcher::{compare_route_candidate, prefer_host_lookup_result, prefer_route_candidate},
+        route::{HostLookupResult, HostMatchKind, IndexedRoute, RouteCandidate},
+    };
+
+    fn indexed_route(
+        upstream_idx: usize,
+        path_len: usize,
+        host_specific: bool,
+        method_specific: bool,
+        order: usize,
+    ) -> IndexedRoute {
+        IndexedRoute {
+            upstream_idx,
+            path_len,
+            host_specific,
+            method_specific,
+            order,
+        }
+    }
+
+    fn candidate(
+        upstream_idx: usize,
+        path_len: usize,
+        host_specific: bool,
+        host_match_kind: HostMatchKind,
+        wildcard_suffix_len: usize,
+        method_specific: bool,
+        order: usize,
+    ) -> RouteCandidate {
+        RouteCandidate {
+            route: indexed_route(
+                upstream_idx,
+                path_len,
+                host_specific,
+                method_specific,
+                order,
+            ),
+            host_match_kind,
+            wildcard_suffix_len,
+        }
+    }
+
+    #[test]
+    fn compare_route_candidate_prefers_longer_path() {
+        let current = candidate(0, 4, false, HostMatchKind::Default, 0, false, 0);
+        let candidate = candidate(1, 7, false, HostMatchKind::Default, 0, false, 1);
+
+        assert_eq!(
+            compare_route_candidate(current, candidate),
+            RoutePreference::TakeCandidatePathLen
+        );
+    }
+
+    #[test]
+    fn compare_route_candidate_prefers_host_specific_route() {
+        let current = candidate(0, 4, false, HostMatchKind::Default, 0, false, 0);
+        let candidate = candidate(1, 4, true, HostMatchKind::Wildcard, 11, false, 1);
+
+        assert_eq!(
+            compare_route_candidate(current, candidate),
+            RoutePreference::TakeCandidateHostSpecific
+        );
+    }
+
+    #[test]
+    fn compare_route_candidate_prefers_exact_host_over_wildcard() {
+        let current = candidate(0, 4, true, HostMatchKind::Wildcard, 11, false, 0);
+        let candidate = candidate(1, 4, true, HostMatchKind::Exact, 0, false, 1);
+
+        assert_eq!(
+            compare_route_candidate(current, candidate),
+            RoutePreference::TakeCandidateExactHost
+        );
+    }
+
+    #[test]
+    fn compare_route_candidate_prefers_more_specific_wildcard_suffix() {
+        let current = candidate(0, 4, true, HostMatchKind::Wildcard, 11, false, 0);
+        let candidate = candidate(1, 4, true, HostMatchKind::Wildcard, 15, false, 1);
+
+        assert_eq!(
+            compare_route_candidate(current, candidate),
+            RoutePreference::TakeCandidateWildcardSpecificity
+        );
+    }
+
+    #[test]
+    fn compare_route_candidate_prefers_method_specific_route() {
+        let current = candidate(0, 4, true, HostMatchKind::Exact, 0, false, 0);
+        let candidate = candidate(1, 4, true, HostMatchKind::Exact, 0, true, 1);
+
+        assert_eq!(
+            compare_route_candidate(current, candidate),
+            RoutePreference::TakeCandidateMethodSpecific
+        );
+    }
+
+    #[test]
+    fn compare_route_candidate_prefers_lexical_order_on_full_tie() {
+        let current = candidate(0, 4, true, HostMatchKind::Exact, 0, true, 2);
+        let candidate = candidate(1, 4, true, HostMatchKind::Exact, 0, true, 1);
+
+        assert_eq!(
+            compare_route_candidate(current, candidate),
+            RoutePreference::TakeCandidateLexicalOrder
+        );
+    }
+
+    #[test]
+    fn prefer_route_candidate_returns_preferred_candidate() {
+        let current = candidate(0, 4, false, HostMatchKind::Default, 0, false, 0);
+        let better = candidate(1, 7, false, HostMatchKind::Default, 0, false, 1);
+
+        assert_eq!(
+            prefer_route_candidate(Some(current), Some(better)),
+            Some(better)
+        );
+    }
+
+    #[test]
+    fn prefer_host_lookup_result_carries_tiebreak_reason() {
+        let current = HostLookupResult {
+            candidate: candidate(0, 4, true, HostMatchKind::Wildcard, 11, false, 0),
+            decision_reason: None,
+        };
+        let better = HostLookupResult {
+            candidate: candidate(1, 4, true, HostMatchKind::Exact, 0, false, 1),
+            decision_reason: None,
+        };
+
+        assert_eq!(
+            prefer_host_lookup_result(Some(current), Some(better)),
+            Some(HostLookupResult {
+                candidate: better.candidate,
+                decision_reason: Some(RouteDecisionReason::ExactHostTieBreak),
+            })
+        );
+    }
 }

--- a/crates/edge/src/routing/scan.rs
+++ b/crates/edge/src/routing/scan.rs
@@ -159,3 +159,98 @@ pub fn scan_lookup_for_method<'a>(
 
     best_match.map(|(name, _, _, _, _, _)| name)
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use spooky_config::config::{Backend, LoadBalancing, RouteMatch, Upstream};
+
+    use crate::routing::{
+        index::RouteIndex,
+        scan::{scan_lookup, scan_lookup_for_method},
+    };
+
+    fn upstream(path_prefix: &str, host: Option<&str>, method: Option<&str>) -> Upstream {
+        Upstream {
+            load_balancing: LoadBalancing {
+                lb_type: "round-robin".to_string(),
+                key: None,
+            },
+            auth: Default::default(),
+            host_policy: Default::default(),
+            forwarded_headers: Default::default(),
+            tls: None,
+            route: RouteMatch {
+                path_prefix: Some(path_prefix.to_string()),
+                host: host.map(str::to_string),
+                method: method.map(str::to_string),
+            },
+            backends: vec![Backend {
+                id: "b1".to_string(),
+                address: "http://127.0.0.1:7001".to_string(),
+                weight: 1,
+                health_check: None,
+            }],
+        }
+    }
+
+    #[test]
+    fn scan_lookup_matches_route_index_lookup_for_reference_inputs() {
+        let upstreams = HashMap::from([
+            ("default".to_string(), upstream("/api", None, None)),
+            (
+                "exact".to_string(),
+                upstream("/api", Some("pay.example.com"), None),
+            ),
+            (
+                "wildcard".to_string(),
+                upstream("/api/private", Some("*.example.com"), None),
+            ),
+            (
+                "method".to_string(),
+                upstream("/transfer", None, Some("POST")),
+            ),
+        ]);
+        let index = RouteIndex::from_upstreams(&upstreams);
+
+        let cases = [
+            ("/api", Some("pay.example.com")),
+            ("/api/private", Some("team.example.com")),
+            ("/api/other", Some("unknown.example.net")),
+            ("/unmatched", Some("pay.example.com")),
+        ];
+
+        for (path, host) in cases {
+            assert_eq!(
+                scan_lookup(&upstreams, path, host),
+                index.lookup(path, host)
+            );
+        }
+    }
+
+    #[test]
+    fn scan_lookup_for_method_matches_route_index_lookup_for_method() {
+        let upstreams = HashMap::from([
+            ("generic".to_string(), upstream("/transfer", None, None)),
+            (
+                "post_only".to_string(),
+                upstream("/transfer", None, Some("POST")),
+            ),
+        ]);
+        let index = RouteIndex::from_upstreams(&upstreams);
+
+        let cases = [
+            ("/transfer", None, Some("POST")),
+            ("/transfer", None, Some("GET")),
+            ("/transfer", None, None),
+        ];
+
+        for (path, host, method) in cases {
+            assert_eq!(
+                scan_lookup_for_method(&upstreams, path, host, method),
+                index.lookup_for_method(path, host, method)
+            );
+        }
+    }
+}

--- a/crates/edge/src/routing/trie.rs
+++ b/crates/edge/src/routing/trie.rs
@@ -107,3 +107,71 @@ impl RouteTrie {
         best
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::routing::{decision::RouteDecisionReason, route::IndexedRoute, trie::RouteTrie};
+
+    fn route(upstream_idx: usize, path_len: usize) -> IndexedRoute {
+        IndexedRoute {
+            upstream_idx,
+            path_len,
+            host_specific: false,
+            method_specific: false,
+            order: upstream_idx,
+        }
+    }
+
+    #[test]
+    fn longest_prefix_returns_none_when_trie_is_empty() {
+        let trie = RouteTrie::default();
+        let upstream_methods = Vec::new();
+
+        assert_eq!(trie.longest_prefix("/api", None, &upstream_methods), None);
+        assert_eq!(
+            trie.longest_prefix_with_reason("/api", None, &upstream_methods),
+            None
+        );
+    }
+
+    #[test]
+    fn longest_prefix_prefers_longest_overlapping_prefix() {
+        let mut trie = RouteTrie::default();
+        let upstream_methods = vec![None, None];
+        trie.insert(Some("/api"), route(0, "/api".len()));
+        trie.insert(Some("/api/v1"), route(1, "/api/v1".len()));
+
+        assert_eq!(
+            trie.longest_prefix("/api/v1/users", None, &upstream_methods),
+            Some(route(1, "/api/v1".len()))
+        );
+    }
+
+    #[test]
+    fn longest_prefix_uses_root_fallback_when_no_child_matches() {
+        let mut trie = RouteTrie::default();
+        let upstream_methods = vec![None];
+        trie.insert(None, route(0, 0));
+
+        assert_eq!(
+            trie.longest_prefix("/unmatched", None, &upstream_methods),
+            Some(route(0, 0))
+        );
+    }
+
+    #[test]
+    fn longest_prefix_with_reason_reports_longer_prefix_preference() {
+        let mut trie = RouteTrie::default();
+        let upstream_methods = vec![None, None];
+        trie.insert(None, route(0, 0));
+        trie.insert(Some("/api"), route(1, "/api".len()));
+
+        assert_eq!(
+            trie.longest_prefix_with_reason("/api/users", None, &upstream_methods),
+            Some((
+                route(1, "/api".len()),
+                Some(RouteDecisionReason::HostPathLongerOrEqual)
+            ))
+        );
+    }
+}

--- a/crates/edge/src/routing/util.rs
+++ b/crates/edge/src/routing/util.rs
@@ -8,3 +8,28 @@ pub fn prefix_boundary_matches(path: &str, prefix_len: usize) -> bool {
     }
     path.as_bytes().get(prefix_len) == Some(&b'/')
 }
+
+#[cfg(test)]
+mod tests {
+    use super::prefix_boundary_matches;
+
+    #[test]
+    fn prefix_boundary_matches_exact_prefix_length() {
+        assert!(prefix_boundary_matches("/api", "/api".len()));
+    }
+
+    #[test]
+    fn prefix_boundary_matches_segment_boundary() {
+        assert!(prefix_boundary_matches("/api/v1", "/api".len()));
+    }
+
+    #[test]
+    fn prefix_boundary_rejects_mid_segment_match() {
+        assert!(!prefix_boundary_matches("/apixyz", "/api".len()));
+    }
+
+    #[test]
+    fn prefix_boundary_treats_root_prefix_as_match() {
+        assert!(prefix_boundary_matches("/anything", 1));
+    }
+}

--- a/crates/edge/tests/h1_upstream.rs
+++ b/crates/edge/tests/h1_upstream.rs
@@ -268,7 +268,9 @@ impl ListenerTaskGuard {
     fn spawn(rt: &tokio::runtime::Runtime, mut listener: QUICListener) -> Self {
         let stop = Arc::new(AtomicBool::new(false));
         let stop_flag = Arc::clone(&stop);
+        let runtime_handle = rt.handle().clone();
         let handle = rt.spawn_blocking(move || {
+            let _enter = runtime_handle.enter();
             while !stop_flag.load(Ordering::Relaxed) {
                 listener.poll();
             }

--- a/crates/edge/tests/h1_upstream.rs
+++ b/crates/edge/tests/h1_upstream.rs
@@ -16,6 +16,7 @@ use quiche::h3::NameValue;
 use rand::RngCore;
 use rcgen::{Certificate, CertificateParams, SanType};
 use rustls_pki_types::{CertificateDer, PrivateKeyDer, pem::PemObject};
+use serial_test::serial;
 use spooky_config::{
     config::{
         Backend, ClientAuth, Config, Listen, LoadBalancing, Log, LogFormat, RouteMatch, Security,
@@ -451,6 +452,7 @@ fn reserve_unused_udp_port() -> u16 {
 }
 
 #[test]
+#[serial]
 fn http_only_upstream_starts_and_forwards_requests_end_to_end() {
     if !local_tcp_bind_available() {
         return;
@@ -500,6 +502,7 @@ fn http_only_upstream_starts_and_forwards_requests_end_to_end() {
 }
 
 #[test]
+#[serial]
 fn http_only_upstream_normalizes_forwarding_headers() {
     if !local_tcp_bind_available() {
         return;
@@ -572,6 +575,7 @@ fn http_only_upstream_normalizes_forwarding_headers() {
 }
 
 #[test]
+#[serial]
 fn http_only_upstream_retries_bodyless_requests_on_alternate_backend() {
     if !local_tcp_bind_available() {
         return;
@@ -616,6 +620,7 @@ fn http_only_upstream_retries_bodyless_requests_on_alternate_backend() {
 }
 
 #[test]
+#[serial]
 fn mixed_http_and_https_upstreams_route_by_scheme() {
     if !local_tcp_bind_available() {
         return;

--- a/crates/errors/Cargo.toml
+++ b/crates/errors/Cargo.toml
@@ -10,3 +10,9 @@ http = { workspace = true }
 hyper-util = { workspace = true }
 quiche = { workspace = true }
 spooky-lb = { path = "../lb" }
+
+[dev-dependencies]
+bytes.workspace = true
+http-body-util.workspace = true
+hyper.workspace = true
+tokio.workspace = true

--- a/crates/errors/src/bridge.rs
+++ b/crates/errors/src/bridge.rs
@@ -13,3 +13,32 @@ pub enum BridgeError {
     #[error("failed to build request: {0}")]
     Build(#[from] http::Error),
 }
+
+#[cfg(test)]
+mod tests {
+    use super::BridgeError;
+
+    fn invalid_build_error() -> http::Error {
+        http::Request::builder()
+            .header("bad\nname", "value")
+            .body(())
+            .expect_err("invalid header name should fail request build")
+    }
+
+    #[test]
+    fn display_covers_simple_bridge_variants() {
+        assert_eq!(
+            BridgeError::InvalidMethod.to_string(),
+            "invalid HTTP method"
+        );
+        assert_eq!(BridgeError::InvalidUri.to_string(), "invalid URI");
+        assert_eq!(BridgeError::InvalidHeader.to_string(), "invalid header");
+    }
+
+    #[test]
+    fn build_variant_display_includes_http_error() {
+        let error = BridgeError::Build(invalid_build_error());
+
+        assert!(error.to_string().starts_with("failed to build request: "));
+    }
+}

--- a/crates/errors/src/pool.rs
+++ b/crates/errors/src/pool.rs
@@ -17,3 +17,88 @@ pub enum PoolError {
     #[error("backend inflight limiter closed")]
     InflightLimiterClosed,
 }
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use http_body_util::Empty;
+    use hyper::Uri;
+    use hyper_util::{client::legacy::Client, rt::TokioExecutor};
+
+    use super::PoolError;
+    use crate::{
+        ProxyError, UpstreamRetryReason, UpstreamRetryability, UpstreamTerminalErrorKind,
+        classify_retryability,
+    };
+
+    async fn connect_send_error() -> hyper_util::client::legacy::Error {
+        let client: Client<hyper_util::client::legacy::connect::HttpConnector, Empty<Bytes>> =
+            Client::builder(TokioExecutor::new()).build_http();
+        let uri: Uri = "http://127.0.0.1:1/".parse().expect("valid local uri");
+
+        client
+            .get(uri)
+            .await
+            .expect_err("connect to unused port should fail")
+    }
+
+    #[test]
+    fn display_covers_named_pool_variants() {
+        assert_eq!(
+            PoolError::UnknownBackend("api-a".to_string()).to_string(),
+            "unknown backend: api-a"
+        );
+        assert_eq!(
+            PoolError::BackendOverloaded("api-b".to_string()).to_string(),
+            "backend overloaded: api-b"
+        );
+        assert_eq!(
+            PoolError::CircuitOpen("api-c".to_string()).to_string(),
+            "backend circuit open: api-c"
+        );
+        assert_eq!(
+            PoolError::InflightLimiterClosed.to_string(),
+            "backend inflight limiter closed"
+        );
+    }
+
+    #[test]
+    fn retryability_classifies_non_send_pool_errors_as_pool_retryable() {
+        assert_eq!(
+            classify_retryability(&ProxyError::Pool(PoolError::UnknownBackend(
+                "api-a".to_string(),
+            ))),
+            UpstreamRetryability::Retryable(UpstreamRetryReason::Pool)
+        );
+        assert_eq!(
+            classify_retryability(&ProxyError::Pool(PoolError::BackendOverloaded(
+                "api-b".to_string(),
+            ))),
+            UpstreamRetryability::Retryable(UpstreamRetryReason::Pool)
+        );
+        assert_eq!(
+            classify_retryability(&ProxyError::Pool(PoolError::CircuitOpen(
+                "api-c".to_string()
+            ))),
+            UpstreamRetryability::Retryable(UpstreamRetryReason::Pool)
+        );
+        assert_eq!(
+            classify_retryability(&ProxyError::Pool(PoolError::InflightLimiterClosed)),
+            UpstreamRetryability::Retryable(UpstreamRetryReason::Pool)
+        );
+    }
+
+    #[tokio::test]
+    async fn send_variant_display_and_retryability_match_contract() {
+        let send_error = connect_send_error().await;
+        let display = PoolError::Send(send_error).to_string();
+
+        assert!(display.starts_with("send failed: client error"));
+
+        let send_error = connect_send_error().await;
+        assert_eq!(
+            classify_retryability(&ProxyError::Pool(PoolError::Send(send_error))),
+            UpstreamRetryability::Terminal(UpstreamTerminalErrorKind::PoolSend)
+        );
+    }
+}

--- a/crates/errors/src/proxy.rs
+++ b/crates/errors/src/proxy.rs
@@ -112,3 +112,190 @@ pub fn classify_upstream_proxy_error(err: &ProxyError) -> Option<ClassifiedUpstr
         | ProxyError::Pool(PoolError::InflightLimiterClosed) => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use http_body_util::Empty;
+    use hyper::Uri;
+    use hyper_util::{client::legacy::Client, rt::TokioExecutor};
+
+    use super::{ProxyError, UpstreamProxyErrorKind, classify_upstream_proxy_error};
+    use crate::{
+        BridgeError, PoolError, UpstreamErrorCategory, UpstreamErrorClassification,
+        UpstreamHealthFailureMapping, UpstreamRetryReason, UpstreamRetryability,
+        UpstreamTerminalErrorKind, UpstreamTlsReason,
+    };
+    use spooky_lb::health::HealthFailureReason;
+
+    async fn connect_send_error() -> hyper_util::client::legacy::Error {
+        let client: Client<hyper_util::client::legacy::connect::HttpConnector, Empty<Bytes>> =
+            Client::builder(TokioExecutor::new()).build_http();
+        let uri: Uri = "http://127.0.0.1:1/".parse().expect("valid local uri");
+
+        client
+            .get(uri)
+            .await
+            .expect_err("connect to unused port should fail")
+    }
+
+    #[test]
+    fn display_covers_proxy_error_variants() {
+        assert_eq!(
+            ProxyError::Bridge(BridgeError::InvalidMethod).to_string(),
+            "bridge error: invalid HTTP method"
+        );
+        assert_eq!(
+            ProxyError::Pool(PoolError::UnknownBackend("api-a".to_string())).to_string(),
+            "pool error: unknown backend: api-a"
+        );
+        assert_eq!(
+            ProxyError::Transport("connection reset by peer".to_string()).to_string(),
+            "transport error: connection reset by peer"
+        );
+        assert_eq!(ProxyError::Timeout.to_string(), "backend timeout");
+        assert_eq!(
+            ProxyError::Protocol("bad response frame".to_string()).to_string(),
+            "protocol error: bad response frame"
+        );
+        assert_eq!(
+            ProxyError::Tls("unknown issuer".to_string()).to_string(),
+            "TLS error: unknown issuer"
+        );
+    }
+
+    #[test]
+    fn bridge_and_non_send_pool_errors_have_no_upstream_category() {
+        assert_eq!(
+            classify_upstream_proxy_error(&ProxyError::Bridge(BridgeError::InvalidHeader)),
+            None
+        );
+        assert_eq!(
+            classify_upstream_proxy_error(&ProxyError::Pool(PoolError::UnknownBackend(
+                "api-a".to_string(),
+            ))),
+            None
+        );
+        assert_eq!(
+            classify_upstream_proxy_error(&ProxyError::Pool(PoolError::BackendOverloaded(
+                "api-b".to_string(),
+            ))),
+            None
+        );
+        assert_eq!(
+            classify_upstream_proxy_error(&ProxyError::Pool(PoolError::CircuitOpen(
+                "api-c".to_string(),
+            ))),
+            None
+        );
+        assert_eq!(
+            classify_upstream_proxy_error(&ProxyError::Pool(PoolError::InflightLimiterClosed)),
+            None
+        );
+    }
+
+    #[test]
+    fn transport_timeout_protocol_and_tls_map_to_expected_categories() {
+        let transport = classify_upstream_proxy_error(&ProxyError::Transport(
+            "connection reset by peer".to_string(),
+        ))
+        .expect("transport should classify");
+        assert_eq!(transport.kind, UpstreamProxyErrorKind::Transport);
+        assert_eq!(transport.detail, "connection reset by peer");
+        assert_eq!(
+            transport.classification,
+            UpstreamErrorClassification::transport()
+        );
+        assert_eq!(
+            transport.health_failure,
+            Some(UpstreamHealthFailureMapping {
+                failure_reason: HealthFailureReason::Transport,
+                metrics_reason: "transport",
+            })
+        );
+        assert_eq!(
+            transport.retryability,
+            UpstreamRetryability::Retryable(UpstreamRetryReason::Transport)
+        );
+
+        let timeout =
+            classify_upstream_proxy_error(&ProxyError::Timeout).expect("timeout should classify");
+        assert_eq!(timeout.kind, UpstreamProxyErrorKind::Timeout);
+        assert_eq!(timeout.detail, "backend timeout");
+        assert_eq!(
+            timeout.classification,
+            UpstreamErrorClassification::timeout()
+        );
+        assert_eq!(
+            timeout.health_failure,
+            Some(UpstreamHealthFailureMapping {
+                failure_reason: HealthFailureReason::Timeout,
+                metrics_reason: "timeout",
+            })
+        );
+        assert_eq!(
+            timeout.retryability,
+            UpstreamRetryability::Retryable(UpstreamRetryReason::Timeout)
+        );
+
+        let protocol =
+            classify_upstream_proxy_error(&ProxyError::Protocol("bad response frame".to_string()))
+                .expect("protocol should classify");
+        assert_eq!(protocol.kind, UpstreamProxyErrorKind::Protocol);
+        assert_eq!(protocol.detail, "bad response frame");
+        assert_eq!(
+            protocol.classification.category,
+            UpstreamErrorCategory::Protocol
+        );
+        assert_eq!(protocol.health_failure, None);
+        assert_eq!(
+            protocol.retryability,
+            UpstreamRetryability::Terminal(UpstreamTerminalErrorKind::Protocol)
+        );
+
+        let tls = classify_upstream_proxy_error(&ProxyError::Tls("unknown issuer".to_string()))
+            .expect("tls should classify");
+        assert_eq!(tls.kind, UpstreamProxyErrorKind::Tls);
+        assert_eq!(tls.detail, "unknown issuer");
+        assert_eq!(
+            tls.classification,
+            UpstreamErrorClassification::tls(UpstreamTlsReason::UnknownIssuer)
+        );
+        assert_eq!(tls.health_failure, None);
+        assert_eq!(
+            tls.retryability,
+            UpstreamRetryability::Terminal(UpstreamTerminalErrorKind::Tls)
+        );
+
+        let generic_tls = classify_upstream_proxy_error(&ProxyError::Tls("boom".to_string()))
+            .expect("generic tls should classify");
+        assert_eq!(
+            generic_tls.classification,
+            UpstreamErrorClassification::tls(UpstreamTlsReason::Handshake)
+        );
+    }
+
+    #[tokio::test]
+    async fn pool_send_classifies_as_terminal_send_error() {
+        let err = ProxyError::Pool(PoolError::Send(connect_send_error().await));
+        let classified = classify_upstream_proxy_error(&err).expect("send should classify");
+
+        assert_eq!(classified.kind, UpstreamProxyErrorKind::Send);
+        assert_eq!(
+            classified.classification.category,
+            UpstreamErrorCategory::Transport
+        );
+        assert_eq!(
+            classified.health_failure,
+            Some(UpstreamHealthFailureMapping {
+                failure_reason: HealthFailureReason::Transport,
+                metrics_reason: "transport",
+            })
+        );
+        assert_eq!(
+            classified.retryability,
+            UpstreamRetryability::Terminal(UpstreamTerminalErrorKind::PoolSend)
+        );
+        assert!(!classified.detail.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

Adds inline unit-test coverage for Spooky's fundamental building blocks — the routing
engine, config defaults, core helpers, and error types. Tests live **inline** as
`#[cfg(test)] mod tests` next to the logic (per the project's unit-test convention),
using each module's private/`pub(crate)` items directly.

Tests only — no product/source behavior changed (plus one dev-dependency for the
errors crate).

## What's covered

**Routing (`crates/edge/src/routing/`)** — previously had **zero** inline tests:
- `util.rs` — `prefix_boundary_matches` (segment boundary, mid-segment rejection, root)
- `host.rs` — host normalization (case/port/trailing-dot/IPv6/invalid) + exact vs wildcard pattern parsing
- `decision.rs` — `route_preference_reason` mapping + new `Display for RouteDecisionReason` (all 8 variants)
- `trie.rs` — longest-prefix matching
- `matcher.rs` — one test per tie-break rung, in documented precedence order
- `index.rs` — end-to-end `lookup` / `lookup_for_method` / `lookup_with_decision`
- `scan.rs` — parity: linear reference `scan_lookup` matches `RouteIndex::lookup`

**Fundamental blocks (`crates/edge/src/`):**
- `hash.rs` — known FNV-1a vectors for `stable_hash64` + socket-addr determinism/distinctness
- `body.rs` — `ChannelBody` chunk ordering, EOF on sender drop, `Infallible` error type

**Config (`crates/config/src/`):**
- `default.rs` / `config.rs` — documented default values + serde-default fill-in from minimal YAML

**Errors (`crates/errors/src/`):**
- `proxy.rs` / `bridge.rs` / `pool.rs` — `Display` output and category/retryability classification

## Verification

- `cargo test --workspace` green.
- New: routing 33, hash 3, body 3, config 4, errors 7 — all passing.

Closes #264
Closes #265
Closes #276