### PR TITLE
refactor(edge): formalize runtime generation ownership and reload boundaries

### DIFF
--- a/crates/edge/src/quic_listener/bootstrap/startup.rs
+++ b/crates/edge/src/quic_listener/bootstrap/startup.rs
@@ -47,6 +47,7 @@ pub(in crate::quic_listener) fn prepare_bootstrap_listener_startup(
     let connection_timeout = timeout_policy.client_body_idle;
     let listener_label = QUICListener::listener_label(config);
     shared_state
+        .shared_services()
         .listener_tls_store
         .bootstrap_server_config(&listener_label)
         .ok_or_else(|| {

--- a/crates/edge/src/quic_listener/bootstrap/state.rs
+++ b/crates/edge/src/quic_listener/bootstrap/state.rs
@@ -85,9 +85,9 @@ pub(in crate::quic_listener) fn bootstrap_connection_state(
         upstream_pools,
         routing_index,
     ) = if let Some(handle) = runtime_bundle {
-        let runtime = handle.current();
-        let shared = runtime.shared_state.shared_services();
-        let generation = runtime.shared_state.generation_state();
+        let runtime = handle.current_view();
+        let shared = runtime.shared_services();
+        let generation = runtime.state();
         (
             runtime.listener_runtime_config(listener_label)?,
             shared.listener_tls_store.clone(),

--- a/crates/edge/src/quic_listener/bootstrap/state.rs
+++ b/crates/edge/src/quic_listener/bootstrap/state.rs
@@ -54,16 +54,18 @@ pub(in crate::quic_listener) fn build_bootstrap_startup_state(
     config: &ListenerRuntimeConfig,
     shared_state: &SharedRuntimeState,
 ) -> BootstrapStartupState {
+    let shared = shared_state.shared_services();
+    let generation = shared_state.generation_state();
     BootstrapStartupState {
         listener_config: config.clone(),
-        listener_tls_store: Arc::clone(&shared_state.listener_tls_store),
-        transport_pool: Arc::clone(&shared_state.transport_pool),
-        backend_endpoints: Arc::clone(&shared_state.backend_endpoints),
-        upstream_policies: Arc::clone(&shared_state.upstream_policies),
-        metrics: Arc::clone(&shared_state.metrics),
-        resilience: Arc::clone(&shared_state.resilience),
-        upstream_pools: shared_state.upstream_pools.clone(),
-        routing_index: Arc::clone(&shared_state.routing_index),
+        listener_tls_store: Arc::clone(&shared.listener_tls_store),
+        transport_pool: Arc::clone(&shared.transport_pool),
+        backend_endpoints: Arc::clone(&generation.backend_endpoints),
+        upstream_policies: Arc::clone(&generation.upstream_policies),
+        metrics: Arc::clone(&shared.metrics),
+        resilience: Arc::clone(&generation.resilience),
+        upstream_pools: generation.upstream_pools.clone(),
+        routing_index: Arc::clone(&generation.routing_index),
     }
 }
 
@@ -84,16 +86,18 @@ pub(in crate::quic_listener) fn bootstrap_connection_state(
         routing_index,
     ) = if let Some(handle) = runtime_bundle {
         let runtime = handle.current();
+        let shared = runtime.shared_state.shared_services();
+        let generation = runtime.shared_state.generation_state();
         (
             runtime.listener_runtime_config(listener_label)?,
-            runtime.shared_state.listener_tls_store.clone(),
-            runtime.shared_state.transport_pool.clone(),
-            runtime.shared_state.backend_endpoints.clone(),
-            runtime.shared_state.upstream_policies.clone(),
-            runtime.shared_state.metrics.clone(),
-            runtime.shared_state.resilience.clone(),
-            runtime.shared_state.upstream_pools.clone(),
-            runtime.shared_state.routing_index.clone(),
+            shared.listener_tls_store.clone(),
+            shared.transport_pool.clone(),
+            generation.backend_endpoints.clone(),
+            generation.upstream_policies.clone(),
+            shared.metrics.clone(),
+            generation.resilience.clone(),
+            generation.upstream_pools.clone(),
+            generation.routing_index.clone(),
         )
     } else {
         (

--- a/crates/edge/src/quic_listener/control_api/http.rs
+++ b/crates/edge/src/quic_listener/control_api/http.rs
@@ -553,10 +553,9 @@ impl QUICListener {
                 }),
             );
         };
-        let runtime = runtime_bundle_handle.current();
-        let shared_state = &runtime.shared_state;
-        let shared = shared_state.shared_services();
-        let generation = shared_state.generation_state();
+        let runtime = runtime_bundle_handle.current_view();
+        let shared = runtime.shared_services();
+        let generation = runtime.state();
 
         if req.method() == Method::GET && path == paths.health_path.as_str() {
             let response = json!({
@@ -653,8 +652,8 @@ impl QUICListener {
                     "listeners": tls_listeners,
                 },
                 "runtime": {
-                    "generation": runtime.generation,
-                    "config_path": runtime.startup.config_path,
+                    "generation": runtime.generation(),
+                    "config_path": runtime.startup().config_path,
                 },
                 "extension_model": {
                     "status": "non_goal",
@@ -693,7 +692,7 @@ impl QUICListener {
                 );
             }
 
-            let config_path = runtime.startup.config_path.clone();
+            let config_path = runtime.startup().config_path.clone();
             let config = match read_config(&config_path) {
                 Ok(config) => config,
                 Err(err) => {
@@ -740,7 +739,7 @@ impl QUICListener {
                 }
             };
             let next_runtime = RuntimeBundle {
-                generation: runtime.generation.saturating_add(1),
+                generation: runtime.generation().saturating_add(1),
                 startup: crate::runtime::generation::StartupOwnedRuntimeState {
                     config_path,
                     log_config: config.log.clone(),
@@ -748,7 +747,8 @@ impl QUICListener {
                 runtime_config,
                 shared_state: Arc::clone(&next_shared_state),
             };
-            if let Some(err) = Self::validate_runtime_reload_compatibility(&runtime, &next_runtime)
+            if let Some(err) =
+                Self::validate_runtime_reload_compatibility(runtime.bundle(), &next_runtime)
             {
                 return Self::json_response(
                     StatusCode::CONFLICT,
@@ -759,7 +759,7 @@ impl QUICListener {
                 );
             }
             if let Some(err) =
-                Self::validate_control_api_reload_compatibility(&runtime, &next_runtime)
+                Self::validate_control_api_reload_compatibility(runtime.bundle(), &next_runtime)
             {
                 return Self::json_response(
                     StatusCode::CONFLICT,
@@ -769,7 +769,8 @@ impl QUICListener {
                     }),
                 );
             }
-            if let Some(err) = Self::validate_metrics_reload_compatibility(&runtime, &next_runtime)
+            if let Some(err) =
+                Self::validate_metrics_reload_compatibility(runtime.bundle(), &next_runtime)
             {
                 return Self::json_response(
                     StatusCode::CONFLICT,
@@ -780,7 +781,7 @@ impl QUICListener {
                 );
             }
             let startup_owned_issues =
-                Self::validate_startup_owned_reload_compatibility(&runtime, &next_runtime);
+                Self::validate_startup_owned_reload_compatibility(runtime.bundle(), &next_runtime);
             if !startup_owned_issues.is_empty() {
                 return Self::json_response(
                     StatusCode::CONFLICT,
@@ -790,7 +791,7 @@ impl QUICListener {
                     }),
                 );
             }
-            let current_log_level = runtime.startup.log_config.level.clone();
+            let current_log_level = runtime.startup().log_config.level.clone();
             let next_log_level = next_runtime.startup.log_config.level.clone();
 
             QUICListener::spawn_generation_background_tasks_for_runtime(

--- a/crates/edge/src/quic_listener/control_api/http.rs
+++ b/crates/edge/src/quic_listener/control_api/http.rs
@@ -798,8 +798,8 @@ impl QUICListener {
                 &next_runtime.runtime_config,
                 next_runtime.shared_state.as_ref(),
             );
-            let (generation, retired_tasks) = match runtime_bundle_handle.replace(next_runtime) {
-                Ok(result) => result,
+            let generation = match runtime_bundle_handle.replace(next_runtime) {
+                Ok(generation) => generation,
                 Err(err) => {
                     return Self::json_response(
                         StatusCode::INTERNAL_SERVER_ERROR,
@@ -817,11 +817,6 @@ impl QUICListener {
                     generation, current_log_level, next_log_level, err
                 );
             }
-            tokio::spawn(async move {
-                retired_tasks
-                    .retire_with_timeout(Duration::from_secs(5))
-                    .await;
-            });
             return Self::json_response(
                 StatusCode::ACCEPTED,
                 json!({

--- a/crates/edge/src/quic_listener/control_api/http.rs
+++ b/crates/edge/src/quic_listener/control_api/http.rs
@@ -366,20 +366,18 @@ impl QUICListener {
         req: Request<Incoming>,
         state: &ControlApiState,
     ) -> Response<Full<Bytes>> {
-        if state.runtime_bundle.is_some() {
-            return Self::handle_runtime_control_api_request(req, state);
-        }
         let paths = state.current_paths();
         let path = req.uri().path();
+        let watchdog = state.current_watchdog();
 
         if req.method() == Method::GET && path == paths.health_path.as_str() {
             let response = json!({
                 "status": "ok",
                 "uptime_ms": state.started_at.elapsed().as_millis() as u64,
                 "watchdog": {
-                    "enabled": state.watchdog.enabled(),
-                    "degraded": state.watchdog.is_degraded(),
-                    "restart_requested": state.watchdog.restart_requested(),
+                    "enabled": watchdog.enabled(),
+                    "degraded": watchdog.is_degraded(),
+                    "restart_requested": watchdog.restart_requested(),
                 },
             });
             return Self::json_response(StatusCode::OK, response);
@@ -387,7 +385,7 @@ impl QUICListener {
 
         if req.method() == Method::GET && path == paths.ready_path.as_str() {
             let (healthy_backends, total_backends) = state.snapshot_backend_health();
-            let restart_requested = state.watchdog.restart_requested();
+            let restart_requested = watchdog.restart_requested();
             let ready = !restart_requested && (total_backends == 0 || healthy_backends > 0);
             let response = json!({
                 "ready": ready,
@@ -434,44 +432,79 @@ impl QUICListener {
                     )
                 })
                 .collect::<serde_json::Map<String, serde_json::Value>>();
-            let response = json!({
-                "uptime_ms": state.started_at.elapsed().as_millis() as u64,
-                "workers": {
-                    "expected": state.expected_workers,
-                },
-                "watchdog": {
-                    "enabled": state.watchdog.enabled(),
-                    "degraded": state.watchdog.is_degraded(),
-                    "restart_requested": state.watchdog.restart_requested(),
-                    "restart_reason": state.watchdog.restart_reason(),
-                    "restart_requested_at_ms": state.watchdog.restart_requested_at_ms(),
-                },
-                "adaptive_admission": {
-                    "enabled": state.resilience.adaptive_admission.enabled(),
-                    "current_limit": state.resilience.adaptive_admission.current_limit(),
-                    "inflight_percent": state.resilience.adaptive_admission.inflight_percent(),
-                },
-                "backends": {
-                    "healthy": healthy_backends,
-                    "total": total_backends,
-                },
-                "metrics": {
-                    "requests_total": state.metrics.requests_total.load(Ordering::Relaxed),
-                    "requests_success": state.metrics.requests_success.load(Ordering::Relaxed),
-                    "requests_failure": state.metrics.requests_failure.load(Ordering::Relaxed),
-                    "active_connections": state.metrics.active_connections.load(Ordering::Relaxed),
-                    "backend_timeouts": state.metrics.backend_timeouts.load(Ordering::Relaxed),
-                    "backend_errors": state.metrics.backend_errors.load(Ordering::Relaxed),
-                },
-                "tls": {
-                    "listeners": tls_listeners,
-                },
-                "extension_model": {
-                    "status": "non_goal",
-                    "details": "No plugin/middleware ABI is exposed in-process today; extension support remains a deliberate non-goal until a safe isolation model is designed.",
-                },
-            });
-            return Self::json_response(StatusCode::OK, response);
+            let resilience = state.current_resilience();
+            let metrics = state.current_metrics();
+            let mut response = serde_json::Map::from_iter([
+                (
+                    "uptime_ms".to_string(),
+                    json!(state.started_at.elapsed().as_millis() as u64),
+                ),
+                (
+                    "workers".to_string(),
+                    json!({
+                        "expected": state.expected_workers,
+                    }),
+                ),
+                (
+                    "watchdog".to_string(),
+                    json!({
+                        "enabled": watchdog.enabled(),
+                        "degraded": watchdog.is_degraded(),
+                        "restart_requested": watchdog.restart_requested(),
+                        "restart_reason": watchdog.restart_reason(),
+                        "restart_requested_at_ms": watchdog.restart_requested_at_ms(),
+                    }),
+                ),
+                (
+                    "adaptive_admission".to_string(),
+                    json!({
+                        "enabled": resilience.adaptive_admission.enabled(),
+                        "current_limit": resilience.adaptive_admission.current_limit(),
+                        "inflight_percent": resilience.adaptive_admission.inflight_percent(),
+                    }),
+                ),
+                (
+                    "backends".to_string(),
+                    json!({
+                        "healthy": healthy_backends,
+                        "total": total_backends,
+                    }),
+                ),
+                (
+                    "metrics".to_string(),
+                    json!({
+                        "requests_total": metrics.requests_total.load(Ordering::Relaxed),
+                        "requests_success": metrics.requests_success.load(Ordering::Relaxed),
+                        "requests_failure": metrics.requests_failure.load(Ordering::Relaxed),
+                        "active_connections": metrics.active_connections.load(Ordering::Relaxed),
+                        "backend_timeouts": metrics.backend_timeouts.load(Ordering::Relaxed),
+                        "backend_errors": metrics.backend_errors.load(Ordering::Relaxed),
+                    }),
+                ),
+                (
+                    "tls".to_string(),
+                    json!({
+                        "listeners": tls_listeners,
+                    }),
+                ),
+                (
+                    "extension_model".to_string(),
+                    json!({
+                        "status": "non_goal",
+                        "details": "No plugin/middleware ABI is exposed in-process today; extension support remains a deliberate non-goal until a safe isolation model is designed.",
+                    }),
+                ),
+            ]);
+            if let Some(runtime) = state.current_generation() {
+                response.insert(
+                    "runtime".to_string(),
+                    json!({
+                        "generation": runtime.generation(),
+                        "config_path": runtime.startup().config_path,
+                    }),
+                );
+            }
+            return Self::json_response(StatusCode::OK, serde_json::Value::Object(response));
         }
 
         if req.method() == Method::POST && path == paths.reload_certs_path.as_str() {
@@ -495,192 +528,6 @@ impl QUICListener {
             );
         }
 
-        if req.method() == Method::POST && path == paths.restart_path.as_str() {
-            if !Self::control_api_is_authorized(&req, state) {
-                return Self::json_response(
-                    StatusCode::UNAUTHORIZED,
-                    json!({
-                        "accepted": false,
-                        "error": "unauthorized",
-                    }),
-                );
-            }
-            if !state.watchdog.enabled() {
-                return Self::json_response(
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    json!({
-                        "accepted": false,
-                        "error": "watchdog disabled",
-                    }),
-                );
-            }
-
-            let accepted = state.watchdog.request_restart("admin_runtime_api");
-            return Self::json_response(
-                if accepted {
-                    StatusCode::ACCEPTED
-                } else {
-                    StatusCode::CONFLICT
-                },
-                json!({
-                    "accepted": accepted,
-                    "restart_requested": state.watchdog.restart_requested(),
-                    "reason": if accepted { "admin_runtime_api" } else { "restart pending or cooldown active" },
-                }),
-            );
-        }
-
-        match Response::builder()
-            .status(StatusCode::NOT_FOUND)
-            .body(Full::new(Bytes::from_static(b"not found\n")))
-        {
-            Ok(resp) => resp,
-            Err(_) => Response::new(Full::new(Bytes::from_static(b"not found\n"))),
-        }
-    }
-
-    fn handle_runtime_control_api_request(
-        req: Request<Incoming>,
-        state: &ControlApiState,
-    ) -> Response<Full<Bytes>> {
-        let paths = state.current_paths();
-        let path = req.uri().path();
-        let Some(runtime_bundle_handle) = state.runtime_bundle.as_ref() else {
-            return Self::json_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                json!({
-                    "error": "runtime bundle missing",
-                }),
-            );
-        };
-        let runtime = runtime_bundle_handle.current_view();
-        let shared = runtime.shared_services();
-        let generation = runtime.state();
-
-        if req.method() == Method::GET && path == paths.health_path.as_str() {
-            let response = json!({
-                "status": "ok",
-                "uptime_ms": state.started_at.elapsed().as_millis() as u64,
-                "watchdog": {
-                    "enabled": shared.watchdog.enabled(),
-                    "degraded": shared.watchdog.is_degraded(),
-                    "restart_requested": shared.watchdog.restart_requested(),
-                },
-            });
-            return Self::json_response(StatusCode::OK, response);
-        }
-
-        if req.method() == Method::GET && path == paths.ready_path.as_str() {
-            let (healthy_backends, total_backends) = state.snapshot_backend_health();
-            let restart_requested = shared.watchdog.restart_requested();
-            let ready = !restart_requested && (total_backends == 0 || healthy_backends > 0);
-            let response = json!({
-                "ready": ready,
-                "healthy_backends": healthy_backends,
-                "total_backends": total_backends,
-                "restart_requested": restart_requested,
-            });
-            return Self::json_response(
-                if ready {
-                    StatusCode::OK
-                } else {
-                    StatusCode::SERVICE_UNAVAILABLE
-                },
-                response,
-            );
-        }
-
-        if req.method() == Method::GET && path == paths.runtime_path.as_str() {
-            if !Self::control_api_is_authorized(&req, state) {
-                return Self::json_response(
-                    StatusCode::UNAUTHORIZED,
-                    json!({
-                        "error": "unauthorized",
-                    }),
-                );
-            }
-            let (healthy_backends, total_backends) = state.snapshot_backend_health();
-            let tls_listeners = shared
-                .listener_tls_store
-                .snapshot()
-                .into_iter()
-                .map(|(listener, inventory)| {
-                    (
-                        listener.clone(),
-                        json!({
-                            "default_cert": inventory.default_identity.identity.cert_path,
-                            "default_key": inventory.default_identity.identity.key_path,
-                            "default_cert_not_after_unix_seconds": inventory.default_identity.metadata.not_after_unix_seconds,
-                            "sni_names": inventory.sni_identities.keys().cloned().collect::<Vec<_>>(),
-                            "client_auth_enabled": inventory.listener_tls.client_auth.enabled,
-                            "require_client_cert": inventory.listener_tls.client_auth.require_client_cert,
-                            "generation": shared.listener_tls_store.generation(&listener).unwrap_or(0),
-                        }),
-                    )
-                })
-                .collect::<serde_json::Map<String, serde_json::Value>>();
-            let response = json!({
-                "uptime_ms": state.started_at.elapsed().as_millis() as u64,
-                "workers": {
-                    "expected": state.expected_workers,
-                },
-                "watchdog": {
-                    "enabled": shared.watchdog.enabled(),
-                    "degraded": shared.watchdog.is_degraded(),
-                    "restart_requested": shared.watchdog.restart_requested(),
-                    "restart_reason": shared.watchdog.restart_reason(),
-                    "restart_requested_at_ms": shared.watchdog.restart_requested_at_ms(),
-                },
-                "adaptive_admission": {
-                    "enabled": generation.resilience.adaptive_admission.enabled(),
-                    "current_limit": generation.resilience.adaptive_admission.current_limit(),
-                    "inflight_percent": generation.resilience.adaptive_admission.inflight_percent(),
-                },
-                "backends": {
-                    "healthy": healthy_backends,
-                    "total": total_backends,
-                },
-                "metrics": {
-                    "requests_total": shared.metrics.requests_total.load(Ordering::Relaxed),
-                    "requests_success": shared.metrics.requests_success.load(Ordering::Relaxed),
-                    "requests_failure": shared.metrics.requests_failure.load(Ordering::Relaxed),
-                    "active_connections": shared.metrics.active_connections.load(Ordering::Relaxed),
-                    "backend_timeouts": shared.metrics.backend_timeouts.load(Ordering::Relaxed),
-                    "backend_errors": shared.metrics.backend_errors.load(Ordering::Relaxed),
-                },
-                "tls": {
-                    "listeners": tls_listeners,
-                },
-                "runtime": {
-                    "generation": runtime.generation(),
-                    "config_path": runtime.startup().config_path,
-                },
-                "extension_model": {
-                    "status": "non_goal",
-                    "details": "No plugin/middleware ABI is exposed in-process today; extension support remains a deliberate non-goal until a safe isolation model is designed.",
-                },
-            });
-            return Self::json_response(StatusCode::OK, response);
-        }
-
-        if req.method() == Method::POST && path == paths.reload_certs_path.as_str() {
-            if !Self::control_api_is_authorized(&req, state) {
-                return Self::json_response(
-                    StatusCode::UNAUTHORIZED,
-                    json!({
-                        "reloaded": false,
-                        "error": "unauthorized",
-                    }),
-                );
-            }
-
-            return Self::reload_listener_certs(
-                generation.listener_runtime_configs.as_ref(),
-                shared.listener_tls_store.as_ref(),
-                shared.metrics.as_ref(),
-            );
-        }
-
         if req.method() == Method::POST && path == paths.reload_path.as_str() {
             if !Self::control_api_is_authorized(&req, state) {
                 return Self::json_response(
@@ -691,6 +538,25 @@ impl QUICListener {
                     }),
                 );
             }
+
+            let Some(runtime_bundle_handle) = state.runtime_bundle.as_ref() else {
+                return match Response::builder()
+                    .status(StatusCode::NOT_FOUND)
+                    .body(Full::new(Bytes::from_static(b"not found\n")))
+                {
+                    Ok(resp) => resp,
+                    Err(_) => Response::new(Full::new(Bytes::from_static(b"not found\n"))),
+                };
+            };
+            let Some(runtime) = state.current_generation() else {
+                return Self::json_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    json!({
+                        "reloaded": false,
+                        "error": "runtime generation unavailable",
+                    }),
+                );
+            };
 
             let plan = match Self::build_runtime_reload_plan(&runtime) {
                 Ok(plan) => plan,
@@ -761,7 +627,7 @@ impl QUICListener {
                     }),
                 );
             }
-            if !shared.watchdog.enabled() {
+            if !watchdog.enabled() {
                 return Self::json_response(
                     StatusCode::SERVICE_UNAVAILABLE,
                     json!({
@@ -771,7 +637,7 @@ impl QUICListener {
                 );
             }
 
-            let accepted = shared.watchdog.request_restart("admin_runtime_api");
+            let accepted = watchdog.request_restart("admin_runtime_api");
             return Self::json_response(
                 if accepted {
                     StatusCode::ACCEPTED
@@ -780,7 +646,7 @@ impl QUICListener {
                 },
                 json!({
                     "accepted": accepted,
-                    "restart_requested": shared.watchdog.restart_requested(),
+                    "restart_requested": watchdog.restart_requested(),
                     "reason": if accepted { "admin_runtime_api" } else { "restart pending or cooldown active" },
                 }),
             );

--- a/crates/edge/src/quic_listener/control_api/http.rs
+++ b/crates/edge/src/quic_listener/control_api/http.rs
@@ -692,12 +692,18 @@ impl QUICListener {
                 );
             }
 
-            let config_path = runtime.startup().config_path.clone();
-            let config = match read_config(&config_path) {
-                Ok(config) => config,
+            let plan = match Self::build_runtime_reload_plan(&runtime) {
+                Ok(plan) => plan,
                 Err(err) => {
+                    let status = if err.starts_with("Configuration validation failed:")
+                        || err.starts_with("Runtime configuration normalization failed:")
+                    {
+                        StatusCode::BAD_REQUEST
+                    } else {
+                        StatusCode::INTERNAL_SERVER_ERROR
+                    };
                     return Self::json_response(
-                        StatusCode::INTERNAL_SERVER_ERROR,
+                        status,
                         json!({
                             "reloaded": false,
                             "error": err,
@@ -705,51 +711,7 @@ impl QUICListener {
                     );
                 }
             };
-            if let Err(err) = spooky_config::validator::validate(&config) {
-                return Self::json_response(
-                    StatusCode::BAD_REQUEST,
-                    json!({
-                        "reloaded": false,
-                        "error": format!("Configuration validation failed: {err}"),
-                    }),
-                );
-            }
-            let runtime_config = match RuntimeConfig::from_config(&config) {
-                Ok(runtime_config) => runtime_config,
-                Err(err) => {
-                    return Self::json_response(
-                        StatusCode::BAD_REQUEST,
-                        json!({
-                            "reloaded": false,
-                            "error": format!("Runtime configuration normalization failed: {err}"),
-                        }),
-                    );
-                }
-            };
-            let next_shared_state = match QUICListener::build_shared_state(&runtime_config) {
-                Ok(shared_state) => Arc::new(shared_state),
-                Err(err) => {
-                    return Self::json_response(
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        json!({
-                            "reloaded": false,
-                            "error": err.to_string(),
-                        }),
-                    );
-                }
-            };
-            let next_runtime = RuntimeBundle {
-                generation: runtime.generation().saturating_add(1),
-                startup: crate::runtime::generation::StartupOwnedRuntimeState {
-                    config_path,
-                    log_config: config.log.clone(),
-                },
-                runtime_config,
-                shared_state: Arc::clone(&next_shared_state),
-            };
-            if let Some(err) =
-                Self::validate_runtime_reload_compatibility(runtime.bundle(), &next_runtime)
-            {
+            if let Err(err) = Self::validate_runtime_reload_plan(&runtime, &plan.next_runtime) {
                 return Self::json_response(
                     StatusCode::CONFLICT,
                     json!({
@@ -758,47 +720,9 @@ impl QUICListener {
                     }),
                 );
             }
-            if let Some(err) =
-                Self::validate_control_api_reload_compatibility(runtime.bundle(), &next_runtime)
-            {
-                return Self::json_response(
-                    StatusCode::CONFLICT,
-                    json!({
-                        "reloaded": false,
-                        "error": err,
-                    }),
-                );
-            }
-            if let Some(err) =
-                Self::validate_metrics_reload_compatibility(runtime.bundle(), &next_runtime)
-            {
-                return Self::json_response(
-                    StatusCode::CONFLICT,
-                    json!({
-                        "reloaded": false,
-                        "error": err,
-                    }),
-                );
-            }
-            let startup_owned_issues =
-                Self::validate_startup_owned_reload_compatibility(runtime.bundle(), &next_runtime);
-            if !startup_owned_issues.is_empty() {
-                return Self::json_response(
-                    StatusCode::CONFLICT,
-                    json!({
-                        "reloaded": false,
-                        "error": startup_owned_issues.join("; "),
-                    }),
-                );
-            }
-            let current_log_level = runtime.startup().log_config.level.clone();
-            let next_log_level = next_runtime.startup.log_config.level.clone();
-
-            QUICListener::spawn_generation_background_tasks_for_runtime(
-                &next_runtime.runtime_config,
-                next_runtime.shared_state.as_ref(),
-            );
-            let generation = match runtime_bundle_handle.replace(next_runtime) {
+            let current_log_level = plan.current_log_level.clone();
+            let next_log_level = plan.next_log_level.clone();
+            let generation = match Self::apply_runtime_reload_plan(runtime_bundle_handle, plan) {
                 Ok(generation) => generation,
                 Err(err) => {
                     return Self::json_response(

--- a/crates/edge/src/quic_listener/control_api/http.rs
+++ b/crates/edge/src/quic_listener/control_api/http.rs
@@ -650,7 +650,7 @@ impl QUICListener {
                 },
                 "runtime": {
                     "generation": runtime.generation,
-                    "config_path": runtime.config_path,
+                    "config_path": runtime.startup.config_path,
                 },
                 "extension_model": {
                     "status": "non_goal",
@@ -689,7 +689,7 @@ impl QUICListener {
                 );
             }
 
-            let config_path = runtime.config_path.clone();
+            let config_path = runtime.startup.config_path.clone();
             let config = match read_config(&config_path) {
                 Ok(config) => config,
                 Err(err) => {
@@ -737,8 +737,10 @@ impl QUICListener {
             };
             let next_runtime = RuntimeBundle {
                 generation: runtime.generation.saturating_add(1),
-                config_path,
-                log_config: config.log.clone(),
+                startup: crate::runtime::generation::StartupOwnedRuntimeState {
+                    config_path,
+                    log_config: config.log.clone(),
+                },
                 runtime_config,
                 shared_state: Arc::clone(&next_shared_state),
             };
@@ -784,8 +786,8 @@ impl QUICListener {
                     }),
                 );
             }
-            let current_log_level = runtime.log_config.level.clone();
-            let next_log_level = next_runtime.log_config.level.clone();
+            let current_log_level = runtime.startup.log_config.level.clone();
+            let next_log_level = next_runtime.startup.log_config.level.clone();
 
             QUICListener::spawn_generation_background_tasks_for_runtime(
                 &next_runtime.runtime_config,

--- a/crates/edge/src/quic_listener/control_api/http.rs
+++ b/crates/edge/src/quic_listener/control_api/http.rs
@@ -52,8 +52,10 @@ impl QUICListener {
             ProxyError::Transport("no effective listeners configured".to_string())
         })?;
         let primary_listener_label = Self::listener_label(&listener_config);
+        let shared = shared_state.shared_services();
+        let generation = shared_state.generation_state();
         if startup_endpoint.enabled
-            && shared_state
+            && shared
                 .listener_tls_store
                 .bootstrap_server_config(&primary_listener_label)
                 .is_none()
@@ -70,12 +72,12 @@ impl QUICListener {
         }
         let state = ControlApiState {
             control_api: endpoint.clone(),
-            metrics: Arc::clone(&shared_state.metrics),
-            resilience: Arc::clone(&shared_state.resilience),
-            watchdog: Arc::clone(&shared_state.watchdog),
-            upstream_pools: shared_state.upstream_pools.clone(),
-            listener_runtime_configs: Arc::clone(&shared_state.listener_runtime_configs),
-            listener_tls_store: Arc::clone(&shared_state.listener_tls_store),
+            metrics: Arc::clone(&shared.metrics),
+            resilience: Arc::clone(&generation.resilience),
+            watchdog: Arc::clone(&shared.watchdog),
+            upstream_pools: generation.upstream_pools.clone(),
+            listener_runtime_configs: Arc::clone(&generation.listener_runtime_configs),
+            listener_tls_store: Arc::clone(&shared.listener_tls_store),
             primary_listener_label,
             expected_workers: worker_count.max(1),
             started_at: Instant::now(),
@@ -117,7 +119,7 @@ impl QUICListener {
         spawn_supervised_async_task(
             &handle,
             "control-api-endpoint",
-            Some(Arc::clone(&shared_state.metrics)),
+            Some(Arc::clone(&shared.metrics)),
             async move {
                 let mut listener_binding = initial_binding;
 
@@ -553,15 +555,17 @@ impl QUICListener {
         };
         let runtime = runtime_bundle_handle.current();
         let shared_state = &runtime.shared_state;
+        let shared = shared_state.shared_services();
+        let generation = shared_state.generation_state();
 
         if req.method() == Method::GET && path == paths.health_path.as_str() {
             let response = json!({
                 "status": "ok",
                 "uptime_ms": state.started_at.elapsed().as_millis() as u64,
                 "watchdog": {
-                    "enabled": shared_state.watchdog.enabled(),
-                    "degraded": shared_state.watchdog.is_degraded(),
-                    "restart_requested": shared_state.watchdog.restart_requested(),
+                    "enabled": shared.watchdog.enabled(),
+                    "degraded": shared.watchdog.is_degraded(),
+                    "restart_requested": shared.watchdog.restart_requested(),
                 },
             });
             return Self::json_response(StatusCode::OK, response);
@@ -569,7 +573,7 @@ impl QUICListener {
 
         if req.method() == Method::GET && path == paths.ready_path.as_str() {
             let (healthy_backends, total_backends) = state.snapshot_backend_health();
-            let restart_requested = shared_state.watchdog.restart_requested();
+            let restart_requested = shared.watchdog.restart_requested();
             let ready = !restart_requested && (total_backends == 0 || healthy_backends > 0);
             let response = json!({
                 "ready": ready,
@@ -597,7 +601,7 @@ impl QUICListener {
                 );
             }
             let (healthy_backends, total_backends) = state.snapshot_backend_health();
-            let tls_listeners = shared_state
+            let tls_listeners = shared
                 .listener_tls_store
                 .snapshot()
                 .into_iter()
@@ -611,7 +615,7 @@ impl QUICListener {
                             "sni_names": inventory.sni_identities.keys().cloned().collect::<Vec<_>>(),
                             "client_auth_enabled": inventory.listener_tls.client_auth.enabled,
                             "require_client_cert": inventory.listener_tls.client_auth.require_client_cert,
-                            "generation": shared_state.listener_tls_store.generation(&listener).unwrap_or(0),
+                            "generation": shared.listener_tls_store.generation(&listener).unwrap_or(0),
                         }),
                     )
                 })
@@ -622,28 +626,28 @@ impl QUICListener {
                     "expected": state.expected_workers,
                 },
                 "watchdog": {
-                    "enabled": shared_state.watchdog.enabled(),
-                    "degraded": shared_state.watchdog.is_degraded(),
-                    "restart_requested": shared_state.watchdog.restart_requested(),
-                    "restart_reason": shared_state.watchdog.restart_reason(),
-                    "restart_requested_at_ms": shared_state.watchdog.restart_requested_at_ms(),
+                    "enabled": shared.watchdog.enabled(),
+                    "degraded": shared.watchdog.is_degraded(),
+                    "restart_requested": shared.watchdog.restart_requested(),
+                    "restart_reason": shared.watchdog.restart_reason(),
+                    "restart_requested_at_ms": shared.watchdog.restart_requested_at_ms(),
                 },
                 "adaptive_admission": {
-                    "enabled": shared_state.resilience.adaptive_admission.enabled(),
-                    "current_limit": shared_state.resilience.adaptive_admission.current_limit(),
-                    "inflight_percent": shared_state.resilience.adaptive_admission.inflight_percent(),
+                    "enabled": generation.resilience.adaptive_admission.enabled(),
+                    "current_limit": generation.resilience.adaptive_admission.current_limit(),
+                    "inflight_percent": generation.resilience.adaptive_admission.inflight_percent(),
                 },
                 "backends": {
                     "healthy": healthy_backends,
                     "total": total_backends,
                 },
                 "metrics": {
-                    "requests_total": shared_state.metrics.requests_total.load(Ordering::Relaxed),
-                    "requests_success": shared_state.metrics.requests_success.load(Ordering::Relaxed),
-                    "requests_failure": shared_state.metrics.requests_failure.load(Ordering::Relaxed),
-                    "active_connections": shared_state.metrics.active_connections.load(Ordering::Relaxed),
-                    "backend_timeouts": shared_state.metrics.backend_timeouts.load(Ordering::Relaxed),
-                    "backend_errors": shared_state.metrics.backend_errors.load(Ordering::Relaxed),
+                    "requests_total": shared.metrics.requests_total.load(Ordering::Relaxed),
+                    "requests_success": shared.metrics.requests_success.load(Ordering::Relaxed),
+                    "requests_failure": shared.metrics.requests_failure.load(Ordering::Relaxed),
+                    "active_connections": shared.metrics.active_connections.load(Ordering::Relaxed),
+                    "backend_timeouts": shared.metrics.backend_timeouts.load(Ordering::Relaxed),
+                    "backend_errors": shared.metrics.backend_errors.load(Ordering::Relaxed),
                 },
                 "tls": {
                     "listeners": tls_listeners,
@@ -672,9 +676,9 @@ impl QUICListener {
             }
 
             return Self::reload_listener_certs(
-                shared_state.listener_runtime_configs.as_ref(),
-                shared_state.listener_tls_store.as_ref(),
-                shared_state.metrics.as_ref(),
+                generation.listener_runtime_configs.as_ref(),
+                shared.listener_tls_store.as_ref(),
+                shared.metrics.as_ref(),
             );
         }
 
@@ -837,7 +841,7 @@ impl QUICListener {
                     }),
                 );
             }
-            if !shared_state.watchdog.enabled() {
+            if !shared.watchdog.enabled() {
                 return Self::json_response(
                     StatusCode::SERVICE_UNAVAILABLE,
                     json!({
@@ -847,7 +851,7 @@ impl QUICListener {
                 );
             }
 
-            let accepted = shared_state.watchdog.request_restart("admin_runtime_api");
+            let accepted = shared.watchdog.request_restart("admin_runtime_api");
             return Self::json_response(
                 if accepted {
                     StatusCode::ACCEPTED
@@ -856,7 +860,7 @@ impl QUICListener {
                 },
                 json!({
                     "accepted": accepted,
-                    "restart_requested": shared_state.watchdog.restart_requested(),
+                    "restart_requested": shared.watchdog.restart_requested(),
                     "reason": if accepted { "admin_runtime_api" } else { "restart pending or cooldown active" },
                 }),
             );

--- a/crates/edge/src/quic_listener/control_api/reload.rs
+++ b/crates/edge/src/quic_listener/control_api/reload.rs
@@ -1,6 +1,75 @@
 use super::*;
+use crate::runtime::bundle::{ActiveRuntimeGeneration, RuntimeBundleHandle};
+
+pub(super) struct RuntimeReloadPlan {
+    pub(super) next_runtime: RuntimeBundle,
+    pub(super) current_log_level: String,
+    pub(super) next_log_level: String,
+}
 
 impl QUICListener {
+    pub(super) fn build_runtime_reload_plan(
+        current: &ActiveRuntimeGeneration,
+    ) -> Result<RuntimeReloadPlan, String> {
+        let config_path = current.startup().config_path.clone();
+        let config = read_config(&config_path)?;
+        spooky_config::validator::validate(&config)
+            .map_err(|err| format!("Configuration validation failed: {err}"))?;
+        let runtime_config = RuntimeConfig::from_config(&config)
+            .map_err(|err| format!("Runtime configuration normalization failed: {err}"))?;
+        let next_shared_state = QUICListener::build_shared_state(&runtime_config)
+            .map(Arc::new)
+            .map_err(|err| err.to_string())?;
+        let current_log_level = current.startup().log_config.level.clone();
+        let next_log_level = config.log.level.clone();
+
+        Ok(RuntimeReloadPlan {
+            next_runtime: RuntimeBundle {
+                generation: current.generation().saturating_add(1),
+                startup: crate::runtime::generation::StartupOwnedRuntimeState {
+                    config_path,
+                    log_config: config.log.clone(),
+                },
+                runtime_config,
+                shared_state: next_shared_state,
+            },
+            current_log_level,
+            next_log_level,
+        })
+    }
+
+    pub(super) fn validate_runtime_reload_plan(
+        current: &ActiveRuntimeGeneration,
+        next: &RuntimeBundle,
+    ) -> Result<(), String> {
+        if let Some(err) = Self::validate_runtime_reload_compatibility(current.bundle(), next) {
+            return Err(err);
+        }
+        if let Some(err) = Self::validate_control_api_reload_compatibility(current.bundle(), next) {
+            return Err(err);
+        }
+        if let Some(err) = Self::validate_metrics_reload_compatibility(current.bundle(), next) {
+            return Err(err);
+        }
+        let startup_owned_issues =
+            Self::validate_startup_owned_reload_compatibility(current.bundle(), next);
+        if !startup_owned_issues.is_empty() {
+            return Err(startup_owned_issues.join("; "));
+        }
+        Ok(())
+    }
+
+    pub(super) fn apply_runtime_reload_plan(
+        runtime_bundle_handle: &RuntimeBundleHandle,
+        plan: RuntimeReloadPlan,
+    ) -> Result<u64, ProxyError> {
+        QUICListener::spawn_generation_background_tasks_for_runtime(
+            &plan.next_runtime.runtime_config,
+            plan.next_runtime.shared_state.as_ref(),
+        );
+        runtime_bundle_handle.replace(plan.next_runtime)
+    }
+
     pub(super) fn validate_runtime_reload_compatibility(
         current: &RuntimeBundle,
         next: &RuntimeBundle,

--- a/crates/edge/src/quic_listener/control_api/reload.rs
+++ b/crates/edge/src/quic_listener/control_api/reload.rs
@@ -142,20 +142,20 @@ impl QUICListener {
         Self::note_restart_required_change(
             &mut issues,
             "log.file.enabled",
-            &current.log_config.file.enabled,
-            &next.log_config.file.enabled,
+            &current.startup.log_config.file.enabled,
+            &next.startup.log_config.file.enabled,
         );
         Self::note_restart_required_change(
             &mut issues,
             "log.file.path",
-            &current.log_config.file.path,
-            &next.log_config.file.path,
+            &current.startup.log_config.file.path,
+            &next.startup.log_config.file.path,
         );
         Self::note_restart_required_change(
             &mut issues,
             "log.format",
-            &current.log_config.format,
-            &next.log_config.format,
+            &current.startup.log_config.format,
+            &next.startup.log_config.format,
         );
 
         let current_tracing = &current.runtime_config.observability.tracing;

--- a/crates/edge/src/quic_listener/control_api/reload.rs
+++ b/crates/edge/src/quic_listener/control_api/reload.rs
@@ -5,9 +5,15 @@ impl QUICListener {
         current: &RuntimeBundle,
         next: &RuntimeBundle,
     ) -> Option<String> {
-        for label in current.shared_state.listener_runtime_configs.keys() {
+        for label in current
+            .shared_state
+            .generation_state()
+            .listener_runtime_configs
+            .keys()
+        {
             if !next
                 .shared_state
+                .generation_state()
                 .listener_runtime_configs
                 .contains_key(label)
             {
@@ -19,9 +25,15 @@ impl QUICListener {
         }
 
         let worker_count = next.runtime_config.performance.worker_threads.max(1);
-        for (label, listener_config) in next.shared_state.listener_runtime_configs.iter() {
+        for (label, listener_config) in next
+            .shared_state
+            .generation_state()
+            .listener_runtime_configs
+            .iter()
+        {
             if current
                 .shared_state
+                .generation_state()
                 .listener_runtime_configs
                 .contains_key(label)
             {
@@ -73,6 +85,7 @@ impl QUICListener {
         let primary_listener_label = Self::listener_label(&listener_config);
         if next
             .shared_state
+            .shared_services()
             .listener_tls_store
             .bootstrap_server_config(&primary_listener_label)
             .is_none()

--- a/crates/edge/src/quic_listener/control_api/state.rs
+++ b/crates/edge/src/quic_listener/control_api/state.rs
@@ -63,13 +63,17 @@ impl Drop for ConnectionSlotGuard {
 }
 
 impl ControlApiState {
-    pub(super) fn current_runtime(&self) -> Option<Arc<RuntimeBundle>> {
-        self.runtime_bundle.as_ref().map(|handle| handle.current())
+    pub(super) fn current_runtime(
+        &self,
+    ) -> Option<crate::runtime::bundle::ActiveRuntimeGeneration> {
+        self.runtime_bundle
+            .as_ref()
+            .map(|handle| handle.current_view())
     }
 
     pub(super) fn current_control_api(&self) -> ControlApiConfig {
         self.current_runtime()
-            .map(|runtime| runtime.runtime_config.observability.control_api.clone())
+            .map(|runtime| runtime.runtime_config().observability.control_api.clone())
             .unwrap_or_else(|| self.control_api.clone())
     }
 
@@ -79,13 +83,7 @@ impl ControlApiState {
 
     pub(super) fn current_listener_tls_store(&self) -> Arc<ListenerTlsReloadStore> {
         self.current_runtime()
-            .map(|runtime| {
-                runtime
-                    .shared_state
-                    .shared_services()
-                    .listener_tls_store
-                    .clone()
-            })
+            .map(|runtime| runtime.shared_services().listener_tls_store.clone())
             .unwrap_or_else(|| Arc::clone(&self.listener_tls_store))
     }
 
@@ -93,19 +91,13 @@ impl ControlApiState {
         &self,
     ) -> Arc<HashMap<String, ListenerRuntimeConfig>> {
         self.current_runtime()
-            .map(|runtime| {
-                runtime
-                    .shared_state
-                    .generation_state()
-                    .listener_runtime_configs
-                    .clone()
-            })
+            .map(|runtime| runtime.state().listener_runtime_configs.clone())
             .unwrap_or_else(|| Arc::clone(&self.listener_runtime_configs))
     }
 
     pub(super) fn current_metrics(&self) -> Arc<Metrics> {
         self.current_runtime()
-            .map(|runtime| runtime.shared_state.shared_services().metrics.clone())
+            .map(|runtime| runtime.shared_services().metrics.clone())
             .unwrap_or_else(|| Arc::clone(&self.metrics))
     }
 
@@ -113,7 +105,7 @@ impl ControlApiState {
         self.current_runtime()
             .and_then(|runtime| {
                 runtime
-                    .runtime_config
+                    .runtime_config()
                     .primary_listener_runtime_config()
                     .map(|listener| QUICListener::listener_label(&listener))
             })
@@ -124,12 +116,7 @@ impl ControlApiState {
         if let Some(runtime) = self.current_runtime() {
             let mut healthy = 0usize;
             let mut total = 0usize;
-            for pool in runtime
-                .shared_state
-                .generation_state()
-                .upstream_pools
-                .values()
-            {
+            for pool in runtime.state().upstream_pools.values() {
                 let guard = match pool.read() {
                     Ok(guard) => guard,
                     Err(_) => continue,

--- a/crates/edge/src/quic_listener/control_api/state.rs
+++ b/crates/edge/src/quic_listener/control_api/state.rs
@@ -1,6 +1,7 @@
 use std::sync::atomic::AtomicUsize;
 
 use super::*;
+use crate::runtime::{bundle::ActiveRuntimeGeneration, generation::RuntimeGenerationView};
 
 #[derive(Clone)]
 pub(super) struct ControlApiPaths {
@@ -63,18 +64,27 @@ impl Drop for ConnectionSlotGuard {
 }
 
 impl ControlApiState {
-    pub(super) fn current_runtime(
-        &self,
-    ) -> Option<crate::runtime::bundle::ActiveRuntimeGeneration> {
+    pub(super) fn current_generation(&self) -> Option<ActiveRuntimeGeneration> {
         self.runtime_bundle
             .as_ref()
             .map(|handle| handle.current_view())
     }
 
+    pub(super) fn with_current_generation<R>(
+        &self,
+        f: impl FnOnce(Option<RuntimeGenerationView<'_>>) -> R,
+    ) -> R {
+        match self.runtime_bundle.as_ref() {
+            Some(handle) => handle.with_current_view(|view| f(Some(view))),
+            None => f(None),
+        }
+    }
+
     pub(super) fn current_control_api(&self) -> ControlApiConfig {
-        self.current_runtime()
-            .map(|runtime| runtime.runtime_config().observability.control_api.clone())
-            .unwrap_or_else(|| self.control_api.clone())
+        self.with_current_generation(|runtime| {
+            runtime.map(|view| view.runtime_config.observability.control_api.clone())
+        })
+        .unwrap_or_else(|| self.control_api.clone())
     }
 
     pub(super) fn current_paths(&self) -> ControlApiPaths {
@@ -82,38 +92,39 @@ impl ControlApiState {
     }
 
     pub(super) fn current_listener_tls_store(&self) -> Arc<ListenerTlsReloadStore> {
-        self.current_runtime()
-            .map(|runtime| runtime.shared_services().listener_tls_store.clone())
-            .unwrap_or_else(|| Arc::clone(&self.listener_tls_store))
+        self.with_current_generation(|runtime| {
+            runtime.map(|view| view.shared.listener_tls_store.clone())
+        })
+        .unwrap_or_else(|| Arc::clone(&self.listener_tls_store))
     }
 
     pub(super) fn current_listener_runtime_configs(
         &self,
     ) -> Arc<HashMap<String, ListenerRuntimeConfig>> {
-        self.current_runtime()
-            .map(|runtime| runtime.state().listener_runtime_configs.clone())
-            .unwrap_or_else(|| Arc::clone(&self.listener_runtime_configs))
+        self.with_current_generation(|runtime| {
+            runtime.map(|view| view.state.listener_runtime_configs.clone())
+        })
+        .unwrap_or_else(|| Arc::clone(&self.listener_runtime_configs))
     }
 
     pub(super) fn current_metrics(&self) -> Arc<Metrics> {
-        self.current_runtime()
-            .map(|runtime| runtime.shared_services().metrics.clone())
+        self.with_current_generation(|runtime| runtime.map(|view| view.shared.metrics.clone()))
             .unwrap_or_else(|| Arc::clone(&self.metrics))
     }
 
     pub(super) fn current_primary_listener_label(&self) -> Option<String> {
-        self.current_runtime()
-            .and_then(|runtime| {
-                runtime
-                    .runtime_config()
+        self.with_current_generation(|runtime| {
+            runtime.and_then(|view| {
+                view.runtime_config
                     .primary_listener_runtime_config()
                     .map(|listener| QUICListener::listener_label(&listener))
             })
-            .or_else(|| Some(self.primary_listener_label.clone()))
+        })
+        .or_else(|| Some(self.primary_listener_label.clone()))
     }
 
     pub(super) fn snapshot_backend_health(&self) -> (usize, usize) {
-        if let Some(runtime) = self.current_runtime() {
+        if let Some(runtime) = self.current_generation() {
             let mut healthy = 0usize;
             let mut total = 0usize;
             for pool in runtime.state().upstream_pools.values() {

--- a/crates/edge/src/quic_listener/control_api/state.rs
+++ b/crates/edge/src/quic_listener/control_api/state.rs
@@ -112,6 +112,16 @@ impl ControlApiState {
             .unwrap_or_else(|| Arc::clone(&self.metrics))
     }
 
+    pub(super) fn current_watchdog(&self) -> Arc<WatchdogCoordinator> {
+        self.with_current_generation(|runtime| runtime.map(|view| view.shared.watchdog.clone()))
+            .unwrap_or_else(|| Arc::clone(&self.watchdog))
+    }
+
+    pub(super) fn current_resilience(&self) -> Arc<RuntimeResilience> {
+        self.with_current_generation(|runtime| runtime.map(|view| view.state.resilience.clone()))
+            .unwrap_or_else(|| Arc::clone(&self.resilience))
+    }
+
     pub(super) fn current_primary_listener_label(&self) -> Option<String> {
         self.with_current_generation(|runtime| {
             runtime.and_then(|view| {

--- a/crates/edge/src/quic_listener/control_api/state.rs
+++ b/crates/edge/src/quic_listener/control_api/state.rs
@@ -79,7 +79,13 @@ impl ControlApiState {
 
     pub(super) fn current_listener_tls_store(&self) -> Arc<ListenerTlsReloadStore> {
         self.current_runtime()
-            .map(|runtime| runtime.shared_state.listener_tls_store.clone())
+            .map(|runtime| {
+                runtime
+                    .shared_state
+                    .shared_services()
+                    .listener_tls_store
+                    .clone()
+            })
             .unwrap_or_else(|| Arc::clone(&self.listener_tls_store))
     }
 
@@ -87,13 +93,19 @@ impl ControlApiState {
         &self,
     ) -> Arc<HashMap<String, ListenerRuntimeConfig>> {
         self.current_runtime()
-            .map(|runtime| runtime.shared_state.listener_runtime_configs.clone())
+            .map(|runtime| {
+                runtime
+                    .shared_state
+                    .generation_state()
+                    .listener_runtime_configs
+                    .clone()
+            })
             .unwrap_or_else(|| Arc::clone(&self.listener_runtime_configs))
     }
 
     pub(super) fn current_metrics(&self) -> Arc<Metrics> {
         self.current_runtime()
-            .map(|runtime| runtime.shared_state.metrics.clone())
+            .map(|runtime| runtime.shared_state.shared_services().metrics.clone())
             .unwrap_or_else(|| Arc::clone(&self.metrics))
     }
 
@@ -112,7 +124,12 @@ impl ControlApiState {
         if let Some(runtime) = self.current_runtime() {
             let mut healthy = 0usize;
             let mut total = 0usize;
-            for pool in runtime.shared_state.upstream_pools.values() {
+            for pool in runtime
+                .shared_state
+                .generation_state()
+                .upstream_pools
+                .values()
+            {
                 let guard = match pool.read() {
                     Ok(guard) => guard,
                     Err(_) => continue,

--- a/crates/edge/src/quic_listener/control_api/tests.rs
+++ b/crates/edge/src/quic_listener/control_api/tests.rs
@@ -506,8 +506,9 @@ async fn runtime_bundle_cert_reload_ignores_unrelated_config_drift_and_bundle_sw
     drifted.performance.control_plane_threads =
         live.performance.control_plane_threads.saturating_add(1);
     let drifted_bundle = runtime_bundle_from_config("drifted.yaml", &drifted);
+    let current_runtime = runtime_handle.current_view();
     let full_reload_issues = QUICListener::validate_startup_owned_reload_compatibility(
-        runtime_handle.current().as_ref(),
+        current_runtime.bundle(),
         &drifted_bundle,
     );
     assert!(
@@ -517,33 +518,18 @@ async fn runtime_bundle_cert_reload_ignores_unrelated_config_drift_and_bundle_sw
         "expected a full reload blocker from on-disk drift, got: {full_reload_issues:?}"
     );
 
-    let generation_before = runtime_handle.generation();
-    let tls_generation_before = runtime_handle
-        .current()
-        .shared_state
+    let generation_before = runtime_handle.current_generation();
+    let live_runtime = runtime_handle.current_view();
+    let tls_generation_before = live_runtime
+        .shared_services()
         .listener_tls_store
         .generation(&state.primary_listener_label)
         .unwrap_or(0);
 
     let response = QUICListener::reload_listener_certs(
-        runtime_handle
-            .current()
-            .shared_state
-            .generation_state()
-            .listener_runtime_configs
-            .as_ref(),
-        runtime_handle
-            .current()
-            .shared_state
-            .shared_services()
-            .listener_tls_store
-            .as_ref(),
-        runtime_handle
-            .current()
-            .shared_state
-            .shared_services()
-            .metrics
-            .as_ref(),
+        live_runtime.state().listener_runtime_configs.as_ref(),
+        live_runtime.shared_services().listener_tls_store.as_ref(),
+        live_runtime.shared_services().metrics.as_ref(),
     );
     assert_eq!(response.status(), StatusCode::ACCEPTED);
 
@@ -556,15 +542,14 @@ async fn runtime_bundle_cert_reload_ignores_unrelated_config_drift_and_bundle_sw
     let payload: serde_json::Value = serde_json::from_slice(&body).expect("response json");
     assert_eq!(payload["reloaded"], serde_json::Value::Bool(true));
 
-    let current_runtime = runtime_handle.current();
-    assert_eq!(current_runtime.generation, generation_before);
+    let current_runtime = runtime_handle.current_view();
+    assert_eq!(current_runtime.generation(), generation_before);
     assert_eq!(
-        current_runtime.runtime_config.observability.metrics.path,
+        current_runtime.runtime_config().observability.metrics.path,
         "/metrics-live"
     );
     assert!(
         current_runtime
-            .shared_state
             .shared_services()
             .listener_tls_store
             .generation(&state.primary_listener_label)

--- a/crates/edge/src/quic_listener/control_api/tests.rs
+++ b/crates/edge/src/quic_listener/control_api/tests.rs
@@ -268,6 +268,46 @@ fn control_api_state_uses_live_primary_listener_label_after_runtime_swap() {
 }
 
 #[test]
+fn control_api_state_sees_the_active_runtime_generation_after_bundle_replace() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+    let mut startup = test_config(cert.clone(), key.clone());
+    startup.observability.control_api.enabled = true;
+    startup.observability.control_api.runtime_path = "/runtime-startup".to_string();
+
+    let startup_bundle = runtime_bundle_from_config("startup.yaml", &startup);
+    let (state, runtime_handle) = runtime_bundle_control_api_state(startup_bundle);
+
+    let current = state.current_generation().expect("current generation");
+    assert_eq!(current.generation(), 0);
+    assert_eq!(
+        state.current_paths().runtime_path,
+        "/runtime-startup".to_string()
+    );
+
+    let mut reloaded = startup.clone();
+    reloaded.observability.control_api.runtime_path = "/runtime-reloaded".to_string();
+    reloaded.observability.metrics.path = "/metrics-reloaded".to_string();
+
+    let mut reloaded_bundle = runtime_bundle_from_config("reloaded.yaml", &reloaded);
+    reloaded_bundle.generation = 1;
+    runtime_handle
+        .replace(reloaded_bundle)
+        .expect("replace runtime bundle");
+
+    let current = state.current_generation().expect("reloaded generation");
+    assert_eq!(current.generation(), 1);
+    assert_eq!(
+        current.runtime_config().observability.metrics.path,
+        "/metrics-reloaded"
+    );
+    assert_eq!(
+        state.current_paths().runtime_path,
+        "/runtime-reloaded".to_string()
+    );
+}
+
+#[test]
 fn validate_control_api_reload_compatibility_allows_bind_change_when_socket_is_free() {
     let dir = tempdir().expect("tempdir");
     let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");

--- a/crates/edge/src/quic_listener/control_api/tests.rs
+++ b/crates/edge/src/quic_listener/control_api/tests.rs
@@ -98,6 +98,8 @@ fn control_api_state_with_runtime_bundle(
 ) -> ControlApiState {
     let startup_bundle = runtime_bundle_from_config("startup.yaml", startup);
     let reloaded_bundle = runtime_bundle_from_config("reloaded.yaml", reloaded);
+    let startup_shared = startup_bundle.shared_state.shared_services();
+    let startup_generation = startup_bundle.shared_state.generation_state();
     let listener_config = startup_bundle
         .runtime_config
         .primary_listener_runtime_config()
@@ -109,12 +111,12 @@ fn control_api_state_with_runtime_bundle(
             .observability
             .control_api
             .clone(),
-        metrics: Arc::clone(&startup_bundle.shared_state.metrics),
-        resilience: Arc::clone(&startup_bundle.shared_state.resilience),
-        watchdog: Arc::clone(&startup_bundle.shared_state.watchdog),
-        upstream_pools: startup_bundle.shared_state.upstream_pools.clone(),
-        listener_runtime_configs: Arc::clone(&startup_bundle.shared_state.listener_runtime_configs),
-        listener_tls_store: Arc::clone(&startup_bundle.shared_state.listener_tls_store),
+        metrics: Arc::clone(&startup_shared.metrics),
+        resilience: Arc::clone(&startup_generation.resilience),
+        watchdog: Arc::clone(&startup_shared.watchdog),
+        upstream_pools: startup_generation.upstream_pools.clone(),
+        listener_runtime_configs: Arc::clone(&startup_generation.listener_runtime_configs),
+        listener_tls_store: Arc::clone(&startup_shared.listener_tls_store),
         primary_listener_label: QUICListener::listener_label(&listener_config),
         expected_workers: 1,
         started_at: Instant::now(),
@@ -125,6 +127,8 @@ fn control_api_state_with_runtime_bundle(
 fn runtime_bundle_control_api_state(
     bundle: RuntimeBundle,
 ) -> (ControlApiState, Arc<RuntimeBundleHandle>) {
+    let bundle_shared = bundle.shared_state.shared_services();
+    let bundle_generation = bundle.shared_state.generation_state();
     let listener_config = bundle
         .runtime_config
         .primary_listener_runtime_config()
@@ -132,12 +136,12 @@ fn runtime_bundle_control_api_state(
     let runtime_handle = Arc::new(RuntimeBundleHandle::new(bundle.clone()));
     let state = ControlApiState {
         control_api: bundle.runtime_config.observability.control_api.clone(),
-        metrics: Arc::clone(&bundle.shared_state.metrics),
-        resilience: Arc::clone(&bundle.shared_state.resilience),
-        watchdog: Arc::clone(&bundle.shared_state.watchdog),
-        upstream_pools: bundle.shared_state.upstream_pools.clone(),
-        listener_runtime_configs: Arc::clone(&bundle.shared_state.listener_runtime_configs),
-        listener_tls_store: Arc::clone(&bundle.shared_state.listener_tls_store),
+        metrics: Arc::clone(&bundle_shared.metrics),
+        resilience: Arc::clone(&bundle_generation.resilience),
+        watchdog: Arc::clone(&bundle_shared.watchdog),
+        upstream_pools: bundle_generation.upstream_pools.clone(),
+        listener_runtime_configs: Arc::clone(&bundle_generation.listener_runtime_configs),
+        listener_tls_store: Arc::clone(&bundle_shared.listener_tls_store),
         primary_listener_label: QUICListener::listener_label(&listener_config),
         expected_workers: 1,
         started_at: Instant::now(),
@@ -525,14 +529,21 @@ async fn runtime_bundle_cert_reload_ignores_unrelated_config_drift_and_bundle_sw
         runtime_handle
             .current()
             .shared_state
+            .generation_state()
             .listener_runtime_configs
             .as_ref(),
         runtime_handle
             .current()
             .shared_state
+            .shared_services()
             .listener_tls_store
             .as_ref(),
-        runtime_handle.current().shared_state.metrics.as_ref(),
+        runtime_handle
+            .current()
+            .shared_state
+            .shared_services()
+            .metrics
+            .as_ref(),
     );
     assert_eq!(response.status(), StatusCode::ACCEPTED);
 
@@ -554,6 +565,7 @@ async fn runtime_bundle_cert_reload_ignores_unrelated_config_drift_and_bundle_sw
     assert!(
         current_runtime
             .shared_state
+            .shared_services()
             .listener_tls_store
             .generation(&state.primary_listener_label)
             .unwrap_or(0)
@@ -594,14 +606,26 @@ async fn reload_listener_certs_is_atomic_when_any_listener_reload_fails() {
     ];
 
     let bundle = runtime_bundle_from_config("current.yaml", &config);
-    let generations_before = bundle.shared_state.listener_tls_store.generations();
+    let generations_before = bundle
+        .shared_state
+        .shared_services()
+        .listener_tls_store
+        .generations();
 
     std::fs::write(&cert2, "not a valid certificate").expect("corrupt cert");
 
     let response = QUICListener::reload_listener_certs(
-        bundle.shared_state.listener_runtime_configs.as_ref(),
-        bundle.shared_state.listener_tls_store.as_ref(),
-        bundle.shared_state.metrics.as_ref(),
+        bundle
+            .shared_state
+            .generation_state()
+            .listener_runtime_configs
+            .as_ref(),
+        bundle
+            .shared_state
+            .shared_services()
+            .listener_tls_store
+            .as_ref(),
+        bundle.shared_state.shared_services().metrics.as_ref(),
     );
     assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
 
@@ -615,7 +639,11 @@ async fn reload_listener_certs_is_atomic_when_any_listener_reload_fails() {
     assert_eq!(payload["reloaded"], serde_json::Value::Bool(false));
 
     assert_eq!(
-        bundle.shared_state.listener_tls_store.generations(),
+        bundle
+            .shared_state
+            .shared_services()
+            .listener_tls_store
+            .generations(),
         generations_before
     );
 }

--- a/crates/edge/src/quic_listener/control_plane.rs
+++ b/crates/edge/src/quic_listener/control_plane.rs
@@ -37,14 +37,12 @@ impl QUICListener {
     fn spawn_control_plane_bootstrap(
         bootstrap: ControlPlaneBootstrap<'_>,
     ) -> Result<(), ProxyError> {
-        Self::configure_expected_workers(bootstrap.shared_state, bootstrap.worker_count);
+        Self::configure_expected_workers(
+            bootstrap.shared_state.shared_services().watchdog.as_ref(),
+            bootstrap.worker_count,
+        );
         Self::spawn_generation_background_tasks(&bootstrap);
-        let shared = bootstrap.shared_state.shared_services();
-        Self::spawn_metrics_endpoint(
-            bootstrap.runtime_config,
-            Arc::clone(&shared.metrics),
-            bootstrap.runtime_bundle.clone(),
-        )?;
+        Self::spawn_metrics_endpoint(&bootstrap)?;
         Self::spawn_control_api_endpoint(
             bootstrap.runtime_config,
             bootstrap.shared_state,
@@ -55,38 +53,39 @@ impl QUICListener {
     }
 
     pub(super) fn spawn_generation_background_tasks(bootstrap: &ControlPlaneBootstrap<'_>) {
-        Self::configure_expected_workers_from_runtime(
-            bootstrap.runtime_config,
-            bootstrap.shared_state,
-        );
-        let shared_state = bootstrap.shared_state;
-        let shared = shared_state.shared_services();
-        let generation = shared_state.generation_state();
-        let task_registry = Arc::clone(&generation.generation_tasks);
-        Self::spawn_backend_dns_refresh(
-            bootstrap.runtime_config,
-            Arc::clone(&shared.transport_pool),
-            Arc::clone(&shared.backend_resolution_store),
-            shared.backend_dns_resolver.clone(),
-            Arc::clone(&shared.metrics),
-            Arc::clone(&task_registry),
-        );
-        Self::spawn_health_checks(
-            generation.upstream_pools.clone(),
-            Arc::clone(&shared.transport_pool),
-            Arc::clone(&generation.backend_endpoints),
-            Arc::clone(&generation.backend_health_checks),
-            Arc::clone(&shared.backend_resolution_store),
-            Arc::clone(&shared.metrics),
-            Arc::clone(&task_registry),
-        );
-        Self::spawn_watchdog(
-            bootstrap.runtime_config,
-            Arc::clone(&shared.metrics),
-            Arc::clone(&generation.resilience),
-            Arc::clone(&shared.watchdog),
-            task_registry,
-        );
+        bootstrap.with_runtime_view(|runtime| {
+            Self::configure_expected_workers_from_runtime(
+                runtime.runtime_config(),
+                runtime.shared_services().watchdog.as_ref(),
+            );
+            let shared = runtime.shared_services();
+            let generation = runtime.generation_state();
+            let task_registry = Arc::clone(&generation.generation_tasks);
+            Self::spawn_backend_dns_refresh(
+                runtime.runtime_config(),
+                Arc::clone(&shared.transport_pool),
+                Arc::clone(&shared.backend_resolution_store),
+                shared.backend_dns_resolver.clone(),
+                Arc::clone(&shared.metrics),
+                Arc::clone(&task_registry),
+            );
+            Self::spawn_health_checks(
+                generation.upstream_pools.clone(),
+                Arc::clone(&shared.transport_pool),
+                Arc::clone(&generation.backend_endpoints),
+                Arc::clone(&generation.backend_health_checks),
+                Arc::clone(&shared.backend_resolution_store),
+                Arc::clone(&shared.metrics),
+                Arc::clone(&task_registry),
+            );
+            Self::spawn_watchdog(
+                runtime.runtime_config(),
+                Arc::clone(&shared.metrics),
+                Arc::clone(&generation.resilience),
+                Arc::clone(&shared.watchdog),
+                task_registry,
+            );
+        });
     }
 
     pub(super) fn spawn_generation_background_tasks_for_runtime(
@@ -107,19 +106,19 @@ impl QUICListener {
         });
     }
 
-    fn configure_expected_workers(shared_state: &SharedRuntimeState, worker_count: usize) {
-        shared_state
-            .shared_services()
-            .watchdog
-            .set_expected_workers(worker_count.max(1));
+    fn configure_expected_workers(
+        watchdog: &crate::watchdog::coordinator::WatchdogCoordinator,
+        worker_count: usize,
+    ) {
+        watchdog.set_expected_workers(worker_count.max(1));
     }
 
     fn configure_expected_workers_from_runtime(
         config: &RuntimeConfig,
-        shared_state: &SharedRuntimeState,
+        watchdog: &crate::watchdog::coordinator::WatchdogCoordinator,
     ) {
         Self::configure_expected_workers(
-            shared_state,
+            watchdog,
             config
                 .policies
                 .transport

--- a/crates/edge/src/quic_listener/control_plane.rs
+++ b/crates/edge/src/quic_listener/control_plane.rs
@@ -39,9 +39,10 @@ impl QUICListener {
     ) -> Result<(), ProxyError> {
         Self::configure_expected_workers(bootstrap.shared_state, bootstrap.worker_count);
         Self::spawn_generation_background_tasks(&bootstrap);
+        let shared = bootstrap.shared_state.shared_services();
         Self::spawn_metrics_endpoint(
             bootstrap.runtime_config,
-            Arc::clone(&bootstrap.shared_state.metrics),
+            Arc::clone(&shared.metrics),
             bootstrap.runtime_bundle.clone(),
         )?;
         Self::spawn_control_api_endpoint(
@@ -59,29 +60,31 @@ impl QUICListener {
             bootstrap.shared_state,
         );
         let shared_state = bootstrap.shared_state;
-        let task_registry = Arc::clone(&shared_state.generation_tasks);
+        let shared = shared_state.shared_services();
+        let generation = shared_state.generation_state();
+        let task_registry = Arc::clone(&generation.generation_tasks);
         Self::spawn_backend_dns_refresh(
             bootstrap.runtime_config,
-            Arc::clone(&shared_state.transport_pool),
-            Arc::clone(&shared_state.backend_resolution_store),
-            shared_state.backend_dns_resolver.clone(),
-            Arc::clone(&shared_state.metrics),
+            Arc::clone(&shared.transport_pool),
+            Arc::clone(&shared.backend_resolution_store),
+            shared.backend_dns_resolver.clone(),
+            Arc::clone(&shared.metrics),
             Arc::clone(&task_registry),
         );
         Self::spawn_health_checks(
-            shared_state.upstream_pools.clone(),
-            Arc::clone(&shared_state.transport_pool),
-            Arc::clone(&shared_state.backend_endpoints),
-            Arc::clone(&shared_state.backend_health_checks),
-            Arc::clone(&shared_state.backend_resolution_store),
-            Arc::clone(&shared_state.metrics),
+            generation.upstream_pools.clone(),
+            Arc::clone(&shared.transport_pool),
+            Arc::clone(&generation.backend_endpoints),
+            Arc::clone(&generation.backend_health_checks),
+            Arc::clone(&shared.backend_resolution_store),
+            Arc::clone(&shared.metrics),
             Arc::clone(&task_registry),
         );
         Self::spawn_watchdog(
             bootstrap.runtime_config,
-            Arc::clone(&shared_state.metrics),
-            Arc::clone(&shared_state.resilience),
-            Arc::clone(&shared_state.watchdog),
+            Arc::clone(&shared.metrics),
+            Arc::clone(&generation.resilience),
+            Arc::clone(&shared.watchdog),
             task_registry,
         );
     }
@@ -106,6 +109,7 @@ impl QUICListener {
 
     fn configure_expected_workers(shared_state: &SharedRuntimeState, worker_count: usize) {
         shared_state
+            .shared_services()
             .watchdog
             .set_expected_workers(worker_count.max(1));
     }

--- a/crates/edge/src/quic_listener/metrics_endpoint.rs
+++ b/crates/edge/src/quic_listener/metrics_endpoint.rs
@@ -213,8 +213,8 @@ impl QUICListener {
         runtime_bundle
             .map(|handle| {
                 handle
-                    .current()
-                    .runtime_config
+                    .current_view()
+                    .runtime_config()
                     .observability
                     .metrics
                     .clone()
@@ -230,13 +230,13 @@ impl QUICListener {
         startup_metrics: Arc<Metrics>,
     ) -> MetricsEndpointState {
         if let Some(handle) = runtime_bundle {
-            let runtime = handle.current();
-            let endpoint = &runtime.runtime_config.observability.metrics;
+            let runtime = handle.current_view();
+            let endpoint = &runtime.runtime_config().observability.metrics;
             return MetricsEndpointState {
                 metrics_path: endpoint.path.clone(),
                 max_connections: endpoint.max_connections.max(1),
                 connection_timeout: Duration::from_millis(endpoint.connection_timeout_ms.max(1)),
-                metrics: runtime.shared_state.shared_services().metrics.clone(),
+                metrics: runtime.shared_services().metrics.clone(),
             };
         }
 

--- a/crates/edge/src/quic_listener/metrics_endpoint.rs
+++ b/crates/edge/src/quic_listener/metrics_endpoint.rs
@@ -13,7 +13,10 @@ use spooky_config::config::MetricsEndpoint;
 use spooky_errors::ProxyError;
 
 use super::{
-    QUICListener, runtime_endpoint::RuntimeConnectionSlotGuard, runtime_handle,
+    QUICListener,
+    runtime_endpoint::RuntimeConnectionSlotGuard,
+    runtime_handle,
+    runtime_state::{CanonicalRuntimeView, ControlPlaneBootstrap},
     spawn_supervised_async_task,
 };
 use crate::{Metrics, runtime::bundle::RuntimeBundleHandle};
@@ -24,29 +27,22 @@ struct MetricsEndpointBinding {
     active_connections: Arc<AtomicUsize>,
 }
 
+#[derive(Clone)]
 pub(super) struct MetricsEndpointState {
-    pub(super) metrics_path: String,
-    pub(super) max_connections: usize,
-    pub(super) connection_timeout: Duration,
+    pub(super) endpoint: MetricsEndpoint,
     pub(super) metrics: Arc<Metrics>,
 }
 
 impl QUICListener {
     pub(super) fn spawn_metrics_endpoint(
-        config: &spooky_config::runtime::RuntimeConfig,
-        metrics: Arc<Metrics>,
-        runtime_bundle: Option<Arc<RuntimeBundleHandle>>,
+        bootstrap: &ControlPlaneBootstrap<'_>,
     ) -> Result<(), ProxyError> {
-        let endpoint = &config.observability.metrics;
-        if runtime_bundle.is_none() && !endpoint.enabled {
+        let startup_state = bootstrap.with_runtime_view(Self::metrics_endpoint_state_from_runtime);
+        if bootstrap.runtime_bundle.is_none() && !startup_state.endpoint.enabled {
             return Ok(());
         }
-        let required = endpoint.required;
-        let startup_endpoint = endpoint.clone();
-        let startup_metrics_path = startup_endpoint.path.clone();
-        let startup_max_connections = startup_endpoint.max_connections.max(1);
-        let startup_connection_timeout =
-            Duration::from_millis(startup_endpoint.connection_timeout_ms.max(1));
+        let runtime_bundle = bootstrap.runtime_bundle.clone();
+        let required = startup_state.endpoint.required;
 
         let handle = match runtime_handle() {
             Some(handle) => handle,
@@ -60,8 +56,11 @@ impl QUICListener {
             }
         };
 
-        let initial_binding = if startup_endpoint.enabled {
-            let bind = format!("{}:{}", startup_endpoint.address, startup_endpoint.port);
+        let initial_binding = if startup_state.endpoint.enabled {
+            let bind = format!(
+                "{}:{}",
+                startup_state.endpoint.address, startup_state.endpoint.port
+            );
             match Self::bind_tcp_listener(&bind, Some(&handle), "metrics endpoint") {
                 Ok(listener) => Some(MetricsEndpointBinding {
                     bind,
@@ -83,15 +82,16 @@ impl QUICListener {
         spawn_supervised_async_task(
             &handle,
             "metrics-endpoint",
-            Some(Arc::clone(&metrics)),
+            Some(Arc::clone(&startup_state.metrics)),
             async move {
                 let mut listener_binding = initial_binding;
 
                 loop {
-                    let endpoint = Self::current_metrics_endpoint_config(
+                    let runtime_state = Self::current_metrics_endpoint_state(
                         runtime_bundle.as_ref(),
-                        &startup_endpoint,
+                        &startup_state,
                     );
+                    let endpoint = &runtime_state.endpoint;
                     let desired_bind = format!("{}:{}", endpoint.address, endpoint.port);
 
                     if !endpoint.enabled {
@@ -155,25 +155,23 @@ impl QUICListener {
                             continue;
                         }
                     };
-                    let runtime_state = Self::metrics_endpoint_state(
+                    let runtime_state = Self::current_metrics_endpoint_state(
                         runtime_bundle.as_ref(),
-                        startup_metrics_path.clone(),
-                        startup_max_connections,
-                        startup_connection_timeout,
-                        Arc::clone(&metrics),
+                        &startup_state,
                     );
                     let active_connections = Arc::clone(&binding.active_connections);
                     if !Self::try_claim_runtime_connection_slot(
                         &active_connections,
-                        runtime_state.max_connections,
+                        runtime_state.endpoint.max_connections.max(1),
                     ) {
                         continue;
                     }
 
                     let io = TokioIo::new(stream);
                     let metrics = Arc::clone(&runtime_state.metrics);
-                    let metrics_path = runtime_state.metrics_path.clone();
-                    let timeout = runtime_state.connection_timeout;
+                    let metrics_path = runtime_state.endpoint.path.clone();
+                    let timeout =
+                        Duration::from_millis(runtime_state.endpoint.connection_timeout_ms.max(1));
 
                     tokio::spawn(async move {
                         let _connection_guard = RuntimeConnectionSlotGuard::new(active_connections);
@@ -206,46 +204,26 @@ impl QUICListener {
         Ok(())
     }
 
-    pub(super) fn current_metrics_endpoint_config(
-        runtime_bundle: Option<&Arc<RuntimeBundleHandle>>,
-        startup_endpoint: &MetricsEndpoint,
-    ) -> MetricsEndpoint {
-        runtime_bundle
-            .map(|handle| {
-                handle
-                    .current_view()
-                    .runtime_config()
-                    .observability
-                    .metrics
-                    .clone()
-            })
-            .unwrap_or_else(|| startup_endpoint.clone())
+    fn metrics_endpoint_state_from_runtime(
+        runtime: CanonicalRuntimeView<'_>,
+    ) -> MetricsEndpointState {
+        MetricsEndpointState {
+            endpoint: runtime.runtime_config().observability.metrics.clone(),
+            metrics: runtime.shared_services().metrics.clone(),
+        }
     }
 
-    pub(super) fn metrics_endpoint_state(
+    pub(super) fn current_metrics_endpoint_state(
         runtime_bundle: Option<&Arc<RuntimeBundleHandle>>,
-        startup_metrics_path: String,
-        startup_max_connections: usize,
-        startup_connection_timeout: Duration,
-        startup_metrics: Arc<Metrics>,
+        startup_state: &MetricsEndpointState,
     ) -> MetricsEndpointState {
-        if let Some(handle) = runtime_bundle {
-            let runtime = handle.current_view();
-            let endpoint = &runtime.runtime_config().observability.metrics;
-            return MetricsEndpointState {
-                metrics_path: endpoint.path.clone(),
-                max_connections: endpoint.max_connections.max(1),
-                connection_timeout: Duration::from_millis(endpoint.connection_timeout_ms.max(1)),
-                metrics: runtime.shared_services().metrics.clone(),
-            };
-        }
-
-        MetricsEndpointState {
-            metrics_path: startup_metrics_path,
-            max_connections: startup_max_connections,
-            connection_timeout: startup_connection_timeout,
-            metrics: startup_metrics,
-        }
+        runtime_bundle
+            .map(|handle| {
+                handle.with_current_view(|view| {
+                    Self::metrics_endpoint_state_from_runtime(CanonicalRuntimeView::Active(view))
+                })
+            })
+            .unwrap_or_else(|| startup_state.clone())
     }
 
     fn handle_metrics_request(

--- a/crates/edge/src/quic_listener/metrics_endpoint.rs
+++ b/crates/edge/src/quic_listener/metrics_endpoint.rs
@@ -236,7 +236,7 @@ impl QUICListener {
                 metrics_path: endpoint.path.clone(),
                 max_connections: endpoint.max_connections.max(1),
                 connection_timeout: Duration::from_millis(endpoint.connection_timeout_ms.max(1)),
-                metrics: runtime.shared_state.metrics.clone(),
+                metrics: runtime.shared_state.shared_services().metrics.clone(),
             };
         }
 

--- a/crates/edge/src/quic_listener/runtime_state.rs
+++ b/crates/edge/src/quic_listener/runtime_state.rs
@@ -4,8 +4,44 @@ use std::{
 };
 
 use spooky_config::runtime::{ListenerRuntimeConfig, RuntimeConfig};
+use spooky_errors::ProxyError;
 
-use crate::runtime::{bundle::RuntimeBundleHandle, shared_state::SharedRuntimeState};
+use crate::runtime::{
+    bundle::RuntimeBundleHandle,
+    generation::{RuntimeGenerationState, RuntimeGenerationView, RuntimeSharedServices},
+    shared_state::SharedRuntimeState,
+};
+
+pub(super) enum CanonicalRuntimeView<'a> {
+    Startup {
+        runtime_config: &'a RuntimeConfig,
+        shared_state: &'a SharedRuntimeState,
+    },
+    Active(RuntimeGenerationView<'a>),
+}
+
+impl<'a> CanonicalRuntimeView<'a> {
+    pub(super) fn runtime_config(&self) -> &RuntimeConfig {
+        match self {
+            Self::Startup { runtime_config, .. } => runtime_config,
+            Self::Active(view) => view.runtime_config,
+        }
+    }
+
+    pub(super) fn shared_services(&self) -> &RuntimeSharedServices {
+        match self {
+            Self::Startup { shared_state, .. } => shared_state.shared_services(),
+            Self::Active(view) => view.shared,
+        }
+    }
+
+    pub(super) fn generation_state(&self) -> &RuntimeGenerationState {
+        match self {
+            Self::Startup { shared_state, .. } => shared_state.generation_state(),
+            Self::Active(view) => view.state,
+        }
+    }
+}
 
 pub(super) struct PreparedListenerStartup {
     pub(super) listener_config: ListenerRuntimeConfig,
@@ -20,9 +56,50 @@ pub(super) struct ControlPlaneBootstrap<'a> {
     pub(super) worker_count: usize,
 }
 
+impl<'a> ControlPlaneBootstrap<'a> {
+    pub(super) fn with_runtime_view<R>(&self, f: impl FnOnce(CanonicalRuntimeView<'_>) -> R) -> R {
+        match self.runtime_bundle.as_ref() {
+            Some(handle) => handle.with_current_view(|view| f(CanonicalRuntimeView::Active(view))),
+            None => f(CanonicalRuntimeView::Startup {
+                runtime_config: self.runtime_config,
+                shared_state: self.shared_state,
+            }),
+        }
+    }
+}
+
 pub struct ListenerWorkerRuntimeState {
     pub listener_config: ListenerRuntimeConfig,
     pub shared_state: Arc<SharedRuntimeState>,
     pub runtime_bundle: Arc<RuntimeBundleHandle>,
     pub shutdown: Arc<AtomicBool>,
+}
+
+impl ListenerWorkerRuntimeState {
+    pub fn listener_label(&self) -> String {
+        crate::quic_listener::QUICListener::listener_label(&self.listener_config)
+    }
+}
+
+pub(super) fn initialize_listener_from_runtime(
+    socket: UdpSocket,
+    startup_listener_config: &ListenerRuntimeConfig,
+    startup_shared_state: Arc<SharedRuntimeState>,
+    runtime_bundle: Option<Arc<RuntimeBundleHandle>>,
+) -> Result<crate::runtime::listener::QUICListener, ProxyError> {
+    let listener_label =
+        crate::quic_listener::QUICListener::listener_label(startup_listener_config);
+    if let Some(runtime_bundle) = runtime_bundle {
+        return crate::quic_listener::QUICListener::new_with_socket_and_runtime_bundle(
+            &listener_label,
+            socket,
+            runtime_bundle,
+        );
+    }
+
+    crate::quic_listener::QUICListener::new_with_socket_and_shared_state(
+        startup_listener_config.clone(),
+        socket,
+        startup_shared_state,
+    )
 }

--- a/crates/edge/src/quic_listener/startup.rs
+++ b/crates/edge/src/quic_listener/startup.rs
@@ -21,6 +21,7 @@ use crate::{
     runtime::{
         backend::{resolution::RuntimeBackendResolution, store::RuntimeBackendResolutionStore},
         bundle::{RuntimeBundle, RuntimeBundleHandle},
+        generation::{RuntimeGenerationState, RuntimeSharedServices, StartupOwnedRuntimeState},
         listener::QUICListener,
         shared_state::SharedRuntimeState,
         tasks::RuntimeTaskRegistry,
@@ -322,30 +323,34 @@ impl QUICListener {
             Self::update_listener_tls_expiry_metrics(&metrics, &listener_label, &inventory);
         }
 
-        Ok(SharedRuntimeState {
-            listener_runtime_configs: Arc::new(listener_runtime_configs),
-            listener_tls_store,
-            transport_pool,
-            backend_endpoints: Arc::new(backend_endpoints),
-            backend_health_checks: Arc::new(backend_health_checks),
-            backend_resolution_store,
-            backend_dns_resolver,
-            upstream_policies: Arc::new(
-                config
-                    .upstreams
-                    .iter()
-                    .map(|(name, upstream)| (name.clone(), upstream.policy.clone()))
-                    .collect(),
-            ),
-            upstream_pools,
-            upstream_inflight,
-            global_inflight: Arc::new(Semaphore::new(global_inflight_limit)),
-            routing_index,
-            metrics,
-            resilience,
-            watchdog,
-            generation_tasks: Arc::new(RuntimeTaskRegistry::new()),
-        })
+        Ok(SharedRuntimeState::from_parts(
+            RuntimeSharedServices {
+                listener_tls_store,
+                transport_pool,
+                backend_resolution_store,
+                backend_dns_resolver,
+                metrics,
+                watchdog,
+            },
+            RuntimeGenerationState {
+                listener_runtime_configs: Arc::new(listener_runtime_configs),
+                backend_endpoints: Arc::new(backend_endpoints),
+                backend_health_checks: Arc::new(backend_health_checks),
+                upstream_policies: Arc::new(
+                    config
+                        .upstreams
+                        .iter()
+                        .map(|(name, upstream)| (name.clone(), upstream.policy.clone()))
+                        .collect(),
+                ),
+                upstream_pools,
+                upstream_inflight,
+                global_inflight: Arc::new(Semaphore::new(global_inflight_limit)),
+                routing_index,
+                resilience,
+                generation_tasks: Arc::new(RuntimeTaskRegistry::new()),
+            },
+        ))
     }
 
     pub fn build_runtime_bundle(
@@ -356,8 +361,10 @@ impl QUICListener {
         let shared_state = Arc::new(Self::build_shared_state(runtime_config)?);
         Ok(RuntimeBundle {
             generation: 0,
-            config_path,
-            log_config,
+            startup: StartupOwnedRuntimeState {
+                config_path,
+                log_config,
+            },
             runtime_config: runtime_config.clone(),
             shared_state,
         })

--- a/crates/edge/src/quic_listener/startup.rs
+++ b/crates/edge/src/quic_listener/startup.rs
@@ -519,7 +519,7 @@ impl QUICListener {
     }
 
     pub fn with_runtime_bundle(mut self, runtime_bundle: Arc<RuntimeBundleHandle>) -> Self {
-        self.runtime_generation = runtime_bundle.generation();
+        self.runtime_generation = runtime_bundle.current_generation();
         self.runtime_bundle = Some(runtime_bundle);
         self
     }

--- a/crates/edge/src/quic_listener/startup.rs
+++ b/crates/edge/src/quic_listener/startup.rs
@@ -494,6 +494,30 @@ impl QUICListener {
         })
     }
 
+    pub fn new_with_socket_and_runtime_bundle(
+        listener_label: &str,
+        socket: UdpSocket,
+        runtime_bundle: Arc<RuntimeBundleHandle>,
+    ) -> Result<Self, ProxyError> {
+        let runtime = runtime_bundle.current_view();
+        let listener_config = runtime
+            .listener_runtime_config(listener_label)
+            .ok_or_else(|| {
+                ProxyError::Transport(format!(
+                    "runtime reload dropped listener '{}'",
+                    listener_label
+                ))
+            })?;
+        let mut listener = Self::new_with_socket_and_shared_state(
+            listener_config,
+            socket,
+            Arc::clone(&runtime.bundle().shared_state),
+        )?;
+        listener.runtime_generation = runtime.generation();
+        listener.runtime_bundle = Some(runtime_bundle);
+        Ok(listener)
+    }
+
     pub fn with_runtime_bundle(mut self, runtime_bundle: Arc<RuntimeBundleHandle>) -> Self {
         self.runtime_generation = runtime_bundle.generation();
         self.runtime_bundle = Some(runtime_bundle);

--- a/crates/edge/src/quic_listener/startup.rs
+++ b/crates/edge/src/quic_listener/startup.rs
@@ -414,7 +414,9 @@ impl QUICListener {
         debug!("Listening on {}", local_addr);
 
         let listener_label = Self::listener_label(&config);
-        let listener_tls_store = Arc::clone(&shared_state.listener_tls_store);
+        let shared_services = shared_state.shared_services();
+        let generation_state = shared_state.generation_state();
+        let listener_tls_store = Arc::clone(&shared_services.listener_tls_store);
         let tls_reload_generation =
             listener_tls_store
                 .generation(&listener_label)
@@ -450,18 +452,18 @@ impl QUICListener {
             tls_reload_generation,
             quic_config,
             h3_config,
-            transport_pool: Arc::clone(&shared_state.transport_pool),
-            backend_endpoints: Arc::clone(&shared_state.backend_endpoints),
-            backend_resolution_store: Arc::clone(&shared_state.backend_resolution_store),
-            backend_dns_resolver: shared_state.backend_dns_resolver.clone(),
-            upstream_policies: Arc::clone(&shared_state.upstream_policies),
-            upstream_pools: shared_state.upstream_pools.clone(),
-            upstream_inflight: shared_state.upstream_inflight.clone(),
-            global_inflight: Arc::clone(&shared_state.global_inflight),
-            routing_index: Arc::clone(&shared_state.routing_index),
-            metrics: Arc::clone(&shared_state.metrics),
-            resilience: Arc::clone(&shared_state.resilience),
-            watchdog: Arc::clone(&shared_state.watchdog),
+            transport_pool: Arc::clone(&shared_services.transport_pool),
+            backend_endpoints: Arc::clone(&generation_state.backend_endpoints),
+            backend_resolution_store: Arc::clone(&shared_services.backend_resolution_store),
+            backend_dns_resolver: shared_services.backend_dns_resolver.clone(),
+            upstream_policies: Arc::clone(&generation_state.upstream_policies),
+            upstream_pools: generation_state.upstream_pools.clone(),
+            upstream_inflight: generation_state.upstream_inflight.clone(),
+            global_inflight: Arc::clone(&generation_state.global_inflight),
+            routing_index: Arc::clone(&generation_state.routing_index),
+            metrics: Arc::clone(&shared_services.metrics),
+            resilience: Arc::clone(&generation_state.resilience),
+            watchdog: Arc::clone(&shared_services.watchdog),
             draining: false,
             drain_start: None,
             watchdog_worker_drained: false,

--- a/crates/edge/src/quic_listener/tests.rs
+++ b/crates/edge/src/quic_listener/tests.rs
@@ -770,10 +770,7 @@ fn build_shared_state_separates_backend_identity_from_resolution_state() {
     let runtime =
         RuntimeConfig::from_config(&dns_resolution_test_config(cert, key)).expect("runtime");
     let shared = super::QUICListener::build_shared_state(&runtime).expect("shared state");
-    let snapshot = shared
-        .shared_services()
-        .backend_resolution_store
-        .snapshot();
+    let snapshot = shared.shared_services().backend_resolution_store.snapshot();
 
     let dns_backend = snapshot
         .get("backend.internal:8443")

--- a/crates/edge/src/quic_listener/tests.rs
+++ b/crates/edge/src/quic_listener/tests.rs
@@ -353,6 +353,7 @@ fn listener_tls_reload_store_refreshes_inventory_and_generation() {
     let shared = super::QUICListener::build_shared_state(&runtime).expect("shared state");
     let listener_label = "127.0.0.1:0";
     let initial_inventory = shared
+        .shared_services()
         .listener_tls_store
         .inventory(listener_label)
         .expect("initial inventory");
@@ -362,19 +363,24 @@ fn listener_tls_reload_store_refreshes_inventory_and_generation() {
         .serial_hex
         .clone();
     assert_eq!(
-        shared.listener_tls_store.generation(listener_label),
+        shared
+            .shared_services()
+            .listener_tls_store
+            .generation(listener_label),
         Some(0)
     );
 
     let (_rotated_cert, _rotated_key) =
         write_test_cert_for_name(dir.path(), "server", "api.example.com");
     let listener_config = shared
+        .generation_state()
         .listener_runtime_configs
         .get(listener_label)
         .expect("listener runtime config");
     let reloaded_state = super::QUICListener::build_listener_tls_reload_state(listener_config)
         .expect("reloaded tls state");
     let generation = shared
+        .shared_services()
         .listener_tls_store
         .replace_listener(
             listener_label,
@@ -385,6 +391,7 @@ fn listener_tls_reload_store_refreshes_inventory_and_generation() {
     assert_eq!(generation, 1);
 
     let refreshed_inventory = shared
+        .shared_services()
         .listener_tls_store
         .inventory(listener_label)
         .expect("refreshed inventory");
@@ -411,7 +418,7 @@ fn quic_listener_syncs_tls_generation_after_reload() {
         super::QUICListener::tls_reload_generation_if_needed(
             &listener_label,
             0,
-            &shared.listener_tls_store
+            &shared.shared_services().listener_tls_store
         )
         .expect("initial generation"),
         None
@@ -422,6 +429,7 @@ fn quic_listener_syncs_tls_generation_after_reload() {
     let reloaded_state = super::QUICListener::build_listener_tls_reload_state(&listener_config)
         .expect("reloaded tls state");
     shared
+        .shared_services()
         .listener_tls_store
         .replace_listener(
             &listener_label,
@@ -434,7 +442,7 @@ fn quic_listener_syncs_tls_generation_after_reload() {
         super::QUICListener::tls_reload_generation_if_needed(
             &listener_label,
             0,
-            &shared.listener_tls_store
+            &shared.shared_services().listener_tls_store
         )
         .expect("reloaded generation"),
         Some(1)
@@ -452,17 +460,19 @@ fn bootstrap_connection_state_prefers_reloaded_runtime_settings() {
         .expect("startup listener config");
     let startup_shared =
         Arc::new(super::QUICListener::build_shared_state(&startup_runtime).expect("shared"));
+    let startup_services = startup_shared.shared_services();
+    let startup_generation = startup_shared.generation_state();
     let listener_label = super::QUICListener::listener_label(&startup_listener_config);
     let startup_state = super::BootstrapStartupState {
         listener_config: startup_listener_config.clone(),
-        listener_tls_store: Arc::clone(&startup_shared.listener_tls_store),
-        transport_pool: Arc::clone(&startup_shared.transport_pool),
-        backend_endpoints: Arc::clone(&startup_shared.backend_endpoints),
-        upstream_policies: Arc::clone(&startup_shared.upstream_policies),
-        metrics: Arc::clone(&startup_shared.metrics),
-        resilience: Arc::clone(&startup_shared.resilience),
-        upstream_pools: startup_shared.upstream_pools.clone(),
-        routing_index: Arc::clone(&startup_shared.routing_index),
+        listener_tls_store: Arc::clone(&startup_services.listener_tls_store),
+        transport_pool: Arc::clone(&startup_services.transport_pool),
+        backend_endpoints: Arc::clone(&startup_generation.backend_endpoints),
+        upstream_policies: Arc::clone(&startup_generation.upstream_policies),
+        metrics: Arc::clone(&startup_services.metrics),
+        resilience: Arc::clone(&startup_generation.resilience),
+        upstream_pools: startup_generation.upstream_pools.clone(),
+        routing_index: Arc::clone(&startup_generation.routing_index),
     };
 
     let mut reloaded = startup.clone();
@@ -507,6 +517,7 @@ fn metrics_endpoint_state_prefers_reloaded_runtime_settings() {
     let startup_runtime = RuntimeConfig::from_config(&startup).expect("startup runtime");
     let startup_shared =
         Arc::new(super::QUICListener::build_shared_state(&startup_runtime).expect("shared"));
+    let startup_metrics = Arc::clone(&startup_shared.shared_services().metrics);
 
     let mut reloaded = startup.clone();
     reloaded.observability.metrics.enabled = true;
@@ -523,17 +534,23 @@ fn metrics_endpoint_state_prefers_reloaded_runtime_settings() {
     .expect("reloaded bundle");
     let runtime_handle = Arc::new(super::RuntimeBundleHandle::new(reloaded_bundle));
 
-    let state = super::QUICListener::metrics_endpoint_state(
+    let state = super::QUICListener::current_metrics_endpoint_state(
         Some(&runtime_handle),
-        "/metrics-startup".to_string(),
-        5,
-        Duration::from_millis(500),
-        Arc::clone(&startup_shared.metrics),
+        &super::metrics_endpoint::MetricsEndpointState {
+            endpoint: spooky_config::config::MetricsEndpoint {
+                enabled: true,
+                path: "/metrics-startup".to_string(),
+                max_connections: 5,
+                connection_timeout_ms: 500,
+                ..Default::default()
+            },
+            metrics: startup_metrics,
+        },
     );
 
-    assert_eq!(state.metrics_path, "/metrics-live");
-    assert_eq!(state.max_connections, 29);
-    assert_eq!(state.connection_timeout, Duration::from_millis(3456));
+    assert_eq!(state.endpoint.path, "/metrics-live");
+    assert_eq!(state.endpoint.max_connections, 29);
+    assert_eq!(state.endpoint.connection_timeout_ms, 3456);
 }
 
 #[test]
@@ -753,7 +770,10 @@ fn build_shared_state_separates_backend_identity_from_resolution_state() {
     let runtime =
         RuntimeConfig::from_config(&dns_resolution_test_config(cert, key)).expect("runtime");
     let shared = super::QUICListener::build_shared_state(&runtime).expect("shared state");
-    let snapshot = shared.backend_resolution_store.snapshot();
+    let snapshot = shared
+        .shared_services()
+        .backend_resolution_store
+        .snapshot();
 
     let dns_backend = snapshot
         .get("backend.internal:8443")

--- a/crates/edge/src/quic_listener/tls_runtime.rs
+++ b/crates/edge/src/quic_listener/tls_runtime.rs
@@ -304,9 +304,8 @@ impl QUICListener {
             return self.sync_tls_reload_state_if_needed();
         };
 
-        let runtime = runtime_bundle.current();
+        let runtime = runtime_bundle.current_view();
         let current_tls_generation = runtime
-            .shared_state
             .shared_services()
             .listener_tls_store
             .generation(&self.listener_label)
@@ -316,7 +315,7 @@ impl QUICListener {
                     self.listener_label
                 ))
             })?;
-        if runtime.generation == self.runtime_generation
+        if runtime.generation() == self.runtime_generation
             && current_tls_generation == self.tls_reload_generation
         {
             return Ok(());
@@ -329,8 +328,8 @@ impl QUICListener {
             )));
         };
 
-        let shared = runtime.shared_state.shared_services();
-        let generation = runtime.shared_state.generation_state();
+        let shared = runtime.shared_services();
+        let generation = runtime.state();
         self.config = listener_config;
         self.listener_tls_store = Arc::clone(&shared.listener_tls_store);
         self.transport_pool = Arc::clone(&shared.transport_pool);
@@ -368,7 +367,7 @@ impl QUICListener {
             settings.new_connections_burst,
         );
         self.quic_config = Self::build_quic_config(&self.config)?;
-        self.runtime_generation = runtime.generation;
+        self.runtime_generation = runtime.generation();
         self.tls_reload_generation = current_tls_generation;
         info!(
             "Reloaded runtime configuration for listener {} at generation {}",

--- a/crates/edge/src/quic_listener/tls_runtime.rs
+++ b/crates/edge/src/quic_listener/tls_runtime.rs
@@ -307,6 +307,7 @@ impl QUICListener {
         let runtime = runtime_bundle.current();
         let current_tls_generation = runtime
             .shared_state
+            .shared_services()
             .listener_tls_store
             .generation(&self.listener_label)
             .ok_or_else(|| {
@@ -328,20 +329,22 @@ impl QUICListener {
             )));
         };
 
+        let shared = runtime.shared_state.shared_services();
+        let generation = runtime.shared_state.generation_state();
         self.config = listener_config;
-        self.listener_tls_store = Arc::clone(&runtime.shared_state.listener_tls_store);
-        self.transport_pool = Arc::clone(&runtime.shared_state.transport_pool);
-        self.backend_endpoints = Arc::clone(&runtime.shared_state.backend_endpoints);
-        self.backend_resolution_store = Arc::clone(&runtime.shared_state.backend_resolution_store);
-        self.backend_dns_resolver = runtime.shared_state.backend_dns_resolver.clone();
-        self.upstream_policies = Arc::clone(&runtime.shared_state.upstream_policies);
-        self.upstream_pools = runtime.shared_state.upstream_pools.clone();
-        self.upstream_inflight = runtime.shared_state.upstream_inflight.clone();
-        self.global_inflight = Arc::clone(&runtime.shared_state.global_inflight);
-        self.routing_index = Arc::clone(&runtime.shared_state.routing_index);
-        self.metrics = Arc::clone(&runtime.shared_state.metrics);
-        self.resilience = Arc::clone(&runtime.shared_state.resilience);
-        self.watchdog = Arc::clone(&runtime.shared_state.watchdog);
+        self.listener_tls_store = Arc::clone(&shared.listener_tls_store);
+        self.transport_pool = Arc::clone(&shared.transport_pool);
+        self.backend_endpoints = Arc::clone(&generation.backend_endpoints);
+        self.backend_resolution_store = Arc::clone(&shared.backend_resolution_store);
+        self.backend_dns_resolver = shared.backend_dns_resolver.clone();
+        self.upstream_policies = Arc::clone(&generation.upstream_policies);
+        self.upstream_pools = generation.upstream_pools.clone();
+        self.upstream_inflight = generation.upstream_inflight.clone();
+        self.global_inflight = Arc::clone(&generation.global_inflight);
+        self.routing_index = Arc::clone(&generation.routing_index);
+        self.metrics = Arc::clone(&shared.metrics);
+        self.resilience = Arc::clone(&generation.resilience);
+        self.watchdog = Arc::clone(&shared.watchdog);
         let settings = Self::listener_runtime_settings(&self.config);
         self.backend_timeout = settings.backend_timeout;
         self.backend_body_idle_timeout = settings.backend_body_idle_timeout;

--- a/crates/edge/src/quic_listener/workers.rs
+++ b/crates/edge/src/quic_listener/workers.rs
@@ -14,7 +14,7 @@ use spooky_config::runtime::ListenerRuntimeConfig;
 
 use crate::{
     constants::MAX_DATAGRAM_SIZE_BYTES,
-    quic_listener::ListenerWorkerRuntimeState,
+    quic_listener::{ListenerWorkerRuntimeState, runtime_state::initialize_listener_from_runtime},
     runtime::{
         bundle::RuntimeBundleHandle, listener::QUICListener, shared_state::SharedRuntimeState,
     },
@@ -169,18 +169,18 @@ fn run_sharded_listener_worker(
             .spawn(move || -> Result<(), String> {
                 maybe_pin_worker(shard_thread_idx, pin_workers);
                 shard_shared.bind_metrics_worker_slot(shard_thread_idx);
-                let mut listener = QUICListener::new_with_socket_and_shared_state(
-                    shard_config,
+                let mut listener = initialize_listener_from_runtime(
                     shard_socket,
+                    &shard_config,
                     shard_shared,
+                    Some(Arc::clone(&shard_runtime_bundle)),
                 )
                 .map_err(|err| {
                     format!(
                         "worker {} shard {} listener init failed: {}",
                         worker_idx, shard_idx, err
                     )
-                })?
-                .with_runtime_bundle(Arc::clone(&shard_runtime_bundle));
+                })?;
 
                 let idle_timeout = Duration::from_millis(10);
                 while !shard_shutdown.load(Ordering::Relaxed) {
@@ -329,18 +329,18 @@ fn run_single_listener_worker(worker_runtime: WorkerThreadRuntime) -> Result<(),
     worker_runtime
         .shared_state
         .bind_metrics_worker_slot(worker_runtime.worker_idx);
-    let mut listener = QUICListener::new_with_socket_and_shared_state(
-        worker_runtime.listener_config,
+    let mut listener = initialize_listener_from_runtime(
         worker_runtime.socket,
+        &worker_runtime.listener_config,
         worker_runtime.shared_state,
+        Some(Arc::clone(&worker_runtime.runtime_bundle)),
     )
     .map_err(|err| {
         format!(
             "worker {} listener init failed: {}",
             worker_runtime.worker_idx, err
         )
-    })?
-    .with_runtime_bundle(Arc::clone(&worker_runtime.runtime_bundle));
+    })?;
 
     while !worker_runtime.shutdown.load(Ordering::Relaxed) {
         listener.poll();

--- a/crates/edge/src/runtime/bundle.rs
+++ b/crates/edge/src/runtime/bundle.rs
@@ -1,4 +1,7 @@
-use std::sync::{Arc, RwLock};
+use std::{
+    sync::{Arc, RwLock},
+    time::Duration,
+};
 
 use spooky_config::runtime::{ListenerRuntimeConfig, RuntimeConfig};
 use spooky_errors::ProxyError;
@@ -9,7 +12,6 @@ use crate::runtime::{
         StartupOwnedRuntimeState,
     },
     shared_state::SharedRuntimeState,
-    tasks::RuntimeTaskRegistry,
 };
 
 #[derive(Clone)]
@@ -120,17 +122,14 @@ impl RuntimeBundleHandle {
         self.with_current_generation(|current| f(current.view()))
     }
 
-    pub fn replace(
-        &self,
-        bundle: RuntimeBundle,
-    ) -> Result<(u64, Arc<RuntimeTaskRegistry>), ProxyError> {
+    pub fn replace(&self, bundle: RuntimeBundle) -> Result<u64, ProxyError> {
         let generation = bundle.generation;
         let next_tasks = Arc::clone(&bundle.shared_state.generation_state().generation_tasks);
         let previous = {
             let mut guard = match self.inner.write() {
                 Ok(guard) => guard,
                 Err(_) => {
-                    next_tasks.abort_all();
+                    next_tasks.abort_generation();
                     return Err(ProxyError::Transport(
                         "runtime bundle lock poisoned".to_string(),
                     ));
@@ -138,7 +137,11 @@ impl RuntimeBundleHandle {
             };
             std::mem::replace(&mut *guard, Arc::new(bundle))
         };
-        let retired_tasks = Arc::clone(&previous.shared_state.generation_state().generation_tasks);
-        Ok((generation, retired_tasks))
+        previous
+            .shared_state
+            .generation_state()
+            .generation_tasks
+            .retire_generation(Duration::from_secs(5));
+        Ok(generation)
     }
 }

--- a/crates/edge/src/runtime/bundle.rs
+++ b/crates/edge/src/runtime/bundle.rs
@@ -4,7 +4,10 @@ use spooky_config::runtime::{ListenerRuntimeConfig, RuntimeConfig};
 use spooky_errors::ProxyError;
 
 use crate::runtime::{
-    generation::{RuntimeGenerationView, StartupOwnedRuntimeState},
+    generation::{
+        RuntimeGenerationState, RuntimeGenerationView, RuntimeSharedServices,
+        StartupOwnedRuntimeState,
+    },
     shared_state::SharedRuntimeState,
     tasks::RuntimeTaskRegistry,
 };
@@ -38,6 +41,45 @@ impl RuntimeBundle {
 }
 
 #[derive(Clone)]
+pub struct ActiveRuntimeGeneration {
+    bundle: Arc<RuntimeBundle>,
+}
+
+impl ActiveRuntimeGeneration {
+    pub fn bundle(&self) -> &RuntimeBundle {
+        self.bundle.as_ref()
+    }
+
+    pub fn generation(&self) -> u64 {
+        self.bundle.generation
+    }
+
+    pub fn startup(&self) -> &StartupOwnedRuntimeState {
+        &self.bundle.startup
+    }
+
+    pub fn runtime_config(&self) -> &RuntimeConfig {
+        &self.bundle.runtime_config
+    }
+
+    pub fn shared_services(&self) -> &RuntimeSharedServices {
+        self.bundle.shared_state.shared_services()
+    }
+
+    pub fn state(&self) -> &RuntimeGenerationState {
+        self.bundle.shared_state.generation_state()
+    }
+
+    pub fn view(&self) -> RuntimeGenerationView<'_> {
+        self.bundle.generation_view()
+    }
+
+    pub fn listener_runtime_config(&self, label: &str) -> Option<ListenerRuntimeConfig> {
+        self.bundle.listener_runtime_config(label)
+    }
+}
+
+#[derive(Clone)]
 pub struct RuntimeBundleHandle {
     inner: Arc<RwLock<Arc<RuntimeBundle>>>,
 }
@@ -56,13 +98,26 @@ impl RuntimeBundleHandle {
             .unwrap_or_else(|_| panic!("runtime bundle lock poisoned"))
     }
 
+    pub fn current_view(&self) -> ActiveRuntimeGeneration {
+        ActiveRuntimeGeneration {
+            bundle: self.current(),
+        }
+    }
+
+    pub fn current_generation(&self) -> u64 {
+        self.current_view().generation()
+    }
+
     pub fn generation(&self) -> u64 {
-        self.current().generation
+        self.current_generation()
+    }
+
+    pub fn with_current_generation<R>(&self, f: impl FnOnce(ActiveRuntimeGeneration) -> R) -> R {
+        f(self.current_view())
     }
 
     pub fn with_current_view<R>(&self, f: impl FnOnce(RuntimeGenerationView<'_>) -> R) -> R {
-        let current = self.current();
-        f(current.generation_view())
+        self.with_current_generation(|current| f(current.view()))
     }
 
     pub fn replace(

--- a/crates/edge/src/runtime/bundle.rs
+++ b/crates/edge/src/runtime/bundle.rs
@@ -93,7 +93,7 @@ impl RuntimeBundleHandle {
         }
     }
 
-    pub fn current(&self) -> Arc<RuntimeBundle> {
+    pub(crate) fn current(&self) -> Arc<RuntimeBundle> {
         self.inner
             .read()
             .map(|bundle| Arc::clone(&*bundle))
@@ -108,10 +108,6 @@ impl RuntimeBundleHandle {
 
     pub fn current_generation(&self) -> u64 {
         self.current_view().generation()
-    }
-
-    pub fn generation(&self) -> u64 {
-        self.current_generation()
     }
 
     pub fn with_current_generation<R>(&self, f: impl FnOnce(ActiveRuntimeGeneration) -> R) -> R {

--- a/crates/edge/src/runtime/bundle.rs
+++ b/crates/edge/src/runtime/bundle.rs
@@ -1,28 +1,39 @@
 use std::sync::{Arc, RwLock};
 
-use spooky_config::{
-    config::Log,
-    runtime::{ListenerRuntimeConfig, RuntimeConfig},
-};
+use spooky_config::runtime::{ListenerRuntimeConfig, RuntimeConfig};
 use spooky_errors::ProxyError;
 
-use crate::runtime::{shared_state::SharedRuntimeState, tasks::RuntimeTaskRegistry};
+use crate::runtime::{
+    generation::{RuntimeGenerationView, StartupOwnedRuntimeState},
+    shared_state::SharedRuntimeState,
+    tasks::RuntimeTaskRegistry,
+};
 
 #[derive(Clone)]
 pub struct RuntimeBundle {
     pub generation: u64,
-    pub config_path: String,
-    pub log_config: Log,
+    pub startup: StartupOwnedRuntimeState,
     pub runtime_config: RuntimeConfig,
     pub shared_state: Arc<SharedRuntimeState>,
 }
 
 impl RuntimeBundle {
+    pub fn startup(&self) -> &StartupOwnedRuntimeState {
+        &self.startup
+    }
+
+    pub fn generation_view(&self) -> RuntimeGenerationView<'_> {
+        RuntimeGenerationView {
+            generation: self.generation,
+            startup: &self.startup,
+            runtime_config: &self.runtime_config,
+            shared: self.shared_state.shared_services(),
+            state: self.shared_state.generation_state(),
+        }
+    }
+
     pub fn listener_runtime_config(&self, label: &str) -> Option<ListenerRuntimeConfig> {
-        self.shared_state
-            .listener_runtime_configs
-            .get(label)
-            .cloned()
+        self.generation_view().listener_runtime_config(label)
     }
 }
 
@@ -49,12 +60,17 @@ impl RuntimeBundleHandle {
         self.current().generation
     }
 
+    pub fn with_current_view<R>(&self, f: impl FnOnce(RuntimeGenerationView<'_>) -> R) -> R {
+        let current = self.current();
+        f(current.generation_view())
+    }
+
     pub fn replace(
         &self,
         bundle: RuntimeBundle,
     ) -> Result<(u64, Arc<RuntimeTaskRegistry>), ProxyError> {
         let generation = bundle.generation;
-        let next_tasks = Arc::clone(&bundle.shared_state.generation_tasks);
+        let next_tasks = Arc::clone(&bundle.shared_state.generation_state().generation_tasks);
         let previous = {
             let mut guard = match self.inner.write() {
                 Ok(guard) => guard,
@@ -67,7 +83,7 @@ impl RuntimeBundleHandle {
             };
             std::mem::replace(&mut *guard, Arc::new(bundle))
         };
-        let retired_tasks = Arc::clone(&previous.shared_state.generation_tasks);
+        let retired_tasks = Arc::clone(&previous.shared_state.generation_state().generation_tasks);
         Ok((generation, retired_tasks))
     }
 }

--- a/crates/edge/src/runtime/bundle.rs
+++ b/crates/edge/src/runtime/bundle.rs
@@ -93,7 +93,7 @@ impl RuntimeBundleHandle {
         }
     }
 
-    pub(crate) fn current(&self) -> Arc<RuntimeBundle> {
+    pub fn current(&self) -> Arc<RuntimeBundle> {
         self.inner
             .read()
             .map(|bundle| Arc::clone(&*bundle))

--- a/crates/edge/src/runtime/generation.rs
+++ b/crates/edge/src/runtime/generation.rs
@@ -1,0 +1,71 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+
+use spooky_config::{
+    backend_endpoint::BackendEndpoint,
+    config::Log,
+    runtime::{
+        ListenerRuntimeConfig, RuntimeBackendHealthCheck, RuntimeConfig, RuntimeUpstreamPolicy,
+    },
+};
+use spooky_lb::upstream_pool::UpstreamPool;
+use spooky_transport::{h2_client::SharedDnsResolver, transport_pool::UpstreamTransportPool};
+use tokio::sync::Semaphore;
+
+use crate::{
+    Metrics,
+    resilience::runtime::RuntimeResilience,
+    routing::index::RouteIndex,
+    runtime::{
+        backend::store::RuntimeBackendResolutionStore, tasks::RuntimeTaskRegistry,
+        tls::store::ListenerTlsReloadStore,
+    },
+    watchdog::coordinator::WatchdogCoordinator,
+};
+
+#[derive(Clone)]
+pub struct StartupOwnedRuntimeState {
+    pub config_path: String,
+    pub log_config: Log,
+}
+
+#[derive(Clone)]
+pub struct RuntimeSharedServices {
+    pub listener_tls_store: Arc<ListenerTlsReloadStore>,
+    pub transport_pool: Arc<UpstreamTransportPool>,
+    pub backend_resolution_store: Arc<RuntimeBackendResolutionStore>,
+    pub backend_dns_resolver: SharedDnsResolver,
+    pub metrics: Arc<Metrics>,
+    pub watchdog: Arc<WatchdogCoordinator>,
+}
+
+#[derive(Clone)]
+pub struct RuntimeGenerationState {
+    pub listener_runtime_configs: Arc<HashMap<String, ListenerRuntimeConfig>>,
+    pub backend_endpoints: Arc<HashMap<String, BackendEndpoint>>,
+    pub backend_health_checks: Arc<HashMap<String, RuntimeBackendHealthCheck>>,
+    pub upstream_policies: Arc<HashMap<String, RuntimeUpstreamPolicy>>,
+    pub upstream_pools: HashMap<String, Arc<RwLock<UpstreamPool>>>,
+    pub upstream_inflight: HashMap<String, Arc<Semaphore>>,
+    pub global_inflight: Arc<Semaphore>,
+    pub routing_index: Arc<RouteIndex>,
+    pub resilience: Arc<RuntimeResilience>,
+    pub generation_tasks: Arc<RuntimeTaskRegistry>,
+}
+
+#[derive(Clone, Copy)]
+pub struct RuntimeGenerationView<'a> {
+    pub generation: u64,
+    pub startup: &'a StartupOwnedRuntimeState,
+    pub runtime_config: &'a RuntimeConfig,
+    pub shared: &'a RuntimeSharedServices,
+    pub state: &'a RuntimeGenerationState,
+}
+
+impl<'a> RuntimeGenerationView<'a> {
+    pub fn listener_runtime_config(&self, label: &str) -> Option<ListenerRuntimeConfig> {
+        self.state.listener_runtime_configs.get(label).cloned()
+    }
+}

--- a/crates/edge/src/runtime/mod.rs
+++ b/crates/edge/src/runtime/mod.rs
@@ -1,6 +1,7 @@
 pub mod backend;
 pub mod bundle;
 pub mod connection;
+pub mod generation;
 pub mod health;
 pub mod listener;
 pub mod shared_state;

--- a/crates/edge/src/runtime/shared_state.rs
+++ b/crates/edge/src/runtime/shared_state.rs
@@ -16,13 +16,17 @@ use crate::{
     resilience::runtime::RuntimeResilience,
     routing::index::RouteIndex,
     runtime::{
-        backend::store::RuntimeBackendResolutionStore, tasks::RuntimeTaskRegistry,
+        backend::store::RuntimeBackendResolutionStore,
+        generation::{RuntimeGenerationState, RuntimeSharedServices},
+        tasks::RuntimeTaskRegistry,
         tls::store::ListenerTlsReloadStore,
     },
     watchdog::coordinator::WatchdogCoordinator,
 };
 
 pub struct SharedRuntimeState {
+    pub(crate) shared_services: Arc<RuntimeSharedServices>,
+    pub(crate) generation_state: Arc<RuntimeGenerationState>,
     pub(crate) listener_runtime_configs: Arc<HashMap<String, ListenerRuntimeConfig>>,
     pub(crate) listener_tls_store: Arc<ListenerTlsReloadStore>,
     pub(crate) transport_pool: Arc<UpstreamTransportPool>,
@@ -42,6 +46,43 @@ pub struct SharedRuntimeState {
 }
 
 impl SharedRuntimeState {
+    pub(crate) fn from_parts(
+        shared_services: RuntimeSharedServices,
+        generation_state: RuntimeGenerationState,
+    ) -> Self {
+        let shared_services = Arc::new(shared_services);
+        let generation_state = Arc::new(generation_state);
+
+        Self {
+            listener_runtime_configs: Arc::clone(&generation_state.listener_runtime_configs),
+            listener_tls_store: Arc::clone(&shared_services.listener_tls_store),
+            transport_pool: Arc::clone(&shared_services.transport_pool),
+            backend_endpoints: Arc::clone(&generation_state.backend_endpoints),
+            backend_health_checks: Arc::clone(&generation_state.backend_health_checks),
+            backend_resolution_store: Arc::clone(&shared_services.backend_resolution_store),
+            backend_dns_resolver: shared_services.backend_dns_resolver.clone(),
+            upstream_policies: Arc::clone(&generation_state.upstream_policies),
+            upstream_pools: generation_state.upstream_pools.clone(),
+            upstream_inflight: generation_state.upstream_inflight.clone(),
+            global_inflight: Arc::clone(&generation_state.global_inflight),
+            routing_index: Arc::clone(&generation_state.routing_index),
+            metrics: Arc::clone(&shared_services.metrics),
+            resilience: Arc::clone(&generation_state.resilience),
+            watchdog: Arc::clone(&shared_services.watchdog),
+            generation_tasks: Arc::clone(&generation_state.generation_tasks),
+            shared_services,
+            generation_state,
+        }
+    }
+
+    pub fn shared_services(&self) -> &RuntimeSharedServices {
+        self.shared_services.as_ref()
+    }
+
+    pub fn generation_state(&self) -> &RuntimeGenerationState {
+        self.generation_state.as_ref()
+    }
+
     pub fn bind_metrics_worker_slot(&self, slot: usize) {
         self.metrics.bind_worker_slot(slot);
     }
@@ -62,7 +103,7 @@ impl SharedRuntimeState {
         let mut healthy = 0usize;
         let mut total = 0usize;
 
-        for pool in self.upstream_pools.values() {
+        for pool in self.generation_state.upstream_pools.values() {
             let guard = match pool.read() {
                 Ok(guard) => guard,
                 Err(_) => continue,

--- a/crates/edge/src/runtime/shared_state.rs
+++ b/crates/edge/src/runtime/shared_state.rs
@@ -1,48 +1,10 @@
-use std::{
-    collections::HashMap,
-    sync::{Arc, RwLock},
-};
+use std::sync::Arc;
 
-use spooky_config::{
-    backend_endpoint::BackendEndpoint,
-    runtime::{ListenerRuntimeConfig, RuntimeBackendHealthCheck, RuntimeUpstreamPolicy},
-};
-use spooky_lb::upstream_pool::UpstreamPool;
-use spooky_transport::{h2_client::SharedDnsResolver, transport_pool::UpstreamTransportPool};
-use tokio::sync::Semaphore;
-
-use crate::{
-    Metrics,
-    resilience::runtime::RuntimeResilience,
-    routing::index::RouteIndex,
-    runtime::{
-        backend::store::RuntimeBackendResolutionStore,
-        generation::{RuntimeGenerationState, RuntimeSharedServices},
-        tasks::RuntimeTaskRegistry,
-        tls::store::ListenerTlsReloadStore,
-    },
-    watchdog::coordinator::WatchdogCoordinator,
-};
+use crate::runtime::generation::{RuntimeGenerationState, RuntimeSharedServices};
 
 pub struct SharedRuntimeState {
     pub(crate) shared_services: Arc<RuntimeSharedServices>,
     pub(crate) generation_state: Arc<RuntimeGenerationState>,
-    pub(crate) listener_runtime_configs: Arc<HashMap<String, ListenerRuntimeConfig>>,
-    pub(crate) listener_tls_store: Arc<ListenerTlsReloadStore>,
-    pub(crate) transport_pool: Arc<UpstreamTransportPool>,
-    pub(crate) backend_endpoints: Arc<HashMap<String, BackendEndpoint>>,
-    pub(crate) backend_health_checks: Arc<HashMap<String, RuntimeBackendHealthCheck>>,
-    pub(crate) backend_resolution_store: Arc<RuntimeBackendResolutionStore>,
-    pub(crate) backend_dns_resolver: SharedDnsResolver,
-    pub(crate) upstream_policies: Arc<HashMap<String, RuntimeUpstreamPolicy>>,
-    pub(crate) upstream_pools: HashMap<String, Arc<RwLock<UpstreamPool>>>,
-    pub(crate) upstream_inflight: HashMap<String, Arc<Semaphore>>,
-    pub(crate) global_inflight: Arc<Semaphore>,
-    pub(crate) routing_index: Arc<RouteIndex>,
-    pub(crate) metrics: Arc<Metrics>,
-    pub(crate) resilience: Arc<RuntimeResilience>,
-    pub(crate) watchdog: Arc<WatchdogCoordinator>,
-    pub(crate) generation_tasks: Arc<RuntimeTaskRegistry>,
 }
 
 impl SharedRuntimeState {
@@ -54,22 +16,6 @@ impl SharedRuntimeState {
         let generation_state = Arc::new(generation_state);
 
         Self {
-            listener_runtime_configs: Arc::clone(&generation_state.listener_runtime_configs),
-            listener_tls_store: Arc::clone(&shared_services.listener_tls_store),
-            transport_pool: Arc::clone(&shared_services.transport_pool),
-            backend_endpoints: Arc::clone(&generation_state.backend_endpoints),
-            backend_health_checks: Arc::clone(&generation_state.backend_health_checks),
-            backend_resolution_store: Arc::clone(&shared_services.backend_resolution_store),
-            backend_dns_resolver: shared_services.backend_dns_resolver.clone(),
-            upstream_policies: Arc::clone(&generation_state.upstream_policies),
-            upstream_pools: generation_state.upstream_pools.clone(),
-            upstream_inflight: generation_state.upstream_inflight.clone(),
-            global_inflight: Arc::clone(&generation_state.global_inflight),
-            routing_index: Arc::clone(&generation_state.routing_index),
-            metrics: Arc::clone(&shared_services.metrics),
-            resilience: Arc::clone(&generation_state.resilience),
-            watchdog: Arc::clone(&shared_services.watchdog),
-            generation_tasks: Arc::clone(&generation_state.generation_tasks),
             shared_services,
             generation_state,
         }
@@ -84,19 +30,21 @@ impl SharedRuntimeState {
     }
 
     pub fn bind_metrics_worker_slot(&self, slot: usize) {
-        self.metrics.bind_worker_slot(slot);
+        self.shared_services.metrics.bind_worker_slot(slot);
     }
 
     pub fn inc_ingress_queue_drop(&self) {
-        self.metrics.inc_ingress_queue_drop();
+        self.shared_services.metrics.inc_ingress_queue_drop();
     }
 
     pub fn inc_ingress_queue_drop_bytes(&self, bytes: usize) {
-        self.metrics.inc_ingress_queue_drop_bytes(bytes);
+        self.shared_services
+            .metrics
+            .inc_ingress_queue_drop_bytes(bytes);
     }
 
     pub fn set_ingress_queue_bytes(&self, bytes: usize) {
-        self.metrics.set_ingress_queue_bytes(bytes);
+        self.shared_services.metrics.set_ingress_queue_bytes(bytes);
     }
 
     pub fn snapshot_backend_health(&self) -> (usize, usize) {

--- a/crates/edge/src/runtime/tasks.rs
+++ b/crates/edge/src/runtime/tasks.rs
@@ -29,7 +29,7 @@ impl RuntimeTaskRegistry {
         }
     }
 
-    fn retire_now(&self) -> Vec<oneshot::Receiver<()>> {
+    fn begin_generation_retirement(&self) -> Vec<oneshot::Receiver<()>> {
         let mut state = match self.state.lock() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
@@ -48,12 +48,14 @@ impl RuntimeTaskRegistry {
             .collect()
     }
 
-    pub(crate) fn abort_all(&self) {
-        let _ = self.retire_now();
+    pub(crate) fn abort_generation(&self) {
+        let _ = self.begin_generation_retirement();
     }
 
-    pub(crate) async fn retire_with_timeout(&self, timeout: Duration) {
-        let completions = self.retire_now();
+    async fn wait_for_generation_retirement(
+        completions: Vec<oneshot::Receiver<()>>,
+        timeout: Duration,
+    ) {
         if completions.is_empty() {
             return;
         }
@@ -74,11 +76,31 @@ impl RuntimeTaskRegistry {
             );
         }
     }
+
+    pub(crate) fn retire_generation(&self, timeout: Duration) {
+        let completions = self.begin_generation_retirement();
+        if completions.is_empty() {
+            return;
+        }
+
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) => {
+                handle.spawn(async move {
+                    Self::wait_for_generation_retirement(completions, timeout).await;
+                });
+            }
+            Err(_) => {
+                warn!(
+                    "generation background tasks retired without an active Tokio runtime; completion wait skipped"
+                );
+            }
+        }
+    }
 }
 
 impl Drop for RuntimeTaskRegistry {
     fn drop(&mut self) {
-        self.abort_all();
+        self.abort_generation();
     }
 }
 

--- a/crates/edge/src/runtime/tasks.rs
+++ b/crates/edge/src/runtime/tasks.rs
@@ -158,7 +158,10 @@ mod tests {
             let _ = task_join.await;
             completed_flag.store(true, Ordering::Release);
         });
-        registry.register(RuntimeTaskRegistration::new(task_handle.clone(), completion_rx));
+        registry.register(RuntimeTaskRegistration::new(
+            task_handle.clone(),
+            completion_rx,
+        ));
         task_handle
     }
 

--- a/crates/edge/src/runtime/tasks.rs
+++ b/crates/edge/src/runtime/tasks.rs
@@ -119,3 +119,75 @@ impl RuntimeTaskRegistration {
         Self { abort, completion }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        future,
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+    };
+
+    use super::*;
+
+    struct CompletionSignal(Option<oneshot::Sender<()>>);
+
+    impl Drop for CompletionSignal {
+        fn drop(&mut self) {
+            if let Some(sender) = self.0.take() {
+                let _ = sender.send(());
+            }
+        }
+    }
+
+    fn spawn_registered_task(
+        registry: &RuntimeTaskRegistry,
+        completed: Arc<AtomicBool>,
+    ) -> AbortHandle {
+        let (completion_tx, completion_rx) = oneshot::channel();
+        let task = tokio::spawn(async move {
+            let _completion = CompletionSignal(Some(completion_tx));
+            future::pending::<()>().await;
+        });
+        let task_handle = task.abort_handle();
+        let task_join = task;
+        let completed_flag = Arc::clone(&completed);
+        tokio::spawn(async move {
+            let _ = task_join.await;
+            completed_flag.store(true, Ordering::Release);
+        });
+        registry.register(RuntimeTaskRegistration::new(task_handle.clone(), completion_rx));
+        task_handle
+    }
+
+    #[tokio::test]
+    async fn task_retirement_is_generation_scoped() {
+        let retired_generation = RuntimeTaskRegistry::new();
+        let active_generation = RuntimeTaskRegistry::new();
+
+        let retired_completed = Arc::new(AtomicBool::new(false));
+        let active_completed = Arc::new(AtomicBool::new(false));
+
+        let _retired_task =
+            spawn_registered_task(&retired_generation, Arc::clone(&retired_completed));
+        let active_task = spawn_registered_task(&active_generation, Arc::clone(&active_completed));
+
+        retired_generation.retire_generation(Duration::from_millis(50));
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        assert!(
+            retired_completed.load(Ordering::Acquire),
+            "retired generation tasks should be aborted during retirement"
+        );
+        assert!(
+            !active_completed.load(Ordering::Acquire),
+            "active generation tasks should remain alive"
+        );
+
+        active_task.abort();
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(active_completed.load(Ordering::Acquire));
+    }
+}


### PR DESCRIPTION
## Summary
This PR formalizes the edge runtime ownership model around explicit runtime generations and shared long-lived services. It reduces ad hoc runtime lookups, makes reload behavior more predictable, and moves listener, control-plane, metrics, and bootstrap paths onto the same canonical runtime view.

## What changed
- Introduced explicit runtime ownership types for:
  - startup-owned state
  - long-lived shared services
  - generation-owned reloadable state
- Routed `RuntimeBundleHandle` through a canonical active-generation view instead of manual nested state access.
- Made runtime task retirement generation-scoped during bundle replacement.
- Updated control API reload flow to consume the runtime generation model directly.
- Routed metrics endpoint, listener startup, worker wiring, and bootstrap compatibility paths through the same runtime view contract.
- Removed stale compatibility shims and scattered runtime-state lookup paths.
- Added focused tests covering:
  - runtime generation ownership behavior
  - bundle replacement visibility
  - control API active-generation reads
  - metrics/bootstrap preference for reloaded generation state
  - generation-scoped task retirement
  - startup-owned drift protection

## Why
Before this change, runtime ownership and reload boundaries were spread across multiple code paths. That made it harder to reason about what is live-reloadable, what is fixed at startup, and which components should observe the currently active runtime generation.

This PR makes that model explicit and keeps reload behavior consistent across the edge runtime.

## Result
- One clearer ownership model for active runtime state
- Cleaner reload boundaries
- Less duplicated runtime lookup logic
- Better test coverage for generation swap and reload semantics