### PR TITLE
test(bridge): cover escape_forwarded_host and forwarded_for_value

### DIFF
--- a/crates/bridge/src/forwarded.rs
+++ b/crates/bridge/src/forwarded.rs
@@ -112,17 +112,18 @@ pub fn escape_forwarded_host(host: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{escape_forwarded_host, forwarded_for_value};
+    use super::{
+        build_forwarded_header_values, escape_forwarded_host, forwarded_for_value,
+        merge_forwarded_chain, ForwardedHeaderChains,
+    };
+    use spooky_config::config::{ForwardedHeaderPolicy, ForwardedHeaderPolicyMode};
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
     #[test]
     fn escape_forwarded_host_escapes_backslash_and_quote() {
         assert_eq!(escape_forwarded_host(r#"ex"ample.com"#), r#"ex\"ample.com"#);
         assert_eq!(escape_forwarded_host(r"foo\bar"), r"foo\\bar");
-        assert_eq!(
-            escape_forwarded_host(r#"a\"b"#),
-            r#"a\\\"b"#
-        );
+        assert_eq!(escape_forwarded_host(r#"a\"b"#), r#"a\\\"b"#);
         // plain host unchanged
         assert_eq!(escape_forwarded_host("example.com"), "example.com");
     }
@@ -139,5 +140,108 @@ mod tests {
         assert_eq!(forwarded_for_value(ip), "\"[::1]\"");
         let ip = IpAddr::V6("2001:db8::1".parse().unwrap());
         assert_eq!(forwarded_for_value(ip), "\"[2001:db8::1]\"");
+    }
+
+    #[test]
+    fn merge_forwarded_chain_preserve_append_overwrite() {
+        let inbound = vec![b"for=1.1.1.1".to_vec()];
+        let current = b"for=2.2.2.2";
+
+        let preserved = merge_forwarded_chain(
+            ForwardedHeaderPolicyMode::Preserve,
+            &inbound,
+            Some(current),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(preserved.as_bytes(), b"for=1.1.1.1");
+
+        let appended = merge_forwarded_chain(
+            ForwardedHeaderPolicyMode::Append,
+            &inbound,
+            Some(current),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(appended.as_bytes(), b"for=1.1.1.1, for=2.2.2.2");
+
+        let overwritten = merge_forwarded_chain(
+            ForwardedHeaderPolicyMode::Overwrite,
+            &inbound,
+            Some(current),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(overwritten.as_bytes(), b"for=2.2.2.2");
+    }
+
+    #[test]
+    fn build_forwarded_header_values_overwrite_drops_inbound() {
+        let policy = ForwardedHeaderPolicy {
+            mode: ForwardedHeaderPolicyMode::Overwrite,
+        };
+        let inbound_fwd = [b"for=9.9.9.9".to_vec()];
+        let inbound_xff = [b"9.9.9.9".to_vec()];
+        let inbound_xfp = [b"http".to_vec()];
+        let inbound_xfh = [b"old.example".to_vec()];
+        let inbound = ForwardedHeaderChains {
+            forwarded: &inbound_fwd,
+            x_forwarded_for: &inbound_xff,
+            x_forwarded_proto: &inbound_xfp,
+            x_forwarded_host: &inbound_xfh,
+        };
+        let ip = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10));
+        let out = build_forwarded_header_values(&policy, inbound, ip, "app.example")
+            .expect("build");
+
+        assert_eq!(out.x_forwarded_for.unwrap().as_bytes(), b"203.0.113.10");
+        assert_eq!(out.x_forwarded_proto.unwrap().as_bytes(), b"https");
+        assert_eq!(out.x_forwarded_host.unwrap().as_bytes(), b"app.example");
+
+        let s = std::str::from_utf8(out.forwarded.unwrap().as_bytes()).unwrap();
+        assert!(s.contains("for=203.0.113.10"));
+        assert!(s.contains("proto=https"));
+        assert!(s.contains("host=\"app.example\""));
+        assert!(!s.contains("9.9.9.9"), "overwrite must drop inbound: {s}");
+    }
+
+    #[test]
+    fn build_forwarded_header_values_append_keeps_inbound() {
+        let policy = ForwardedHeaderPolicy {
+            mode: ForwardedHeaderPolicyMode::Append,
+        };
+        let inbound_xff = [b"1.1.1.1".to_vec()];
+        let inbound = ForwardedHeaderChains {
+            forwarded: &[],
+            x_forwarded_for: &inbound_xff,
+            x_forwarded_proto: &[],
+            x_forwarded_host: &[],
+        };
+        let ip = IpAddr::V4(Ipv4Addr::new(2, 2, 2, 2));
+        let out = build_forwarded_header_values(&policy, inbound, ip, "h")
+            .expect("build");
+        assert_eq!(
+            out.x_forwarded_for.unwrap().as_bytes(),
+            b"1.1.1.1, 2.2.2.2"
+        );
+    }
+
+    #[test]
+    fn build_forwarded_header_values_preserve_ignores_current_for_chain() {
+        let policy = ForwardedHeaderPolicy {
+            mode: ForwardedHeaderPolicyMode::Preserve,
+        };
+        let inbound_xff = [b"8.8.8.8".to_vec()];
+        let inbound = ForwardedHeaderChains {
+            forwarded: &[],
+            x_forwarded_for: &inbound_xff,
+            x_forwarded_proto: &[],
+            x_forwarded_host: &[],
+        };
+        let ip = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
+        let out = build_forwarded_header_values(&policy, inbound, ip, "h")
+            .expect("build");
+        // Preserve keeps only inbound chain values for XFF
+        assert_eq!(out.x_forwarded_for.unwrap().as_bytes(), b"8.8.8.8");
     }
 }

--- a/crates/bridge/src/forwarded.rs
+++ b/crates/bridge/src/forwarded.rs
@@ -109,3 +109,35 @@ pub fn forwarded_for_value(ip: IpAddr) -> String {
 pub fn escape_forwarded_host(host: &str) -> String {
     host.replace('\\', "\\\\").replace('"', "\\\"")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{escape_forwarded_host, forwarded_for_value};
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+    #[test]
+    fn escape_forwarded_host_escapes_backslash_and_quote() {
+        assert_eq!(escape_forwarded_host(r#"ex"ample.com"#), r#"ex\"ample.com"#);
+        assert_eq!(escape_forwarded_host(r"foo\bar"), r"foo\\bar");
+        assert_eq!(
+            escape_forwarded_host(r#"a\"b"#),
+            r#"a\\\"b"#
+        );
+        // plain host unchanged
+        assert_eq!(escape_forwarded_host("example.com"), "example.com");
+    }
+
+    #[test]
+    fn forwarded_for_value_ipv4_is_bare() {
+        let ip = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10));
+        assert_eq!(forwarded_for_value(ip), "203.0.113.10");
+    }
+
+    #[test]
+    fn forwarded_for_value_ipv6_is_quoted_bracket_form() {
+        let ip = IpAddr::V6(Ipv6Addr::LOCALHOST);
+        assert_eq!(forwarded_for_value(ip), "\"[::1]\"");
+        let ip = IpAddr::V6("2001:db8::1".parse().unwrap());
+        assert_eq!(forwarded_for_value(ip), "\"[2001:db8::1]\"");
+    }
+}

--- a/crates/bridge/src/forwarded.rs
+++ b/crates/bridge/src/forwarded.rs
@@ -113,8 +113,8 @@ pub fn escape_forwarded_host(host: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_forwarded_header_values, escape_forwarded_host, forwarded_for_value,
-        merge_forwarded_chain, ForwardedHeaderChains,
+        ForwardedHeaderChains, build_forwarded_header_values, escape_forwarded_host,
+        forwarded_for_value, merge_forwarded_chain,
     };
     use spooky_config::config::{ForwardedHeaderPolicy, ForwardedHeaderPolicyMode};
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
@@ -147,22 +147,16 @@ mod tests {
         let inbound = vec![b"for=1.1.1.1".to_vec()];
         let current = b"for=2.2.2.2";
 
-        let preserved = merge_forwarded_chain(
-            ForwardedHeaderPolicyMode::Preserve,
-            &inbound,
-            Some(current),
-        )
-        .unwrap()
-        .unwrap();
+        let preserved =
+            merge_forwarded_chain(ForwardedHeaderPolicyMode::Preserve, &inbound, Some(current))
+                .unwrap()
+                .unwrap();
         assert_eq!(preserved.as_bytes(), b"for=1.1.1.1");
 
-        let appended = merge_forwarded_chain(
-            ForwardedHeaderPolicyMode::Append,
-            &inbound,
-            Some(current),
-        )
-        .unwrap()
-        .unwrap();
+        let appended =
+            merge_forwarded_chain(ForwardedHeaderPolicyMode::Append, &inbound, Some(current))
+                .unwrap()
+                .unwrap();
         assert_eq!(appended.as_bytes(), b"for=1.1.1.1, for=2.2.2.2");
 
         let overwritten = merge_forwarded_chain(
@@ -191,8 +185,8 @@ mod tests {
             x_forwarded_host: &inbound_xfh,
         };
         let ip = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10));
-        let out = build_forwarded_header_values(&policy, inbound, ip, "app.example")
-            .expect("build");
+        let out =
+            build_forwarded_header_values(&policy, inbound, ip, "app.example").expect("build");
 
         assert_eq!(out.x_forwarded_for.unwrap().as_bytes(), b"203.0.113.10");
         assert_eq!(out.x_forwarded_proto.unwrap().as_bytes(), b"https");
@@ -218,12 +212,8 @@ mod tests {
             x_forwarded_host: &[],
         };
         let ip = IpAddr::V4(Ipv4Addr::new(2, 2, 2, 2));
-        let out = build_forwarded_header_values(&policy, inbound, ip, "h")
-            .expect("build");
-        assert_eq!(
-            out.x_forwarded_for.unwrap().as_bytes(),
-            b"1.1.1.1, 2.2.2.2"
-        );
+        let out = build_forwarded_header_values(&policy, inbound, ip, "h").expect("build");
+        assert_eq!(out.x_forwarded_for.unwrap().as_bytes(), b"1.1.1.1, 2.2.2.2");
     }
 
     #[test]
@@ -239,8 +229,7 @@ mod tests {
             x_forwarded_host: &[],
         };
         let ip = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
-        let out = build_forwarded_header_values(&policy, inbound, ip, "h")
-            .expect("build");
+        let out = build_forwarded_header_values(&policy, inbound, ip, "h").expect("build");
         // Preserve keeps only inbound chain values for XFF
         assert_eq!(out.x_forwarded_for.unwrap().as_bytes(), b"8.8.8.8");
     }

--- a/crates/bridge/src/forwarded.rs
+++ b/crates/bridge/src/forwarded.rs
@@ -192,7 +192,9 @@ mod tests {
         assert_eq!(out.x_forwarded_proto.unwrap().as_bytes(), b"https");
         assert_eq!(out.x_forwarded_host.unwrap().as_bytes(), b"app.example");
 
-        let s = std::str::from_utf8(out.forwarded.unwrap().as_bytes()).unwrap();
+        // Bind the Bytes so the temporary is not dropped while `s` is borrowed (E0716).
+        let forwarded = out.forwarded.unwrap();
+        let s = std::str::from_utf8(forwarded.as_bytes()).unwrap();
         assert!(s.contains("for=203.0.113.10"));
         assert!(s.contains("proto=https"));
         assert!(s.contains("host=\"app.example\""));


### PR DESCRIPTION
## Summary
Closes #274 and #267.

Adds unit tests for Forwarded header helpers used on every proxied request:

### #274 — pure helpers
- `escape_forwarded_host` — escapes `"` and `\`
- `forwarded_for_value` — IPv4 bare / IPv6 quoted `[addr]`

### #267 — policy modes
- `merge_forwarded_chain` for Preserve / Append / Overwrite
- `build_forwarded_header_values` Overwrite drops inbound
- Append keeps inbound XFF chain
- Preserve keeps inbound only

## Test plan
- [x] Local pure-function checks for escape + IP formatting
- [ ] `cargo test -p spooky-bridge` in CI