### PR TITLE
Refactor transport into a canonical backend execution facade

### DIFF
--- a/crates/config/src/runtime/policies.rs
+++ b/crates/config/src/runtime/policies.rs
@@ -800,6 +800,7 @@ pub struct RuntimeBackendConnectionPolicy {
     pub max_idle_per_backend: usize,
     pub pool_idle_timeout: Duration,
     pub connect_timeout: Duration,
+    pub execution_timeout: Duration,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -988,6 +989,7 @@ impl RuntimeTransportPolicy {
                 max_idle_per_backend: performance.h2_pool_max_idle_per_backend,
                 pool_idle_timeout: Duration::from_millis(performance.h2_pool_idle_timeout_ms),
                 connect_timeout: Duration::from_millis(performance.backend_connect_timeout_ms),
+                execution_timeout: Duration::from_millis(performance.backend_timeout_ms),
             },
             backend_dns: RuntimeBackendDnsPolicy {
                 refresh_enabled: performance.backend_dns_refresh_enabled,

--- a/crates/edge/src/quic_listener/bootstrap/context.rs
+++ b/crates/edge/src/quic_listener/bootstrap/context.rs
@@ -7,7 +7,7 @@ use std::{
 
 use spooky_config::{backend_endpoint::BackendEndpoint, runtime::RuntimeUpstreamPolicy};
 use spooky_lb::upstream_pool::UpstreamPool;
-use spooky_transport::transport_pool::UpstreamTransportPool;
+use spooky_transport::UpstreamTransportPool;
 
 use super::state::BootstrapConnectionState;
 use crate::{Metrics, resilience::runtime::RuntimeResilience, routing::index::RouteIndex};

--- a/crates/edge/src/quic_listener/bootstrap/dispatch.rs
+++ b/crates/edge/src/quic_listener/bootstrap/dispatch.rs
@@ -22,50 +22,39 @@ pub(in crate::quic_listener) struct BootstrapDispatchInput<'a> {
 async fn dispatch_bootstrap_http(
     input: BootstrapDispatchInput<'_>,
 ) -> Result<Response<Incoming>, Response<BoxBody<Bytes, Infallible>>> {
-    match tokio::time::timeout(
-        input.dispatch_ctx.request.runtime.backend_timeout,
-        input
-            .dispatch_ctx
-            .request
-            .runtime
-            .transport_pool
-            .execute(
-                TransportExecutionTarget::new(&input.prepared_route.backend_addr),
-                input.upstream_req,
-            ),
-    )
+    match input
+        .dispatch_ctx
+        .request
+        .runtime
+        .transport_pool
+        .execute(
+            TransportExecutionTarget::new(&input.prepared_route.backend_addr),
+            input.upstream_req,
+        )
     .await
     {
-        Ok(Ok(result)) => Ok(result.into_response()),
-        Ok(Err(err)) => {
-            let proxy_err = ProxyError::Pool(err);
+        Ok(result) => Ok(result.into_response()),
+        Err(proxy_err) => {
+            let status = match proxy_err {
+                ProxyError::Timeout => StatusCode::GATEWAY_TIMEOUT,
+                _ => StatusCode::BAD_GATEWAY,
+            };
             observe_bootstrap_dispatch_failure(
                 input.prepared_route,
                 input.dispatch_ctx.request.runtime.metrics.as_ref(),
                 input.dispatch_ctx.request.request_start,
                 input.dispatch_ctx.request_id,
-                StatusCode::BAD_GATEWAY,
+                status,
                 &proxy_err,
             );
             Err(bootstrap_error_response(
                 &input.dispatch_ctx.request.runtime.alt_svc,
-                StatusCode::BAD_GATEWAY,
-                b"upstream error\n",
-            ))
-        }
-        Err(_) => {
-            observe_bootstrap_dispatch_failure(
-                input.prepared_route,
-                input.dispatch_ctx.request.runtime.metrics.as_ref(),
-                input.dispatch_ctx.request.request_start,
-                input.dispatch_ctx.request_id,
-                StatusCode::GATEWAY_TIMEOUT,
-                &ProxyError::Timeout,
-            );
-            Err(bootstrap_error_response(
-                &input.dispatch_ctx.request.runtime.alt_svc,
-                StatusCode::GATEWAY_TIMEOUT,
-                b"upstream timeout\n",
+                status,
+                if matches!(proxy_err, ProxyError::Timeout) {
+                    b"upstream timeout\n"
+                } else {
+                    b"upstream error\n"
+                },
             ))
         }
     }

--- a/crates/edge/src/quic_listener/bootstrap/dispatch.rs
+++ b/crates/edge/src/quic_listener/bootstrap/dispatch.rs
@@ -5,7 +5,6 @@ use http::{Request, Response, StatusCode};
 use http_body_util::combinators::BoxBody;
 use hyper::body::Incoming;
 use spooky_errors::ProxyError;
-use spooky_transport::transport_pool::TransportExecutionTarget;
 
 use super::{
     context::BootstrapDispatchCtx, intake::bootstrap_error_response,
@@ -27,13 +26,10 @@ async fn dispatch_bootstrap_http(
         .request
         .runtime
         .transport_pool
-        .execute(
-            TransportExecutionTarget::new(&input.prepared_route.backend_addr),
-            input.upstream_req,
-        )
+        .send_backend_request(&input.prepared_route.backend_addr, input.upstream_req)
     .await
     {
-        Ok(result) => Ok(result.into_response()),
+        Ok(response) => Ok(response),
         Err(proxy_err) => {
             let status = match proxy_err {
                 ProxyError::Timeout => StatusCode::GATEWAY_TIMEOUT,

--- a/crates/edge/src/quic_listener/bootstrap/dispatch.rs
+++ b/crates/edge/src/quic_listener/bootstrap/dispatch.rs
@@ -5,6 +5,7 @@ use http::{Request, Response, StatusCode};
 use http_body_util::combinators::BoxBody;
 use hyper::body::Incoming;
 use spooky_errors::ProxyError;
+use spooky_transport::transport_pool::TransportExecutionTarget;
 
 use super::{
     context::BootstrapDispatchCtx, intake::bootstrap_error_response,
@@ -28,11 +29,14 @@ async fn dispatch_bootstrap_http(
             .request
             .runtime
             .transport_pool
-            .send(&input.prepared_route.backend_addr, input.upstream_req),
+            .execute(
+                TransportExecutionTarget::new(&input.prepared_route.backend_addr),
+                input.upstream_req,
+            ),
     )
     .await
     {
-        Ok(Ok(resp)) => Ok(resp),
+        Ok(Ok(result)) => Ok(result.into_response()),
         Ok(Err(err)) => {
             let proxy_err = ProxyError::Pool(err);
             observe_bootstrap_dispatch_failure(

--- a/crates/edge/src/quic_listener/bootstrap/dispatch.rs
+++ b/crates/edge/src/quic_listener/bootstrap/dispatch.rs
@@ -27,7 +27,7 @@ async fn dispatch_bootstrap_http(
         .runtime
         .transport_pool
         .send_backend_request(&input.prepared_route.backend_addr, input.upstream_req)
-    .await
+        .await
     {
         Ok(response) => Ok(response),
         Err(proxy_err) => {

--- a/crates/edge/src/quic_listener/bootstrap/state.rs
+++ b/crates/edge/src/quic_listener/bootstrap/state.rs
@@ -9,7 +9,7 @@ use spooky_config::{
     runtime::{ListenerRuntimeConfig, RuntimeUpstreamPolicy},
 };
 use spooky_lb::upstream_pool::UpstreamPool;
-use spooky_transport::transport_pool::UpstreamTransportPool;
+use spooky_transport::UpstreamTransportPool;
 
 use crate::{
     Metrics,

--- a/crates/edge/src/quic_listener/forwarding/dispatch.rs
+++ b/crates/edge/src/quic_listener/forwarding/dispatch.rs
@@ -6,7 +6,6 @@ use spooky_errors::{
 use spooky_lb::alternate_backend::{
     AlternateBackendDecision, AlternateBackendFailureReason, choose_alternate_backend,
 };
-use spooky_transport::transport_pool::TransportExecutionTarget;
 
 use super::*;
 use crate::runtime::connection::response::ForwardingPolicyTelemetry;
@@ -165,9 +164,8 @@ impl QUICListener {
         }
 
         let send_result = transport
-            .execute(TransportExecutionTarget::new(&backend), request)
-            .await
-            .map(|execution| execution.into_response());
+            .send_backend_request(&backend, request)
+            .await;
         match &send_result {
             Ok(_) => circuit_breakers.record_success(&backend),
             _ => circuit_breakers.record_failure(&backend),

--- a/crates/edge/src/quic_listener/forwarding/dispatch.rs
+++ b/crates/edge/src/quic_listener/forwarding/dispatch.rs
@@ -53,7 +53,6 @@ struct RetryExecutionCtx<'a> {
     pending_forward: &'a PendingForward,
     circuit_breakers: Arc<crate::resilience::circuit_breaker::CircuitBreakers>,
     transport: Arc<UpstreamTransportPool>,
-    backend_timeout: Duration,
 }
 
 #[derive(Clone, Copy)]
@@ -160,24 +159,20 @@ impl QUICListener {
         request: UpstreamRequest,
         circuit_breakers: Arc<crate::resilience::circuit_breaker::CircuitBreakers>,
         transport: Arc<UpstreamTransportPool>,
-        backend_timeout: Duration,
     ) -> Result<Response<Incoming>, ProxyError> {
         if !circuit_breakers.allow_request(&backend) {
             return Err(ProxyError::Pool(PoolError::CircuitOpen(backend)));
         }
 
-        let send_result = tokio::time::timeout(
-            backend_timeout,
-            transport.execute(TransportExecutionTarget::new(&backend), request),
-        )
-        .await
-        .map(|result| result.map(|execution| execution.into_response()))
-        .map_err(|_| ProxyError::Timeout);
+        let send_result = transport
+            .execute(TransportExecutionTarget::new(&backend), request)
+            .await
+            .map(|execution| execution.into_response());
         match &send_result {
-            Ok(Ok(_)) => circuit_breakers.record_success(&backend),
+            Ok(_) => circuit_breakers.record_success(&backend),
             _ => circuit_breakers.record_failure(&backend),
         }
-        Ok(send_result??)
+        send_result
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -347,7 +342,6 @@ impl QUICListener {
             pending_forward,
             circuit_breakers,
             transport,
-            backend_timeout,
         } = retry_ctx;
         let retry_decision = policy.retry_after_error(
             &primary_err,
@@ -390,7 +384,6 @@ impl QUICListener {
             retry_request,
             circuit_breakers,
             transport,
-            backend_timeout,
         )
         .await
     }
@@ -483,7 +476,6 @@ impl QUICListener {
                                 request,
                                 Arc::clone(&cb),
                                 Arc::clone(&transport),
-                                backend_timeout,
                             );
                             tokio::pin!(primary_fut);
                             let hedge_sleep = tokio::time::sleep(hedge_delay);
@@ -509,7 +501,6 @@ impl QUICListener {
                                             hedge_request,
                                             Arc::clone(&cb),
                                             Arc::clone(&transport),
-                                            backend_timeout,
                                         );
                                         tokio::pin!(hedge_fut);
                                         tokio::select! {
@@ -573,7 +564,6 @@ impl QUICListener {
                                     request,
                                     Arc::clone(&cb),
                                     Arc::clone(&transport),
-                                    backend_timeout,
                                 )
                                 .await?
                             }
@@ -588,7 +578,6 @@ impl QUICListener {
                                 request,
                                 Arc::clone(&cb),
                                 Arc::clone(&transport),
-                                backend_timeout,
                             )
                             .await
                             {
@@ -606,7 +595,6 @@ impl QUICListener {
                                             pending_forward: pending_forward_for_upstream.as_ref(),
                                             circuit_breakers: Arc::clone(&cb),
                                             transport: Arc::clone(&transport),
-                                            backend_timeout,
                                         },
                                     )
                                     .await?,
@@ -622,7 +610,6 @@ impl QUICListener {
                                 request,
                                 Arc::clone(&cb),
                                 Arc::clone(&transport),
-                                backend_timeout,
                             )
                             .await
                             {
@@ -640,7 +627,6 @@ impl QUICListener {
                                             pending_forward: pending_forward_for_upstream.as_ref(),
                                             circuit_breakers: Arc::clone(&cb),
                                             transport: Arc::clone(&transport),
-                                            backend_timeout,
                                         },
                                     )
                                     .await?,

--- a/crates/edge/src/quic_listener/forwarding/dispatch.rs
+++ b/crates/edge/src/quic_listener/forwarding/dispatch.rs
@@ -163,9 +163,7 @@ impl QUICListener {
             return Err(ProxyError::Pool(PoolError::CircuitOpen(backend)));
         }
 
-        let send_result = transport
-            .send_backend_request(&backend, request)
-            .await;
+        let send_result = transport.send_backend_request(&backend, request).await;
         match &send_result {
             Ok(_) => circuit_breakers.record_success(&backend),
             _ => circuit_breakers.record_failure(&backend),
@@ -377,13 +375,7 @@ impl QUICListener {
             "request_id={} retrying request on alternate backend: route={} reason={:?}",
             request_id, route_name, retry_reason
         );
-        Self::send_upstream_request(
-            retry_backend,
-            retry_request,
-            circuit_breakers,
-            transport,
-        )
-        .await
+        Self::send_upstream_request(retry_backend, retry_request, circuit_breakers, transport).await
     }
 
     pub(super) fn spawn_upstream_forward_task(

--- a/crates/edge/src/quic_listener/forwarding/dispatch.rs
+++ b/crates/edge/src/quic_listener/forwarding/dispatch.rs
@@ -6,6 +6,7 @@ use spooky_errors::{
 use spooky_lb::alternate_backend::{
     AlternateBackendDecision, AlternateBackendFailureReason, choose_alternate_backend,
 };
+use spooky_transport::transport_pool::TransportExecutionTarget;
 
 use super::*;
 use crate::runtime::connection::response::ForwardingPolicyTelemetry;
@@ -165,9 +166,13 @@ impl QUICListener {
             return Err(ProxyError::Pool(PoolError::CircuitOpen(backend)));
         }
 
-        let send_result = tokio::time::timeout(backend_timeout, transport.send(&backend, request))
-            .await
-            .map_err(|_| ProxyError::Timeout);
+        let send_result = tokio::time::timeout(
+            backend_timeout,
+            transport.execute(TransportExecutionTarget::new(&backend), request),
+        )
+        .await
+        .map(|result| result.map(|execution| execution.into_response()))
+        .map_err(|_| ProxyError::Timeout);
         match &send_result {
             Ok(Ok(_)) => circuit_breakers.record_success(&backend),
             _ => circuit_breakers.record_failure(&backend),

--- a/crates/edge/src/quic_listener/health_check.rs
+++ b/crates/edge/src/quic_listener/health_check.rs
@@ -33,7 +33,6 @@ impl QUICListener {
             // underneath this identity without changing health ownership.
             backend_identity: String,
             health_uri: String,
-            timeout: Duration,
             base_interval_ms: u64,
             consecutive_failures: u32,
             next_due_at: Instant,
@@ -80,7 +79,6 @@ impl QUICListener {
                     index,
                     backend_identity: address,
                     health_uri: endpoint.uri_for_path(&health.path),
-                    timeout: health.timeout,
                     base_interval_ms,
                     consecutive_failures: 0,
                     next_due_at,
@@ -134,17 +132,15 @@ impl QUICListener {
                                 Err(_) => continue,
                             };
 
-                            let result = tokio::time::timeout(
-                                job.timeout,
-                                transport_pool.execute(
+                            let result = transport_pool
+                                .execute(
                                     TransportExecutionTarget::new(&job.backend_identity),
                                     request,
-                                ),
-                            )
-                            .await;
+                                )
+                                .await;
 
                             let evaluation = match result {
-                                Ok(Ok(result)) => {
+                                Ok(result) => {
                                     let response = result.into_response();
                                     let outcome = match classify_active_health_check_response(
                                         response.status(),
@@ -167,32 +163,22 @@ impl QUICListener {
                                         job.consecutive_failures,
                                     )
                                 }
-                                Ok(Err(PoolError::Send(send_err))) => {
+                                Err(proxy_err) => {
+                                    let failure_reason =
+                                        if matches!(proxy_err, ProxyError::Timeout) {
+                                            HealthFailureReason::Timeout
+                                        } else {
+                                            HealthFailureReason::Transport
+                                        };
                                     Self::evaluate_failed_health_check(
                                         &job.backend_identity,
                                         task_metrics.as_ref(),
                                         job.base_interval_ms,
                                         job.consecutive_failures,
-                                        ProxyError::Pool(PoolError::Send(send_err)),
-                                        HealthFailureReason::Transport,
+                                        proxy_err,
+                                        failure_reason,
                                     )
                                 }
-                                Ok(Err(pool_err)) => Self::evaluate_failed_health_check(
-                                    &job.backend_identity,
-                                    task_metrics.as_ref(),
-                                    job.base_interval_ms,
-                                    job.consecutive_failures,
-                                    ProxyError::Pool(pool_err),
-                                    HealthFailureReason::Transport,
-                                ),
-                                Err(_) => Self::evaluate_failed_health_check(
-                                    &job.backend_identity,
-                                    task_metrics.as_ref(),
-                                    job.base_interval_ms,
-                                    job.consecutive_failures,
-                                    ProxyError::Timeout,
-                                    HealthFailureReason::Timeout,
-                                ),
                             };
 
                             let transition = backend_lifecycle.apply_health_observation(

--- a/crates/edge/src/quic_listener/health_check.rs
+++ b/crates/edge/src/quic_listener/health_check.rs
@@ -1,5 +1,6 @@
 use http_body_util::Full;
 use spooky_errors::classify_upstream_proxy_error;
+use spooky_transport::transport_pool::TransportExecutionTarget;
 
 use super::*;
 use crate::runtime::{
@@ -135,12 +136,16 @@ impl QUICListener {
 
                             let result = tokio::time::timeout(
                                 job.timeout,
-                                transport_pool.send(&job.backend_identity, request),
+                                transport_pool.execute(
+                                    TransportExecutionTarget::new(&job.backend_identity),
+                                    request,
+                                ),
                             )
                             .await;
 
                             let evaluation = match result {
-                                Ok(Ok(response)) => {
+                                Ok(Ok(result)) => {
+                                    let response = result.into_response();
                                     let outcome = match classify_active_health_check_response(
                                         response.status(),
                                     ) {

--- a/crates/edge/src/quic_listener/health_check.rs
+++ b/crates/edge/src/quic_listener/health_check.rs
@@ -159,12 +159,12 @@ impl QUICListener {
                                     )
                                 }
                                 Err(proxy_err) => {
-                                    let failure_reason =
-                                        if matches!(proxy_err, ProxyError::Timeout) {
-                                            HealthFailureReason::Timeout
-                                        } else {
-                                            HealthFailureReason::Transport
-                                        };
+                                    let failure_reason = if matches!(proxy_err, ProxyError::Timeout)
+                                    {
+                                        HealthFailureReason::Timeout
+                                    } else {
+                                        HealthFailureReason::Transport
+                                    };
                                     Self::evaluate_failed_health_check(
                                         &job.backend_identity,
                                         task_metrics.as_ref(),

--- a/crates/edge/src/quic_listener/health_check.rs
+++ b/crates/edge/src/quic_listener/health_check.rs
@@ -1,6 +1,5 @@
 use http_body_util::Full;
 use spooky_errors::classify_upstream_proxy_error;
-use spooky_transport::transport_pool::TransportExecutionTarget;
 
 use super::*;
 use crate::runtime::{
@@ -133,15 +132,11 @@ impl QUICListener {
                             };
 
                             let result = transport_pool
-                                .execute(
-                                    TransportExecutionTarget::new(&job.backend_identity),
-                                    request,
-                                )
+                                .send_backend_request(&job.backend_identity, request)
                                 .await;
 
                             let evaluation = match result {
-                                Ok(result) => {
-                                    let response = result.into_response();
+                                Ok(response) => {
                                     let outcome = match classify_active_health_check_response(
                                         response.status(),
                                     ) {

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -44,7 +44,7 @@ use spooky_config::{
 };
 use spooky_errors::{PoolError, ProxyError};
 use spooky_lb::{health::HealthFailureReason, upstream_pool::UpstreamPool};
-use spooky_transport::{h2_client::SharedDnsResolver, transport_pool::UpstreamTransportPool};
+use spooky_transport::{SharedDnsResolver, transport_pool::UpstreamTransportPool};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     sync::{Semaphore, mpsc, mpsc::error::TrySendError, oneshot},

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -44,7 +44,7 @@ use spooky_config::{
 };
 use spooky_errors::{PoolError, ProxyError};
 use spooky_lb::{health::HealthFailureReason, upstream_pool::UpstreamPool};
-use spooky_transport::{SharedDnsResolver, transport_pool::UpstreamTransportPool};
+use spooky_transport::{SharedDnsResolver, UpstreamTransportPool};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     sync::{Semaphore, mpsc, mpsc::error::TrySendError, oneshot},

--- a/crates/edge/src/quic_listener/startup.rs
+++ b/crates/edge/src/quic_listener/startup.rs
@@ -11,7 +11,7 @@ use spooky_config::runtime::{ListenerRuntimeConfig, RuntimeBackendAddressKind, R
 use spooky_errors::ProxyError;
 use spooky_lb::upstream_pool::UpstreamPool;
 use spooky_transport::{
-    ConnectObservation, ConnectObserver, SharedDnsResolver, transport_pool::UpstreamTransportPool,
+    ConnectObservation, ConnectObserver, SharedDnsResolver, UpstreamTransportPool,
 };
 use tokio::sync::Semaphore;
 

--- a/crates/edge/src/quic_listener/startup.rs
+++ b/crates/edge/src/quic_listener/startup.rs
@@ -10,7 +10,9 @@ use socket2::{Domain, Protocol, Socket, Type};
 use spooky_config::runtime::{ListenerRuntimeConfig, RuntimeBackendAddressKind, RuntimeConfig};
 use spooky_errors::ProxyError;
 use spooky_lb::upstream_pool::UpstreamPool;
-use spooky_transport::{h2_client::SharedDnsResolver, transport_pool::UpstreamTransportPool};
+use spooky_transport::{
+    ConnectObservation, ConnectObserver, SharedDnsResolver, transport_pool::UpstreamTransportPool,
+};
 use tokio::sync::Semaphore;
 
 use crate::{
@@ -250,16 +252,15 @@ impl QUICListener {
             &backend_resolution_store,
         )));
         let connect_metrics = Arc::clone(&metrics);
-        let connect_observer: spooky_transport::h2_client::ConnectObserver = Arc::new(
-            move |observation: spooky_transport::h2_client::ConnectObservation| {
+        let connect_observer: ConnectObserver =
+            Arc::new(move |observation: ConnectObservation| {
                 Self::record_backend_connect(
                     &connect_metrics,
                     &observation.backend,
                     &observation.hostname,
                     observation.resolved_addr,
                 );
-            },
-        );
+            });
         let transport_pool = Arc::new(
             UpstreamTransportPool::from_runtime_upstreams(
                 config.upstreams.values(),

--- a/crates/edge/src/quic_listener/startup.rs
+++ b/crates/edge/src/quic_listener/startup.rs
@@ -252,15 +252,14 @@ impl QUICListener {
             &backend_resolution_store,
         )));
         let connect_metrics = Arc::clone(&metrics);
-        let connect_observer: ConnectObserver =
-            Arc::new(move |observation: ConnectObservation| {
-                Self::record_backend_connect(
-                    &connect_metrics,
-                    &observation.backend,
-                    &observation.hostname,
-                    observation.resolved_addr,
-                );
-            });
+        let connect_observer: ConnectObserver = Arc::new(move |observation: ConnectObservation| {
+            Self::record_backend_connect(
+                &connect_metrics,
+                &observation.backend,
+                &observation.hostname,
+                observation.resolved_addr,
+            );
+        });
         let transport_pool = Arc::new(
             UpstreamTransportPool::from_runtime_upstreams(
                 config.upstreams.values(),

--- a/crates/edge/src/runtime/backend/lifecycle.rs
+++ b/crates/edge/src/runtime/backend/lifecycle.rs
@@ -626,11 +626,13 @@ mod tests {
         UpstreamTransportPool::new_from_runtime_backends(
             [(backend_addr.to_string(), RuntimeBackendTransportKind::Http1)],
             HashMap::new(),
-            32,
-            8,
-            Duration::from_secs(30),
-            Duration::from_secs(2),
-            Duration::from_secs(5),
+            spooky_config::runtime::RuntimeBackendConnectionPolicy {
+                max_inflight: 32,
+                max_idle_per_backend: 8,
+                pool_idle_timeout: Duration::from_secs(30),
+                connect_timeout: Duration::from_secs(2),
+                execution_timeout: Duration::from_secs(5),
+            },
             SharedDnsResolver::new(),
         )
         .expect("transport pool")

--- a/crates/edge/src/runtime/backend/lifecycle.rs
+++ b/crates/edge/src/runtime/backend/lifecycle.rs
@@ -7,7 +7,7 @@ use std::{
 
 use log::{debug, info, warn};
 use spooky_lb::{backend::HealthTransition, upstream_pool::UpstreamPool};
-use spooky_transport::{h2_client::SharedDnsResolver, transport_pool::UpstreamTransportPool};
+use spooky_transport::{SharedDnsResolver, transport_pool::UpstreamTransportPool};
 
 use super::{
     event::{
@@ -386,10 +386,8 @@ pub(crate) fn apply_backend_dns_refresh(
             let client_rotated = if matches!(result.outcome, BackendRefreshOutcome::Updated { .. })
             {
                 matches!(
-                    transport_pool.rotate_backend_client(
-                        spooky_transport::transport_pool::TransportExecutionTarget::new(
-                            &result.identity.backend_addr,
-                        ),
+                    transport_pool.rotate_backend_client_for_backend(
+                        &result.identity.backend_addr,
                     ),
                     Ok(rotation) if rotation.rotated()
                 )
@@ -552,10 +550,7 @@ mod tests {
         config::{Backend, Config, HealthCheck, Listen, LoadBalancing, RouteMatch, Tls, Upstream},
         runtime::{RuntimeBackendTransportKind, RuntimeConfig},
     };
-    use spooky_transport::{
-        h2_client::SharedDnsResolver,
-        transport_pool::UpstreamTransportPool,
-    };
+    use spooky_transport::{SharedDnsResolver, transport_pool::UpstreamTransportPool};
 
     use super::*;
     use crate::runtime::backend::event::{BackendHealthObservationOutcome, BackendRequestFeedback};

--- a/crates/edge/src/runtime/backend/lifecycle.rs
+++ b/crates/edge/src/runtime/backend/lifecycle.rs
@@ -635,6 +635,7 @@ mod tests {
             8,
             Duration::from_secs(30),
             Duration::from_secs(2),
+            Duration::from_secs(5),
             SharedDnsResolver::new(),
         )
         .expect("transport pool")

--- a/crates/edge/src/runtime/backend/lifecycle.rs
+++ b/crates/edge/src/runtime/backend/lifecycle.rs
@@ -386,8 +386,12 @@ pub(crate) fn apply_backend_dns_refresh(
             let client_rotated = if matches!(result.outcome, BackendRefreshOutcome::Updated { .. })
             {
                 matches!(
-                    transport_pool.rotate_backend_client(&result.identity.backend_addr),
-                    Ok(true)
+                    transport_pool.rotate_backend_client(
+                        spooky_transport::transport_pool::TransportExecutionTarget::new(
+                            &result.identity.backend_addr,
+                        ),
+                    ),
+                    Ok(rotation) if rotation.rotated()
                 )
             } else {
                 false
@@ -550,7 +554,7 @@ mod tests {
     };
     use spooky_transport::{
         h2_client::SharedDnsResolver,
-        transport_pool::{BackendTransportKind, UpstreamTransportPool},
+        transport_pool::{ResolvedBackendTransport, UpstreamTransportPool},
     };
 
     use super::*;
@@ -625,7 +629,7 @@ mod tests {
 
     fn test_transport_pool(backend_addr: &str) -> UpstreamTransportPool {
         UpstreamTransportPool::new(
-            [(backend_addr.to_string(), BackendTransportKind::Http1)],
+            [(backend_addr.to_string(), ResolvedBackendTransport::Http1)],
             HashMap::new(),
             32,
             8,

--- a/crates/edge/src/runtime/backend/lifecycle.rs
+++ b/crates/edge/src/runtime/backend/lifecycle.rs
@@ -550,11 +550,11 @@ mod tests {
 
     use spooky_config::{
         config::{Backend, Config, HealthCheck, Listen, LoadBalancing, RouteMatch, Tls, Upstream},
-        runtime::RuntimeConfig,
+        runtime::{RuntimeBackendTransportKind, RuntimeConfig},
     };
     use spooky_transport::{
         h2_client::SharedDnsResolver,
-        transport_pool::{ResolvedBackendTransport, UpstreamTransportPool},
+        transport_pool::UpstreamTransportPool,
     };
 
     use super::*;
@@ -628,8 +628,8 @@ mod tests {
     }
 
     fn test_transport_pool(backend_addr: &str) -> UpstreamTransportPool {
-        UpstreamTransportPool::new(
-            [(backend_addr.to_string(), ResolvedBackendTransport::Http1)],
+        UpstreamTransportPool::new_from_runtime_backends(
+            [(backend_addr.to_string(), RuntimeBackendTransportKind::Http1)],
             HashMap::new(),
             32,
             8,

--- a/crates/edge/src/runtime/backend/lifecycle.rs
+++ b/crates/edge/src/runtime/backend/lifecycle.rs
@@ -7,7 +7,7 @@ use std::{
 
 use log::{debug, info, warn};
 use spooky_lb::{backend::HealthTransition, upstream_pool::UpstreamPool};
-use spooky_transport::{SharedDnsResolver, transport_pool::UpstreamTransportPool};
+use spooky_transport::{SharedDnsResolver, UpstreamTransportPool};
 
 use super::{
     event::{
@@ -386,7 +386,7 @@ pub(crate) fn apply_backend_dns_refresh(
             let client_rotated = if matches!(result.outcome, BackendRefreshOutcome::Updated { .. })
             {
                 matches!(
-                    transport_pool.rotate_backend_client_for_backend(
+                    transport_pool.rotate_backend_client(
                         &result.identity.backend_addr,
                     ),
                     Ok(rotation) if rotation.rotated()
@@ -550,7 +550,7 @@ mod tests {
         config::{Backend, Config, HealthCheck, Listen, LoadBalancing, RouteMatch, Tls, Upstream},
         runtime::{RuntimeBackendTransportKind, RuntimeConfig},
     };
-    use spooky_transport::{SharedDnsResolver, transport_pool::UpstreamTransportPool};
+    use spooky_transport::{SharedDnsResolver, UpstreamTransportPool};
 
     use super::*;
     use crate::runtime::backend::event::{BackendHealthObservationOutcome, BackendRequestFeedback};

--- a/crates/edge/src/runtime/generation.rs
+++ b/crates/edge/src/runtime/generation.rs
@@ -11,7 +11,7 @@ use spooky_config::{
     },
 };
 use spooky_lb::upstream_pool::UpstreamPool;
-use spooky_transport::{SharedDnsResolver, transport_pool::UpstreamTransportPool};
+use spooky_transport::{SharedDnsResolver, UpstreamTransportPool};
 use tokio::sync::Semaphore;
 
 use crate::{

--- a/crates/edge/src/runtime/generation.rs
+++ b/crates/edge/src/runtime/generation.rs
@@ -11,7 +11,7 @@ use spooky_config::{
     },
 };
 use spooky_lb::upstream_pool::UpstreamPool;
-use spooky_transport::{h2_client::SharedDnsResolver, transport_pool::UpstreamTransportPool};
+use spooky_transport::{SharedDnsResolver, transport_pool::UpstreamTransportPool};
 use tokio::sync::Semaphore;
 
 use crate::{

--- a/crates/edge/src/runtime/listener.rs
+++ b/crates/edge/src/runtime/listener.rs
@@ -10,7 +10,7 @@ use spooky_config::{
     runtime::{ListenerRuntimeConfig, RuntimeUpstreamPolicy},
 };
 use spooky_lb::upstream_pool::UpstreamPool;
-use spooky_transport::{h2_client::SharedDnsResolver, transport_pool::UpstreamTransportPool};
+use spooky_transport::{SharedDnsResolver, transport_pool::UpstreamTransportPool};
 use tokio::sync::Semaphore;
 
 use crate::{

--- a/crates/edge/src/runtime/listener.rs
+++ b/crates/edge/src/runtime/listener.rs
@@ -10,7 +10,7 @@ use spooky_config::{
     runtime::{ListenerRuntimeConfig, RuntimeUpstreamPolicy},
 };
 use spooky_lb::upstream_pool::UpstreamPool;
-use spooky_transport::{SharedDnsResolver, transport_pool::UpstreamTransportPool};
+use spooky_transport::{SharedDnsResolver, UpstreamTransportPool};
 use tokio::sync::Semaphore;
 
 use crate::{

--- a/crates/transport/src/client_rotation.rs
+++ b/crates/transport/src/client_rotation.rs
@@ -35,10 +35,6 @@ impl BackendClientRotation {
         }
     }
 
-    pub fn state(self) -> BackendClientRotationState {
-        self.state
-    }
-
     pub fn changed(self) -> bool {
         !matches!(self.state, BackendClientRotationState::MissingBackend)
     }

--- a/crates/transport/src/client_rotation.rs
+++ b/crates/transport/src/client_rotation.rs
@@ -1,0 +1,55 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackendClientRotationState {
+    MissingBackend,
+    Recreated,
+    Rotated {
+        previous_generation: u64,
+        current_generation: u64,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BackendClientRotation {
+    state: BackendClientRotationState,
+}
+
+impl BackendClientRotation {
+    pub fn missing_backend() -> Self {
+        Self {
+            state: BackendClientRotationState::MissingBackend,
+        }
+    }
+
+    pub fn recreated() -> Self {
+        Self {
+            state: BackendClientRotationState::Recreated,
+        }
+    }
+
+    pub fn rotated(previous_generation: u64, current_generation: u64) -> Self {
+        Self {
+            state: BackendClientRotationState::Rotated {
+                previous_generation,
+                current_generation,
+            },
+        }
+    }
+
+    pub fn state(self) -> BackendClientRotationState {
+        self.state
+    }
+
+    pub fn changed(self) -> bool {
+        !matches!(self.state, BackendClientRotationState::MissingBackend)
+    }
+
+    pub fn generations(self) -> Option<(u64, u64)> {
+        match self.state {
+            BackendClientRotationState::Rotated {
+                previous_generation,
+                current_generation,
+            } => Some((previous_generation, current_generation)),
+            _ => None,
+        }
+    }
+}

--- a/crates/transport/src/h1_client.rs
+++ b/crates/transport/src/h1_client.rs
@@ -9,7 +9,7 @@ use crate::h2_client::{
     ObservedHttpConnector, SharedDnsResolver, TokioExecutor, build_observed_http_connector,
 };
 
-pub struct H1Client {
+pub(crate) struct H1Client {
     client: Client<ObservedHttpConnector, BoxBody<Bytes, Infallible>>,
 }
 
@@ -25,7 +25,7 @@ impl Default for H1Client {
 }
 
 impl H1Client {
-    pub fn new(
+    pub(crate) fn new(
         max_idle_per_host: usize,
         pool_idle_timeout: std::time::Duration,
         connect_timeout: std::time::Duration,
@@ -40,7 +40,7 @@ impl H1Client {
         )
     }
 
-    pub fn new_with_observer(
+    pub(crate) fn new_with_observer(
         max_idle_per_host: usize,
         pool_idle_timeout: std::time::Duration,
         connect_timeout: std::time::Duration,
@@ -58,14 +58,15 @@ impl H1Client {
         Self { client }
     }
 
-    pub async fn send(
+    pub(crate) async fn send(
         &self,
         req: Request<BoxBody<Bytes, Infallible>>,
     ) -> Result<hyper::Response<hyper::body::Incoming>, hyper_util::client::legacy::Error> {
         self.client.request(req).await
     }
 
-    pub fn try_default() -> Self {
+    #[cfg(test)]
+    fn try_default() -> Self {
         Self::new(
             DEFAULT_MAX_IDLE_PER_HOST,
             DEFAULT_POOL_IDLE_TIMEOUT,

--- a/crates/transport/src/h1_pool.rs
+++ b/crates/transport/src/h1_pool.rs
@@ -14,6 +14,7 @@ pub use spooky_errors::PoolError;
 use tokio::sync::{Semaphore, TryAcquireError};
 
 use crate::{
+    client_rotation::BackendClientRotation,
     h1_client::H1Client,
     h2_client::{ConnectObserver, SharedDnsResolver},
 };
@@ -113,9 +114,9 @@ impl H1Pool {
         client.send(req).await.map_err(PoolError::Send)
     }
 
-    pub fn rotate_backend_client(&self, backend: &str) -> Result<bool, String> {
+    pub fn rotate_backend_client(&self, backend: &str) -> Result<BackendClientRotation, String> {
         let Some(handle) = self.backends.get(backend) else {
-            return Ok(false);
+            return Ok(BackendClientRotation::missing_backend());
         };
 
         let client = Arc::new(H1Client::new_with_observer(
@@ -131,7 +132,7 @@ impl H1Pool {
             .write()
             .map_err(|_| format!("backend client state poisoned for '{backend}'"))?;
         state.client = client;
-        Ok(true)
+        Ok(BackendClientRotation::recreated())
     }
 
     fn backend_handle(&self, backend: &str) -> Result<&BackendHandle, PoolError> {

--- a/crates/transport/src/h1_pool.rs
+++ b/crates/transport/src/h1_pool.rs
@@ -106,23 +106,9 @@ impl H1Pool {
         backend: &str,
         req: Request<BoxBody<Bytes, Infallible>>,
     ) -> Result<hyper::Response<Incoming>, PoolError> {
-        let handle = self
-            .backends
-            .get(backend)
-            .ok_or_else(|| PoolError::UnknownBackend(backend.to_string()))?;
-        let client = handle
-            .state
-            .read()
-            .map(|state| Arc::clone(&state.client))
-            .map_err(|_| PoolError::InflightLimiterClosed)?;
-
-        let _permit = match Arc::clone(&handle.inflight).try_acquire_owned() {
-            Ok(permit) => permit,
-            Err(TryAcquireError::NoPermits) => {
-                return Err(PoolError::BackendOverloaded(backend.to_string()));
-            }
-            Err(TryAcquireError::Closed) => return Err(PoolError::InflightLimiterClosed),
-        };
+        let handle = self.backend_handle(backend)?;
+        let _permit = Self::acquire_inflight_permit(handle, backend)?;
+        let client = Self::current_client(handle)?;
 
         client.send(req).await.map_err(PoolError::Send)
     }
@@ -146,5 +132,32 @@ impl H1Pool {
             .map_err(|_| format!("backend client state poisoned for '{backend}'"))?;
         state.client = client;
         Ok(true)
+    }
+
+    fn backend_handle(&self, backend: &str) -> Result<&BackendHandle, PoolError> {
+        self.backends
+            .get(backend)
+            .ok_or_else(|| PoolError::UnknownBackend(backend.to_string()))
+    }
+
+    fn acquire_inflight_permit(
+        handle: &BackendHandle,
+        backend: &str,
+    ) -> Result<tokio::sync::OwnedSemaphorePermit, PoolError> {
+        match Arc::clone(&handle.inflight).try_acquire_owned() {
+            Ok(permit) => Ok(permit),
+            Err(TryAcquireError::NoPermits) => {
+                Err(PoolError::BackendOverloaded(backend.to_string()))
+            }
+            Err(TryAcquireError::Closed) => Err(PoolError::InflightLimiterClosed),
+        }
+    }
+
+    fn current_client(handle: &BackendHandle) -> Result<Arc<H1Client>, PoolError> {
+        handle
+            .state
+            .read()
+            .map(|state| Arc::clone(&state.client))
+            .map_err(|_| PoolError::InflightLimiterClosed)
     }
 }

--- a/crates/transport/src/h1_pool.rs
+++ b/crates/transport/src/h1_pool.rs
@@ -28,7 +28,7 @@ struct BackendHandle {
     inflight: Arc<Semaphore>,
 }
 
-pub struct H1Pool {
+pub(crate) struct H1Pool {
     backends: HashMap<String, BackendHandle>,
     max_idle_per_backend: usize,
     pool_idle_timeout: Duration,
@@ -38,29 +38,7 @@ pub struct H1Pool {
 }
 
 impl H1Pool {
-    pub fn new<I>(
-        backends: I,
-        max_inflight: usize,
-        max_idle_per_backend: usize,
-        pool_idle_timeout: Duration,
-        connect_timeout: Duration,
-        dns_resolver: SharedDnsResolver,
-    ) -> Self
-    where
-        I: IntoIterator<Item = String>,
-    {
-        Self::new_with_observer(
-            backends,
-            max_inflight,
-            max_idle_per_backend,
-            pool_idle_timeout,
-            connect_timeout,
-            dns_resolver,
-            None,
-        )
-    }
-
-    pub fn new_with_observer<I>(
+    pub(crate) fn new_with_observer<I>(
         backends: I,
         max_inflight: usize,
         max_idle_per_backend: usize,
@@ -102,7 +80,7 @@ impl H1Pool {
         }
     }
 
-    pub async fn send(
+    pub(crate) async fn send(
         &self,
         backend: &str,
         req: Request<BoxBody<Bytes, Infallible>>,
@@ -114,7 +92,10 @@ impl H1Pool {
         client.send(req).await.map_err(PoolError::Send)
     }
 
-    pub fn rotate_backend_client(&self, backend: &str) -> Result<BackendClientRotation, String> {
+    pub(crate) fn rotate_backend_client(
+        &self,
+        backend: &str,
+    ) -> Result<BackendClientRotation, String> {
         let Some(handle) = self.backends.get(backend) else {
             return Ok(BackendClientRotation::missing_backend());
         };

--- a/crates/transport/src/h2_client.rs
+++ b/crates/transport/src/h2_client.rs
@@ -252,7 +252,7 @@ impl Service<Name> for SharedDnsResolver {
     }
 }
 
-pub struct H2Client {
+pub(crate) struct H2Client {
     client: Client<HttpsConnector<ObservedHttpConnector>, BoxBody<Bytes, Infallible>>,
 }
 
@@ -285,7 +285,7 @@ where
 }
 
 impl H2Client {
-    pub fn new(
+    pub(crate) fn new(
         max_idle_per_host: usize,
         pool_idle_timeout: Duration,
         connect_timeout: Duration,
@@ -302,7 +302,7 @@ impl H2Client {
         )
     }
 
-    pub fn new_with_observer(
+    pub(crate) fn new_with_observer(
         max_idle_per_host: usize,
         pool_idle_timeout: Duration,
         connect_timeout: Duration,
@@ -329,14 +329,15 @@ impl H2Client {
         Ok(Self { client })
     }
 
-    pub async fn send(
+    pub(crate) async fn send(
         &self,
         req: Request<BoxBody<Bytes, Infallible>>,
     ) -> Result<hyper::Response<hyper::body::Incoming>, hyper_util::client::legacy::Error> {
         self.client.request(req).await
     }
 
-    pub fn try_default() -> Result<Self, String> {
+    #[cfg(test)]
+    fn try_default() -> Result<Self, String> {
         Self::new(
             DEFAULT_MAX_IDLE_PER_HOST,
             DEFAULT_POOL_IDLE_TIMEOUT,

--- a/crates/transport/src/h2_pool.rs
+++ b/crates/transport/src/h2_pool.rs
@@ -33,7 +33,7 @@ struct BackendHandle {
 // When DNS refresh updates a hostname's address set, new connects pick up the
 // refreshed resolver results, while already-pooled H2 connections may continue
 // using older addresses until Hyper retires them via the normal idle timeout.
-pub struct H2Pool {
+pub(crate) struct H2Pool {
     backends: HashMap<String, BackendHandle>,
     max_idle_per_backend: usize,
     pool_idle_timeout: Duration,
@@ -43,32 +43,8 @@ pub struct H2Pool {
 }
 
 impl H2Pool {
-    pub fn new<I>(
-        backends: I,
-        backend_tls: HashMap<String, TlsClientConfig>,
-        max_inflight: usize,
-        max_idle_per_backend: usize,
-        pool_idle_timeout: Duration,
-        connect_timeout: Duration,
-        dns_resolver: SharedDnsResolver,
-    ) -> Result<Self, String>
-    where
-        I: IntoIterator<Item = String>,
-    {
-        Self::new_with_observer(
-            backends,
-            backend_tls,
-            max_inflight,
-            max_idle_per_backend,
-            pool_idle_timeout,
-            connect_timeout,
-            dns_resolver,
-            None,
-        )
-    }
-
     #[allow(clippy::too_many_arguments)]
-    pub fn new_with_observer<I>(
+    pub(crate) fn new_with_observer<I>(
         backends: I,
         backend_tls: HashMap<String, TlsClientConfig>,
         max_inflight: usize,
@@ -116,11 +92,12 @@ impl H2Pool {
         })
     }
 
-    pub fn has_backend(&self, backend: &str) -> bool {
+    #[allow(dead_code)]
+    pub(crate) fn has_backend(&self, backend: &str) -> bool {
         self.backends.contains_key(backend)
     }
 
-    pub fn rotate_backend_client(
+    pub(crate) fn rotate_backend_client(
         &self,
         backend: &str,
     ) -> Result<BackendClientRotation, String> {
@@ -150,7 +127,7 @@ impl H2Pool {
         ))
     }
 
-    pub async fn send(
+    pub(crate) async fn send(
         &self,
         backend: &str,
         req: Request<BoxBody<Bytes, Infallible>>,

--- a/crates/transport/src/h2_pool.rs
+++ b/crates/transport/src/h2_pool.rs
@@ -13,7 +13,10 @@ use hyper::{
 pub use spooky_errors::PoolError;
 use tokio::sync::{Semaphore, TryAcquireError};
 
-use crate::h2_client::{ConnectObserver, H2Client, SharedDnsResolver, TlsClientConfig};
+use crate::{
+    client_rotation::BackendClientRotation,
+    h2_client::{ConnectObserver, H2Client, SharedDnsResolver, TlsClientConfig},
+};
 
 struct BackendClientState {
     client: Arc<H2Client>,
@@ -37,12 +40,6 @@ pub struct H2Pool {
     connect_timeout: Duration,
     dns_resolver: SharedDnsResolver,
     connect_observer: Option<ConnectObserver>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct BackendClientRotation {
-    pub previous_generation: u64,
-    pub current_generation: u64,
 }
 
 impl H2Pool {
@@ -126,9 +123,9 @@ impl H2Pool {
     pub fn rotate_backend_client(
         &self,
         backend: &str,
-    ) -> Result<Option<BackendClientRotation>, String> {
+    ) -> Result<BackendClientRotation, String> {
         let Some(handle) = self.backends.get(backend) else {
-            return Ok(None);
+            return Ok(BackendClientRotation::missing_backend());
         };
 
         let client = Arc::new(H2Client::new_with_observer(
@@ -147,10 +144,10 @@ impl H2Pool {
         let previous_generation = state.generation;
         state.client = client;
         state.generation = state.generation.saturating_add(1);
-        Ok(Some(BackendClientRotation {
+        Ok(BackendClientRotation::rotated(
             previous_generation,
-            current_generation: state.generation,
-        }))
+            state.generation,
+        ))
     }
 
     pub async fn send(

--- a/crates/transport/src/h2_pool.rs
+++ b/crates/transport/src/h2_pool.rs
@@ -158,23 +158,36 @@ impl H2Pool {
         backend: &str,
         req: Request<BoxBody<Bytes, Infallible>>,
     ) -> Result<hyper::Response<Incoming>, PoolError> {
-        let handle = self
-            .backends
+        let handle = self.backend_handle(backend)?;
+        let _permit = Self::acquire_inflight_permit(handle, backend)?;
+        let client = Self::current_client(handle)?;
+        client.send(req).await.map_err(PoolError::Send)
+    }
+
+    fn backend_handle(&self, backend: &str) -> Result<&BackendHandle, PoolError> {
+        self.backends
             .get(backend)
-            .ok_or_else(|| PoolError::UnknownBackend(backend.to_string()))?;
-        let client = handle
+            .ok_or_else(|| PoolError::UnknownBackend(backend.to_string()))
+    }
+
+    fn acquire_inflight_permit(
+        handle: &BackendHandle,
+        backend: &str,
+    ) -> Result<tokio::sync::OwnedSemaphorePermit, PoolError> {
+        match Arc::clone(&handle.inflight).try_acquire_owned() {
+            Ok(permit) => Ok(permit),
+            Err(TryAcquireError::NoPermits) => {
+                Err(PoolError::BackendOverloaded(backend.to_string()))
+            }
+            Err(TryAcquireError::Closed) => Err(PoolError::InflightLimiterClosed),
+        }
+    }
+
+    fn current_client(handle: &BackendHandle) -> Result<Arc<H2Client>, PoolError> {
+        handle
             .state
             .read()
             .map(|state| Arc::clone(&state.client))
-            .map_err(|_| PoolError::InflightLimiterClosed)?;
-
-        let _permit = match Arc::clone(&handle.inflight).try_acquire_owned() {
-            Ok(permit) => permit,
-            Err(TryAcquireError::NoPermits) => {
-                return Err(PoolError::BackendOverloaded(backend.to_string()));
-            }
-            Err(TryAcquireError::Closed) => return Err(PoolError::InflightLimiterClosed),
-        };
-        client.send(req).await.map_err(PoolError::Send)
+            .map_err(|_| PoolError::InflightLimiterClosed)
     }
 }

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -1,6 +1,11 @@
 pub mod client_rotation;
-pub mod h1_client;
-pub mod h1_pool;
-pub mod h2_client;
-pub mod h2_pool;
+mod h1_client;
+mod h1_pool;
+mod h2_client;
+mod h2_pool;
 pub mod transport_pool;
+
+pub use transport_pool::{
+    ConnectObservation, ConnectObserver, SharedDnsResolver, TlsClientConfig,
+    TransportClientRotation, UpstreamTransportPool,
+};

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -1,9 +1,9 @@
-pub mod client_rotation;
+mod client_rotation;
 mod h1_client;
 mod h1_pool;
 mod h2_client;
 mod h2_pool;
-pub mod transport_pool;
+mod transport_pool;
 
 pub use transport_pool::{
     ConnectObservation, ConnectObserver, SharedDnsResolver, TlsClientConfig,

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod client_rotation;
 pub mod h1_client;
 pub mod h1_pool;
 pub mod h2_client;

--- a/crates/transport/src/transport_pool.rs
+++ b/crates/transport/src/transport_pool.rs
@@ -8,7 +8,7 @@ use hyper::{
 use spooky_config::runtime::{
     RuntimeBackendConnectionPolicy, RuntimeBackendTransportKind, RuntimeUpstream,
 };
-pub use spooky_errors::{PoolError, ProxyError};
+use spooky_errors::{PoolError, ProxyError};
 pub use crate::h2_client::{
     ConnectObservation, ConnectObserver, SharedDnsResolver, TlsClientConfig,
 };
@@ -23,20 +23,6 @@ use crate::{
 enum BackendTransportEntry {
     Http1,
     H2,
-}
-
-struct TransportExecutionResult {
-    response: hyper::Response<Incoming>,
-}
-
-impl TransportExecutionResult {
-    fn new(response: hyper::Response<Incoming>) -> Self {
-        Self { response }
-    }
-
-    fn into_response(self) -> hyper::Response<Incoming> {
-        self.response
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -67,9 +53,7 @@ impl UpstreamTransportPool {
         backend: &str,
         req: Request<BoxBody<Bytes, Infallible>>,
     ) -> Result<hyper::Response<Incoming>, ProxyError> {
-        self.execute(backend, req)
-            .await
-            .map(TransportExecutionResult::into_response)
+        self.execute(backend, req).await
     }
 
     pub fn new_from_runtime_backends<I>(
@@ -209,23 +193,21 @@ impl UpstreamTransportPool {
         &self,
         backend: &str,
         req: Request<BoxBody<Bytes, Infallible>>,
-    ) -> Result<TransportExecutionResult, ProxyError> {
+    ) -> Result<hyper::Response<Incoming>, ProxyError> {
         match self.backend_entry(backend) {
             Some(BackendTransportEntry::Http1) => self
                 .execute_with_timeout(backend, self.h1_pool.send(backend, req))
-                .await
-                .map(TransportExecutionResult::new),
+                .await,
             Some(BackendTransportEntry::H2) => self
                 .execute_with_timeout(backend, self.h2_pool.send(backend, req))
-                .await
-                .map(TransportExecutionResult::new),
+                .await,
             None => Err(ProxyError::Pool(PoolError::UnknownBackend(
                 backend.to_string(),
             ))),
         }
     }
 
-    pub fn rotate_backend_client_for_backend(
+    pub fn rotate_backend_client(
         &self,
         backend: &str,
     ) -> Result<TransportClientRotation, String> {

--- a/crates/transport/src/transport_pool.rs
+++ b/crates/transport/src/transport_pool.rs
@@ -17,13 +17,75 @@ use crate::{
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BackendTransportKind {
+pub enum ResolvedBackendTransport {
     Http1,
     H2,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TransportExecutionTarget<'a> {
+    backend: &'a str,
+}
+
+impl<'a> TransportExecutionTarget<'a> {
+    pub fn new(backend: &'a str) -> Self {
+        Self { backend }
+    }
+
+    pub fn backend(&self) -> &'a str {
+        self.backend
+    }
+}
+
+pub struct TransportExecutionResult {
+    pub transport: ResolvedBackendTransport,
+    response: hyper::Response<Incoming>,
+}
+
+impl TransportExecutionResult {
+    pub fn new(
+        transport: ResolvedBackendTransport,
+        response: hyper::Response<Incoming>,
+    ) -> Self {
+        Self {
+            transport,
+            response,
+        }
+    }
+
+    pub fn into_response(self) -> hyper::Response<Incoming> {
+        self.response
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportClientRotation {
+    MissingBackend,
+    Recreated {
+        transport: ResolvedBackendTransport,
+    },
+    Rotated {
+        transport: ResolvedBackendTransport,
+        previous_generation: u64,
+        current_generation: u64,
+    },
+}
+
+impl TransportClientRotation {
+    pub fn rotated(self) -> bool {
+        !matches!(self, Self::MissingBackend)
+    }
+
+    pub fn transport(self) -> Option<ResolvedBackendTransport> {
+        match self {
+            Self::MissingBackend => None,
+            Self::Recreated { transport } | Self::Rotated { transport, .. } => Some(transport),
+        }
+    }
+}
+
 pub struct UpstreamTransportPool {
-    backend_kinds: HashMap<String, BackendTransportKind>,
+    backend_transports: HashMap<String, ResolvedBackendTransport>,
     h1_pool: H1Pool,
     h2_pool: H2Pool,
 }
@@ -39,7 +101,7 @@ impl UpstreamTransportPool {
         dns_resolver: SharedDnsResolver,
     ) -> Result<Self, String>
     where
-        I: IntoIterator<Item = (String, BackendTransportKind)>,
+        I: IntoIterator<Item = (String, ResolvedBackendTransport)>,
     {
         Self::new_with_observer(
             backends,
@@ -65,17 +127,17 @@ impl UpstreamTransportPool {
         connect_observer: Option<ConnectObserver>,
     ) -> Result<Self, String>
     where
-        I: IntoIterator<Item = (String, BackendTransportKind)>,
+        I: IntoIterator<Item = (String, ResolvedBackendTransport)>,
     {
-        let mut backend_kinds = HashMap::new();
+        let mut backend_transports = HashMap::new();
         let mut h1_backends = Vec::new();
         let mut h2_backends = Vec::new();
 
-        for (backend, kind) in backends {
-            backend_kinds.insert(backend.clone(), kind);
-            match kind {
-                BackendTransportKind::Http1 => h1_backends.push(backend),
-                BackendTransportKind::H2 => h2_backends.push(backend),
+        for (backend, transport) in backends {
+            backend_transports.insert(backend.clone(), transport);
+            match transport {
+                ResolvedBackendTransport::Http1 => h1_backends.push(backend),
+                ResolvedBackendTransport::H2 => h2_backends.push(backend),
             }
         }
 
@@ -100,7 +162,7 @@ impl UpstreamTransportPool {
         )?;
 
         Ok(Self {
-            backend_kinds,
+            backend_transports,
             h1_pool,
             h2_pool,
         })
@@ -121,12 +183,12 @@ impl UpstreamTransportPool {
         for upstream in upstreams {
             for backend in &upstream.backends {
                 let backend_addr = backend.backend.address.clone();
-                let kind = match backend.endpoint.transport_kind {
-                    RuntimeBackendTransportKind::Http1 => BackendTransportKind::Http1,
-                    RuntimeBackendTransportKind::H2 => BackendTransportKind::H2,
+                let transport = match backend.endpoint.transport_kind {
+                    RuntimeBackendTransportKind::Http1 => ResolvedBackendTransport::Http1,
+                    RuntimeBackendTransportKind::H2 => ResolvedBackendTransport::H2,
                 };
-                backends.push((backend_addr.clone(), kind));
-                if matches!(kind, BackendTransportKind::H2) {
+                backends.push((backend_addr.clone(), transport));
+                if matches!(transport, ResolvedBackendTransport::H2) {
                     backend_tls.insert(
                         backend_addr,
                         TlsClientConfig::from(&upstream.policy_set.transport.tls),
@@ -147,26 +209,64 @@ impl UpstreamTransportPool {
         )
     }
 
-    pub async fn send(
+    pub fn resolve_backend_transport(
         &self,
-        backend: &str,
+        target: TransportExecutionTarget<'_>,
+    ) -> Option<ResolvedBackendTransport> {
+        self.backend_transports.get(target.backend()).copied()
+    }
+
+    pub async fn execute(
+        &self,
+        target: TransportExecutionTarget<'_>,
         req: Request<BoxBody<Bytes, Infallible>>,
-    ) -> Result<hyper::Response<Incoming>, PoolError> {
-        match self.backend_kinds.get(backend).copied() {
-            Some(BackendTransportKind::Http1) => self.h1_pool.send(backend, req).await,
-            Some(BackendTransportKind::H2) => self.h2_pool.send(backend, req).await,
-            None => Err(PoolError::UnknownBackend(backend.to_string())),
+    ) -> Result<TransportExecutionResult, PoolError> {
+        match self.resolve_backend_transport(target) {
+            Some(ResolvedBackendTransport::Http1) => self
+                .h1_pool
+                .send(target.backend(), req)
+                .await
+                .map(|response| {
+                    TransportExecutionResult::new(ResolvedBackendTransport::Http1, response)
+                }),
+            Some(ResolvedBackendTransport::H2) => self
+                .h2_pool
+                .send(target.backend(), req)
+                .await
+                .map(|response| TransportExecutionResult::new(ResolvedBackendTransport::H2, response)),
+            None => Err(PoolError::UnknownBackend(target.backend().to_string())),
         }
     }
 
-    pub fn rotate_backend_client(&self, backend: &str) -> Result<bool, String> {
-        match self.backend_kinds.get(backend).copied() {
-            Some(BackendTransportKind::Http1) => self.h1_pool.rotate_backend_client(backend),
-            Some(BackendTransportKind::H2) => self
+    pub fn rotate_backend_client(
+        &self,
+        target: TransportExecutionTarget<'_>,
+    ) -> Result<TransportClientRotation, String> {
+        match self.resolve_backend_transport(target) {
+            Some(ResolvedBackendTransport::Http1) => self
+                .h1_pool
+                .rotate_backend_client(target.backend())
+                .map(|rotated| {
+                    if rotated {
+                        TransportClientRotation::Recreated {
+                            transport: ResolvedBackendTransport::Http1,
+                        }
+                    } else {
+                        TransportClientRotation::MissingBackend
+                    }
+                }),
+            Some(ResolvedBackendTransport::H2) => self
                 .h2_pool
-                .rotate_backend_client(backend)
-                .map(|rotation| rotation.is_some()),
-            None => Ok(false),
+                .rotate_backend_client(target.backend())
+                .map(|rotation| match rotation {
+                    Some(rotation) => TransportClientRotation::Rotated {
+                        transport: ResolvedBackendTransport::H2,
+                        previous_generation: rotation.previous_generation,
+                        current_generation: rotation.current_generation,
+                    },
+                    None => TransportClientRotation::MissingBackend,
+                }),
+            None => Ok(TransportClientRotation::MissingBackend),
         }
     }
 }

--- a/crates/transport/src/transport_pool.rs
+++ b/crates/transport/src/transport_pool.rs
@@ -11,6 +11,7 @@ use spooky_config::runtime::{
 pub use spooky_errors::PoolError;
 
 use crate::{
+    client_rotation::{BackendClientRotation, BackendClientRotationState},
     h1_pool::H1Pool,
     h2_client::{ConnectObserver, SharedDnsResolver, TlsClientConfig},
     h2_pool::H2Pool,
@@ -72,24 +73,14 @@ impl TransportExecutionResult {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum TransportClientRotationState {
-    MissingBackend,
-    Recreated,
-    Rotated {
-        previous_generation: u64,
-        current_generation: u64,
-    },
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TransportClientRotation {
     transport: Option<ResolvedBackendTransport>,
-    state: TransportClientRotationState,
+    rotation: BackendClientRotation,
 }
 
 impl TransportClientRotation {
     pub fn rotated(self) -> bool {
-        !matches!(self.state, TransportClientRotationState::MissingBackend)
+        self.rotation.changed()
     }
 
     pub fn protocol_name(self) -> Option<&'static str> {
@@ -100,13 +91,7 @@ impl TransportClientRotation {
     }
 
     pub fn generations(self) -> Option<(u64, u64)> {
-        match self.state {
-            TransportClientRotationState::Rotated {
-                previous_generation,
-                current_generation,
-            } => Some((previous_generation, current_generation)),
-            _ => None,
-        }
+        self.rotation.generations()
     }
 }
 
@@ -277,39 +262,32 @@ impl UpstreamTransportPool {
             Some(BackendTransportEntry::Http1) => self
                 .h1_pool
                 .rotate_backend_client(target.backend())
-                .map(|rotated| {
-                    if rotated {
-                        TransportClientRotation {
-                            transport: Some(ResolvedBackendTransport::Http1),
-                            state: TransportClientRotationState::Recreated,
-                        }
-                    } else {
-                        TransportClientRotation {
-                            transport: None,
-                            state: TransportClientRotationState::MissingBackend,
-                        }
-                    }
-                }),
+                .map(|rotation| Self::transport_rotation(ResolvedBackendTransport::Http1, rotation)),
             Some(BackendTransportEntry::H2) => self
                 .h2_pool
                 .rotate_backend_client(target.backend())
-                .map(|rotation| match rotation {
-                    Some(rotation) => TransportClientRotation {
-                        transport: Some(ResolvedBackendTransport::H2),
-                        state: TransportClientRotationState::Rotated {
-                            previous_generation: rotation.previous_generation,
-                            current_generation: rotation.current_generation,
-                        },
-                    },
-                    None => TransportClientRotation {
-                        transport: None,
-                        state: TransportClientRotationState::MissingBackend,
-                    },
-                }),
+                .map(|rotation| Self::transport_rotation(ResolvedBackendTransport::H2, rotation)),
             None => Ok(TransportClientRotation {
                 transport: None,
-                state: TransportClientRotationState::MissingBackend,
+                rotation: BackendClientRotation::missing_backend(),
             }),
+        }
+    }
+
+    fn transport_rotation(
+        transport: ResolvedBackendTransport,
+        rotation: BackendClientRotation,
+    ) -> TransportClientRotation {
+        let transport = match rotation.state() {
+            BackendClientRotationState::MissingBackend => None,
+            BackendClientRotationState::Recreated | BackendClientRotationState::Rotated { .. } => {
+                Some(transport)
+            }
+        };
+
+        TransportClientRotation {
+            transport,
+            rotation,
         }
     }
 }

--- a/crates/transport/src/transport_pool.rs
+++ b/crates/transport/src/transport_pool.rs
@@ -9,15 +9,11 @@ use spooky_config::runtime::{
     RuntimeBackendConnectionPolicy, RuntimeBackendTransportKind, RuntimeUpstream,
 };
 use spooky_errors::{PoolError, ProxyError};
+
 pub use crate::h2_client::{
     ConnectObservation, ConnectObserver, SharedDnsResolver, TlsClientConfig,
 };
-
-use crate::{
-    client_rotation::BackendClientRotation,
-    h1_pool::H1Pool,
-    h2_pool::H2Pool,
-};
+use crate::{client_rotation::BackendClientRotation, h1_pool::H1Pool, h2_pool::H2Pool};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum BackendTransportEntry {
@@ -134,9 +130,7 @@ impl UpstreamTransportPool {
         })
     }
 
-    fn resolve_runtime_transport(
-        transport: RuntimeBackendTransportKind,
-    ) -> BackendTransportEntry {
+    fn resolve_runtime_transport(transport: RuntimeBackendTransportKind) -> BackendTransportEntry {
         match transport {
             RuntimeBackendTransportKind::Http1 => BackendTransportEntry::Http1,
             RuntimeBackendTransportKind::H2 => BackendTransportEntry::H2,
@@ -159,7 +153,10 @@ impl UpstreamTransportPool {
             for backend in &upstream.backends {
                 let backend_addr = backend.backend.address.clone();
                 backends.push((backend_addr.clone(), backend.endpoint.transport_kind));
-                if matches!(backend.endpoint.transport_kind, RuntimeBackendTransportKind::H2) {
+                if matches!(
+                    backend.endpoint.transport_kind,
+                    RuntimeBackendTransportKind::H2
+                ) {
                     backend_tls.insert(
                         backend_addr,
                         TlsClientConfig::from(&upstream.policy_set.transport.tls),
@@ -191,22 +188,21 @@ impl UpstreamTransportPool {
         req: Request<BoxBody<Bytes, Infallible>>,
     ) -> Result<hyper::Response<Incoming>, ProxyError> {
         match self.backend_entry(backend) {
-            Some(BackendTransportEntry::Http1) => self
-                .execute_with_timeout(backend, self.h1_pool.send(backend, req))
-                .await,
-            Some(BackendTransportEntry::H2) => self
-                .execute_with_timeout(backend, self.h2_pool.send(backend, req))
-                .await,
+            Some(BackendTransportEntry::Http1) => {
+                self.execute_with_timeout(backend, self.h1_pool.send(backend, req))
+                    .await
+            }
+            Some(BackendTransportEntry::H2) => {
+                self.execute_with_timeout(backend, self.h2_pool.send(backend, req))
+                    .await
+            }
             None => Err(ProxyError::Pool(PoolError::UnknownBackend(
                 backend.to_string(),
             ))),
         }
     }
 
-    pub fn rotate_backend_client(
-        &self,
-        backend: &str,
-    ) -> Result<TransportClientRotation, String> {
+    pub fn rotate_backend_client(&self, backend: &str) -> Result<TransportClientRotation, String> {
         match self.backend_entry(backend) {
             Some(BackendTransportEntry::Http1) => self
                 .h1_pool

--- a/crates/transport/src/transport_pool.rs
+++ b/crates/transport/src/transport_pool.rs
@@ -23,6 +23,12 @@ enum ResolvedBackendTransport {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BackendTransportEntry {
+    Http1,
+    H2,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TransportExecutionTarget<'a> {
     backend: &'a str,
 }
@@ -105,7 +111,7 @@ impl TransportClientRotation {
 }
 
 pub struct UpstreamTransportPool {
-    backend_transports: HashMap<String, ResolvedBackendTransport>,
+    backend_entries: HashMap<String, BackendTransportEntry>,
     h1_pool: H1Pool,
     h2_pool: H2Pool,
 }
@@ -149,16 +155,16 @@ impl UpstreamTransportPool {
     where
         I: IntoIterator<Item = (String, RuntimeBackendTransportKind)>,
     {
-        let mut backend_transports = HashMap::new();
+        let mut backend_entries = HashMap::new();
         let mut h1_backends = Vec::new();
         let mut h2_backends = Vec::new();
 
         for (backend, runtime_transport) in backends {
-            let transport = Self::resolve_runtime_transport(runtime_transport);
-            backend_transports.insert(backend.clone(), transport);
-            match transport {
-                ResolvedBackendTransport::Http1 => h1_backends.push(backend),
-                ResolvedBackendTransport::H2 => h2_backends.push(backend),
+            let entry = Self::resolve_runtime_transport(runtime_transport);
+            backend_entries.insert(backend.clone(), entry);
+            match entry {
+                BackendTransportEntry::Http1 => h1_backends.push(backend),
+                BackendTransportEntry::H2 => h2_backends.push(backend),
             }
         }
 
@@ -183,7 +189,7 @@ impl UpstreamTransportPool {
         )?;
 
         Ok(Self {
-            backend_transports,
+            backend_entries,
             h1_pool,
             h2_pool,
         })
@@ -191,10 +197,10 @@ impl UpstreamTransportPool {
 
     fn resolve_runtime_transport(
         transport: RuntimeBackendTransportKind,
-    ) -> ResolvedBackendTransport {
+    ) -> BackendTransportEntry {
         match transport {
-            RuntimeBackendTransportKind::Http1 => ResolvedBackendTransport::Http1,
-            RuntimeBackendTransportKind::H2 => ResolvedBackendTransport::H2,
+            RuntimeBackendTransportKind::Http1 => BackendTransportEntry::Http1,
+            RuntimeBackendTransportKind::H2 => BackendTransportEntry::H2,
         }
     }
 
@@ -235,11 +241,8 @@ impl UpstreamTransportPool {
         )
     }
 
-    fn resolve_backend_transport(
-        &self,
-        target: TransportExecutionTarget<'_>,
-    ) -> Option<ResolvedBackendTransport> {
-        self.backend_transports.get(target.backend()).copied()
+    fn backend_entry(&self, target: TransportExecutionTarget<'_>) -> Option<BackendTransportEntry> {
+        self.backend_entries.get(target.backend()).copied()
     }
 
     pub async fn execute(
@@ -247,19 +250,21 @@ impl UpstreamTransportPool {
         target: TransportExecutionTarget<'_>,
         req: Request<BoxBody<Bytes, Infallible>>,
     ) -> Result<TransportExecutionResult, PoolError> {
-        match self.resolve_backend_transport(target) {
-            Some(ResolvedBackendTransport::Http1) => self
+        match self.backend_entry(target) {
+            Some(BackendTransportEntry::Http1) => self
                 .h1_pool
                 .send(target.backend(), req)
                 .await
                 .map(|response| {
                     TransportExecutionResult::new(ResolvedBackendTransport::Http1, response)
                 }),
-            Some(ResolvedBackendTransport::H2) => self
+            Some(BackendTransportEntry::H2) => self
                 .h2_pool
                 .send(target.backend(), req)
                 .await
-                .map(|response| TransportExecutionResult::new(ResolvedBackendTransport::H2, response)),
+                .map(|response| {
+                    TransportExecutionResult::new(ResolvedBackendTransport::H2, response)
+                }),
             None => Err(PoolError::UnknownBackend(target.backend().to_string())),
         }
     }
@@ -268,8 +273,8 @@ impl UpstreamTransportPool {
         &self,
         target: TransportExecutionTarget<'_>,
     ) -> Result<TransportClientRotation, String> {
-        match self.resolve_backend_transport(target) {
-            Some(ResolvedBackendTransport::Http1) => self
+        match self.backend_entry(target) {
+            Some(BackendTransportEntry::Http1) => self
                 .h1_pool
                 .rotate_backend_client(target.backend())
                 .map(|rotated| {
@@ -285,7 +290,7 @@ impl UpstreamTransportPool {
                         }
                     }
                 }),
-            Some(ResolvedBackendTransport::H2) => self
+            Some(BackendTransportEntry::H2) => self
                 .h2_pool
                 .rotate_backend_client(target.backend())
                 .map(|rotation| match rotation {

--- a/crates/transport/src/transport_pool.rs
+++ b/crates/transport/src/transport_pool.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ResolvedBackendTransport {
+enum ResolvedBackendTransport {
     Http1,
     H2,
 }
@@ -38,12 +38,12 @@ impl<'a> TransportExecutionTarget<'a> {
 }
 
 pub struct TransportExecutionResult {
-    pub transport: ResolvedBackendTransport,
+    transport: ResolvedBackendTransport,
     response: hyper::Response<Incoming>,
 }
 
 impl TransportExecutionResult {
-    pub fn new(
+    fn new(
         transport: ResolvedBackendTransport,
         response: hyper::Response<Incoming>,
     ) -> Self {
@@ -56,30 +56,50 @@ impl TransportExecutionResult {
     pub fn into_response(self) -> hyper::Response<Incoming> {
         self.response
     }
+
+    pub fn protocol_name(&self) -> &'static str {
+        match self.transport {
+            ResolvedBackendTransport::Http1 => "http1",
+            ResolvedBackendTransport::H2 => "h2",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TransportClientRotation {
+enum TransportClientRotationState {
     MissingBackend,
-    Recreated {
-        transport: ResolvedBackendTransport,
-    },
+    Recreated,
     Rotated {
-        transport: ResolvedBackendTransport,
         previous_generation: u64,
         current_generation: u64,
     },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TransportClientRotation {
+    transport: Option<ResolvedBackendTransport>,
+    state: TransportClientRotationState,
+}
+
 impl TransportClientRotation {
     pub fn rotated(self) -> bool {
-        !matches!(self, Self::MissingBackend)
+        !matches!(self.state, TransportClientRotationState::MissingBackend)
     }
 
-    pub fn transport(self) -> Option<ResolvedBackendTransport> {
-        match self {
-            Self::MissingBackend => None,
-            Self::Recreated { transport } | Self::Rotated { transport, .. } => Some(transport),
+    pub fn protocol_name(self) -> Option<&'static str> {
+        self.transport.map(|transport| match transport {
+            ResolvedBackendTransport::Http1 => "http1",
+            ResolvedBackendTransport::H2 => "h2",
+        })
+    }
+
+    pub fn generations(self) -> Option<(u64, u64)> {
+        match self.state {
+            TransportClientRotationState::Rotated {
+                previous_generation,
+                current_generation,
+            } => Some((previous_generation, current_generation)),
+            _ => None,
         }
     }
 }
@@ -91,7 +111,7 @@ pub struct UpstreamTransportPool {
 }
 
 impl UpstreamTransportPool {
-    pub fn new<I>(
+    pub fn new_from_runtime_backends<I>(
         backends: I,
         backend_tls: HashMap<String, TlsClientConfig>,
         max_inflight: usize,
@@ -101,9 +121,9 @@ impl UpstreamTransportPool {
         dns_resolver: SharedDnsResolver,
     ) -> Result<Self, String>
     where
-        I: IntoIterator<Item = (String, ResolvedBackendTransport)>,
+        I: IntoIterator<Item = (String, RuntimeBackendTransportKind)>,
     {
-        Self::new_with_observer(
+        Self::new_runtime_with_observer(
             backends,
             backend_tls,
             max_inflight,
@@ -116,7 +136,7 @@ impl UpstreamTransportPool {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn new_with_observer<I>(
+    fn new_runtime_with_observer<I>(
         backends: I,
         backend_tls: HashMap<String, TlsClientConfig>,
         max_inflight: usize,
@@ -127,13 +147,14 @@ impl UpstreamTransportPool {
         connect_observer: Option<ConnectObserver>,
     ) -> Result<Self, String>
     where
-        I: IntoIterator<Item = (String, ResolvedBackendTransport)>,
+        I: IntoIterator<Item = (String, RuntimeBackendTransportKind)>,
     {
         let mut backend_transports = HashMap::new();
         let mut h1_backends = Vec::new();
         let mut h2_backends = Vec::new();
 
-        for (backend, transport) in backends {
+        for (backend, runtime_transport) in backends {
+            let transport = Self::resolve_runtime_transport(runtime_transport);
             backend_transports.insert(backend.clone(), transport);
             match transport {
                 ResolvedBackendTransport::Http1 => h1_backends.push(backend),
@@ -168,6 +189,15 @@ impl UpstreamTransportPool {
         })
     }
 
+    fn resolve_runtime_transport(
+        transport: RuntimeBackendTransportKind,
+    ) -> ResolvedBackendTransport {
+        match transport {
+            RuntimeBackendTransportKind::Http1 => ResolvedBackendTransport::Http1,
+            RuntimeBackendTransportKind::H2 => ResolvedBackendTransport::H2,
+        }
+    }
+
     pub fn from_runtime_upstreams<'a, I>(
         upstreams: I,
         connection_policy: &RuntimeBackendConnectionPolicy,
@@ -183,12 +213,8 @@ impl UpstreamTransportPool {
         for upstream in upstreams {
             for backend in &upstream.backends {
                 let backend_addr = backend.backend.address.clone();
-                let transport = match backend.endpoint.transport_kind {
-                    RuntimeBackendTransportKind::Http1 => ResolvedBackendTransport::Http1,
-                    RuntimeBackendTransportKind::H2 => ResolvedBackendTransport::H2,
-                };
-                backends.push((backend_addr.clone(), transport));
-                if matches!(transport, ResolvedBackendTransport::H2) {
+                backends.push((backend_addr.clone(), backend.endpoint.transport_kind));
+                if matches!(backend.endpoint.transport_kind, RuntimeBackendTransportKind::H2) {
                     backend_tls.insert(
                         backend_addr,
                         TlsClientConfig::from(&upstream.policy_set.transport.tls),
@@ -197,7 +223,7 @@ impl UpstreamTransportPool {
             }
         }
 
-        Self::new_with_observer(
+        Self::new_runtime_with_observer(
             backends,
             backend_tls,
             connection_policy.max_inflight,
@@ -209,7 +235,7 @@ impl UpstreamTransportPool {
         )
     }
 
-    pub fn resolve_backend_transport(
+    fn resolve_backend_transport(
         &self,
         target: TransportExecutionTarget<'_>,
     ) -> Option<ResolvedBackendTransport> {
@@ -248,25 +274,37 @@ impl UpstreamTransportPool {
                 .rotate_backend_client(target.backend())
                 .map(|rotated| {
                     if rotated {
-                        TransportClientRotation::Recreated {
-                            transport: ResolvedBackendTransport::Http1,
+                        TransportClientRotation {
+                            transport: Some(ResolvedBackendTransport::Http1),
+                            state: TransportClientRotationState::Recreated,
                         }
                     } else {
-                        TransportClientRotation::MissingBackend
+                        TransportClientRotation {
+                            transport: None,
+                            state: TransportClientRotationState::MissingBackend,
+                        }
                     }
                 }),
             Some(ResolvedBackendTransport::H2) => self
                 .h2_pool
                 .rotate_backend_client(target.backend())
                 .map(|rotation| match rotation {
-                    Some(rotation) => TransportClientRotation::Rotated {
-                        transport: ResolvedBackendTransport::H2,
-                        previous_generation: rotation.previous_generation,
-                        current_generation: rotation.current_generation,
+                    Some(rotation) => TransportClientRotation {
+                        transport: Some(ResolvedBackendTransport::H2),
+                        state: TransportClientRotationState::Rotated {
+                            previous_generation: rotation.previous_generation,
+                            current_generation: rotation.current_generation,
+                        },
                     },
-                    None => TransportClientRotation::MissingBackend,
+                    None => TransportClientRotation {
+                        transport: None,
+                        state: TransportClientRotationState::MissingBackend,
+                    },
                 }),
-            None => Ok(TransportClientRotation::MissingBackend),
+            None => Ok(TransportClientRotation {
+                transport: None,
+                state: TransportClientRotationState::MissingBackend,
+            }),
         }
     }
 }

--- a/crates/transport/src/transport_pool.rs
+++ b/crates/transport/src/transport_pool.rs
@@ -103,6 +103,16 @@ pub struct UpstreamTransportPool {
 }
 
 impl UpstreamTransportPool {
+    pub async fn send_backend_request(
+        &self,
+        backend: &str,
+        req: Request<BoxBody<Bytes, Infallible>>,
+    ) -> Result<hyper::Response<Incoming>, ProxyError> {
+        self.execute(TransportExecutionTarget::new(backend), req)
+            .await
+            .map(TransportExecutionResult::into_response)
+    }
+
     pub fn new_from_runtime_backends<I>(
         backends: I,
         backend_tls: HashMap<String, TlsClientConfig>,

--- a/crates/transport/src/transport_pool.rs
+++ b/crates/transport/src/transport_pool.rs
@@ -8,7 +8,7 @@ use hyper::{
 use spooky_config::runtime::{
     RuntimeBackendConnectionPolicy, RuntimeBackendTransportKind, RuntimeUpstream,
 };
-pub use spooky_errors::PoolError;
+pub use spooky_errors::{PoolError, ProxyError};
 
 use crate::{
     client_rotation::{BackendClientRotation, BackendClientRotationState},
@@ -99,6 +99,7 @@ pub struct UpstreamTransportPool {
     backend_entries: HashMap<String, BackendTransportEntry>,
     h1_pool: H1Pool,
     h2_pool: H2Pool,
+    execution_timeout: Duration,
 }
 
 impl UpstreamTransportPool {
@@ -109,6 +110,7 @@ impl UpstreamTransportPool {
         max_idle_per_backend: usize,
         pool_idle_timeout: Duration,
         connect_timeout: Duration,
+        execution_timeout: Duration,
         dns_resolver: SharedDnsResolver,
     ) -> Result<Self, String>
     where
@@ -121,6 +123,7 @@ impl UpstreamTransportPool {
             max_idle_per_backend,
             pool_idle_timeout,
             connect_timeout,
+            execution_timeout,
             dns_resolver,
             None,
         )
@@ -134,6 +137,7 @@ impl UpstreamTransportPool {
         max_idle_per_backend: usize,
         pool_idle_timeout: Duration,
         connect_timeout: Duration,
+        execution_timeout: Duration,
         dns_resolver: SharedDnsResolver,
         connect_observer: Option<ConnectObserver>,
     ) -> Result<Self, String>
@@ -177,6 +181,7 @@ impl UpstreamTransportPool {
             backend_entries,
             h1_pool,
             h2_pool,
+            execution_timeout,
         })
     }
 
@@ -221,6 +226,7 @@ impl UpstreamTransportPool {
             connection_policy.max_idle_per_backend,
             connection_policy.pool_idle_timeout,
             connection_policy.connect_timeout,
+            connection_policy.execution_timeout,
             dns_resolver,
             connect_observer,
         )
@@ -234,23 +240,23 @@ impl UpstreamTransportPool {
         &self,
         target: TransportExecutionTarget<'_>,
         req: Request<BoxBody<Bytes, Infallible>>,
-    ) -> Result<TransportExecutionResult, PoolError> {
+    ) -> Result<TransportExecutionResult, ProxyError> {
         match self.backend_entry(target) {
             Some(BackendTransportEntry::Http1) => self
-                .h1_pool
-                .send(target.backend(), req)
+                .execute_with_timeout(target.backend(), self.h1_pool.send(target.backend(), req))
                 .await
                 .map(|response| {
                     TransportExecutionResult::new(ResolvedBackendTransport::Http1, response)
                 }),
             Some(BackendTransportEntry::H2) => self
-                .h2_pool
-                .send(target.backend(), req)
+                .execute_with_timeout(target.backend(), self.h2_pool.send(target.backend(), req))
                 .await
                 .map(|response| {
                     TransportExecutionResult::new(ResolvedBackendTransport::H2, response)
                 }),
-            None => Err(PoolError::UnknownBackend(target.backend().to_string())),
+            None => Err(ProxyError::Pool(PoolError::UnknownBackend(
+                target.backend().to_string(),
+            ))),
         }
     }
 
@@ -289,5 +295,19 @@ impl UpstreamTransportPool {
             transport,
             rotation,
         }
+    }
+
+    async fn execute_with_timeout<F>(
+        &self,
+        _backend: &str,
+        send: F,
+    ) -> Result<hyper::Response<Incoming>, ProxyError>
+    where
+        F: std::future::Future<Output = Result<hyper::Response<Incoming>, PoolError>>,
+    {
+        tokio::time::timeout(self.execution_timeout, send)
+            .await
+            .map_err(|_| ProxyError::Timeout)?
+            .map_err(ProxyError::Pool)
     }
 }

--- a/crates/transport/src/transport_pool.rs
+++ b/crates/transport/src/transport_pool.rs
@@ -9,19 +9,15 @@ use spooky_config::runtime::{
     RuntimeBackendConnectionPolicy, RuntimeBackendTransportKind, RuntimeUpstream,
 };
 pub use spooky_errors::{PoolError, ProxyError};
-
-use crate::{
-    client_rotation::{BackendClientRotation, BackendClientRotationState},
-    h1_pool::H1Pool,
-    h2_client::{ConnectObserver, SharedDnsResolver, TlsClientConfig},
-    h2_pool::H2Pool,
+pub use crate::h2_client::{
+    ConnectObservation, ConnectObserver, SharedDnsResolver, TlsClientConfig,
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ResolvedBackendTransport {
-    Http1,
-    H2,
-}
+use crate::{
+    client_rotation::BackendClientRotation,
+    h1_pool::H1Pool,
+    h2_pool::H2Pool,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum BackendTransportEntry {
@@ -29,65 +25,28 @@ enum BackendTransportEntry {
     H2,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct TransportExecutionTarget<'a> {
-    backend: &'a str,
-}
-
-impl<'a> TransportExecutionTarget<'a> {
-    pub fn new(backend: &'a str) -> Self {
-        Self { backend }
-    }
-
-    pub fn backend(&self) -> &'a str {
-        self.backend
-    }
-}
-
-pub struct TransportExecutionResult {
-    transport: ResolvedBackendTransport,
+struct TransportExecutionResult {
     response: hyper::Response<Incoming>,
 }
 
 impl TransportExecutionResult {
-    fn new(
-        transport: ResolvedBackendTransport,
-        response: hyper::Response<Incoming>,
-    ) -> Self {
-        Self {
-            transport,
-            response,
-        }
+    fn new(response: hyper::Response<Incoming>) -> Self {
+        Self { response }
     }
 
-    pub fn into_response(self) -> hyper::Response<Incoming> {
+    fn into_response(self) -> hyper::Response<Incoming> {
         self.response
-    }
-
-    pub fn protocol_name(&self) -> &'static str {
-        match self.transport {
-            ResolvedBackendTransport::Http1 => "http1",
-            ResolvedBackendTransport::H2 => "h2",
-        }
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TransportClientRotation {
-    transport: Option<ResolvedBackendTransport>,
     rotation: BackendClientRotation,
 }
 
 impl TransportClientRotation {
     pub fn rotated(self) -> bool {
         self.rotation.changed()
-    }
-
-    pub fn protocol_name(self) -> Option<&'static str> {
-        self.transport.map(|transport| match transport {
-            ResolvedBackendTransport::Http1 => "http1",
-            ResolvedBackendTransport::H2 => "h2",
-        })
     }
 
     pub fn generations(self) -> Option<(u64, u64)> {
@@ -108,7 +67,7 @@ impl UpstreamTransportPool {
         backend: &str,
         req: Request<BoxBody<Bytes, Infallible>>,
     ) -> Result<hyper::Response<Incoming>, ProxyError> {
-        self.execute(TransportExecutionTarget::new(backend), req)
+        self.execute(backend, req)
             .await
             .map(TransportExecutionResult::into_response)
     }
@@ -242,69 +201,51 @@ impl UpstreamTransportPool {
         )
     }
 
-    fn backend_entry(&self, target: TransportExecutionTarget<'_>) -> Option<BackendTransportEntry> {
-        self.backend_entries.get(target.backend()).copied()
+    fn backend_entry(&self, backend: &str) -> Option<BackendTransportEntry> {
+        self.backend_entries.get(backend).copied()
     }
 
-    pub async fn execute(
+    async fn execute(
         &self,
-        target: TransportExecutionTarget<'_>,
+        backend: &str,
         req: Request<BoxBody<Bytes, Infallible>>,
     ) -> Result<TransportExecutionResult, ProxyError> {
-        match self.backend_entry(target) {
+        match self.backend_entry(backend) {
             Some(BackendTransportEntry::Http1) => self
-                .execute_with_timeout(target.backend(), self.h1_pool.send(target.backend(), req))
+                .execute_with_timeout(backend, self.h1_pool.send(backend, req))
                 .await
-                .map(|response| {
-                    TransportExecutionResult::new(ResolvedBackendTransport::Http1, response)
-                }),
+                .map(TransportExecutionResult::new),
             Some(BackendTransportEntry::H2) => self
-                .execute_with_timeout(target.backend(), self.h2_pool.send(target.backend(), req))
+                .execute_with_timeout(backend, self.h2_pool.send(backend, req))
                 .await
-                .map(|response| {
-                    TransportExecutionResult::new(ResolvedBackendTransport::H2, response)
-                }),
+                .map(TransportExecutionResult::new),
             None => Err(ProxyError::Pool(PoolError::UnknownBackend(
-                target.backend().to_string(),
+                backend.to_string(),
             ))),
         }
     }
 
-    pub fn rotate_backend_client(
+    pub fn rotate_backend_client_for_backend(
         &self,
-        target: TransportExecutionTarget<'_>,
+        backend: &str,
     ) -> Result<TransportClientRotation, String> {
-        match self.backend_entry(target) {
+        match self.backend_entry(backend) {
             Some(BackendTransportEntry::Http1) => self
                 .h1_pool
-                .rotate_backend_client(target.backend())
-                .map(|rotation| Self::transport_rotation(ResolvedBackendTransport::Http1, rotation)),
+                .rotate_backend_client(backend)
+                .map(Self::transport_rotation),
             Some(BackendTransportEntry::H2) => self
                 .h2_pool
-                .rotate_backend_client(target.backend())
-                .map(|rotation| Self::transport_rotation(ResolvedBackendTransport::H2, rotation)),
+                .rotate_backend_client(backend)
+                .map(Self::transport_rotation),
             None => Ok(TransportClientRotation {
-                transport: None,
                 rotation: BackendClientRotation::missing_backend(),
             }),
         }
     }
 
-    fn transport_rotation(
-        transport: ResolvedBackendTransport,
-        rotation: BackendClientRotation,
-    ) -> TransportClientRotation {
-        let transport = match rotation.state() {
-            BackendClientRotationState::MissingBackend => None,
-            BackendClientRotationState::Recreated | BackendClientRotationState::Rotated { .. } => {
-                Some(transport)
-            }
-        };
-
-        TransportClientRotation {
-            transport,
-            rotation,
-        }
+    fn transport_rotation(rotation: BackendClientRotation) -> TransportClientRotation {
+        TransportClientRotation { rotation }
     }
 
     async fn execute_with_timeout<F>(

--- a/crates/transport/src/transport_pool.rs
+++ b/crates/transport/src/transport_pool.rs
@@ -59,11 +59,7 @@ impl UpstreamTransportPool {
     pub fn new_from_runtime_backends<I>(
         backends: I,
         backend_tls: HashMap<String, TlsClientConfig>,
-        max_inflight: usize,
-        max_idle_per_backend: usize,
-        pool_idle_timeout: Duration,
-        connect_timeout: Duration,
-        execution_timeout: Duration,
+        connection_policy: RuntimeBackendConnectionPolicy,
         dns_resolver: SharedDnsResolver,
     ) -> Result<Self, String>
     where
@@ -72,11 +68,11 @@ impl UpstreamTransportPool {
         Self::new_runtime_with_observer(
             backends,
             backend_tls,
-            max_inflight,
-            max_idle_per_backend,
-            pool_idle_timeout,
-            connect_timeout,
-            execution_timeout,
+            connection_policy.max_inflight,
+            connection_policy.max_idle_per_backend,
+            connection_policy.pool_idle_timeout,
+            connection_policy.connect_timeout,
+            connection_policy.execution_timeout,
             dns_resolver,
             None,
         )

--- a/crates/transport/tests/abstraction.rs
+++ b/crates/transport/tests/abstraction.rs
@@ -60,8 +60,9 @@ fn loopback_bind_restricted(err: &std::io::Error) -> bool {
         || matches!(err.raw_os_error(), Some(1) | Some(13))
 }
 
-fn request(uri: &str) -> Request<http_body_util::combinators::BoxBody<Bytes, std::convert::Infallible>>
-{
+fn request(
+    uri: &str,
+) -> Request<http_body_util::combinators::BoxBody<Bytes, std::convert::Infallible>> {
     Request::builder()
         .method("GET")
         .uri(uri)
@@ -77,7 +78,9 @@ fn reserve_unused_port() -> u16 {
         .port()
 }
 
-fn test_connection_policy(max_inflight: usize) -> spooky_config::runtime::RuntimeBackendConnectionPolicy {
+fn test_connection_policy(
+    max_inflight: usize,
+) -> spooky_config::runtime::RuntimeBackendConnectionPolicy {
     spooky_config::runtime::RuntimeBackendConnectionPolicy {
         max_inflight,
         max_idle_per_backend: 64,
@@ -163,9 +166,9 @@ async fn start_h2_server(
                     if let Some(tracker) = &tracker {
                         tracker.exit();
                     }
-                    Ok::<_, std::convert::Infallible>(Response::new(Full::new(
-                        Bytes::from_static(body),
-                    )))
+                    Ok::<_, std::convert::Infallible>(Response::new(Full::new(Bytes::from_static(
+                        body,
+                    ))))
                 }
             });
 
@@ -390,7 +393,10 @@ async fn canonical_error_mapping_is_consistent() {
         Err(err) => panic!("failed to start h1 overload server: {err}"),
     };
     let h1_overload_pool = Arc::new(build_pool(
-        [("h1-overload".to_string(), RuntimeBackendTransportKind::Http1)],
+        [(
+            "h1-overload".to_string(),
+            RuntimeBackendTransportKind::Http1,
+        )],
         1,
         SharedDnsResolver::new(),
     ));
@@ -418,14 +424,17 @@ async fn canonical_error_mapping_is_consistent() {
     assert_eq!(h1_tracker.max.load(Ordering::SeqCst), 0);
 
     let h2_tracker = Arc::new(ConcurrencyTracker::new());
-    let h2_overload_port =
-        match start_h2_server(b"h2", Duration::from_millis(50), Some(Arc::clone(&h2_tracker)))
-            .await
-        {
-            Ok(port) => port,
-            Err(err) if loopback_bind_restricted(&err) => return,
-            Err(err) => panic!("failed to start h2 overload server: {err}"),
-        };
+    let h2_overload_port = match start_h2_server(
+        b"h2",
+        Duration::from_millis(50),
+        Some(Arc::clone(&h2_tracker)),
+    )
+    .await
+    {
+        Ok(port) => port,
+        Err(err) if loopback_bind_restricted(&err) => return,
+        Err(err) => panic!("failed to start h2 overload server: {err}"),
+    };
     let h2_overload_pool = Arc::new(build_pool(
         [("h2-overload".to_string(), RuntimeBackendTransportKind::H2)],
         1,

--- a/crates/transport/tests/abstraction.rs
+++ b/crates/transport/tests/abstraction.rs
@@ -1,0 +1,486 @@
+use std::{
+    collections::HashMap,
+    net::TcpListener as StdTcpListener,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use bytes::Bytes;
+use http_body_util::{BodyExt, Full};
+use hyper::{Request, Response, body::Incoming, service::service_fn};
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use spooky_config::{
+    config::{
+        ClientAuth, Config, Listen, LoadBalancing, Log, Observability, Performance, Resilience,
+        RouteMatch, Security, Tls, Upstream, UpstreamTls,
+    },
+    runtime::{RuntimeBackendTransportKind, RuntimeConfig},
+};
+use spooky_errors::{PoolError, ProxyError};
+use spooky_transport::{SharedDnsResolver, UpstreamTransportPool};
+use tokio::net::TcpListener;
+
+struct ConcurrencyTracker {
+    current: AtomicUsize,
+    max: AtomicUsize,
+}
+
+impl ConcurrencyTracker {
+    fn new() -> Self {
+        Self {
+            current: AtomicUsize::new(0),
+            max: AtomicUsize::new(0),
+        }
+    }
+
+    fn enter(&self) {
+        let now = self.current.fetch_add(1, Ordering::SeqCst) + 1;
+        let mut prev = self.max.load(Ordering::SeqCst);
+        while now > prev {
+            match self
+                .max
+                .compare_exchange(prev, now, Ordering::SeqCst, Ordering::SeqCst)
+            {
+                Ok(_) => break,
+                Err(next) => prev = next,
+            }
+        }
+    }
+
+    fn exit(&self) {
+        self.current.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+fn loopback_bind_restricted(err: &std::io::Error) -> bool {
+    err.kind() == std::io::ErrorKind::PermissionDenied
+        || matches!(err.raw_os_error(), Some(1) | Some(13))
+}
+
+fn request(uri: &str) -> Request<http_body_util::combinators::BoxBody<Bytes, std::convert::Infallible>>
+{
+    Request::builder()
+        .method("GET")
+        .uri(uri)
+        .body(Full::new(Bytes::new()).boxed())
+        .expect("request")
+}
+
+fn reserve_unused_port() -> u16 {
+    StdTcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("local addr")
+        .port()
+}
+
+fn build_pool(
+    backends: impl IntoIterator<Item = (String, RuntimeBackendTransportKind)>,
+    max_inflight: usize,
+    resolver: SharedDnsResolver,
+) -> UpstreamTransportPool {
+    UpstreamTransportPool::new_from_runtime_backends(
+        backends,
+        HashMap::new(),
+        max_inflight,
+        64,
+        Duration::from_secs(30),
+        Duration::from_secs(2),
+        Duration::from_secs(5),
+        resolver,
+    )
+    .expect("transport pool")
+}
+
+async fn read_body(response: Response<Incoming>) -> Bytes {
+    response
+        .into_body()
+        .collect()
+        .await
+        .expect("collect body")
+        .to_bytes()
+}
+
+async fn start_h1_server(body: &'static [u8], delay: Duration) -> std::io::Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let port = listener.local_addr()?.port();
+
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = match listener.accept().await {
+                Ok(v) => v,
+                Err(_) => break,
+            };
+            let service = service_fn(move |_req: Request<Incoming>| async move {
+                tokio::time::sleep(delay).await;
+                Ok::<_, std::convert::Infallible>(Response::new(Full::new(Bytes::from_static(
+                    body,
+                ))))
+            });
+
+            tokio::spawn(async move {
+                let _ = hyper::server::conn::http1::Builder::new()
+                    .serve_connection(TokioIo::new(stream), service)
+                    .await;
+            });
+        }
+    });
+
+    Ok(port)
+}
+
+async fn start_h2_server(
+    body: &'static [u8],
+    delay: Duration,
+    tracker: Option<Arc<ConcurrencyTracker>>,
+) -> std::io::Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let port = listener.local_addr()?.port();
+
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = match listener.accept().await {
+                Ok(v) => v,
+                Err(_) => break,
+            };
+            let tracker = tracker.clone();
+            let service = service_fn(move |_req: Request<Incoming>| {
+                let tracker = tracker.clone();
+                async move {
+                    if let Some(tracker) = &tracker {
+                        tracker.enter();
+                    }
+                    tokio::time::sleep(delay).await;
+                    if let Some(tracker) = &tracker {
+                        tracker.exit();
+                    }
+                    Ok::<_, std::convert::Infallible>(Response::new(Full::new(
+                        Bytes::from_static(body),
+                    )))
+                }
+            });
+
+            tokio::spawn(async move {
+                let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
+                    .serve_connection(TokioIo::new(stream), service)
+                    .await;
+            });
+        }
+    });
+
+    Ok(port)
+}
+
+fn transport_test_config(http_backend: &str, https_backend: &str) -> Config {
+    let mut config = Config {
+        version: 1,
+        listen: Listen {
+            protocol: "http3".to_string(),
+            port: 443,
+            address: "0.0.0.0".to_string(),
+            tls: Tls {
+                cert: "/tmp/tls/default.pem".to_string(),
+                key: "/tmp/tls/default.key".to_string(),
+                certificates: Vec::new(),
+                client_auth: ClientAuth::default(),
+            },
+        },
+        listeners: Vec::new(),
+        upstream: HashMap::new(),
+        load_balancing: None,
+        upstream_tls: UpstreamTls::default(),
+        log: Log::default(),
+        performance: Performance::default(),
+        observability: Observability::default(),
+        resilience: Resilience::default(),
+        security: Security::default(),
+    };
+
+    for (name, route_host, backend) in [
+        ("plain", "plain.example.com", http_backend),
+        ("secure", "secure.example.com", https_backend),
+    ] {
+        config.upstream.insert(
+            name.to_string(),
+            Upstream {
+                load_balancing: LoadBalancing {
+                    lb_type: "round-robin".to_string(),
+                    key: None,
+                },
+                auth: Default::default(),
+                host_policy: Default::default(),
+                forwarded_headers: Default::default(),
+                tls: None,
+                route: RouteMatch {
+                    host: Some(route_host.to_string()),
+                    path_prefix: Some("/".to_string()),
+                    method: None,
+                },
+                backends: vec![spooky_config::config::Backend {
+                    id: format!("{name}-1"),
+                    address: backend.to_string(),
+                    weight: 100,
+                    health_check: None,
+                }],
+            },
+        );
+    }
+
+    config
+}
+
+#[test]
+fn runtime_upstream_interpretation_selects_protocol_internally() {
+    let config = transport_test_config("http://127.0.0.1:8080", "https://127.0.0.1:8443");
+    let runtime = RuntimeConfig::from_config(&config).expect("runtime config");
+
+    let pool = UpstreamTransportPool::from_runtime_upstreams(
+        runtime.upstreams.values(),
+        &runtime.policies.transport.backend_connections,
+        SharedDnsResolver::new(),
+        None,
+    )
+    .expect("transport pool");
+
+    let h1_rotation = pool
+        .rotate_backend_client_for_backend("http://127.0.0.1:8080")
+        .expect("h1 rotation");
+    assert!(h1_rotation.rotated());
+    assert_eq!(h1_rotation.generations(), None);
+
+    let h2_rotation = pool
+        .rotate_backend_client_for_backend("https://127.0.0.1:8443")
+        .expect("h2 rotation");
+    assert!(h2_rotation.rotated());
+    assert_eq!(h2_rotation.generations(), Some((0, 1)));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn request_execution_routes_without_protocol_branching() {
+    let h1_port = match start_h1_server(b"h1", Duration::ZERO).await {
+        Ok(port) => port,
+        Err(err) if loopback_bind_restricted(&err) => return,
+        Err(err) => panic!("failed to start h1 server: {err}"),
+    };
+    let h2_port = match start_h2_server(b"h2", Duration::ZERO, None).await {
+        Ok(port) => port,
+        Err(err) if loopback_bind_restricted(&err) => return,
+        Err(err) => panic!("failed to start h2 server: {err}"),
+    };
+
+    let h1_backend = "h1-backend".to_string();
+    let h2_backend = "h2-backend".to_string();
+    let pool = build_pool(
+        [
+            (h1_backend.clone(), RuntimeBackendTransportKind::Http1),
+            (h2_backend.clone(), RuntimeBackendTransportKind::H2),
+        ],
+        4,
+        SharedDnsResolver::new(),
+    );
+
+    let h1_response = pool
+        .send_backend_request(
+            &h1_backend,
+            request(&format!("http://127.0.0.1:{h1_port}/")),
+        )
+        .await
+        .expect("h1 response");
+    assert_eq!(read_body(h1_response).await, Bytes::from_static(b"h1"));
+
+    let h2_response = pool
+        .send_backend_request(
+            &h2_backend,
+            request(&format!("http://127.0.0.1:{h2_port}/")),
+        )
+        .await
+        .expect("h2 response");
+    assert_eq!(read_body(h2_response).await, Bytes::from_static(b"h2"));
+}
+
+#[test]
+fn client_rotation_behavior_is_stable_across_h1_and_h2() {
+    let pool = build_pool(
+        [
+            ("h1-backend".to_string(), RuntimeBackendTransportKind::Http1),
+            ("h2-backend".to_string(), RuntimeBackendTransportKind::H2),
+        ],
+        4,
+        SharedDnsResolver::new(),
+    );
+
+    let h1_rotation = pool
+        .rotate_backend_client_for_backend("h1-backend")
+        .expect("h1 rotation");
+    assert!(h1_rotation.rotated());
+    assert_eq!(h1_rotation.generations(), None);
+
+    let h2_rotation = pool
+        .rotate_backend_client_for_backend("h2-backend")
+        .expect("h2 rotation");
+    assert!(h2_rotation.rotated());
+    assert_eq!(h2_rotation.generations(), Some((0, 1)));
+
+    let h2_second_rotation = pool
+        .rotate_backend_client_for_backend("h2-backend")
+        .expect("second h2 rotation");
+    assert!(h2_second_rotation.rotated());
+    assert_eq!(h2_second_rotation.generations(), Some((1, 2)));
+
+    let missing_rotation = pool
+        .rotate_backend_client_for_backend("missing")
+        .expect("missing rotation should not error");
+    assert!(!missing_rotation.rotated());
+    assert_eq!(missing_rotation.generations(), None);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn canonical_error_mapping_is_consistent() {
+    let unknown_pool = build_pool(
+        [("known".to_string(), RuntimeBackendTransportKind::Http1)],
+        1,
+        SharedDnsResolver::new(),
+    );
+    let unknown_err = unknown_pool
+        .send_backend_request("missing", request("http://127.0.0.1:1/"))
+        .await
+        .expect_err("missing backend should fail");
+    assert!(matches!(
+        unknown_err,
+        ProxyError::Pool(PoolError::UnknownBackend(name)) if name == "missing"
+    ));
+
+    let failing_h1_pool = build_pool(
+        [("h1-fail".to_string(), RuntimeBackendTransportKind::Http1)],
+        1,
+        SharedDnsResolver::new(),
+    );
+    let h1_port = reserve_unused_port();
+    let h1_err = failing_h1_pool
+        .send_backend_request("h1-fail", request(&format!("http://127.0.0.1:{h1_port}/")))
+        .await
+        .expect_err("h1 send should fail");
+    assert!(matches!(h1_err, ProxyError::Pool(PoolError::Send(_))));
+
+    let failing_h2_pool = build_pool(
+        [("h2-fail".to_string(), RuntimeBackendTransportKind::H2)],
+        1,
+        SharedDnsResolver::new(),
+    );
+    let h2_port = reserve_unused_port();
+    let h2_err = failing_h2_pool
+        .send_backend_request("h2-fail", request(&format!("http://127.0.0.1:{h2_port}/")))
+        .await
+        .expect_err("h2 send should fail");
+    assert!(matches!(h2_err, ProxyError::Pool(PoolError::Send(_))));
+
+    let h1_tracker = Arc::new(ConcurrencyTracker::new());
+    let h1_overload_port = match start_h1_server(b"h1", Duration::from_millis(50)).await {
+        Ok(port) => port,
+        Err(err) if loopback_bind_restricted(&err) => return,
+        Err(err) => panic!("failed to start h1 overload server: {err}"),
+    };
+    let h1_overload_pool = Arc::new(build_pool(
+        [("h1-overload".to_string(), RuntimeBackendTransportKind::Http1)],
+        1,
+        SharedDnsResolver::new(),
+    ));
+    let h1_task_pool = Arc::clone(&h1_overload_pool);
+    let h1_task = tokio::spawn(async move {
+        h1_task_pool
+            .send_backend_request(
+                "h1-overload",
+                request(&format!("http://127.0.0.1:{h1_overload_port}/")),
+            )
+            .await
+    });
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    let h1_overload = h1_overload_pool
+        .send_backend_request(
+            "h1-overload",
+            request(&format!("http://127.0.0.1:{h1_overload_port}/")),
+        )
+        .await;
+    assert!(matches!(
+        h1_overload,
+        Err(ProxyError::Pool(PoolError::BackendOverloaded(_)))
+    ));
+    let _ = h1_task.await.expect("h1 task join");
+    assert_eq!(h1_tracker.max.load(Ordering::SeqCst), 0);
+
+    let h2_tracker = Arc::new(ConcurrencyTracker::new());
+    let h2_overload_port =
+        match start_h2_server(b"h2", Duration::from_millis(50), Some(Arc::clone(&h2_tracker)))
+            .await
+        {
+            Ok(port) => port,
+            Err(err) if loopback_bind_restricted(&err) => return,
+            Err(err) => panic!("failed to start h2 overload server: {err}"),
+        };
+    let h2_overload_pool = Arc::new(build_pool(
+        [("h2-overload".to_string(), RuntimeBackendTransportKind::H2)],
+        1,
+        SharedDnsResolver::new(),
+    ));
+    let h2_task_pool = Arc::clone(&h2_overload_pool);
+    let h2_task = tokio::spawn(async move {
+        h2_task_pool
+            .send_backend_request(
+                "h2-overload",
+                request(&format!("http://127.0.0.1:{h2_overload_port}/")),
+            )
+            .await
+    });
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    let h2_overload = h2_overload_pool
+        .send_backend_request(
+            "h2-overload",
+            request(&format!("http://127.0.0.1:{h2_overload_port}/")),
+        )
+        .await;
+    assert!(matches!(
+        h2_overload,
+        Err(ProxyError::Pool(PoolError::BackendOverloaded(_)))
+    ));
+    let _ = h2_task.await.expect("h2 task join");
+    assert_eq!(h2_tracker.max.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn dns_refresh_rotation_works_through_unified_surface() {
+    let resolver = SharedDnsResolver::new();
+    let backend = "https://api.example.com:443".to_string();
+    let pool = build_pool(
+        [(backend.clone(), RuntimeBackendTransportKind::H2)],
+        4,
+        resolver.clone(),
+    );
+
+    resolver.replace_host_addrs(
+        "api.example.com",
+        [std::net::SocketAddr::from(([127, 0, 0, 10], 443))],
+    );
+    let first_rotation = pool
+        .rotate_backend_client_for_backend(&backend)
+        .expect("first rotation");
+    assert!(first_rotation.rotated());
+    assert_eq!(first_rotation.generations(), Some((0, 1)));
+
+    resolver.replace_host_addrs(
+        "api.example.com",
+        [std::net::SocketAddr::from(([127, 0, 0, 11], 443))],
+    );
+    let second_rotation = pool
+        .rotate_backend_client_for_backend(&backend)
+        .expect("second rotation");
+    assert!(second_rotation.rotated());
+    assert_eq!(second_rotation.generations(), Some((1, 2)));
+
+    assert_eq!(
+        resolver.cached_addrs("api.example.com"),
+        Some(vec![std::net::SocketAddr::from(([127, 0, 0, 11], 443))])
+    );
+}

--- a/crates/transport/tests/abstraction.rs
+++ b/crates/transport/tests/abstraction.rs
@@ -77,6 +77,16 @@ fn reserve_unused_port() -> u16 {
         .port()
 }
 
+fn test_connection_policy(max_inflight: usize) -> spooky_config::runtime::RuntimeBackendConnectionPolicy {
+    spooky_config::runtime::RuntimeBackendConnectionPolicy {
+        max_inflight,
+        max_idle_per_backend: 64,
+        pool_idle_timeout: Duration::from_secs(30),
+        connect_timeout: Duration::from_secs(2),
+        execution_timeout: Duration::from_secs(5),
+    }
+}
+
 fn build_pool(
     backends: impl IntoIterator<Item = (String, RuntimeBackendTransportKind)>,
     max_inflight: usize,
@@ -85,11 +95,7 @@ fn build_pool(
     UpstreamTransportPool::new_from_runtime_backends(
         backends,
         HashMap::new(),
-        max_inflight,
-        64,
-        Duration::from_secs(30),
-        Duration::from_secs(2),
-        Duration::from_secs(5),
+        test_connection_policy(max_inflight),
         resolver,
     )
     .expect("transport pool")

--- a/crates/transport/tests/abstraction.rs
+++ b/crates/transport/tests/abstraction.rs
@@ -246,13 +246,13 @@ fn runtime_upstream_interpretation_selects_protocol_internally() {
     .expect("transport pool");
 
     let h1_rotation = pool
-        .rotate_backend_client_for_backend("http://127.0.0.1:8080")
+        .rotate_backend_client("http://127.0.0.1:8080")
         .expect("h1 rotation");
     assert!(h1_rotation.rotated());
     assert_eq!(h1_rotation.generations(), None);
 
     let h2_rotation = pool
-        .rotate_backend_client_for_backend("https://127.0.0.1:8443")
+        .rotate_backend_client("https://127.0.0.1:8443")
         .expect("h2 rotation");
     assert!(h2_rotation.rotated());
     assert_eq!(h2_rotation.generations(), Some((0, 1)));
@@ -313,25 +313,25 @@ fn client_rotation_behavior_is_stable_across_h1_and_h2() {
     );
 
     let h1_rotation = pool
-        .rotate_backend_client_for_backend("h1-backend")
+        .rotate_backend_client("h1-backend")
         .expect("h1 rotation");
     assert!(h1_rotation.rotated());
     assert_eq!(h1_rotation.generations(), None);
 
     let h2_rotation = pool
-        .rotate_backend_client_for_backend("h2-backend")
+        .rotate_backend_client("h2-backend")
         .expect("h2 rotation");
     assert!(h2_rotation.rotated());
     assert_eq!(h2_rotation.generations(), Some((0, 1)));
 
     let h2_second_rotation = pool
-        .rotate_backend_client_for_backend("h2-backend")
+        .rotate_backend_client("h2-backend")
         .expect("second h2 rotation");
     assert!(h2_second_rotation.rotated());
     assert_eq!(h2_second_rotation.generations(), Some((1, 2)));
 
     let missing_rotation = pool
-        .rotate_backend_client_for_backend("missing")
+        .rotate_backend_client("missing")
         .expect("missing rotation should not error");
     assert!(!missing_rotation.rotated());
     assert_eq!(missing_rotation.generations(), None);
@@ -464,7 +464,7 @@ fn dns_refresh_rotation_works_through_unified_surface() {
         [std::net::SocketAddr::from(([127, 0, 0, 10], 443))],
     );
     let first_rotation = pool
-        .rotate_backend_client_for_backend(&backend)
+        .rotate_backend_client(&backend)
         .expect("first rotation");
     assert!(first_rotation.rotated());
     assert_eq!(first_rotation.generations(), Some((0, 1)));
@@ -474,7 +474,7 @@ fn dns_refresh_rotation_works_through_unified_surface() {
         [std::net::SocketAddr::from(([127, 0, 0, 11], 443))],
     );
     let second_rotation = pool
-        .rotate_backend_client_for_backend(&backend)
+        .rotate_backend_client(&backend)
         .expect("second rotation");
     assert!(second_rotation.rotated());
     assert_eq!(second_rotation.generations(), Some((1, 2)));

--- a/crates/transport/tests/h1_pool.rs
+++ b/crates/transport/tests/h1_pool.rs
@@ -216,10 +216,12 @@ fn pool_rotates_known_backend_client_and_ignores_unknown_backend() {
     assert!(
         pool.rotate_backend_client("127.0.0.1:12345")
             .expect("known backend")
+            .changed()
     );
     assert!(
         !pool
             .rotate_backend_client("127.0.0.1:9999")
             .expect("unknown backend should be ignored")
+            .changed()
     );
 }

--- a/crates/transport/tests/h1_pool.rs
+++ b/crates/transport/tests/h1_pool.rs
@@ -241,13 +241,13 @@ fn pool_rotates_known_backend_client_and_ignores_unknown_backend() {
     .expect("pool");
 
     assert!(
-        pool.rotate_backend_client_for_backend("127.0.0.1:12345")
+        pool.rotate_backend_client("127.0.0.1:12345")
             .expect("known backend")
             .rotated()
     );
     assert!(
         !pool
-            .rotate_backend_client_for_backend("127.0.0.1:9999")
+            .rotate_backend_client("127.0.0.1:9999")
             .expect("unknown backend should be ignored")
             .rotated()
     );

--- a/crates/transport/tests/h1_pool.rs
+++ b/crates/transport/tests/h1_pool.rs
@@ -10,7 +10,7 @@ use bytes::Bytes;
 use http_body_util::{BodyExt, Full};
 use hyper::{Request, Response, body::Incoming, service::service_fn};
 use hyper_util::rt::TokioIo;
-use spooky_config::runtime::RuntimeBackendTransportKind;
+use spooky_config::runtime::{RuntimeBackendConnectionPolicy, RuntimeBackendTransportKind};
 use spooky_errors::{PoolError, ProxyError};
 use spooky_transport::{SharedDnsResolver, UpstreamTransportPool};
 use tokio::net::TcpListener;
@@ -50,6 +50,16 @@ impl ConcurrencyTracker {
 fn loopback_bind_restricted(err: &std::io::Error) -> bool {
     err.kind() == std::io::ErrorKind::PermissionDenied
         || matches!(err.raw_os_error(), Some(1) | Some(13))
+}
+
+fn test_connection_policy() -> RuntimeBackendConnectionPolicy {
+    RuntimeBackendConnectionPolicy {
+        max_inflight: 1,
+        max_idle_per_backend: 64,
+        pool_idle_timeout: Duration::from_secs(30),
+        connect_timeout: Duration::from_secs(2),
+        execution_timeout: Duration::from_secs(5),
+    }
 }
 
 async fn start_h1_server(tracker: Arc<ConcurrencyTracker>) -> std::io::Result<u16> {
@@ -98,11 +108,7 @@ async fn pool_limits_inflight_per_backend() {
         UpstreamTransportPool::new_from_runtime_backends(
             [(backend.clone(), RuntimeBackendTransportKind::Http1)],
             std::collections::HashMap::new(),
-            1,
-            64,
-            Duration::from_secs(30),
-            Duration::from_secs(2),
-            Duration::from_secs(5),
+            test_connection_policy(),
             SharedDnsResolver::new(),
         )
         .expect("pool"),
@@ -151,11 +157,7 @@ async fn pool_rejects_unknown_backend() {
             RuntimeBackendTransportKind::Http1,
         )],
         std::collections::HashMap::new(),
-        1,
-        64,
-        Duration::from_secs(30),
-        Duration::from_secs(2),
-        Duration::from_secs(5),
+        test_connection_policy(),
         SharedDnsResolver::new(),
     )
     .expect("pool");
@@ -187,11 +189,7 @@ async fn pool_reports_overload_when_inflight_is_exhausted() {
         UpstreamTransportPool::new_from_runtime_backends(
             [(backend.clone(), RuntimeBackendTransportKind::Http1)],
             std::collections::HashMap::new(),
-            1,
-            64,
-            Duration::from_secs(30),
-            Duration::from_secs(2),
-            Duration::from_secs(5),
+            test_connection_policy(),
             SharedDnsResolver::new(),
         )
         .expect("pool"),
@@ -231,11 +229,7 @@ fn pool_rotates_known_backend_client_and_ignores_unknown_backend() {
             RuntimeBackendTransportKind::Http1,
         )],
         std::collections::HashMap::new(),
-        1,
-        64,
-        Duration::from_secs(30),
-        Duration::from_secs(2),
-        Duration::from_secs(5),
+        test_connection_policy(),
         SharedDnsResolver::new(),
     )
     .expect("pool");

--- a/crates/transport/tests/h1_pool.rs
+++ b/crates/transport/tests/h1_pool.rs
@@ -10,10 +10,9 @@ use bytes::Bytes;
 use http_body_util::{BodyExt, Full};
 use hyper::{Request, Response, body::Incoming, service::service_fn};
 use hyper_util::rt::TokioIo;
-use spooky_transport::{
-    h1_pool::{H1Pool, PoolError},
-    h2_client::SharedDnsResolver,
-};
+use spooky_config::runtime::RuntimeBackendTransportKind;
+use spooky_errors::{PoolError, ProxyError};
+use spooky_transport::{SharedDnsResolver, UpstreamTransportPool};
 use tokio::net::TcpListener;
 
 struct ConcurrencyTracker {
@@ -95,14 +94,19 @@ async fn pool_limits_inflight_per_backend() {
     };
     let backend = format!("127.0.0.1:{port}");
 
-    let pool = Arc::new(H1Pool::new(
-        vec![backend.clone()],
-        1,
-        64,
-        Duration::from_secs(30),
-        Duration::from_secs(2),
-        SharedDnsResolver::new(),
-    ));
+    let pool = Arc::new(
+        UpstreamTransportPool::new_from_runtime_backends(
+            [(backend.clone(), RuntimeBackendTransportKind::Http1)],
+            std::collections::HashMap::new(),
+            1,
+            64,
+            Duration::from_secs(30),
+            Duration::from_secs(2),
+            Duration::from_secs(5),
+            SharedDnsResolver::new(),
+        )
+        .expect("pool"),
+    );
     let req1 = Request::builder()
         .method("GET")
         .uri(format!("http://{backend}/"))
@@ -116,11 +120,11 @@ async fn pool_limits_inflight_per_backend() {
 
     let pool1 = pool.clone();
     let backend1 = backend.clone();
-    let r1 = tokio::spawn(async move { pool1.send(&backend1, req1).await });
+    let r1 = tokio::spawn(async move { pool1.send_backend_request(&backend1, req1).await });
 
     let pool2 = pool.clone();
     let backend2 = backend.clone();
-    let r2 = tokio::spawn(async move { pool2.send(&backend2, req2).await });
+    let r2 = tokio::spawn(async move { pool2.send_backend_request(&backend2, req2).await });
 
     let (r1, r2) = tokio::join!(r1, r2);
     let r1 = r1.unwrap();
@@ -130,8 +134,8 @@ async fn pool_limits_inflight_per_backend() {
         "at least one request should be admitted"
     );
     assert!(
-        matches!(r1, Err(PoolError::BackendOverloaded(_)))
-            || matches!(r2, Err(PoolError::BackendOverloaded(_))),
+        matches!(r1, Err(ProxyError::Pool(PoolError::BackendOverloaded(_))))
+            || matches!(r2, Err(ProxyError::Pool(PoolError::BackendOverloaded(_)))),
         "one request should be rejected by backend inflight admission"
     );
 
@@ -141,23 +145,31 @@ async fn pool_limits_inflight_per_backend() {
 
 #[tokio::test]
 async fn pool_rejects_unknown_backend() {
-    let pool = H1Pool::new(
-        vec!["127.0.0.1:12345".to_string()],
+    let pool = UpstreamTransportPool::new_from_runtime_backends(
+        [(
+            "127.0.0.1:12345".to_string(),
+            RuntimeBackendTransportKind::Http1,
+        )],
+        std::collections::HashMap::new(),
         1,
         64,
         Duration::from_secs(30),
         Duration::from_secs(2),
+        Duration::from_secs(5),
         SharedDnsResolver::new(),
-    );
+    )
+    .expect("pool");
     let req = Request::builder()
         .method("GET")
         .uri("http://127.0.0.1:12345/")
         .body(Full::new(Bytes::new()).boxed())
         .unwrap();
 
-    let err = pool.send("127.0.0.1:9999", req).await.unwrap_err();
+    let err = pool.send_backend_request("127.0.0.1:9999", req).await.unwrap_err();
     match err {
-        PoolError::UnknownBackend(name) => assert_eq!(name, "127.0.0.1:9999"),
+        ProxyError::Pool(PoolError::UnknownBackend(name)) => {
+            assert_eq!(name, "127.0.0.1:9999")
+        }
         _ => panic!("unexpected error"),
     }
 }
@@ -171,14 +183,19 @@ async fn pool_reports_overload_when_inflight_is_exhausted() {
         Err(err) => panic!("failed to start h1 test server: {err}"),
     };
     let backend = format!("127.0.0.1:{port}");
-    let pool = Arc::new(H1Pool::new(
-        vec![backend.clone()],
-        1,
-        64,
-        Duration::from_secs(30),
-        Duration::from_secs(2),
-        SharedDnsResolver::new(),
-    ));
+    let pool = Arc::new(
+        UpstreamTransportPool::new_from_runtime_backends(
+            [(backend.clone(), RuntimeBackendTransportKind::Http1)],
+            std::collections::HashMap::new(),
+            1,
+            64,
+            Duration::from_secs(30),
+            Duration::from_secs(2),
+            Duration::from_secs(5),
+            SharedDnsResolver::new(),
+        )
+        .expect("pool"),
+    );
 
     let req1 = Request::builder()
         .method("GET")
@@ -193,35 +210,45 @@ async fn pool_reports_overload_when_inflight_is_exhausted() {
 
     let pool_task = Arc::clone(&pool);
     let backend_task = backend.clone();
-    let handle = tokio::spawn(async move { pool_task.send(&backend_task, req1).await });
+    let handle =
+        tokio::spawn(async move { pool_task.send_backend_request(&backend_task, req1).await });
 
     tokio::time::sleep(Duration::from_millis(10)).await;
-    let overload = pool.send(&backend, req2).await;
-    assert!(matches!(overload, Err(PoolError::BackendOverloaded(_))));
+    let overload = pool.send_backend_request(&backend, req2).await;
+    assert!(matches!(
+        overload,
+        Err(ProxyError::Pool(PoolError::BackendOverloaded(_)))
+    ));
 
     let _ = handle.await.expect("request task join");
 }
 
 #[test]
 fn pool_rotates_known_backend_client_and_ignores_unknown_backend() {
-    let pool = H1Pool::new(
-        vec!["127.0.0.1:12345".to_string()],
+    let pool = UpstreamTransportPool::new_from_runtime_backends(
+        [(
+            "127.0.0.1:12345".to_string(),
+            RuntimeBackendTransportKind::Http1,
+        )],
+        std::collections::HashMap::new(),
         1,
         64,
         Duration::from_secs(30),
         Duration::from_secs(2),
+        Duration::from_secs(5),
         SharedDnsResolver::new(),
-    );
+    )
+    .expect("pool");
 
     assert!(
-        pool.rotate_backend_client("127.0.0.1:12345")
+        pool.rotate_backend_client_for_backend("127.0.0.1:12345")
             .expect("known backend")
-            .changed()
+            .rotated()
     );
     assert!(
         !pool
-            .rotate_backend_client("127.0.0.1:9999")
+            .rotate_backend_client_for_backend("127.0.0.1:9999")
             .expect("unknown backend should be ignored")
-            .changed()
+            .rotated()
     );
 }

--- a/crates/transport/tests/h1_pool.rs
+++ b/crates/transport/tests/h1_pool.rs
@@ -167,7 +167,10 @@ async fn pool_rejects_unknown_backend() {
         .body(Full::new(Bytes::new()).boxed())
         .unwrap();
 
-    let err = pool.send_backend_request("127.0.0.1:9999", req).await.unwrap_err();
+    let err = pool
+        .send_backend_request("127.0.0.1:9999", req)
+        .await
+        .unwrap_err();
     match err {
         ProxyError::Pool(PoolError::UnknownBackend(name)) => {
             assert_eq!(name, "127.0.0.1:9999")

--- a/crates/transport/tests/h2_pool.rs
+++ b/crates/transport/tests/h2_pool.rs
@@ -11,7 +11,7 @@ use bytes::Bytes;
 use http_body_util::{BodyExt, Full};
 use hyper::{Request, Response, body::Incoming, service::service_fn};
 use hyper_util::rt::{TokioExecutor, TokioIo};
-use spooky_config::runtime::RuntimeBackendTransportKind;
+use spooky_config::runtime::{RuntimeBackendConnectionPolicy, RuntimeBackendTransportKind};
 use spooky_errors::{PoolError, ProxyError};
 use spooky_transport::{SharedDnsResolver, UpstreamTransportPool};
 use tokio::net::TcpListener;
@@ -51,6 +51,16 @@ impl ConcurrencyTracker {
 fn loopback_bind_restricted(err: &std::io::Error) -> bool {
     err.kind() == std::io::ErrorKind::PermissionDenied
         || matches!(err.raw_os_error(), Some(1) | Some(13))
+}
+
+fn test_connection_policy() -> RuntimeBackendConnectionPolicy {
+    RuntimeBackendConnectionPolicy {
+        max_inflight: 1,
+        max_idle_per_backend: 64,
+        pool_idle_timeout: Duration::from_secs(30),
+        connect_timeout: Duration::from_secs(2),
+        execution_timeout: Duration::from_secs(5),
+    }
 }
 
 async fn start_h2_server(tracker: Arc<ConcurrencyTracker>) -> std::io::Result<u16> {
@@ -99,11 +109,7 @@ async fn pool_limits_inflight_per_backend() {
         UpstreamTransportPool::new_from_runtime_backends(
             [(backend.clone(), RuntimeBackendTransportKind::H2)],
             HashMap::new(),
-            1,
-            64,
-            Duration::from_secs(30),
-            Duration::from_secs(2),
-            Duration::from_secs(5),
+            test_connection_policy(),
             SharedDnsResolver::new(),
         )
         .expect("pool"),
@@ -152,11 +158,7 @@ async fn pool_rejects_unknown_backend() {
             RuntimeBackendTransportKind::H2,
         )],
         HashMap::new(),
-        1,
-        64,
-        Duration::from_secs(30),
-        Duration::from_secs(2),
-        Duration::from_secs(5),
+        test_connection_policy(),
         SharedDnsResolver::new(),
     )
     .expect("pool");
@@ -188,11 +190,7 @@ async fn pool_reports_overload_when_inflight_is_exhausted() {
         UpstreamTransportPool::new_from_runtime_backends(
             [(backend.clone(), RuntimeBackendTransportKind::H2)],
             HashMap::new(),
-            1,
-            64,
-            Duration::from_secs(30),
-            Duration::from_secs(2),
-            Duration::from_secs(5),
+            test_connection_policy(),
             SharedDnsResolver::new(),
         )
         .expect("pool"),

--- a/crates/transport/tests/h2_pool.rs
+++ b/crates/transport/tests/h2_pool.rs
@@ -11,10 +11,9 @@ use bytes::Bytes;
 use http_body_util::{BodyExt, Full};
 use hyper::{Request, Response, body::Incoming, service::service_fn};
 use hyper_util::rt::{TokioExecutor, TokioIo};
-use spooky_transport::{
-    h2_client::{SharedDnsResolver, TlsClientConfig},
-    h2_pool::{H2Pool, PoolError},
-};
+use spooky_config::runtime::RuntimeBackendTransportKind;
+use spooky_errors::{PoolError, ProxyError};
+use spooky_transport::{SharedDnsResolver, UpstreamTransportPool};
 use tokio::net::TcpListener;
 
 struct ConcurrencyTracker {
@@ -97,13 +96,14 @@ async fn pool_limits_inflight_per_backend() {
     let backend = format!("127.0.0.1:{port}");
 
     let pool = Arc::new(
-        H2Pool::new(
-            vec![backend.clone()],
-            HashMap::from([(backend.clone(), TlsClientConfig::default())]),
+        UpstreamTransportPool::new_from_runtime_backends(
+            [(backend.clone(), RuntimeBackendTransportKind::H2)],
+            HashMap::new(),
             1,
             64,
             Duration::from_secs(30),
             Duration::from_secs(2),
+            Duration::from_secs(5),
             SharedDnsResolver::new(),
         )
         .expect("pool"),
@@ -121,11 +121,11 @@ async fn pool_limits_inflight_per_backend() {
 
     let pool1 = pool.clone();
     let backend1 = backend.clone();
-    let r1 = tokio::spawn(async move { pool1.send(&backend1, req1).await });
+    let r1 = tokio::spawn(async move { pool1.send_backend_request(&backend1, req1).await });
 
     let pool2 = pool.clone();
     let backend2 = backend.clone();
-    let r2 = tokio::spawn(async move { pool2.send(&backend2, req2).await });
+    let r2 = tokio::spawn(async move { pool2.send_backend_request(&backend2, req2).await });
 
     let (r1, r2) = tokio::join!(r1, r2);
     let r1 = r1.unwrap();
@@ -135,8 +135,8 @@ async fn pool_limits_inflight_per_backend() {
         "at least one request should be admitted"
     );
     assert!(
-        matches!(r1, Err(PoolError::BackendOverloaded(_)))
-            || matches!(r2, Err(PoolError::BackendOverloaded(_))),
+        matches!(r1, Err(ProxyError::Pool(PoolError::BackendOverloaded(_))))
+            || matches!(r2, Err(ProxyError::Pool(PoolError::BackendOverloaded(_)))),
         "one request should be rejected by backend inflight admission"
     );
 
@@ -146,13 +146,17 @@ async fn pool_limits_inflight_per_backend() {
 
 #[tokio::test]
 async fn pool_rejects_unknown_backend() {
-    let pool = H2Pool::new(
-        vec!["127.0.0.1:12345".to_string()],
-        HashMap::from([("127.0.0.1:12345".to_string(), TlsClientConfig::default())]),
+    let pool = UpstreamTransportPool::new_from_runtime_backends(
+        [(
+            "127.0.0.1:12345".to_string(),
+            RuntimeBackendTransportKind::H2,
+        )],
+        HashMap::new(),
         1,
         64,
         Duration::from_secs(30),
         Duration::from_secs(2),
+        Duration::from_secs(5),
         SharedDnsResolver::new(),
     )
     .expect("pool");
@@ -162,9 +166,11 @@ async fn pool_rejects_unknown_backend() {
         .body(Full::new(Bytes::new()).boxed())
         .unwrap();
 
-    let err = pool.send("127.0.0.1:9999", req).await.unwrap_err();
+    let err = pool.send_backend_request("127.0.0.1:9999", req).await.unwrap_err();
     match err {
-        PoolError::UnknownBackend(name) => assert_eq!(name, "127.0.0.1:9999"),
+        ProxyError::Pool(PoolError::UnknownBackend(name)) => {
+            assert_eq!(name, "127.0.0.1:9999")
+        }
         _ => panic!("unexpected error"),
     }
 }
@@ -179,13 +185,14 @@ async fn pool_reports_overload_when_inflight_is_exhausted() {
     };
     let backend = format!("127.0.0.1:{port}");
     let pool = Arc::new(
-        H2Pool::new(
-            vec![backend.clone()],
-            HashMap::from([(backend.clone(), TlsClientConfig::default())]),
+        UpstreamTransportPool::new_from_runtime_backends(
+            [(backend.clone(), RuntimeBackendTransportKind::H2)],
+            HashMap::new(),
             1,
             64,
             Duration::from_secs(30),
             Duration::from_secs(2),
+            Duration::from_secs(5),
             SharedDnsResolver::new(),
         )
         .expect("pool"),
@@ -204,11 +211,15 @@ async fn pool_reports_overload_when_inflight_is_exhausted() {
 
     let pool_task = Arc::clone(&pool);
     let backend_task = backend.clone();
-    let handle = tokio::spawn(async move { pool_task.send(&backend_task, req1).await });
+    let handle =
+        tokio::spawn(async move { pool_task.send_backend_request(&backend_task, req1).await });
 
     tokio::time::sleep(Duration::from_millis(10)).await;
-    let overload = pool.send(&backend, req2).await;
-    assert!(matches!(overload, Err(PoolError::BackendOverloaded(_))));
+    let overload = pool.send_backend_request(&backend, req2).await;
+    assert!(matches!(
+        overload,
+        Err(ProxyError::Pool(PoolError::BackendOverloaded(_)))
+    ));
 
     let _ = handle.await.expect("request task join");
 }

--- a/crates/transport/tests/h2_pool.rs
+++ b/crates/transport/tests/h2_pool.rs
@@ -168,7 +168,10 @@ async fn pool_rejects_unknown_backend() {
         .body(Full::new(Bytes::new()).boxed())
         .unwrap();
 
-    let err = pool.send_backend_request("127.0.0.1:9999", req).await.unwrap_err();
+    let err = pool
+        .send_backend_request("127.0.0.1:9999", req)
+        .await
+        .unwrap_err();
     match err {
         ProxyError::Pool(PoolError::UnknownBackend(name)) => {
             assert_eq!(name, "127.0.0.1:9999")


### PR DESCRIPTION
## Summary
This PR finishes the transport abstraction cleanup by turning `spooky-transport` into a single canonical backend execution facade and pushing H1/H2 details behind internal module boundaries.

## What changed
- unified H1/H2 request execution flow behind the same pool execution shape
- normalized client rotation behavior across protocols with one shared rotation contract
- centralized transport execution timeout ownership inside transport
- routed forwarding, bootstrap, health checks, and lifecycle callers through canonical transport APIs
- made H1/H2 pool and client modules internal implementation details
- moved callers to crate-root transport exports instead of protocol-specific module paths
- added focused abstraction tests for:
  - runtime upstream protocol interpretation
  - protocol-agnostic request execution
  - stable client rotation behavior
  - consistent unknown backend / overload / send failure mapping
  - DNS-refresh-driven rotation through the unified surface

## Result
- edge now talks to transport in backend-execution terms instead of H1/H2 terms
- transport owns protocol selection, pooled execution behavior, and client rotation semantics
- protocol-specific implementation details are contained inside `spooky-transport`
