### PR TITLE
refactor(core): harden public APIs and clarify subsystem ownership

### DIFF
--- a/crates/bridge/src/h3_to_h1.rs
+++ b/crates/bridge/src/h3_to_h1.rs
@@ -18,7 +18,7 @@ use crate::{
 /// For plain requests: strips hop-by-hop headers and adds `TE: trailers`.
 /// For WebSocket legacy upgrades (`GET` + `Upgrade: websocket`): preserves
 /// `Connection` and `Upgrade` so the H1 upstream can complete the handshake.
-pub fn build_h1_request(
+pub(crate) fn build_h1_request(
     target: RequestBuildTarget<'_>,
     input: RequestBuildInput<'_, BoxBody<Bytes, Infallible>>,
 ) -> Result<Request<BoxBody<Bytes, Infallible>>, BridgeError> {

--- a/crates/bridge/src/h3_to_h2.rs
+++ b/crates/bridge/src/h3_to_h2.rs
@@ -14,8 +14,7 @@ use crate::{
     websocket::{H3WebsocketRequestKind, h3_websocket_request_kind},
 };
 
-#[allow(clippy::too_many_arguments)]
-pub fn build_h2_request_for_target(
+pub(crate) fn build_h2_request_for_target(
     target: RequestBuildTarget<'_>,
     input: RequestBuildInput<'_, BoxBody<Bytes, Infallible>>,
 ) -> Result<Request<BoxBody<Bytes, Infallible>>, BridgeError> {

--- a/crates/bridge/src/lib.rs
+++ b/crates/bridge/src/lib.rs
@@ -1,6 +1,16 @@
+//! Canonical request/response conversion surface for upstream bridging.
+//!
+//! Consumers should use:
+//! - [`request`] for upstream request construction and header policy application
+//! - [`response`] for downstream response normalization and emission policy
+//! - [`websocket`] for websocket and upgrade helpers
+//!
+//! Protocol-specific H1/H2 builders are internal implementation details behind
+//! the canonical request-building surface.
+
 mod forwarded;
-pub mod h3_to_h1;
-pub mod h3_to_h2;
+mod h3_to_h1;
+mod h3_to_h2;
 mod headers;
 mod host;
 pub mod request;

--- a/crates/bridge/src/request.rs
+++ b/crates/bridge/src/request.rs
@@ -17,8 +17,8 @@ use spooky_config::{
 use crate::{
     BridgeError,
     forwarded::{ForwardedHeaderChains, ForwardedHeaderValues, build_forwarded_header_values},
-    headers::{connection_header_tokens, should_strip_request_header},
     h3_to_h1, h3_to_h2,
+    headers::{connection_header_tokens, should_strip_request_header},
     host::resolve_upstream_host_value,
 };
 

--- a/crates/bridge/src/request.rs
+++ b/crates/bridge/src/request.rs
@@ -1,3 +1,9 @@
+//! Canonical upstream request-building surface.
+//!
+//! This module owns request-shaping inputs, host/forwarded-header policy
+//! application, and the stable entrypoints callers should use. Protocol-specific
+//! H1/H2 encoding details are delegated to internal builder modules.
+
 use std::{convert::Infallible, net::SocketAddr};
 
 use bytes::Bytes;
@@ -12,8 +18,23 @@ use crate::{
     BridgeError,
     forwarded::{ForwardedHeaderChains, ForwardedHeaderValues, build_forwarded_header_values},
     headers::{connection_header_tokens, should_strip_request_header},
+    h3_to_h1, h3_to_h2,
     host::resolve_upstream_host_value,
 };
+
+pub fn build_h1_request(
+    target: RequestBuildTarget<'_>,
+    input: RequestBuildInput<'_, BoxBody<Bytes, Infallible>>,
+) -> Result<http::Request<BoxBody<Bytes, Infallible>>, BridgeError> {
+    h3_to_h1::build_h1_request(target, input)
+}
+
+pub fn build_h2_request_for_target(
+    target: RequestBuildTarget<'_>,
+    input: RequestBuildInput<'_, BoxBody<Bytes, Infallible>>,
+) -> Result<http::Request<BoxBody<Bytes, Infallible>>, BridgeError> {
+    h3_to_h2::build_h2_request_for_target(target, input)
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RequestBodyMode {

--- a/crates/bridge/src/response.rs
+++ b/crates/bridge/src/response.rs
@@ -1,3 +1,9 @@
+//! Canonical downstream response normalization surface.
+//!
+//! This module owns header/trailer filtering, bodyless/no-content shaping, and
+//! response emission policy decisions shared across forwarding and bootstrap
+//! compatibility paths.
+
 use std::collections::HashSet;
 
 use http::{HeaderMap, HeaderName, HeaderValue, StatusCode};

--- a/crates/bridge/src/websocket.rs
+++ b/crates/bridge/src/websocket.rs
@@ -1,3 +1,9 @@
+//! Canonical websocket and upgrade detection helpers for bridge callers.
+//!
+//! This module owns request-shape inspection for websocket tunneling semantics.
+//! Transport execution and tunnel I/O stay outside this crate; callers should
+//! use these helpers only to decide whether websocket-specific bridging rules apply.
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum H3WebsocketRequestKind {
     None,

--- a/crates/bridge/tests/regression/h3_to_h1.rs
+++ b/crates/bridge/tests/regression/h3_to_h1.rs
@@ -5,7 +5,7 @@ use http::{
     header::{CONTENT_LENGTH, HOST, TE},
 };
 use quiche::h3::Header;
-use spooky_bridge::h3_to_h1::build_h1_request;
+use spooky_bridge::request::build_h1_request;
 use spooky_config::{
     backend_endpoint::BackendEndpoint,
     config::{ForwardedHeaderPolicy, UpstreamHostPolicy},

--- a/crates/bridge/tests/regression/h3_to_h2.rs
+++ b/crates/bridge/tests/regression/h3_to_h2.rs
@@ -8,7 +8,8 @@ use http_body_util::combinators::BoxBody;
 use hyper::ext::Protocol;
 use quiche::h3::Header;
 use spooky_bridge::{
-    BridgeError, h3_to_h1::build_h1_request, h3_to_h2::build_h2_request_for_target,
+    BridgeError,
+    request::{build_h1_request, build_h2_request_for_target},
 };
 use spooky_config::{
     backend_endpoint::BackendEndpoint,

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1,3 +1,12 @@
+//! Canonical configuration surface for Spooky.
+//!
+//! This crate owns raw config parsing/validation plus the runtime-ready policy
+//! interpretation that downstream crates consume. Use:
+//! - [`config`] for deserialized user-facing configuration shapes
+//! - [`validator`] for config validation rules
+//! - [`runtime`] for normalized, validated runtime policy output
+//! - [`backend_endpoint`] for shared backend endpoint parsing/runtime shaping
+
 pub mod backend_endpoint;
 pub mod config;
 pub mod default;

--- a/crates/config/src/runtime.rs
+++ b/crates/config/src/runtime.rs
@@ -1,3 +1,9 @@
+//! Canonical runtime-ready configuration for the rest of the system.
+//!
+//! `RuntimeConfig` and the types re-exported from this module are the validated,
+//! normalized outputs that downstream crates should consume. Interpreter-only
+//! shaping details stay internal to the runtime lowering modules.
+
 use std::{collections::HashMap, fmt, net::IpAddr};
 
 use crate::config::{
@@ -21,7 +27,7 @@ pub use self::policies::{
     RuntimePolicySet, RuntimeRateLimitPolicy, RuntimeRequestKeySpec, RuntimeRetryBudgetPolicy,
     RuntimeRouteHostPattern, RuntimeRouteMatchPolicy, RuntimeRouteQueuePolicy,
     RuntimeScopedRateLimitPolicy, RuntimeTimeoutPolicy, RuntimeTransportPolicy,
-    RuntimeUpstreamPolicySet, RuntimeUpstreamTransportPolicy, RuntimeWatchdogPolicy,
+    RuntimeWatchdogPolicy,
 };
 
 #[derive(Debug, Clone)]
@@ -82,14 +88,6 @@ impl RuntimeConfig {
 
     pub fn policies(&self) -> RuntimePolicySet {
         self.policies.clone()
-    }
-
-    #[cfg(test)]
-    pub(crate) fn upstream_policy_sets(&self) -> HashMap<String, RuntimeUpstreamPolicySet> {
-        self.upstreams
-            .iter()
-            .map(|(name, upstream)| (name.clone(), upstream.policy_set.clone()))
-            .collect()
     }
 }
 
@@ -237,9 +235,15 @@ pub struct RuntimeUpstream {
     pub load_balancing: RuntimeLoadBalancingPolicy,
     pub route: RuntimeRouteMatchPolicy,
     pub policy: RuntimeUpstreamPolicy,
-    pub policy_set: RuntimeUpstreamPolicySet,
     pub effective_tls: UpstreamTls,
     pub backends: Vec<RuntimeBackend>,
+    pub(crate) backend_tls_policy: RuntimeBackendTlsPolicy,
+}
+
+impl RuntimeUpstream {
+    pub fn backend_tls_policy(&self) -> &RuntimeBackendTlsPolicy {
+        &self.backend_tls_policy
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -270,9 +274,8 @@ pub struct RuntimeUpstreamPolicy {
 // NOTE: Public-API `RuntimeConfig::from_config` contract tests live in the
 // regression suite at `crates/config/tests/regression/`. The tests kept here are
 // the ones that reach crate-internal items — the private `listeners` module's
-// `runtime_listeners`, and the `#[cfg(test)] pub(crate)` `upstreams_as_config` /
-// `upstream_policy_sets` helpers — which are not reachable from an external
-// integration-test crate.
+// `runtime_listeners` and the `#[cfg(test)] pub(crate)` `upstreams_as_config`
+// helper — which are not reachable from an external integration-test crate.
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
@@ -342,7 +345,7 @@ mod tests {
     }
 
     #[test]
-    fn runtime_upstream_policy_set_carries_canonical_lb_auth_and_tls_shapes() {
+    fn runtime_upstream_carries_canonical_lb_auth_and_tls_shapes() {
         let mut config = sample_config();
         let upstream = config.upstream.get_mut("api").expect("api upstream");
         upstream.load_balancing = LoadBalancing {
@@ -370,10 +373,7 @@ mod tests {
         }];
 
         let runtime = RuntimeConfig::from_config(&config).expect("runtime config");
-        let upstream_policies = runtime.upstream_policy_sets();
-        let api = upstream_policies
-            .get("api")
-            .expect("api runtime policy set");
+        let api = runtime.upstreams.get("api").expect("api runtime upstream");
 
         assert_eq!(
             api.load_balancing.strategy,
@@ -381,27 +381,32 @@ mod tests {
         );
         assert_eq!(api.load_balancing.key.as_deref(), Some("header:x-user-id"));
         assert_eq!(
-            api.auth
+            api.policy
+                .upstream_auth
                 .api_key
                 .as_ref()
                 .map(|auth| auth.header_name.as_str()),
             Some("x-api-key")
         );
         assert_eq!(
-            api.transport.tls.ca_file.as_deref(),
+            api.backend_tls_policy().ca_file.as_deref(),
             Some("/tmp/upstream-ca.pem")
         );
         assert_eq!(
-            api.transport.connection.max_inflight,
+            runtime
+                .policies
+                .transport
+                .backend_connections
+                .max_inflight,
             runtime
                 .policies
                 .transport
                 .connection_limits
                 .backend_pool_max_inflight
         );
-        assert_eq!(api.rate_limits.scoped_limits.len(), 1);
+        assert_eq!(runtime.policies.rate_limits.scoped_limits.len(), 1);
         assert_eq!(
-            api.rate_limits.scoped_limits[0].idle_ttl,
+            runtime.policies.rate_limits.scoped_limits[0].idle_ttl,
             Duration::from_secs(30)
         );
     }

--- a/crates/config/src/runtime.rs
+++ b/crates/config/src/runtime.rs
@@ -393,11 +393,7 @@ mod tests {
             Some("/tmp/upstream-ca.pem")
         );
         assert_eq!(
-            runtime
-                .policies
-                .transport
-                .backend_connections
-                .max_inflight,
+            runtime.policies.transport.backend_connections.max_inflight,
             runtime
                 .policies
                 .transport

--- a/crates/config/src/runtime/policies/mod.rs
+++ b/crates/config/src/runtime/policies/mod.rs
@@ -1,3 +1,9 @@
+//! Runtime policy interpreter façade.
+//!
+//! This module re-exports the stable normalized policy types that downstream
+//! crates consume. Domain-local normalization helpers and intermediate policy
+//! set assembly stay crate-private to avoid leaking interpreter structure.
+
 mod admission;
 mod auth;
 mod backend;
@@ -30,11 +36,8 @@ pub use self::{
     watchdog::RuntimeWatchdogPolicy,
 };
 use super::{
-    Config, ListenerRuntimeConfig, RuntimeConfigError, RuntimeForwardedHeaderPolicy,
-    RuntimeHostPolicy, RuntimeListenerTls, RuntimeProtocolPolicy,
+    Config, ListenerRuntimeConfig, RuntimeConfigError, RuntimeListenerTls,
 };
-use crate::config::UpstreamTls;
-
 fn config_invalid(message: impl Into<String>) -> RuntimeConfigError {
     RuntimeConfigError::ConfigInvalid(message.into())
 }
@@ -149,26 +152,6 @@ pub enum RuntimeBackendTransportKind {
 }
 
 #[derive(Debug, Clone)]
-pub struct RuntimeUpstreamTransportPolicy {
-    pub tls: RuntimeBackendTlsPolicy,
-    pub connection: RuntimeBackendConnectionPolicy,
-    pub dns: RuntimeBackendDnsPolicy,
-}
-
-impl RuntimeUpstreamTransportPolicy {
-    pub(crate) fn from_effective_tls(
-        effective_tls: &UpstreamTls,
-        transport: &RuntimeTransportPolicy,
-    ) -> Self {
-        Self {
-            tls: RuntimeBackendTlsPolicy::from_effective_tls(effective_tls),
-            connection: transport.backend_connections.clone(),
-            dns: transport.backend_dns.clone(),
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
 pub struct RuntimePolicySet {
     pub timeouts: RuntimeTimeoutPolicy,
     pub admission: RuntimeAdmissionPolicy,
@@ -208,17 +191,4 @@ impl RuntimeListenerPolicySet {
             tls: config.listen.tls.clone(),
         }
     }
-}
-
-#[derive(Debug, Clone)]
-pub struct RuntimeUpstreamPolicySet {
-    pub timeouts: RuntimeTimeoutPolicy,
-    pub auth: RuntimeAuthPolicy,
-    pub rate_limits: RuntimeRateLimitPolicy,
-    pub load_balancing: RuntimeLoadBalancingPolicy,
-    pub admission: RuntimeAdmissionPolicy,
-    pub transport: RuntimeUpstreamTransportPolicy,
-    pub host: RuntimeHostPolicy,
-    pub forwarded_headers: RuntimeForwardedHeaderPolicy,
-    pub protocol: RuntimeProtocolPolicy,
 }

--- a/crates/config/src/runtime/policies/mod.rs
+++ b/crates/config/src/runtime/policies/mod.rs
@@ -35,9 +35,7 @@ pub use self::{
     transport::{RuntimeBackendConnectionPolicy, RuntimeConnectionLimits, RuntimeTransportPolicy},
     watchdog::RuntimeWatchdogPolicy,
 };
-use super::{
-    Config, ListenerRuntimeConfig, RuntimeConfigError, RuntimeListenerTls,
-};
+use super::{Config, ListenerRuntimeConfig, RuntimeConfigError, RuntimeListenerTls};
 fn config_invalid(message: impl Into<String>) -> RuntimeConfigError {
     RuntimeConfigError::ConfigInvalid(message.into())
 }

--- a/crates/config/src/runtime/upstreams.rs
+++ b/crates/config/src/runtime/upstreams.rs
@@ -13,10 +13,6 @@ impl RuntimeUpstream {
             .tls
             .clone()
             .unwrap_or_else(|| config.upstream_tls.clone());
-        let upstream_transport = RuntimeUpstreamTransportPolicy::from_effective_tls(
-            &effective_tls,
-            &base_policies.transport,
-        );
         let load_balancing = RuntimeLoadBalancingPolicy::normalize(&upstream.load_balancing)?;
         let route = RuntimeRouteMatchPolicy::normalize(name, &upstream.route)?;
         let policy = RuntimeUpstreamPolicy {
@@ -25,30 +21,19 @@ impl RuntimeUpstream {
             forwarded_headers: RuntimeForwardedHeaderPolicy(upstream.forwarded_headers.clone()),
             protocol: base_policies.admission.protocol.clone(),
         };
-        let mut runtime_upstream = Self {
+        let runtime_upstream = Self {
             name: name.to_string(),
             load_balancing: load_balancing.clone(),
             route: route.clone(),
             policy,
-            policy_set: RuntimeUpstreamPolicySet {
-                timeouts: base_policies.timeouts.clone(),
-                auth: RuntimeAuthPolicy::default(),
-                rate_limits: base_policies.rate_limits.clone(),
-                load_balancing,
-                admission: base_policies.admission.clone(),
-                transport: upstream_transport,
-                host: RuntimeHostPolicy(upstream.host_policy.clone()),
-                forwarded_headers: RuntimeForwardedHeaderPolicy(upstream.forwarded_headers.clone()),
-                protocol: base_policies.admission.protocol.clone(),
-            },
             effective_tls: effective_tls.clone(),
+            backend_tls_policy: RuntimeBackendTlsPolicy::from_effective_tls(&effective_tls),
             backends: upstream
                 .backends
                 .iter()
                 .map(|backend| RuntimeBackend::normalize(name, backend))
                 .collect::<Result<Vec<_>, _>>()?,
         };
-        runtime_upstream.policy_set.auth = runtime_upstream.policy.upstream_auth.clone();
 
         Ok(runtime_upstream)
     }
@@ -140,7 +125,7 @@ pub(super) fn normalize_upstreams(
         if upstream_uses_https_backends {
             validate_runtime_upstream_tls(
                 upstream_name,
-                &runtime_upstream.policy_set.transport.tls.as_upstream_tls(),
+                &runtime_upstream.backend_tls_policy.as_upstream_tls(),
             )?;
         }
 

--- a/crates/config/tests/regression/tls.rs
+++ b/crates/config/tests/regression/tls.rs
@@ -45,7 +45,7 @@ fn runtime_upstream_applies_effective_tls_and_policy_wrappers() {
         RuntimeBackendTransportKind::H2
     );
     assert_eq!(
-        upstream.policy_set.transport.tls.ca_file.as_deref(),
+        upstream.backend_tls_policy().ca_file.as_deref(),
         Some("/tmp/roots/upstream.pem")
     );
     assert_eq!(upstream.policy.host.0.mode, UpstreamHostPolicyMode::Rewrite);

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -19,9 +19,10 @@ mod quic_listener;
 pub use body::ChannelBody;
 pub(crate) use hash::REQUEST_ID_COUNTER;
 pub use hash::{stable_hash_socket_addr, stable_hash64};
-pub use metrics::{HealthFailureReason, Metrics, OverloadShedReason, RouteOutcome};
-pub use quic_listener::{
-    ListenerWorkerGroupConfig, ListenerWorkerRuntimeState, configure_async_runtime,
-    release_shard_queue_bytes, shard_index_for_peer, spawn_listener_worker_group,
-    try_reserve_shard_queue_bytes,
+pub use metrics::{Metrics, OverloadShedReason, RouteOutcome};
+pub use quic_listener::{ListenerWorkerRuntimeState, configure_async_runtime};
+pub use quic_listener::workers::{
+    ListenerWorkerGroupConfig, release_shard_queue_bytes, shard_index_for_peer,
+    spawn_listener_worker_group, try_reserve_shard_queue_bytes,
 };
+pub use spooky_lb::health::HealthFailureReason;

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -1,17 +1,27 @@
+//! Public API for the Spooky edge runtime.
+//!
+//! The crate root exposes the small set of entrypoints that other crates should
+//! depend on directly. Listener orchestration, runtime wiring, and control-plane
+//! mechanics stay behind internal subsystem modules.
+
 pub mod benchmark;
 pub mod body;
 pub mod cid_radix;
 pub mod constants;
 pub mod hash;
 pub mod metrics;
-pub mod quic_listener;
 pub mod resilience;
 pub mod routing;
 pub mod runtime;
 pub mod watchdog;
+mod quic_listener;
 
 pub use body::ChannelBody;
 pub(crate) use hash::REQUEST_ID_COUNTER;
 pub use hash::{stable_hash_socket_addr, stable_hash64};
 pub use metrics::{HealthFailureReason, Metrics, OverloadShedReason, RouteOutcome};
-pub use quic_listener::configure_async_runtime;
+pub use quic_listener::{
+    ListenerWorkerGroupConfig, ListenerWorkerRuntimeState, configure_async_runtime,
+    release_shard_queue_bytes, shard_index_for_peer, spawn_listener_worker_group,
+    try_reserve_shard_queue_bytes,
+};

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -10,11 +10,11 @@ pub mod cid_radix;
 pub mod constants;
 pub mod hash;
 pub mod metrics;
+mod quic_listener;
 pub mod resilience;
 pub mod routing;
 pub mod runtime;
 pub mod watchdog;
-mod quic_listener;
 
 pub use body::ChannelBody;
 pub(crate) use hash::REQUEST_ID_COUNTER;
@@ -22,7 +22,7 @@ pub use hash::{stable_hash_socket_addr, stable_hash64};
 pub use metrics::{Metrics, OverloadShedReason, RouteOutcome};
 pub use quic_listener::{
     ListenerWorkerGroupConfig, ListenerWorkerRuntimeState, configure_async_runtime,
-    release_shard_queue_bytes, shard_index_for_peer,
-    spawn_listener_worker_group, try_reserve_shard_queue_bytes,
+    release_shard_queue_bytes, shard_index_for_peer, spawn_listener_worker_group,
+    try_reserve_shard_queue_bytes,
 };
 pub use spooky_lb::health::HealthFailureReason;

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -20,9 +20,9 @@ pub use body::ChannelBody;
 pub(crate) use hash::REQUEST_ID_COUNTER;
 pub use hash::{stable_hash_socket_addr, stable_hash64};
 pub use metrics::{Metrics, OverloadShedReason, RouteOutcome};
-pub use quic_listener::{ListenerWorkerRuntimeState, configure_async_runtime};
-pub use quic_listener::workers::{
-    ListenerWorkerGroupConfig, release_shard_queue_bytes, shard_index_for_peer,
+pub use quic_listener::{
+    ListenerWorkerGroupConfig, ListenerWorkerRuntimeState, configure_async_runtime,
+    release_shard_queue_bytes, shard_index_for_peer,
     spawn_listener_worker_group, try_reserve_shard_queue_bytes,
 };
 pub use spooky_lb::health::HealthFailureReason;

--- a/crates/edge/src/metrics/mod.rs
+++ b/crates/edge/src/metrics/mod.rs
@@ -13,7 +13,7 @@ use spooky_errors::{
     HedgeOutcomeTelemetryReason, HedgeTriggerTelemetryReason, RetryAttemptTelemetryReason,
     RetryPolicyDenialReason,
 };
-pub use spooky_lb::health::HealthFailureReason;
+use spooky_lb::health::HealthFailureReason;
 
 pub struct Metrics {
     pub requests_total: AtomicU64,

--- a/crates/edge/src/quic_listener/bootstrap/request.rs
+++ b/crates/edge/src/quic_listener/bootstrap/request.rs
@@ -13,9 +13,8 @@ use log::warn;
 use spooky_bridge::{
     BridgeError,
     request::{
-        build_h1_request, build_h2_request_for_target,
         RequestBuildInput, RequestBuildPolicies, RequestBuildTarget, RequestForwardedContext,
-        RequestTraceContext,
+        RequestTraceContext, build_h1_request, build_h2_request_for_target,
     },
 };
 use spooky_config::{

--- a/crates/edge/src/quic_listener/bootstrap/request.rs
+++ b/crates/edge/src/quic_listener/bootstrap/request.rs
@@ -12,9 +12,8 @@ use hyper::body::Incoming;
 use log::warn;
 use spooky_bridge::{
     BridgeError,
-    h3_to_h1::build_h1_request,
-    h3_to_h2::build_h2_request_for_target,
     request::{
+        build_h1_request, build_h2_request_for_target,
         RequestBuildInput, RequestBuildPolicies, RequestBuildTarget, RequestForwardedContext,
         RequestTraceContext,
     },

--- a/crates/edge/src/quic_listener/forwarding/prepare.rs
+++ b/crates/edge/src/quic_listener/forwarding/prepare.rs
@@ -112,13 +112,13 @@ impl PendingForward {
     ) -> Result<Request<BoxBody<Bytes, Infallible>>, ProxyError> {
         let headers = self.request_headers();
         if endpoint.scheme() == BackendScheme::Http {
-            spooky_bridge::h3_to_h1::build_h1_request(
+            spooky_bridge::request::build_h1_request(
                 self.request_build_target(endpoint),
                 self.request_build_input(&self.method, &headers, body, content_length),
             )
             .map_err(ProxyError::from)
         } else {
-            spooky_bridge::h3_to_h2::build_h2_request_for_target(
+            spooky_bridge::request::build_h2_request_for_target(
                 self.request_build_target(endpoint),
                 self.request_build_input(&self.method, &headers, body, content_length),
             )
@@ -151,7 +151,7 @@ impl PendingForward {
             request_headers.push(quiche::h3::Header::new(b"connection", b"upgrade"));
         }
 
-        spooky_bridge::h3_to_h1::build_h1_request(
+        spooky_bridge::request::build_h1_request(
             self.request_build_target(endpoint),
             self.request_build_input(
                 "GET",

--- a/crates/edge/src/quic_listener/forwarding/resolve.rs
+++ b/crates/edge/src/quic_listener/forwarding/resolve.rs
@@ -374,8 +374,7 @@ impl QUICListener {
         }
         .ok_or_else(|| Self::no_healthy_servers_error(pool))?;
         let backend_addr = pool
-            .pool
-            .address(idx)
+            .backend_address(idx)
             .map(str::to_string)
             .ok_or_else(|| ProxyError::Transport("invalid server address".into()))?;
         Ok(SelectedBackend {
@@ -393,7 +392,7 @@ impl QUICListener {
         let mut pool = upstream_pool
             .write()
             .map_err(|_| ProxyError::Transport("upstream pool lock poisoned".into()))?;
-        if pool.pool.is_empty() {
+        if pool.is_empty() {
             return Err(Self::no_servers_in_upstream_error());
         }
         let plan = Self::build_backend_selection_plan(request, &pool);

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -119,7 +119,7 @@ mod startup;
 mod tls_runtime;
 mod token_bucket;
 mod validation;
-pub mod workers;
+mod workers;
 
 pub use async_runtime::configure_async_runtime;
 pub(in crate::quic_listener) use async_runtime::{
@@ -150,6 +150,10 @@ pub(crate) use token_bucket::TokenBucket;
 use validation::{
     RequestBufferError, extract_header_value, generated_span_id, generated_trace_id,
     parse_traceparent, validate_request_headers,
+};
+pub use workers::{
+    ListenerWorkerGroupConfig, release_shard_queue_bytes, shard_index_for_peer,
+    spawn_listener_worker_group, try_reserve_shard_queue_bytes,
 };
 use x509_parser::{extensions::GeneralName, parse_x509_certificate};
 

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -151,10 +151,6 @@ use validation::{
     RequestBufferError, extract_header_value, generated_span_id, generated_trace_id,
     parse_traceparent, validate_request_headers,
 };
-pub use workers::{
-    ListenerWorkerGroupConfig, release_shard_queue_bytes, shard_index_for_peer,
-    spawn_listener_worker_group, try_reserve_shard_queue_bytes,
-};
 use x509_parser::{extensions::GeneralName, parse_x509_certificate};
 
 struct ListenerRuntimeSettings {

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -1,3 +1,10 @@
+//! Internal listener subsystem façade.
+//!
+//! This module owns startup, worker orchestration, request ingress, and
+//! control-plane wiring for the QUIC and bootstrap listeners. The crate root
+//! re-exports the narrow worker/runtime entrypoints that external callers should
+//! depend on.
+
 use core::net::SocketAddr;
 use std::{
     collections::{HashMap, HashSet},
@@ -144,7 +151,10 @@ use validation::{
     RequestBufferError, extract_header_value, generated_span_id, generated_trace_id,
     parse_traceparent, validate_request_headers,
 };
-pub use workers::{ListenerWorkerGroupConfig, spawn_listener_worker_group};
+pub use workers::{
+    ListenerWorkerGroupConfig, release_shard_queue_bytes, shard_index_for_peer,
+    spawn_listener_worker_group, try_reserve_shard_queue_bytes,
+};
 use x509_parser::{extensions::GeneralName, parse_x509_certificate};
 
 struct ListenerRuntimeSettings {

--- a/crates/edge/src/quic_listener/startup.rs
+++ b/crates/edge/src/quic_listener/startup.rs
@@ -228,10 +228,10 @@ impl QUICListener {
                     "Configured upstream TLS policy backend={} upstream={} verify_certificates={} strict_sni={} ca_file={:?} ca_dir={:?} authority_kind={}",
                     backend.backend.address,
                     upstream_name,
-                    upstream.policy_set.transport.tls.verify_certificates,
-                    upstream.policy_set.transport.tls.strict_sni,
-                    upstream.policy_set.transport.tls.ca_file,
-                    upstream.policy_set.transport.tls.ca_dir,
+                    upstream.backend_tls_policy().verify_certificates,
+                    upstream.backend_tls_policy().strict_sni,
+                    upstream.backend_tls_policy().ca_file,
+                    upstream.backend_tls_policy().ca_dir,
                     authority_kind
                 );
                 backend_endpoints.insert(backend.backend.address.clone(), endpoint);

--- a/crates/edge/src/quic_listener/tests.rs
+++ b/crates/edge/src/quic_listener/tests.rs
@@ -854,9 +854,9 @@ fn resolve_backend_skips_unhealthy_backends() {
         test_routing_context("round-robin");
     {
         let mut guard = pool.write().expect("pool write");
-        guard.pool.mark_failure(0);
-        guard.pool.mark_failure(0);
-        guard.pool.mark_failure(0);
+        guard.mark_backend_failure_from_active_check(0);
+        guard.mark_backend_failure_from_active_check(0);
+        guard.mark_backend_failure_from_active_check(0);
     }
 
     let request =
@@ -881,8 +881,8 @@ fn resolve_backend_respects_least_connections_strategy() {
         test_routing_context("least-connections");
     {
         let guard = pool.read().expect("pool read");
-        guard.pool.begin_request(0);
-        guard.pool.begin_request(0);
+        guard.begin_request_for_accounting(0);
+        guard.begin_request_for_accounting(0);
     }
 
     let request =

--- a/crates/edge/src/quic_listener/workers.rs
+++ b/crates/edge/src/quic_listener/workers.rs
@@ -14,7 +14,7 @@ use spooky_config::runtime::ListenerRuntimeConfig;
 
 use crate::{
     constants::MAX_DATAGRAM_SIZE_BYTES,
-    quic_listener::{ListenerWorkerRuntimeState, runtime_state::initialize_listener_from_runtime},
+    quic_listener::runtime_state::{ListenerWorkerRuntimeState, initialize_listener_from_runtime},
     runtime::{
         bundle::RuntimeBundleHandle, listener::QUICListener, shared_state::SharedRuntimeState,
     },

--- a/crates/edge/src/runtime/backend/lifecycle.rs
+++ b/crates/edge/src/runtime/backend/lifecycle.rs
@@ -367,7 +367,7 @@ pub(crate) fn apply_backend_dns_refresh(
                 };
             };
 
-            let _ = backend_dns_resolver.replace_host_addrs(
+            backend_dns_resolver.set_host_addrs(
                 &backend.resolution.authority_host,
                 resolved
                     .into_iter()

--- a/crates/edge/src/runtime/backend/lifecycle.rs
+++ b/crates/edge/src/runtime/backend/lifecycle.rs
@@ -173,7 +173,7 @@ impl BackendLifecycleCoordinator {
                 let Some(backend_addr) = guard.backend_address(backend_index) else {
                     continue;
                 };
-                let Some(backend) = guard.pool.backend(backend_index) else {
+                let Some(backend) = guard.backend_runtime_state(backend_index) else {
                     continue;
                 };
                 let entry = snapshots
@@ -195,9 +195,9 @@ impl BackendLifecycleCoordinator {
                 entry.placements.push(BackendPoolPlacementSnapshot {
                     upstream_name: upstream_name.clone(),
                     backend_index,
-                    healthy: guard.pool.is_healthy_index(backend_index),
-                    active_requests: backend.active_requests(),
-                    ewma_latency_ms: backend.ewma_latency_ms(),
+                    healthy: backend.healthy,
+                    active_requests: backend.active_requests,
+                    ewma_latency_ms: backend.ewma_latency_ms,
                     membership_epoch: membership_summary.membership_epoch,
                 });
             }
@@ -851,8 +851,9 @@ mod tests {
         );
 
         let guard = pool.read().expect("read");
-        assert_eq!(guard.pool.backends[0].active_requests(), 0);
-        assert!(guard.pool.backends[0].ewma_latency_ms().is_some());
+        let state = guard.backend_runtime_state(0).expect("backend state");
+        assert_eq!(state.active_requests, 0);
+        assert!(state.ewma_latency_ms.is_some());
     }
 
     #[test]

--- a/crates/edge/src/runtime/backend/mod.rs
+++ b/crates/edge/src/runtime/backend/mod.rs
@@ -1,6 +1,12 @@
+//! Backend lifecycle state exposed to the rest of the edge runtime.
+//!
+//! External consumers should rely on the stable resolution, snapshot, and
+//! inventory types. Lifecycle mutation coordinators and refresh update helpers
+//! remain internal implementation details.
+
 pub mod event;
-pub mod lifecycle;
+pub(crate) mod lifecycle;
 pub mod resolution;
 pub mod state;
 pub mod store;
-pub mod update;
+pub(crate) mod update;

--- a/crates/edge/src/runtime/connection/outcome.rs
+++ b/crates/edge/src/runtime/connection/outcome.rs
@@ -566,7 +566,7 @@ mod tests {
                     weight: 1,
                     health_check: Some(HealthCheck {
                         path: "/health".to_string(),
-                        interval: 1,
+                        interval: 0,
                         timeout_ms: 1000,
                         failure_threshold: 1,
                         success_threshold: 1,
@@ -598,19 +598,10 @@ mod tests {
         })
         .expect("runtime config");
 
-        let mut pool =
+        Arc::new(RwLock::new(
             UpstreamPool::from_runtime_upstream(runtime.upstreams.get("api").expect("upstream"))
-                .expect("pool");
-        pool.pool.backends[0].health_check = Some(HealthCheck {
-            path: "/health".to_string(),
-            interval: 0,
-            timeout_ms: 1000,
-            failure_threshold: 1,
-            success_threshold: 1,
-            cooldown_ms: 0,
-        });
-
-        Arc::new(RwLock::new(pool))
+                .expect("pool"),
+        ))
     }
 
     fn upstream_request_count(
@@ -858,8 +849,9 @@ mod tests {
         });
         {
             let guard = pool.read().expect("read");
-            assert_eq!(guard.pool.backends[0].active_requests(), 0);
-            assert!(guard.pool.backends[0].ewma_latency_ms().is_some());
+            let state = guard.backend_runtime_state(0).expect("backend state");
+            assert_eq!(state.active_requests, 0);
+            assert!(state.ewma_latency_ms.is_some());
         }
 
         let unhealthy = observe_backend_response_status(BackendHealthObservationInput {

--- a/crates/edge/src/runtime/connection/outcome.rs
+++ b/crates/edge/src/runtime/connection/outcome.rs
@@ -598,11 +598,7 @@ mod tests {
         })
         .expect("runtime config");
 
-        let mut runtime_upstream = runtime
-            .upstreams
-            .get("api")
-            .expect("upstream")
-            .clone();
+        let mut runtime_upstream = runtime.upstreams.get("api").expect("upstream").clone();
         runtime_upstream.backends[0].backend.health_check = Some(HealthCheck {
             path: "/health".to_string(),
             interval: 0,

--- a/crates/edge/src/runtime/connection/outcome.rs
+++ b/crates/edge/src/runtime/connection/outcome.rs
@@ -566,7 +566,7 @@ mod tests {
                     weight: 1,
                     health_check: Some(HealthCheck {
                         path: "/health".to_string(),
-                        interval: 0,
+                        interval: 1,
                         timeout_ms: 1000,
                         failure_threshold: 1,
                         success_threshold: 1,
@@ -598,9 +598,22 @@ mod tests {
         })
         .expect("runtime config");
 
+        let mut runtime_upstream = runtime
+            .upstreams
+            .get("api")
+            .expect("upstream")
+            .clone();
+        runtime_upstream.backends[0].backend.health_check = Some(HealthCheck {
+            path: "/health".to_string(),
+            interval: 0,
+            timeout_ms: 1000,
+            failure_threshold: 1,
+            success_threshold: 1,
+            cooldown_ms: 0,
+        });
+
         Arc::new(RwLock::new(
-            UpstreamPool::from_runtime_upstream(runtime.upstreams.get("api").expect("upstream"))
-                .expect("pool"),
+            UpstreamPool::from_runtime_upstream(&runtime_upstream).expect("pool"),
         ))
     }
 

--- a/crates/edge/src/runtime/mod.rs
+++ b/crates/edge/src/runtime/mod.rs
@@ -1,9 +1,15 @@
+//! Runtime ownership and state model for the edge data plane.
+//!
+//! External callers should treat this module as the source of stable runtime
+//! state types. Connection plumbing, generation swaps, and TLS/task internals
+//! remain crate-private implementation details.
+
 pub mod backend;
 pub mod bundle;
-pub mod connection;
-pub mod generation;
+pub(crate) mod connection;
+pub(crate) mod generation;
 pub mod health;
 pub mod listener;
 pub mod shared_state;
-pub mod tasks;
-pub mod tls;
+pub(crate) mod tasks;
+pub(crate) mod tls;

--- a/crates/edge/src/watchdog/mod.rs
+++ b/crates/edge/src/watchdog/mod.rs
@@ -1,5 +1,11 @@
-pub mod config;
+//! Watchdog coordination for the edge runtime.
+//!
+//! The public surface is intentionally small: external callers interact with
+//! the coordinator, while service execution, timing helpers, and config
+//! translation stay internal to the crate.
+
+pub(crate) mod config;
 pub mod coordinator;
-pub mod service;
-pub mod state;
-pub mod time;
+pub(crate) mod service;
+pub(crate) mod state;
+pub(crate) mod time;

--- a/crates/errors/src/lib.rs
+++ b/crates/errors/src/lib.rs
@@ -1,8 +1,14 @@
-pub mod bridge;
-pub mod pool;
-pub mod proxy;
-pub mod retry;
-pub mod upstream;
+//! Shared error and error-policy contract for Spooky runtime crates.
+//!
+//! Consumers should depend on the re-exported error types and classifier
+//! entrypoints from this crate root instead of reaching into module internals.
+//! Backend-selection policy types remain owned by `spooky-lb`.
+
+mod bridge;
+mod pool;
+mod proxy;
+mod retry;
+mod upstream;
 
 pub use bridge::BridgeError;
 pub use pool::PoolError;
@@ -16,10 +22,6 @@ pub use retry::{
     RetryPolicyDecision, RetryPolicyDenialReason, RetryPolicyFacts, UpstreamRetryReason,
     UpstreamRetryability, UpstreamTerminalErrorKind, classify_retryability, evaluate_hedge_policy,
     evaluate_retry_policy, is_idempotent_method, is_retryable,
-};
-pub use spooky_lb::alternate_backend::{
-    AlternateBackendChoice, AlternateBackendDecision, AlternateBackendFailureReason,
-    AlternateBackendSelectionMode,
 };
 pub use upstream::{
     UpstreamErrorCategory, UpstreamErrorClassification, UpstreamHealthFailureMapping,

--- a/crates/errors/src/proxy.rs
+++ b/crates/errors/src/proxy.rs
@@ -1,3 +1,5 @@
+//! Canonical proxy and upstream error classification surface.
+
 use thiserror::Error;
 
 use crate::{

--- a/crates/errors/src/upstream.rs
+++ b/crates/errors/src/upstream.rs
@@ -1,3 +1,5 @@
+//! Shared upstream error-detail classification and health-mapping contract.
+
 use std::error::Error as StdError;
 
 use spooky_lb::health::HealthFailureReason;
@@ -142,7 +144,7 @@ impl UpstreamErrorClassification {
         }
     }
 
-    pub fn health_failure_mapping(self) -> UpstreamHealthFailureMapping {
+    pub(crate) fn health_failure_mapping(self) -> UpstreamHealthFailureMapping {
         match self.category {
             UpstreamErrorCategory::Timeout => UpstreamHealthFailureMapping {
                 failure_reason: HealthFailureReason::Timeout,

--- a/crates/errors/tests/proxy.rs
+++ b/crates/errors/tests/proxy.rs
@@ -1,10 +1,10 @@
 use spooky_errors::{
-    AlternateBackendFailureReason, PoolError, ProxyError, RetryPolicyDecision,
-    RetryPolicyDenialReason, RetryPolicyFacts, UpstreamErrorClassification,
-    UpstreamHealthFailureMapping, UpstreamProxyErrorKind, UpstreamRetryReason,
-    UpstreamRetryability, UpstreamTerminalErrorKind, UpstreamTlsReason, classify_retryability,
-    classify_upstream_proxy_error, evaluate_retry_policy, is_retryable,
+    PoolError, ProxyError, RetryPolicyDecision, RetryPolicyDenialReason, RetryPolicyFacts,
+    UpstreamErrorClassification, UpstreamHealthFailureMapping, UpstreamProxyErrorKind,
+    UpstreamRetryReason, UpstreamRetryability, UpstreamTerminalErrorKind, UpstreamTlsReason,
+    classify_retryability, classify_upstream_proxy_error, evaluate_retry_policy, is_retryable,
 };
+use spooky_lb::alternate_backend::AlternateBackendFailureReason;
 
 #[test]
 fn pool_and_transport_errors_have_distinct_display_text() {

--- a/crates/lb/src/alternate_backend.rs
+++ b/crates/lb/src/alternate_backend.rs
@@ -1,3 +1,9 @@
+//! Alternate-backend selection façade.
+//!
+//! This module owns retry/hedge follow-up backend choice on top of
+//! [`UpstreamPool`]. It consumes pool-level read APIs and does not mutate pool
+//! internals directly.
+
 use crate::upstream_pool::UpstreamPool;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -84,8 +90,6 @@ mod tests {
     };
 
     use super::*;
-    use crate::health::HealthFailureReason;
-
     fn upstream(lb_type: &str, backends: &[&str]) -> Upstream {
         Upstream {
             tls: None,
@@ -227,12 +231,8 @@ mod tests {
         )))
         .expect("pool");
 
-        let _ = pool
-            .pool
-            .mark_failure_with_reason(0, HealthFailureReason::Transport);
-        let _ = pool
-            .pool
-            .mark_failure_with_reason(1, HealthFailureReason::Transport);
+        let _ = pool.mark_backend_failure_from_active_check(0);
+        let _ = pool.mark_backend_failure_from_active_check(1);
 
         let decision = choose_alternate_backend(&pool, &[], None);
         assert_eq!(

--- a/crates/lb/src/lib.rs
+++ b/crates/lb/src/lib.rs
@@ -1,8 +1,18 @@
+//! Load-balancing primitives for runtime-selected backend picking.
+//!
+//! Canonical consumers should depend on [`upstream_pool`], [`load_balancing`],
+//! [`alternate_backend`], and [`health`]. The remaining modules are kept
+//! visible only as compatibility/testing substrate and are not intended as
+//! orchestration entrypoints.
+
+#[doc(hidden)]
 pub mod algorithms;
 pub mod alternate_backend;
+#[doc(hidden)]
 pub mod backend;
+#[doc(hidden)]
 pub mod backend_pool;
-pub mod hash;
+pub(crate) mod hash;
 pub mod health;
 pub mod load_balancing;
 pub mod upstream_pool;

--- a/crates/lb/src/load_balancing.rs
+++ b/crates/lb/src/load_balancing.rs
@@ -1,3 +1,9 @@
+//! Canonical load-balancing strategy façade.
+//!
+//! Strategy-specific implementations stay internal; callers should choose and
+//! query strategies through [`LoadBalancing`] instead of depending on
+//! algorithm-specific state.
+
 use crate::{
     algorithms::{
         consistent_hash::ConsistentHash, latency_aware::LatencyAware,

--- a/crates/lb/src/upstream_pool.rs
+++ b/crates/lb/src/upstream_pool.rs
@@ -1,3 +1,9 @@
+//! Canonical upstream pool façade.
+//!
+//! [`UpstreamPool`] owns balancing primitives plus the narrow lifecycle-facing
+//! mutation surface that edge/runtime code is allowed to use. Strategy state is
+//! encapsulated here; callers should not reach into [`BackendPool`] directly.
+
 use std::time::Duration;
 
 use spooky_config::runtime::{
@@ -19,9 +25,16 @@ pub struct UpstreamPoolMembershipSummary {
     pub membership_epoch: u64,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct UpstreamBackendRuntimeState {
+    pub healthy: bool,
+    pub active_requests: usize,
+    pub ewma_latency_ms: Option<f64>,
+}
+
 pub struct UpstreamPool {
-    pub pool: BackendPool,
-    pub load_balancer: LoadBalancing,
+    pool: BackendPool,
+    load_balancer: LoadBalancing,
     lb_policy: RuntimeLoadBalancingPolicy,
 }
 
@@ -95,8 +108,33 @@ impl UpstreamPool {
         self.pool.address(index)
     }
 
+    pub fn backend_count(&self) -> usize {
+        self.pool.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.pool.is_empty()
+    }
+
     pub fn backend_indices(&self) -> Vec<usize> {
         self.pool.all_indices()
+    }
+
+    pub fn is_backend_healthy(&self, index: usize) -> bool {
+        self.pool.is_healthy_index(index)
+    }
+
+    pub fn begin_request_for_accounting(&self, index: usize) {
+        self.pool.begin_request(index);
+    }
+
+    pub fn backend_runtime_state(&self, index: usize) -> Option<UpstreamBackendRuntimeState> {
+        let backend = self.pool.backend(index)?;
+        Some(UpstreamBackendRuntimeState {
+            healthy: self.pool.is_healthy_index(index),
+            active_requests: backend.active_requests(),
+            ewma_latency_ms: backend.ewma_latency_ms(),
+        })
     }
 
     pub fn healthy_backend_indices_iter(&self) -> impl Iterator<Item = usize> + '_ {
@@ -117,6 +155,10 @@ impl UpstreamPool {
 
     pub fn lb_strategy(&self) -> RuntimeLoadBalancingStrategy {
         self.lb_policy.strategy
+    }
+
+    pub fn load_balancer_name(&self) -> &'static str {
+        self.load_balancer.name()
     }
 
     pub fn lb_key_spec(&self) -> Option<&RuntimeRequestKeySpec> {

--- a/crates/lb/tests/upstream_pool.rs
+++ b/crates/lb/tests/upstream_pool.rs
@@ -4,7 +4,7 @@ use spooky_config::{
     config::{Backend, Config, HealthCheck, Listen, RouteMatch, Tls},
     runtime::RuntimeConfig,
 };
-use spooky_lb::{load_balancing::LoadBalancing, upstream_pool::UpstreamPool};
+use spooky_lb::upstream_pool::UpstreamPool;
 
 #[test]
 fn upstream_pool_from_config() {
@@ -78,11 +78,8 @@ fn upstream_pool_from_config() {
 
     let upstream_pool =
         UpstreamPool::from_runtime_upstream(runtime.upstreams.get("api").unwrap()).unwrap();
-    assert!(matches!(
-        upstream_pool.load_balancer,
-        LoadBalancing::RoundRobin(_)
-    ));
-    assert_eq!(upstream_pool.pool.len(), 2);
-    assert_eq!(upstream_pool.pool.address(0), Some("127.0.0.1:8001"));
-    assert_eq!(upstream_pool.pool.address(1), Some("127.0.0.1:8002"));
+    assert_eq!(upstream_pool.load_balancer_name(), "round-robin");
+    assert_eq!(upstream_pool.backend_count(), 2);
+    assert_eq!(upstream_pool.backend_address(0), Some("127.0.0.1:8001"));
+    assert_eq!(upstream_pool.backend_address(1), Some("127.0.0.1:8002"));
 }

--- a/crates/transport/src/client_rotation.rs
+++ b/crates/transport/src/client_rotation.rs
@@ -1,5 +1,5 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BackendClientRotationState {
+pub(crate) enum BackendClientRotationState {
     MissingBackend,
     Recreated,
     Rotated {
@@ -9,24 +9,24 @@ pub enum BackendClientRotationState {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct BackendClientRotation {
+pub(crate) struct BackendClientRotation {
     state: BackendClientRotationState,
 }
 
 impl BackendClientRotation {
-    pub fn missing_backend() -> Self {
+    pub(crate) fn missing_backend() -> Self {
         Self {
             state: BackendClientRotationState::MissingBackend,
         }
     }
 
-    pub fn recreated() -> Self {
+    pub(crate) fn recreated() -> Self {
         Self {
             state: BackendClientRotationState::Recreated,
         }
     }
 
-    pub fn rotated(previous_generation: u64, current_generation: u64) -> Self {
+    pub(crate) fn rotated(previous_generation: u64, current_generation: u64) -> Self {
         Self {
             state: BackendClientRotationState::Rotated {
                 previous_generation,
@@ -35,11 +35,11 @@ impl BackendClientRotation {
         }
     }
 
-    pub fn changed(self) -> bool {
+    pub(crate) fn changed(self) -> bool {
         !matches!(self.state, BackendClientRotationState::MissingBackend)
     }
 
-    pub fn generations(self) -> Option<(u64, u64)> {
+    pub(crate) fn generations(self) -> Option<(u64, u64)> {
         match self.state {
             BackendClientRotationState::Rotated {
                 previous_generation,

--- a/crates/transport/src/h1_pool.rs
+++ b/crates/transport/src/h1_pool.rs
@@ -10,7 +10,7 @@ use hyper::{
     Request,
     body::{Bytes, Incoming},
 };
-pub use spooky_errors::PoolError;
+use spooky_errors::PoolError;
 use tokio::sync::{Semaphore, TryAcquireError};
 
 use crate::{

--- a/crates/transport/src/h2_client.rs
+++ b/crates/transport/src/h2_client.rs
@@ -35,6 +35,7 @@ use rustls_pki_types::pem::PemObject;
 use spooky_config::runtime::RuntimeBackendTlsPolicy;
 use tower_service::Service;
 
+/// TLS client policy applied to HTTP/2 backend connections.
 #[derive(Debug, Clone)]
 pub struct TlsClientConfig {
     pub verify_certificates: bool,
@@ -73,6 +74,8 @@ pub(crate) const DEFAULT_MAX_IDLE_PER_HOST: usize = 64;
 pub(crate) const DEFAULT_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
 pub(crate) const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Transport-level observation emitted when a backend connect resolves to a
+/// concrete socket address.
 #[derive(Debug, Clone)]
 pub struct ConnectObservation {
     pub backend: String,
@@ -80,25 +83,29 @@ pub struct ConnectObservation {
     pub resolved_addr: SocketAddr,
 }
 
+/// Optional hook used by transport to observe outbound backend connects.
 pub type ConnectObserver = Arc<dyn Fn(ConnectObservation) + Send + Sync>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DnsCacheUpdate {
+pub(crate) struct DnsCacheUpdate {
     pub host: String,
     pub previous_addrs: Vec<SocketAddr>,
     pub current_addrs: Vec<SocketAddr>,
 }
 
 impl DnsCacheUpdate {
-    pub fn changed(&self) -> bool {
+    #[cfg(test)]
+    pub(crate) fn changed(&self) -> bool {
         self.previous_addrs != self.current_addrs
     }
 
-    pub fn cleared(&self) -> bool {
+    #[cfg(test)]
+    pub(crate) fn cleared(&self) -> bool {
         self.current_addrs.is_empty()
     }
 }
 
+/// Shared DNS cache and resolver used by backend transports.
 #[derive(Clone)]
 pub struct SharedDnsResolver {
     cache: Arc<RwLock<HashMap<String, Vec<SocketAddr>>>>,
@@ -180,7 +187,7 @@ impl SharedDnsResolver {
         let _ = self.replace_host_addrs(host, addrs);
     }
 
-    pub fn replace_host_addrs<I>(&self, host: &str, addrs: I) -> DnsCacheUpdate
+    pub(crate) fn replace_host_addrs<I>(&self, host: &str, addrs: I) -> DnsCacheUpdate
     where
         I: IntoIterator<Item = SocketAddr>,
     {
@@ -205,7 +212,8 @@ impl SharedDnsResolver {
         }
     }
 
-    pub fn remove_host(&self, host: &str) -> DnsCacheUpdate {
+    #[cfg(test)]
+    pub(crate) fn remove_host(&self, host: &str) -> DnsCacheUpdate {
         self.replace_host_addrs(host, Vec::<SocketAddr>::new())
     }
 

--- a/crates/transport/src/h2_pool.rs
+++ b/crates/transport/src/h2_pool.rs
@@ -10,7 +10,7 @@ use hyper::{
     Request,
     body::{Bytes, Incoming},
 };
-pub use spooky_errors::PoolError;
+use spooky_errors::PoolError;
 use tokio::sync::{Semaphore, TryAcquireError};
 
 use crate::{

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -1,3 +1,10 @@
+//! Canonical upstream transport façade.
+//!
+//! Callers should depend on this crate for backend request execution, backend
+//! client rotation, DNS cache coordination, and transport-scoped connection
+//! policy application. Protocol-specific H1/H2 client and pool implementations
+//! remain internal details behind [`UpstreamTransportPool`].
+
 mod client_rotation;
 mod h1_client;
 mod h1_pool;

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -12,7 +12,5 @@ mod h2_client;
 mod h2_pool;
 mod transport_pool;
 
-pub use transport_pool::{
-    ConnectObservation, ConnectObserver, SharedDnsResolver, TlsClientConfig,
-    TransportClientRotation, UpstreamTransportPool,
-};
+pub use h2_client::{ConnectObservation, ConnectObserver, SharedDnsResolver, TlsClientConfig};
+pub use transport_pool::{TransportClientRotation, UpstreamTransportPool};

--- a/crates/transport/src/transport_pool.rs
+++ b/crates/transport/src/transport_pool.rs
@@ -17,10 +17,12 @@ use spooky_config::runtime::{
 };
 use spooky_errors::{PoolError, ProxyError};
 
-pub use crate::h2_client::{
-    ConnectObservation, ConnectObserver, SharedDnsResolver, TlsClientConfig,
+use crate::{
+    client_rotation::BackendClientRotation,
+    h1_pool::H1Pool,
+    h2_client::{ConnectObserver, SharedDnsResolver, TlsClientConfig},
+    h2_pool::H2Pool,
 };
-use crate::{client_rotation::BackendClientRotation, h1_pool::H1Pool, h2_pool::H2Pool};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum BackendTransportEntry {

--- a/crates/transport/src/transport_pool.rs
+++ b/crates/transport/src/transport_pool.rs
@@ -172,8 +172,10 @@ impl UpstreamTransportPool {
                     backend.endpoint.transport_kind,
                     RuntimeBackendTransportKind::H2
                 ) {
-                    backend_tls
-                        .insert(backend_addr, TlsClientConfig::from(upstream.backend_tls_policy()));
+                    backend_tls.insert(
+                        backend_addr,
+                        TlsClientConfig::from(upstream.backend_tls_policy()),
+                    );
                 }
             }
         }

--- a/crates/transport/src/transport_pool.rs
+++ b/crates/transport/src/transport_pool.rs
@@ -1,3 +1,10 @@
+//! Canonical transport execution façade.
+//!
+//! This module owns runtime-selected backend protocol dispatch, transport-level
+//! timeout application, connection reuse, and backend client rotation. Callers
+//! should hand it a backend identity plus a canonical request and avoid
+//! reconstructing H1/H2 selection logic themselves.
+
 use std::{collections::HashMap, convert::Infallible, time::Duration};
 
 use http_body_util::combinators::BoxBody;
@@ -27,15 +34,18 @@ pub struct TransportClientRotation {
 }
 
 impl TransportClientRotation {
+    /// Returns true when transport rotated or recreated the backend client.
     pub fn rotated(self) -> bool {
         self.rotation.changed()
     }
 
+    /// Returns generation movement for protocols that track reusable client generations.
     pub fn generations(self) -> Option<(u64, u64)> {
         self.rotation.generations()
     }
 }
 
+/// Canonical transport façade used by edge/runtime code for backend execution.
 pub struct UpstreamTransportPool {
     backend_entries: HashMap<String, BackendTransportEntry>,
     h1_pool: H1Pool,
@@ -44,6 +54,7 @@ pub struct UpstreamTransportPool {
 }
 
 impl UpstreamTransportPool {
+    /// Execute a canonical upstream request against the resolved backend target.
     pub async fn send_backend_request(
         &self,
         backend: &str,
@@ -52,6 +63,7 @@ impl UpstreamTransportPool {
         self.execute(backend, req).await
     }
 
+    /// Build a transport pool from already-interpreted backend transport entries.
     pub fn new_from_runtime_backends<I>(
         backends: I,
         backend_tls: HashMap<String, TlsClientConfig>,
@@ -137,6 +149,7 @@ impl UpstreamTransportPool {
         }
     }
 
+    /// Build the canonical transport façade directly from runtime upstream definitions.
     pub fn from_runtime_upstreams<'a, I>(
         upstreams: I,
         connection_policy: &RuntimeBackendConnectionPolicy,

--- a/crates/transport/src/transport_pool.rs
+++ b/crates/transport/src/transport_pool.rs
@@ -157,10 +157,8 @@ impl UpstreamTransportPool {
                     backend.endpoint.transport_kind,
                     RuntimeBackendTransportKind::H2
                 ) {
-                    backend_tls.insert(
-                        backend_addr,
-                        TlsClientConfig::from(&upstream.policy_set.transport.tls),
-                    );
+                    backend_tls
+                        .insert(backend_addr, TlsClientConfig::from(upstream.backend_tls_policy()));
                 }
             }
         }

--- a/crates/transport/tests/abstraction.rs
+++ b/crates/transport/tests/abstraction.rs
@@ -474,7 +474,7 @@ fn dns_refresh_rotation_works_through_unified_surface() {
         resolver.clone(),
     );
 
-    resolver.replace_host_addrs(
+    resolver.set_host_addrs(
         "api.example.com",
         [std::net::SocketAddr::from(([127, 0, 0, 10], 443))],
     );
@@ -484,7 +484,7 @@ fn dns_refresh_rotation_works_through_unified_surface() {
     assert!(first_rotation.rotated());
     assert_eq!(first_rotation.generations(), Some((0, 1)));
 
-    resolver.replace_host_addrs(
+    resolver.set_host_addrs(
         "api.example.com",
         [std::net::SocketAddr::from(([127, 0, 0, 11], 443))],
     );

--- a/docs/public-api-surface-inventory.md
+++ b/docs/public-api-surface-inventory.md
@@ -1,203 +1,165 @@
 # Public API Surface Inventory
 
-Phase 2 inventory for `refactor/public-api-and-visibility-hardening`.
+Current Phase 2 surface for `refactor/public-api-and-visibility-hardening`.
 
 Scope:
 - crate `lib.rs` façades
-- top-level `mod.rs` files that currently fan out public surface area
-- current re-exports and compatibility paths that look broader than the canonical entrypoints
+- intentionally public subsystem entrypoints
+- remaining hidden or compatibility-oriented surfaces that are still exposed on purpose
 
-This document is a baseline audit. It does not change visibility yet.
+This document reflects the current branch state after the visibility-hardening work, not the original baseline audit.
 
 ## `spooky-edge`
 
-### Primary façades
+### Crate façade
 - `crates/edge/src/lib.rs`
-- `crates/edge/src/quic_listener/mod.rs`
-- `crates/edge/src/runtime/mod.rs`
-- `crates/edge/src/routing/mod.rs`
-- `crates/edge/src/resilience/mod.rs`
-- `crates/edge/src/watchdog/mod.rs`
 
-### Current public surface
-- `pub mod benchmark`
-- `pub mod body`
-- `pub mod cid_radix`
-- `pub mod constants`
-- `pub mod hash`
-- `pub mod metrics`
-- `pub mod quic_listener`
-- `pub mod resilience`
-- `pub mod routing`
-- `pub mod runtime`
-- `pub mod watchdog`
-- `pub use body::ChannelBody`
-- `pub use hash::{stable_hash_socket_addr, stable_hash64}`
-- `pub use metrics::{HealthFailureReason, Metrics, OverloadShedReason, RouteOutcome}`
-- `pub use quic_listener::configure_async_runtime`
-- `quic_listener/mod.rs` also publicly exposes:
-  - `pub mod workers`
-  - `pub use runtime_state::ListenerWorkerRuntimeState`
-  - `pub use workers::{ListenerWorkerGroupConfig, spawn_listener_worker_group}`
+### Public surface
+- modules:
+  - `benchmark`
+  - `body`
+  - `cid_radix`
+  - `constants`
+  - `hash`
+  - `metrics`
+  - `resilience`
+  - `routing`
+  - `runtime`
+  - `watchdog`
+- re-exports:
+  - `ChannelBody`
+  - `stable_hash_socket_addr`
+  - `stable_hash64`
+  - `Metrics`
+  - `OverloadShedReason`
+  - `RouteOutcome`
+  - `HealthFailureReason`
+  - `configure_async_runtime`
+  - `ListenerWorkerRuntimeState`
+  - `ListenerWorkerGroupConfig`
+  - `spawn_listener_worker_group`
+  - `release_shard_queue_bytes`
+  - `shard_index_for_peer`
+  - `try_reserve_shard_queue_bytes`
 
-### Likely canonical entrypoints
-- `configure_async_runtime`
-- listener worker startup types/functions if they are intentionally crate-external
-- `Metrics`
-- top-level stable hashing helpers if consumed outside `edge`
-- `ChannelBody`
+### Internal façades intentionally kept private
+- `quic_listener`
+- runtime connection/task/tls internals
+- bootstrap/control-plane/request-path decomposition modules under `quic_listener`
 
-### Likely leakage / visibility review targets
-- crate-wide public exposure of `runtime`, `routing`, `resilience`, and `watchdog`
-- public `benchmark` module
-- public `constants` and `cid_radix`
-- public `ListenerWorkerRuntimeState`
-- `quic_listener` as a large mixed façade instead of a narrow service entrypoint
-- top-level `routing` and `resilience` submodules are all `pub mod`, which currently exposes internal policy/mechanics as crate API
-- top-level `watchdog` submodules are all `pub mod`, including service/state/time internals
+### Phase 2 hardening result
+- `quic_listener` is no longer crate-public
+- `quic_listener::workers` is no longer a public module
+- worker/runtime entrypoints are exposed only through the crate root and listener façade re-exports
+- `HealthFailureReason` is re-exported from its owning crate path, not through `metrics`
+
+### Remaining intentional exposure
+- `runtime`, `routing`, `resilience`, and `watchdog` remain public because cross-crate tests and consumers still use stable types from those subsystems
+- `benchmark` remains public as an explicitly exposed support surface
 
 ## `spooky-config`
 
-### Primary façades
+### Crate façade
 - `crates/config/src/lib.rs`
-- `crates/config/src/runtime/policies/mod.rs`
 
-### Current public surface
-- `pub mod backend_endpoint`
-- `pub mod config`
-- `pub mod default`
-- `pub mod loader`
-- `pub mod runtime`
-- `pub mod validator`
-- `runtime/policies/mod.rs` publicly re-exports canonical runtime policy/output types:
-  - admission policies
-  - auth policies
-  - backend policies
-  - load-balancing policies
-  - resilience policies
-  - timeout policies
-  - transport policies
-  - watchdog policies
-- `runtime/policies/mod.rs` also defines and exports:
-  - `RuntimeRouteHostPattern`
-  - `RuntimeRouteMatchPolicy`
-  - `RuntimeBackendTransportKind`
-  - `RuntimeUpstreamTransportPolicy`
-  - `RuntimePolicySet`
-  - `RuntimeListenerPolicySet`
-  - `RuntimeUpstreamPolicySet`
+### Public surface
+- modules:
+  - `backend_endpoint`
+  - `config`
+  - `default`
+  - `loader`
+  - `runtime`
+  - `validator`
 
-### Likely canonical entrypoints
-- raw config types under `config`
-- loader entrypoints
-- validated runtime config/output types under `runtime`
-- backend endpoint shape if used cross-crate
+### Canonical consumer paths
+- raw config shapes from `config`
+- runtime-ready policy/config output from `runtime`
+- backend endpoint parsing/runtime shaping from `backend_endpoint`
 
-### Likely leakage / visibility review targets
-- `default` and `validator` as top-level public modules may be broader than needed
-- some `runtime/policies/mod.rs` structs may be intermediate interpreter outputs rather than stable consumer-facing API
-- route-match normalization types may belong under `runtime` but not necessarily as crate-public guarantees
+### Internal façades intentionally kept private
+- `runtime::listeners`
+- `runtime::policies` domain modules
+- `runtime::upstreams`
+
+### Phase 2 hardening result
+- runtime policy interpretation is centralized under `runtime`
+- domain interpreter modules are no longer exposed as their own public surface
+- crate-level ownership docs now direct consumers to `runtime` rather than policy internals
 
 ## `spooky-bridge`
 
-### Primary façade
+### Crate façade
 - `crates/bridge/src/lib.rs`
 
-### Current public surface
-- `pub mod h3_to_h1`
-- `pub mod h3_to_h2`
-- `pub mod request`
-- `pub mod response`
-- `pub mod websocket`
-- `pub use spooky_errors::BridgeError`
+### Public surface
+- modules:
+  - `request`
+  - `response`
+  - `websocket`
+- re-exports:
+  - `BridgeError`
 
-### Likely canonical entrypoints
-- `request`
-- `response`
-- `websocket`
-- `BridgeError`
+### Internal façades intentionally kept private
+- `h3_to_h1`
+- `h3_to_h2`
+- forwarded/header/host helper modules
 
-### Likely leakage / visibility review targets
-- public `h3_to_h1` and `h3_to_h2` modules look implementation-shaped, not policy-surface-shaped
-- host/forwarded/header internals are already private; the remaining cleanup target is protocol-specific request builder exposure
+### Phase 2 hardening result
+- protocol-specific request builder modules are internal
+- public surface is now the canonical request/response/websocket policy layer only
 
 ## `spooky-errors`
 
-### Primary façade
+### Crate façade
 - `crates/errors/src/lib.rs`
 
-### Current public surface
-- `pub mod bridge`
-- `pub mod pool`
-- `pub mod proxy`
-- `pub mod retry`
-- `pub mod upstream`
-- `pub use bridge::BridgeError`
-- `pub use pool::PoolError`
-- `pub use proxy::{ClassifiedUpstreamProxyError, ProxyError, UpstreamProxyErrorKind, classify_upstream_proxy_error, classify_upstream_send_error}`
-- `pub use retry::{HedgeOutcomeTelemetryReason, HedgePolicyDecision, HedgePolicyDenialReason, HedgePolicyFacts, HedgePrimaryState, HedgeTriggerTelemetryReason, RetryAttemptTelemetryReason, RetryPolicyDecision, RetryPolicyDenialReason, RetryPolicyFacts, UpstreamRetryReason, UpstreamRetryability, UpstreamTerminalErrorKind, classify_retryability, evaluate_hedge_policy, evaluate_retry_policy, is_idempotent_method, is_retryable}`
-- `pub use spooky_lb::alternate_backend::{AlternateBackendChoice, AlternateBackendDecision, AlternateBackendFailureReason, AlternateBackendSelectionMode}`
-- `pub use upstream::{UpstreamErrorCategory, UpstreamErrorClassification, UpstreamHealthFailureMapping, UpstreamTlsReason, classify_upstream_error_detail}`
+### Public surface
+- re-exported error and policy types from:
+  - `bridge`
+  - `pool`
+  - `proxy`
+  - `retry`
+  - `upstream`
 
-### Likely canonical entrypoints
-- `ProxyError`
-- `PoolError`
-- bridge/pool/proxy/upstream shared classifiers
-- retry/hedge policy result types if `errors` is intentionally the shared policy surface
+### Internal façades intentionally kept private
+- module files themselves are private; consumers use only crate-root re-exports
 
-### Likely leakage / visibility review targets
-- crate re-export of `spooky_lb::alternate_backend::*` crosses ownership boundaries and looks like a compatibility path
-- both `pub mod retry` and large `pub use retry::*` surface may be redundant
-- crate-level surface mixes true error types with policy evaluators and LB-owned types
+### Phase 2 hardening result
+- stale `spooky_lb::alternate_backend::*` compatibility re-exports are gone
+- formatting and normalization helpers remain internal to the module implementations
+- consumers see one shared classifier/error contract from the crate root
 
 ## `spooky-lb`
 
-### Primary façades
+### Crate façade
 - `crates/lb/src/lib.rs`
-- `crates/lb/src/algorithms/mod.rs`
 
-### Current public surface
-- `pub mod algorithms`
-- `pub mod alternate_backend`
-- `pub mod backend`
-- `pub mod backend_pool`
-- `pub mod hash`
-- `pub mod health`
-- `pub mod load_balancing`
-- `pub mod upstream_pool`
-- `algorithms/mod.rs` publicly exposes:
-  - `consistent_hash`
-  - `latency_aware`
-  - `least_connections`
-  - `random`
-  - `round_robin`
-  - `sticky_cid`
+### Public surface
+- canonical modules:
+  - `alternate_backend`
+  - `health`
+  - `load_balancing`
+  - `upstream_pool`
+- hidden compatibility/testing substrate:
+  - `algorithms`
+  - `backend`
+  - `backend_pool`
+- crate-private:
+  - `hash`
 
-### Likely canonical entrypoints
-- `upstream_pool`
-- `load_balancing`
-- `alternate_backend`
-- `health`
-
-### Likely leakage / visibility review targets
-- direct public exposure of individual algorithm modules
-- `backend` and `backend_pool` may be internal substrate rather than consumer API
-- `hash` may be implementation detail unless deliberately shared
+### Phase 2 hardening result
+- `UpstreamPool` internals are private
+- callers use narrow pool-level methods instead of reaching through internal fields
+- implementation algorithms remain exposed only as hidden compatibility/test substrate, not as the recommended crate surface
 
 ## `spooky-transport`
 
-### Primary façade
+### Crate façade
 - `crates/transport/src/lib.rs`
+- `crates/transport/src/transport_pool.rs`
 
-### Current public surface
-- private modules:
-  - `client_rotation`
-  - `h1_client`
-  - `h1_pool`
-  - `h2_client`
-  - `h2_pool`
-  - `transport_pool`
-- public re-exports from `transport_pool`:
+### Public surface
+- re-exports from owning modules:
   - `ConnectObservation`
   - `ConnectObserver`
   - `SharedDnsResolver`
@@ -205,59 +167,35 @@ This document is a baseline audit. It does not change visibility yet.
   - `TransportClientRotation`
   - `UpstreamTransportPool`
 
-### Likely canonical entrypoints
-- `UpstreamTransportPool`
-- `TlsClientConfig`
-- `SharedDnsResolver`
-- connection observation hooks if used by `edge`
+### Internal façades intentionally kept private
+- `client_rotation`
+- `h1_client`
+- `h1_pool`
+- `h2_client`
+- `h2_pool`
+- `transport_pool` module itself remains internal; only its façade types are re-exported
 
-### Likely leakage / visibility review targets
-- `TransportClientRotation` may still be more internal than desired after transport abstraction cleanup
-- confirm `ConnectObservation` / `ConnectObserver` are intentionally public and not just cross-crate plumbing
+### Phase 2 hardening result
+- protocol-specific pools/clients remain implementation details
+- DNS/connect configuration types are re-exported from their owning module path, not via a secondary `transport_pool` shim
+- internal client rotation state is no longer public
 
-## Cross-crate leakage patterns to address next
+## Summary of Resolved Baseline Leaks
 
-### 1. Whole-subsystem public modules
-Current examples:
-- `edge::runtime`
-- `edge::routing`
-- `edge::resilience`
-- `edge::watchdog`
-- `lb::algorithms`
+Resolved during this branch:
+- `edge::quic_listener` is no longer public API
+- `edge::quic_listener::workers` is no longer a public module
+- `bridge::h3_to_h1` and `bridge::h3_to_h2` are no longer public
+- `errors` no longer re-exports `lb` alternate-backend types
+- `lb::hash` is no longer public
+- `transport_pool` no longer acts as a compatibility re-export hop for DNS/connect config types
 
-These make internal organization look like external API.
+## Remaining Intentional Public Areas
 
-### 2. Compatibility re-exports that blur ownership
-Current examples:
-- `errors` re-exporting `spooky_lb::alternate_backend::*`
-- `edge::quic_listener` re-exporting worker/runtime-state details directly
+These are still public by design or current test/consumer need:
+- `edge::runtime` subsystem types
+- `edge::routing` and `edge::resilience` subsystems
+- `config::{default, validator}` modules
+- hidden-but-public `lb` substrate modules used by compatibility/tests
 
-These are the first candidates to replace with narrower canonical entrypoints.
-
-### 3. Implementation-shaped public modules
-Current examples:
-- `bridge::h3_to_h1`
-- `bridge::h3_to_h2`
-- individual LB algorithm modules
-
-These expose transport/protocol detail instead of domain contracts.
-
-### 4. Façades that are still too broad
-Current examples:
-- `edge::quic_listener`
-- `config::runtime::policies`
-
-These should stay façades, but the next step should make their outward surfaces more intentional.
-
-## Proposed hardening order
-
-1. `edge`
-2. `config`
-3. `bridge`
-4. `errors`
-5. `lb`
-6. `transport`
-
-Reason:
-- `edge` and `config` currently define the broadest visible internal surface.
-- `bridge`, `errors`, `lb`, and `transport` mostly need narrowing and ownership cleanup, not structural discovery.
+These should be treated as the current deliberate surface, not accidental leftovers from the Phase 2 refactors.

--- a/docs/public-api-surface-inventory.md
+++ b/docs/public-api-surface-inventory.md
@@ -1,0 +1,263 @@
+# Public API Surface Inventory
+
+Phase 2 inventory for `refactor/public-api-and-visibility-hardening`.
+
+Scope:
+- crate `lib.rs` façades
+- top-level `mod.rs` files that currently fan out public surface area
+- current re-exports and compatibility paths that look broader than the canonical entrypoints
+
+This document is a baseline audit. It does not change visibility yet.
+
+## `spooky-edge`
+
+### Primary façades
+- `crates/edge/src/lib.rs`
+- `crates/edge/src/quic_listener/mod.rs`
+- `crates/edge/src/runtime/mod.rs`
+- `crates/edge/src/routing/mod.rs`
+- `crates/edge/src/resilience/mod.rs`
+- `crates/edge/src/watchdog/mod.rs`
+
+### Current public surface
+- `pub mod benchmark`
+- `pub mod body`
+- `pub mod cid_radix`
+- `pub mod constants`
+- `pub mod hash`
+- `pub mod metrics`
+- `pub mod quic_listener`
+- `pub mod resilience`
+- `pub mod routing`
+- `pub mod runtime`
+- `pub mod watchdog`
+- `pub use body::ChannelBody`
+- `pub use hash::{stable_hash_socket_addr, stable_hash64}`
+- `pub use metrics::{HealthFailureReason, Metrics, OverloadShedReason, RouteOutcome}`
+- `pub use quic_listener::configure_async_runtime`
+- `quic_listener/mod.rs` also publicly exposes:
+  - `pub mod workers`
+  - `pub use runtime_state::ListenerWorkerRuntimeState`
+  - `pub use workers::{ListenerWorkerGroupConfig, spawn_listener_worker_group}`
+
+### Likely canonical entrypoints
+- `configure_async_runtime`
+- listener worker startup types/functions if they are intentionally crate-external
+- `Metrics`
+- top-level stable hashing helpers if consumed outside `edge`
+- `ChannelBody`
+
+### Likely leakage / visibility review targets
+- crate-wide public exposure of `runtime`, `routing`, `resilience`, and `watchdog`
+- public `benchmark` module
+- public `constants` and `cid_radix`
+- public `ListenerWorkerRuntimeState`
+- `quic_listener` as a large mixed façade instead of a narrow service entrypoint
+- top-level `routing` and `resilience` submodules are all `pub mod`, which currently exposes internal policy/mechanics as crate API
+- top-level `watchdog` submodules are all `pub mod`, including service/state/time internals
+
+## `spooky-config`
+
+### Primary façades
+- `crates/config/src/lib.rs`
+- `crates/config/src/runtime/policies/mod.rs`
+
+### Current public surface
+- `pub mod backend_endpoint`
+- `pub mod config`
+- `pub mod default`
+- `pub mod loader`
+- `pub mod runtime`
+- `pub mod validator`
+- `runtime/policies/mod.rs` publicly re-exports canonical runtime policy/output types:
+  - admission policies
+  - auth policies
+  - backend policies
+  - load-balancing policies
+  - resilience policies
+  - timeout policies
+  - transport policies
+  - watchdog policies
+- `runtime/policies/mod.rs` also defines and exports:
+  - `RuntimeRouteHostPattern`
+  - `RuntimeRouteMatchPolicy`
+  - `RuntimeBackendTransportKind`
+  - `RuntimeUpstreamTransportPolicy`
+  - `RuntimePolicySet`
+  - `RuntimeListenerPolicySet`
+  - `RuntimeUpstreamPolicySet`
+
+### Likely canonical entrypoints
+- raw config types under `config`
+- loader entrypoints
+- validated runtime config/output types under `runtime`
+- backend endpoint shape if used cross-crate
+
+### Likely leakage / visibility review targets
+- `default` and `validator` as top-level public modules may be broader than needed
+- some `runtime/policies/mod.rs` structs may be intermediate interpreter outputs rather than stable consumer-facing API
+- route-match normalization types may belong under `runtime` but not necessarily as crate-public guarantees
+
+## `spooky-bridge`
+
+### Primary façade
+- `crates/bridge/src/lib.rs`
+
+### Current public surface
+- `pub mod h3_to_h1`
+- `pub mod h3_to_h2`
+- `pub mod request`
+- `pub mod response`
+- `pub mod websocket`
+- `pub use spooky_errors::BridgeError`
+
+### Likely canonical entrypoints
+- `request`
+- `response`
+- `websocket`
+- `BridgeError`
+
+### Likely leakage / visibility review targets
+- public `h3_to_h1` and `h3_to_h2` modules look implementation-shaped, not policy-surface-shaped
+- host/forwarded/header internals are already private; the remaining cleanup target is protocol-specific request builder exposure
+
+## `spooky-errors`
+
+### Primary façade
+- `crates/errors/src/lib.rs`
+
+### Current public surface
+- `pub mod bridge`
+- `pub mod pool`
+- `pub mod proxy`
+- `pub mod retry`
+- `pub mod upstream`
+- `pub use bridge::BridgeError`
+- `pub use pool::PoolError`
+- `pub use proxy::{ClassifiedUpstreamProxyError, ProxyError, UpstreamProxyErrorKind, classify_upstream_proxy_error, classify_upstream_send_error}`
+- `pub use retry::{HedgeOutcomeTelemetryReason, HedgePolicyDecision, HedgePolicyDenialReason, HedgePolicyFacts, HedgePrimaryState, HedgeTriggerTelemetryReason, RetryAttemptTelemetryReason, RetryPolicyDecision, RetryPolicyDenialReason, RetryPolicyFacts, UpstreamRetryReason, UpstreamRetryability, UpstreamTerminalErrorKind, classify_retryability, evaluate_hedge_policy, evaluate_retry_policy, is_idempotent_method, is_retryable}`
+- `pub use spooky_lb::alternate_backend::{AlternateBackendChoice, AlternateBackendDecision, AlternateBackendFailureReason, AlternateBackendSelectionMode}`
+- `pub use upstream::{UpstreamErrorCategory, UpstreamErrorClassification, UpstreamHealthFailureMapping, UpstreamTlsReason, classify_upstream_error_detail}`
+
+### Likely canonical entrypoints
+- `ProxyError`
+- `PoolError`
+- bridge/pool/proxy/upstream shared classifiers
+- retry/hedge policy result types if `errors` is intentionally the shared policy surface
+
+### Likely leakage / visibility review targets
+- crate re-export of `spooky_lb::alternate_backend::*` crosses ownership boundaries and looks like a compatibility path
+- both `pub mod retry` and large `pub use retry::*` surface may be redundant
+- crate-level surface mixes true error types with policy evaluators and LB-owned types
+
+## `spooky-lb`
+
+### Primary façades
+- `crates/lb/src/lib.rs`
+- `crates/lb/src/algorithms/mod.rs`
+
+### Current public surface
+- `pub mod algorithms`
+- `pub mod alternate_backend`
+- `pub mod backend`
+- `pub mod backend_pool`
+- `pub mod hash`
+- `pub mod health`
+- `pub mod load_balancing`
+- `pub mod upstream_pool`
+- `algorithms/mod.rs` publicly exposes:
+  - `consistent_hash`
+  - `latency_aware`
+  - `least_connections`
+  - `random`
+  - `round_robin`
+  - `sticky_cid`
+
+### Likely canonical entrypoints
+- `upstream_pool`
+- `load_balancing`
+- `alternate_backend`
+- `health`
+
+### Likely leakage / visibility review targets
+- direct public exposure of individual algorithm modules
+- `backend` and `backend_pool` may be internal substrate rather than consumer API
+- `hash` may be implementation detail unless deliberately shared
+
+## `spooky-transport`
+
+### Primary façade
+- `crates/transport/src/lib.rs`
+
+### Current public surface
+- private modules:
+  - `client_rotation`
+  - `h1_client`
+  - `h1_pool`
+  - `h2_client`
+  - `h2_pool`
+  - `transport_pool`
+- public re-exports from `transport_pool`:
+  - `ConnectObservation`
+  - `ConnectObserver`
+  - `SharedDnsResolver`
+  - `TlsClientConfig`
+  - `TransportClientRotation`
+  - `UpstreamTransportPool`
+
+### Likely canonical entrypoints
+- `UpstreamTransportPool`
+- `TlsClientConfig`
+- `SharedDnsResolver`
+- connection observation hooks if used by `edge`
+
+### Likely leakage / visibility review targets
+- `TransportClientRotation` may still be more internal than desired after transport abstraction cleanup
+- confirm `ConnectObservation` / `ConnectObserver` are intentionally public and not just cross-crate plumbing
+
+## Cross-crate leakage patterns to address next
+
+### 1. Whole-subsystem public modules
+Current examples:
+- `edge::runtime`
+- `edge::routing`
+- `edge::resilience`
+- `edge::watchdog`
+- `lb::algorithms`
+
+These make internal organization look like external API.
+
+### 2. Compatibility re-exports that blur ownership
+Current examples:
+- `errors` re-exporting `spooky_lb::alternate_backend::*`
+- `edge::quic_listener` re-exporting worker/runtime-state details directly
+
+These are the first candidates to replace with narrower canonical entrypoints.
+
+### 3. Implementation-shaped public modules
+Current examples:
+- `bridge::h3_to_h1`
+- `bridge::h3_to_h2`
+- individual LB algorithm modules
+
+These expose transport/protocol detail instead of domain contracts.
+
+### 4. Façades that are still too broad
+Current examples:
+- `edge::quic_listener`
+- `config::runtime::policies`
+
+These should stay façades, but the next step should make their outward surfaces more intentional.
+
+## Proposed hardening order
+
+1. `edge`
+2. `config`
+3. `bridge`
+4. `errors`
+5. `lb`
+6. `transport`
+
+Reason:
+- `edge` and `config` currently define the broadest visible internal surface.
+- `bridge`, `errors`, `lb`, and `transport` mostly need narrowing and ownership cleanup, not structural discovery.

--- a/spooky/src/listener_group.rs
+++ b/spooky/src/listener_group.rs
@@ -10,9 +10,7 @@ use std::{
 use log::{error, info};
 use spooky_config::runtime::{ListenerRuntimeConfig, RuntimeConfig};
 use spooky_edge::{
-    quic_listener::{
-        ListenerWorkerGroupConfig, ListenerWorkerRuntimeState, spawn_listener_worker_group,
-    },
+    ListenerWorkerGroupConfig, ListenerWorkerRuntimeState, spawn_listener_worker_group,
     runtime::{
         bundle::RuntimeBundleHandle, listener::QUICListener, shared_state::SharedRuntimeState,
     },
@@ -335,7 +333,7 @@ fn group_signature_worker_count(group: &ListenerGroupRuntime) -> usize {
 mod tests {
     use std::{net::SocketAddr, sync::atomic::AtomicUsize};
 
-    use spooky_edge::quic_listener::workers::{
+    use spooky_edge::{
         release_shard_queue_bytes, shard_index_for_peer, try_reserve_shard_queue_bytes,
     };
 

--- a/spooky/src/listener_group.rs
+++ b/spooky/src/listener_group.rs
@@ -10,10 +10,11 @@ use std::{
 use log::{error, info};
 use spooky_config::runtime::{ListenerRuntimeConfig, RuntimeConfig};
 use spooky_edge::{
-    ListenerWorkerGroupConfig, ListenerWorkerRuntimeState, spawn_listener_worker_group,
+    ListenerWorkerGroupConfig, ListenerWorkerRuntimeState,
     runtime::{
         bundle::RuntimeBundleHandle, listener::QUICListener, shared_state::SharedRuntimeState,
     },
+    spawn_listener_worker_group,
 };
 
 use crate::runtime_guard;


### PR DESCRIPTION
## Summary
This PR closes the Phase 2 public API and visibility hardening pass across `edge`, `config`, `bridge`, `errors`, `lb`, and `transport`.

It tightens crate boundaries, removes stale compatibility export paths, documents façade ownership, and keeps internal implementation modules behind smaller canonical entrypoints.

## What Changed
- hardened `edge` listener/runtime public surface and reduced accidental export paths
- tightened `config` runtime interpreter boundaries around canonical runtime outputs
- kept `bridge` public surface focused on canonical request/response/websocket entrypoints
- removed stale cross-crate compatibility re-exports from `errors`
- narrowed `lb` to canonical pool/strategy/alternate-backend surfaces and hid pool internals
- tightened `transport` so callers depend on the unified transport façade instead of protocol details
- removed stale export hops and dead helper paths across crates
- added/update subsystem ownership docs and refreshed the public API inventory
- fixed the `spooky-edge` outcome test fixture regression caused by stricter health-check validation
