### PR TITLE
refactor(edge): model the data-plane request lifecycle as an explicit state machine

### DIFF
--- a/crates/edge/src/constants.rs
+++ b/crates/edge/src/constants.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 //
 //   Request path
 //   ├─ body channel:    REQUEST_CHUNK_CHANNEL_CAPACITY * REQUEST_CHUNK_BYTES_LIMIT
-//   │                   = 8 * 16 KiB = 128 KiB
+//   │                   = 64 * 16 KiB = 1 MiB
 //   ├─ backpressure buf: REQUEST_BUFFERED_CHUNK_BYTES_LIMIT = 1 MiB (== MAX_REQUEST_BODY_BYTES)
 //   └─ hard request cap: MAX_REQUEST_BODY_BYTES = 1 MiB → 413 on breach
 //
@@ -20,7 +20,7 @@ use std::time::Duration;
 //
 // Per-connection worst-case:
 //   MAX_STREAMS_PER_CONNECTION (= QUIC_INITIAL_MAX_STREAMS_BIDI = 100) streams
-//   × per-stream worst case above → ~101 MiB request + ~100 MiB response ≈ 200 MiB
+//   × per-stream worst case above → ~200 MiB request + ~100 MiB response ≈ 300 MiB
 //   (all caps enforced; no path causes unbounded growth)
 //
 // ─────────────────────────────────────────────────────────────────────────────
@@ -60,7 +60,7 @@ pub const RESET_TOKEN_LEN_BYTES: usize = 16;
 pub const MIN_SCID_LEN_BYTES: usize = 8;
 
 // Queue/backpressure controls for streaming request/response bodies.
-pub const REQUEST_CHUNK_CHANNEL_CAPACITY: usize = 8;
+pub const REQUEST_CHUNK_CHANNEL_CAPACITY: usize = 64;
 pub const REQUEST_CHUNK_BYTES_LIMIT: usize = 16 * 1024;
 pub const REQUEST_BUFFERED_CHUNK_BYTES_LIMIT: usize = MAX_REQUEST_BODY_BYTES;
 pub const RESPONSE_CHUNK_CHANNEL_CAPACITY: usize = 16;

--- a/crates/edge/src/quic_listener/admission.rs
+++ b/crates/edge/src/quic_listener/admission.rs
@@ -367,11 +367,11 @@ pub(super) fn execute_forwarding_post_auth_admission(
         ));
     };
 
-    let request_started = upstream_pool
+    let backend_healthy = upstream_pool
         .read()
         .ok()
-        .is_some_and(|pool| pool.begin_request_if_healthy(backend_index));
-    if !request_started {
+        .is_some_and(|pool| pool.is_backend_healthy(backend_index));
+    if !backend_healthy {
         return PostAuthAdmissionExecution::Rejected(PostAuthAdmissionRejection::Failed(
             PostAuthAdmissionFailure {
                 status: StatusCode::SERVICE_UNAVAILABLE,

--- a/crates/edge/src/quic_listener/bootstrap/dispatch.rs
+++ b/crates/edge/src/quic_listener/bootstrap/dispatch.rs
@@ -7,8 +7,14 @@ use hyper::body::Incoming;
 use spooky_errors::ProxyError;
 
 use super::{
-    context::BootstrapDispatchCtx, intake::bootstrap_error_response,
-    outcome::observe_bootstrap_dispatch_failure, request::BootstrapPreparedRoute,
+    context::BootstrapDispatchCtx,
+    intake::bootstrap_error_response,
+    outcome::observe_bootstrap_dispatch_failure,
+    request::BootstrapPreparedRoute,
+    request::{
+        BootstrapBackendFailureReason, BootstrapLifecycleStage, BootstrapTerminalOutcome,
+        BootstrapTerminalResponse, BootstrapTerminalResult, BootstrapTimeoutReason,
+    },
     websocket::dispatch_bootstrap_websocket,
 };
 
@@ -20,7 +26,7 @@ pub(in crate::quic_listener) struct BootstrapDispatchInput<'a> {
 
 async fn dispatch_bootstrap_http(
     input: BootstrapDispatchInput<'_>,
-) -> Result<Response<Incoming>, Response<BoxBody<Bytes, Infallible>>> {
+) -> BootstrapTerminalResult<Response<Incoming>> {
     match input
         .dispatch_ctx
         .request
@@ -43,14 +49,24 @@ async fn dispatch_bootstrap_http(
                 status,
                 &proxy_err,
             );
-            Err(bootstrap_error_response(
-                &input.dispatch_ctx.request.runtime.alt_svc,
-                status,
+            Err(BootstrapTerminalResponse::new(
+                BootstrapLifecycleStage::Dispatch,
                 if matches!(proxy_err, ProxyError::Timeout) {
-                    b"upstream timeout\n"
+                    BootstrapTerminalOutcome::TimedOut(BootstrapTimeoutReason::Upstream)
                 } else {
-                    b"upstream error\n"
+                    BootstrapTerminalOutcome::BackendFailed(
+                        BootstrapBackendFailureReason::DispatchFailed,
+                    )
                 },
+                bootstrap_error_response(
+                    &input.dispatch_ctx.request.runtime.alt_svc,
+                    status,
+                    if matches!(proxy_err, ProxyError::Timeout) {
+                        b"upstream timeout\n"
+                    } else {
+                        b"upstream error\n"
+                    },
+                ),
             ))
         }
     }
@@ -58,7 +74,7 @@ async fn dispatch_bootstrap_http(
 
 pub(in crate::quic_listener) async fn dispatch_bootstrap_upstream(
     input: BootstrapDispatchInput<'_>,
-) -> Result<Response<Incoming>, Response<BoxBody<Bytes, Infallible>>> {
+) -> BootstrapTerminalResult<Response<Incoming>> {
     if input.dispatch_ctx.is_websocket_upgrade {
         dispatch_bootstrap_websocket(input).await
     } else {

--- a/crates/edge/src/quic_listener/bootstrap/intake.rs
+++ b/crates/edge/src/quic_listener/bootstrap/intake.rs
@@ -8,6 +8,10 @@ use spooky_errors::{BridgeError, ProxyError};
 
 use super::{
     super::{protocol::is_head_method, validation::validate_http_request},
+    request::{
+        BootstrapLifecycleStage, BootstrapRejectionReason, BootstrapRequestMode,
+        BootstrapTerminalOutcome, BootstrapTerminalResponse,
+    },
     response::boxed_full,
     websocket::capture_bootstrap_websocket_flow,
 };
@@ -23,7 +27,7 @@ pub(in crate::quic_listener) struct BootstrapRequestIntake {
     pub(in crate::quic_listener) authority: Option<String>,
     pub(in crate::quic_listener) content_length: Option<usize>,
     pub(in crate::quic_listener) suppress_downstream_body: bool,
-    pub(in crate::quic_listener) is_websocket_upgrade: bool,
+    pub(in crate::quic_listener) request_mode: BootstrapRequestMode,
     pub(in crate::quic_listener) client_upgrade: Option<OnUpgrade>,
 }
 
@@ -65,7 +69,14 @@ pub(in crate::quic_listener) fn prepare_bootstrap_request_intake(
                 &ProxyError::Bridge(BridgeError::InvalidHeader),
                 None,
             );
-            return Err(Box::new(bootstrap_error_response(alt_svc, status, body)));
+            return Err(Box::new(
+                BootstrapTerminalResponse::new(
+                    BootstrapLifecycleStage::Validate,
+                    BootstrapTerminalOutcome::Rejected(BootstrapRejectionReason::ValidationFailed),
+                    bootstrap_error_response(alt_svc, status, body),
+                )
+                .into_response(),
+            ));
         }
     };
 
@@ -75,7 +86,11 @@ pub(in crate::quic_listener) fn prepare_bootstrap_request_intake(
         path: request.path,
         authority: request.authority,
         content_length: request.content_length,
-        is_websocket_upgrade: websocket_flow.is_websocket_upgrade,
+        request_mode: if websocket_flow.is_websocket_upgrade {
+            BootstrapRequestMode::WebsocketUpgrade
+        } else {
+            BootstrapRequestMode::Standard
+        },
         client_upgrade: websocket_flow.client_upgrade,
     })
 }

--- a/crates/edge/src/quic_listener/bootstrap/listener.rs
+++ b/crates/edge/src/quic_listener/bootstrap/listener.rs
@@ -25,8 +25,9 @@ use super::{
     intake::{BootstrapRequestIntake, prepare_bootstrap_request_intake},
     outcome::observe_bootstrap_request_proxy_error,
     request::{
-        BootstrapBuildRequestInput, BootstrapPolicyEvaluationInput,
-        build_bootstrap_upstream_request, evaluate_bootstrap_request_policy,
+        BootstrapBuildRequestInput, BootstrapPolicyEvaluationInput, BootstrapRequestMode,
+        BootstrapTerminalOutcome, build_bootstrap_upstream_request,
+        evaluate_bootstrap_request_policy,
     },
     response::{BootstrapWritebackInput, boxed_full, write_bootstrap_response},
     startup::{
@@ -237,7 +238,7 @@ pub(in crate::quic_listener) fn spawn_bootstrap_tls_listener(
                                 authority,
                                 content_length,
                                 suppress_downstream_body,
-                                is_websocket_upgrade,
+                                request_mode,
                                 client_upgrade,
                             } = match prepare_bootstrap_request_intake(
                                 &mut req,
@@ -257,7 +258,7 @@ pub(in crate::quic_listener) fn spawn_bootstrap_tls_listener(
                                 authority: authority.clone(),
                                 content_length,
                                 suppress_downstream_body,
-                                is_websocket_upgrade,
+                                request_mode,
                                 client_upgrade: None,
                             };
                             let prepared_route = match evaluate_bootstrap_request_policy(
@@ -268,7 +269,7 @@ pub(in crate::quic_listener) fn spawn_bootstrap_tls_listener(
                                 },
                             ) {
                                 Ok(prepared) => prepared,
-                                Err(response) => return Ok(*response),
+                                Err(terminal) => return Ok(terminal.into_response()),
                             };
 
                             let request_path = if path.is_empty() { "/" } else { &path };
@@ -286,7 +287,7 @@ pub(in crate::quic_listener) fn spawn_bootstrap_tls_listener(
                                     buffered_bytes: 0,
                                     next_chunk_bytes: 0,
                                     declared_content_length: content_length,
-                                    exempt_from_body_size_cap: is_websocket_upgrade,
+                                    exempt_from_body_size_cap: request_mode.is_websocket_upgrade(),
                                 },
                             );
                             if matches!(
@@ -304,15 +305,26 @@ pub(in crate::quic_listener) fn spawn_bootstrap_tls_listener(
                                     StatusCode::PAYLOAD_TOO_LARGE,
                                     &ProxyError::Transport("request body too large".into()),
                                 );
-                                return Ok(Response::builder()
-                                    .status(StatusCode::PAYLOAD_TOO_LARGE)
-                                    .header("alt-svc", &runtime_ctx.alt_svc)
-                                    .body(boxed_full(Bytes::from_static(
-                                        REQUEST_BODY_TOO_LARGE_BODY,
-                                    )))
-                                    .unwrap_or_else(|_| {
-                                        Response::new(boxed_full(Bytes::from_static(b"error\n")))
-                                    }));
+                                return Ok(
+                                    super::request::BootstrapTerminalResponse::new(
+                                        super::request::BootstrapLifecycleStage::Validate,
+                                        BootstrapTerminalOutcome::Rejected(
+                                            super::request::BootstrapRejectionReason::RequestBodyTooLarge,
+                                        ),
+                                        Response::builder()
+                                            .status(StatusCode::PAYLOAD_TOO_LARGE)
+                                            .header("alt-svc", &runtime_ctx.alt_svc)
+                                            .body(boxed_full(Bytes::from_static(
+                                                REQUEST_BODY_TOO_LARGE_BODY,
+                                            )))
+                                            .unwrap_or_else(|_| {
+                                                Response::new(boxed_full(Bytes::from_static(
+                                                    b"error\n",
+                                                )))
+                                            }),
+                                    )
+                                    .into_response(),
+                                );
                             }
 
                             let request_id = REQUEST_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
@@ -327,60 +339,68 @@ pub(in crate::quic_listener) fn spawn_bootstrap_tls_listener(
                                 authority: authority.clone(),
                                 content_length,
                                 suppress_downstream_body,
-                                is_websocket_upgrade,
+                                request_mode,
                                 client_upgrade: None,
                             };
-                            let upstream_req =
-                                match build_bootstrap_upstream_request(BootstrapBuildRequestInput {
+                            let upstream_req = match build_bootstrap_upstream_request(
+                                BootstrapBuildRequestInput {
                                     request: req,
                                     intake: &intake_for_build,
                                     prepared_route: &prepared_route,
                                     request_ctx,
                                     request_id,
                                     traceparent: traceparent.as_deref(),
-                                }) {
-                                    Ok(request) => request,
-                                    Err(err) => {
-                                        warn!("Bootstrap request build failed: {}", err);
-                                        let (status, body) = if is_websocket_upgrade
-                                            && matches!(err, spooky_bridge::BridgeError::Build(_))
-                                        {
-                                            (
-                                                StatusCode::BAD_GATEWAY,
-                                                b"request build error\n".as_slice(),
+                                },
+                            ) {
+                                Ok(request) => request,
+                                Err(err) => {
+                                    warn!("Bootstrap request build failed: {}", err);
+                                    let (status, body) = if request_mode
+                                        == BootstrapRequestMode::WebsocketUpgrade
+                                        && matches!(err, spooky_bridge::BridgeError::Build(_))
+                                    {
+                                        (
+                                            StatusCode::BAD_GATEWAY,
+                                            b"request build error\n".as_slice(),
+                                        )
+                                    } else {
+                                        (StatusCode::BAD_REQUEST, b"invalid request\n".as_slice())
+                                    };
+                                    let proxy_err = ProxyError::from(err);
+                                    observe_bootstrap_request_proxy_error(
+                                        runtime_ctx.metrics.as_ref(),
+                                        &prepared_route.upstream_name,
+                                        &prepared_route.backend_addr,
+                                        prepared_route.backend_index,
+                                        request_start,
+                                        status,
+                                        &proxy_err,
+                                    );
+                                    return Ok(
+                                            super::request::BootstrapTerminalResponse::new(
+                                                super::request::BootstrapLifecycleStage::Dispatch,
+                                                BootstrapTerminalOutcome::BackendFailed(
+                                                    super::request::BootstrapBackendFailureReason::RequestBuildFailed,
+                                                ),
+                                                Response::builder()
+                                                    .status(status)
+                                                    .header("alt-svc", &runtime_ctx.alt_svc)
+                                                    .body(boxed_full(Bytes::copy_from_slice(body)))
+                                                    .unwrap_or_else(|_| {
+                                                        Response::new(boxed_full(
+                                                            Bytes::from_static(b"error\n"),
+                                                        ))
+                                                    }),
                                             )
-                                        } else {
-                                            (
-                                                StatusCode::BAD_REQUEST,
-                                                b"invalid request\n".as_slice(),
-                                            )
-                                        };
-                                        let proxy_err = ProxyError::from(err);
-                                        observe_bootstrap_request_proxy_error(
-                                            runtime_ctx.metrics.as_ref(),
-                                            &prepared_route.upstream_name,
-                                            &prepared_route.backend_addr,
-                                            prepared_route.backend_index,
-                                            request_start,
-                                            status,
-                                            &proxy_err,
+                                            .into_response(),
                                         );
-                                        return Ok(Response::builder()
-                                            .status(status)
-                                            .header("alt-svc", &runtime_ctx.alt_svc)
-                                            .body(boxed_full(Bytes::copy_from_slice(body)))
-                                            .unwrap_or_else(|_| {
-                                                Response::new(boxed_full(Bytes::from_static(
-                                                    b"error\n",
-                                                )))
-                                            }));
-                                    }
-                                };
+                                }
+                            };
                             let dispatch_ctx = BootstrapDispatchCtx {
                                 request: request_ctx,
                                 request_id,
                                 request_path,
-                                is_websocket_upgrade,
+                                is_websocket_upgrade: request_mode.is_websocket_upgrade(),
                             };
                             let upstream_resp =
                                 match dispatch_bootstrap_upstream(BootstrapDispatchInput {
@@ -391,16 +411,18 @@ pub(in crate::quic_listener) fn spawn_bootstrap_tls_listener(
                                 .await
                                 {
                                     Ok(resp) => resp,
-                                    Err(response) => return Ok(response),
+                                    Err(terminal) => return Ok(terminal.into_response()),
                                 };
 
-                            write_bootstrap_response(BootstrapWritebackInput {
+                            let writeback = write_bootstrap_response(BootstrapWritebackInput {
                                 upstream_resp,
                                 prepared_route: &prepared_route,
                                 dispatch_ctx,
                                 suppress_downstream_body,
+                                request_mode,
                                 client_upgrade,
-                            })
+                            })?;
+                            Ok(writeback.response)
                         })
                     },
                 );

--- a/crates/edge/src/quic_listener/bootstrap/request.rs
+++ b/crates/edge/src/quic_listener/bootstrap/request.rs
@@ -40,6 +40,90 @@ use super::{
 };
 use crate::runtime::connection::outcome::AdmissionOutcomeClass;
 
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::quic_listener) enum BootstrapLifecycleStage {
+    Intake,
+    Validate,
+    ResolveRoute,
+    AdmitOrReject,
+    Dispatch,
+    WriteResponse,
+    Terminalize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::quic_listener) enum BootstrapRequestMode {
+    Standard,
+    WebsocketUpgrade,
+}
+
+impl BootstrapRequestMode {
+    pub(in crate::quic_listener) fn is_websocket_upgrade(self) -> bool {
+        matches!(self, Self::WebsocketUpgrade)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::quic_listener) enum BootstrapRejectionReason {
+    ValidationFailed,
+    AuthDenied,
+    RateLimited,
+    Overloaded,
+    RequestBodyTooLarge,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::quic_listener) enum BootstrapBackendFailureReason {
+    RouteResolutionFailed,
+    MissingEndpoint,
+    RequestBuildFailed,
+    DispatchFailed,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::quic_listener) enum BootstrapTimeoutReason {
+    Upstream,
+    ResponseBody,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::quic_listener) enum BootstrapTerminalOutcome {
+    AcceptedStandardResponse,
+    AcceptedWebsocketUpgrade,
+    Rejected(BootstrapRejectionReason),
+    BackendFailed(BootstrapBackendFailureReason),
+    TimedOut(BootstrapTimeoutReason),
+}
+
+#[allow(dead_code)]
+pub(in crate::quic_listener) struct BootstrapTerminalResponse {
+    pub(in crate::quic_listener) stage: BootstrapLifecycleStage,
+    pub(in crate::quic_listener) outcome: BootstrapTerminalOutcome,
+    pub(in crate::quic_listener) response: Response<BoxBody<Bytes, Infallible>>,
+}
+
+impl BootstrapTerminalResponse {
+    pub(in crate::quic_listener) fn new(
+        stage: BootstrapLifecycleStage,
+        outcome: BootstrapTerminalOutcome,
+        response: Response<BoxBody<Bytes, Infallible>>,
+    ) -> Self {
+        Self {
+            stage,
+            outcome,
+            response,
+        }
+    }
+
+    pub(in crate::quic_listener) fn into_response(self) -> Response<BoxBody<Bytes, Infallible>> {
+        self.response
+    }
+}
+
+pub(in crate::quic_listener) type BootstrapTerminalResult<T> = Result<T, BootstrapTerminalResponse>;
+
 pub(in crate::quic_listener) struct BootstrapPreparedRoute {
     pub(in crate::quic_listener) endpoint: BackendEndpoint,
     pub(in crate::quic_listener) backend_addr: String,
@@ -141,7 +225,7 @@ fn resolve_scoped_rate_limit_key_for_bootstrap(
 
 pub(in crate::quic_listener) fn evaluate_bootstrap_request_policy(
     input: BootstrapPolicyEvaluationInput<'_>,
-) -> Result<BootstrapPreparedRoute, Box<Response<BoxBody<Bytes, Infallible>>>> {
+) -> BootstrapTerminalResult<BootstrapPreparedRoute> {
     let lb_header_lookup = |name: &str| {
         input
             .headers
@@ -164,11 +248,13 @@ pub(in crate::quic_listener) fn evaluate_bootstrap_request_policy(
         Ok(value) => value,
         Err(err) => {
             let (status, body) = QUICListener::bootstrap_route_resolution_error_response(&err);
-            return Err(Box::new(bootstrap_error_response(
-                &input.request_ctx.runtime.alt_svc,
-                status,
-                body,
-            )));
+            return Err(BootstrapTerminalResponse::new(
+                BootstrapLifecycleStage::ResolveRoute,
+                BootstrapTerminalOutcome::BackendFailed(
+                    BootstrapBackendFailureReason::RouteResolutionFailed,
+                ),
+                bootstrap_error_response(&input.request_ctx.runtime.alt_svc, status, body),
+            ));
         }
     };
 
@@ -228,20 +314,26 @@ pub(in crate::quic_listener) fn evaluate_bootstrap_request_policy(
                     "Bootstrap request route={} missing admission rejection response for unauthorized decision",
                     resolved.upstream_name
                 );
-                return Err(Box::new(internal_proxy_error_response(
-                    &input.request_ctx.runtime.alt_svc,
-                )));
+                return Err(BootstrapTerminalResponse::new(
+                    BootstrapLifecycleStage::AdmitOrReject,
+                    BootstrapTerminalOutcome::Rejected(BootstrapRejectionReason::AuthDenied),
+                    internal_proxy_error_response(&input.request_ctx.runtime.alt_svc),
+                ));
             };
             let Some(challenge) = response.www_authenticate else {
                 warn!(
                     "Bootstrap request route={} missing auth challenge in admission rejection response",
                     resolved.upstream_name
                 );
-                return Err(Box::new(internal_proxy_error_response(
-                    &input.request_ctx.runtime.alt_svc,
-                )));
+                return Err(BootstrapTerminalResponse::new(
+                    BootstrapLifecycleStage::AdmitOrReject,
+                    BootstrapTerminalOutcome::Rejected(BootstrapRejectionReason::AuthDenied),
+                    internal_proxy_error_response(&input.request_ctx.runtime.alt_svc),
+                ));
             };
-            return Err(Box::new(
+            return Err(BootstrapTerminalResponse::new(
+                BootstrapLifecycleStage::AdmitOrReject,
+                BootstrapTerminalOutcome::Rejected(BootstrapRejectionReason::AuthDenied),
                 Response::builder()
                     .status(response.status)
                     .header("alt-svc", &input.request_ctx.runtime.alt_svc)
@@ -270,20 +362,26 @@ pub(in crate::quic_listener) fn evaluate_bootstrap_request_policy(
                     "Bootstrap request route={} missing admission rejection response for rate-limited decision",
                     resolved.upstream_name
                 );
-                return Err(Box::new(internal_proxy_error_response(
-                    &input.request_ctx.runtime.alt_svc,
-                )));
+                return Err(BootstrapTerminalResponse::new(
+                    BootstrapLifecycleStage::AdmitOrReject,
+                    BootstrapTerminalOutcome::Rejected(BootstrapRejectionReason::RateLimited),
+                    internal_proxy_error_response(&input.request_ctx.runtime.alt_svc),
+                ));
             };
             let Some(retry_after_seconds) = response.retry_after_seconds else {
                 warn!(
                     "Bootstrap request route={} missing retry-after in rate-limited admission rejection response",
                     resolved.upstream_name
                 );
-                return Err(Box::new(internal_proxy_error_response(
-                    &input.request_ctx.runtime.alt_svc,
-                )));
+                return Err(BootstrapTerminalResponse::new(
+                    BootstrapLifecycleStage::AdmitOrReject,
+                    BootstrapTerminalOutcome::Rejected(BootstrapRejectionReason::RateLimited),
+                    internal_proxy_error_response(&input.request_ctx.runtime.alt_svc),
+                ));
             };
-            return Err(Box::new(
+            return Err(BootstrapTerminalResponse::new(
+                BootstrapLifecycleStage::AdmitOrReject,
+                BootstrapTerminalOutcome::Rejected(BootstrapRejectionReason::RateLimited),
                 Response::builder()
                     .status(response.status)
                     .header("alt-svc", &input.request_ctx.runtime.alt_svc)
@@ -315,20 +413,26 @@ pub(in crate::quic_listener) fn evaluate_bootstrap_request_policy(
                     "Bootstrap request route={} missing admission rejection response for overload decision",
                     resolved.upstream_name
                 );
-                return Err(Box::new(internal_proxy_error_response(
-                    &input.request_ctx.runtime.alt_svc,
-                )));
+                return Err(BootstrapTerminalResponse::new(
+                    BootstrapLifecycleStage::AdmitOrReject,
+                    BootstrapTerminalOutcome::Rejected(BootstrapRejectionReason::Overloaded),
+                    internal_proxy_error_response(&input.request_ctx.runtime.alt_svc),
+                ));
             };
             let Some(retry_after_seconds) = response.retry_after_seconds else {
                 warn!(
                     "Bootstrap request route={} missing retry-after in overload admission rejection response",
                     resolved.upstream_name
                 );
-                return Err(Box::new(internal_proxy_error_response(
-                    &input.request_ctx.runtime.alt_svc,
-                )));
+                return Err(BootstrapTerminalResponse::new(
+                    BootstrapLifecycleStage::AdmitOrReject,
+                    BootstrapTerminalOutcome::Rejected(BootstrapRejectionReason::Overloaded),
+                    internal_proxy_error_response(&input.request_ctx.runtime.alt_svc),
+                ));
             };
-            return Err(Box::new(
+            return Err(BootstrapTerminalResponse::new(
+                BootstrapLifecycleStage::AdmitOrReject,
+                BootstrapTerminalOutcome::Rejected(BootstrapRejectionReason::Overloaded),
                 Response::builder()
                     .status(response.status)
                     .header("alt-svc", &input.request_ctx.runtime.alt_svc)
@@ -356,11 +460,17 @@ pub(in crate::quic_listener) fn evaluate_bootstrap_request_policy(
                 StatusCode::BAD_GATEWAY,
                 &ProxyError::Transport("no endpoint".into()),
             );
-            return Err(Box::new(bootstrap_error_response(
-                &input.request_ctx.runtime.alt_svc,
-                StatusCode::BAD_GATEWAY,
-                b"no endpoint\n",
-            )));
+            return Err(BootstrapTerminalResponse::new(
+                BootstrapLifecycleStage::ResolveRoute,
+                BootstrapTerminalOutcome::BackendFailed(
+                    BootstrapBackendFailureReason::MissingEndpoint,
+                ),
+                bootstrap_error_response(
+                    &input.request_ctx.runtime.alt_svc,
+                    StatusCode::BAD_GATEWAY,
+                    b"no endpoint\n",
+                ),
+            ));
         }
     };
 
@@ -383,7 +493,7 @@ pub(in crate::quic_listener) fn build_bootstrap_upstream_request(
         &input.prepared_route.upstream_policy,
     );
 
-    if input.intake.is_websocket_upgrade {
+    if input.intake.request_mode.is_websocket_upgrade() {
         return build_h1_request(
             request_target,
             bootstrap_request_build_input(

--- a/crates/edge/src/quic_listener/bootstrap/request.rs
+++ b/crates/edge/src/quic_listener/bootstrap/request.rs
@@ -109,12 +109,12 @@ impl BootstrapTerminalResponse {
         stage: BootstrapLifecycleStage,
         outcome: BootstrapTerminalOutcome,
         response: Response<BoxBody<Bytes, Infallible>>,
-    ) -> Self {
-        Self {
+    ) -> Box<Self> {
+        Box::new(Self {
             stage,
             outcome,
             response,
-        }
+        })
     }
 
     pub(in crate::quic_listener) fn into_response(self) -> Response<BoxBody<Bytes, Infallible>> {
@@ -122,7 +122,8 @@ impl BootstrapTerminalResponse {
     }
 }
 
-pub(in crate::quic_listener) type BootstrapTerminalResult<T> = Result<T, BootstrapTerminalResponse>;
+pub(in crate::quic_listener) type BootstrapTerminalResult<T> =
+    Result<T, Box<BootstrapTerminalResponse>>;
 
 pub(in crate::quic_listener) struct BootstrapPreparedRoute {
     pub(in crate::quic_listener) endpoint: BackendEndpoint,

--- a/crates/edge/src/quic_listener/bootstrap/response.rs
+++ b/crates/edge/src/quic_listener/bootstrap/response.rs
@@ -22,7 +22,10 @@ use super::{
         finish_bootstrap_backend_request_accounting, observe_bootstrap_response_prebuffer_overflow,
         observe_bootstrap_response_status,
     },
-    request::BootstrapPreparedRoute,
+    request::{
+        BootstrapPreparedRoute, BootstrapRejectionReason, BootstrapRequestMode,
+        BootstrapTerminalOutcome,
+    },
     websocket::write_bootstrap_websocket_upgrade,
 };
 use crate::runtime::connection::guardrails::{
@@ -36,7 +39,40 @@ pub(in crate::quic_listener) struct BootstrapStreamingBody {
     bytes_seen: usize,
     prebuffered_bytes: usize,
     capped: bool,
+    terminal: Option<BootstrapStreamingTerminal>,
     backend_accounting: Option<BootstrapBackendAccounting>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::quic_listener) enum BootstrapResponseMode {
+    StandardResponse,
+    WebsocketUpgrade,
+}
+
+impl BootstrapResponseMode {
+    fn from_request_mode(request_mode: BootstrapRequestMode, status: StatusCode) -> Self {
+        match request_mode {
+            BootstrapRequestMode::WebsocketUpgrade if status == StatusCode::SWITCHING_PROTOCOLS => {
+                Self::WebsocketUpgrade
+            }
+            BootstrapRequestMode::WebsocketUpgrade | BootstrapRequestMode::Standard => {
+                Self::StandardResponse
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::quic_listener) enum BootstrapStreamingTerminal {
+    Completed,
+    CappedRejected,
+    UpstreamBodyFailed,
+}
+
+#[allow(dead_code)]
+pub(in crate::quic_listener) struct BootstrapWritebackOutcome {
+    pub(in crate::quic_listener) response: Response<BoxBody<Bytes, Infallible>>,
+    pub(in crate::quic_listener) terminal: BootstrapTerminalOutcome,
 }
 
 struct BootstrapBackendAccounting {
@@ -56,6 +92,7 @@ impl BootstrapStreamingBody {
             bytes_seen: 0,
             prebuffered_bytes: 0,
             capped: false,
+            terminal: None,
             backend_accounting: None,
         }
     }
@@ -82,6 +119,7 @@ impl BootstrapStreamingBody {
             bytes_seen: 0,
             prebuffered_bytes: 0,
             capped: false,
+            terminal: None,
             backend_accounting: Some(BootstrapBackendAccounting {
                 upstream_pool,
                 backend_index,
@@ -107,6 +145,14 @@ impl BootstrapStreamingBody {
             );
             accounting.finished = true;
         }
+    }
+
+    fn terminalize(&mut self, terminal: BootstrapStreamingTerminal) {
+        if self.terminal.is_some() {
+            return;
+        }
+        self.terminal = Some(terminal);
+        self.finish_backend_accounting();
     }
 }
 
@@ -146,18 +192,18 @@ impl Body for BootstrapStreamingBody {
                         self.prebuffered_bytes = next_state.next_state.prebuffered_bytes;
                     } else {
                         self.capped = true;
-                        self.finish_backend_accounting();
+                        self.terminalize(BootstrapStreamingTerminal::CappedRejected);
                         return Poll::Ready(None);
                     }
                 }
                 Poll::Ready(Some(Ok(frame)))
             }
             Poll::Ready(Some(Err(_))) => {
-                self.finish_backend_accounting();
+                self.terminalize(BootstrapStreamingTerminal::UpstreamBodyFailed);
                 Poll::Ready(None)
             }
             Poll::Ready(None) => {
-                self.finish_backend_accounting();
+                self.terminalize(BootstrapStreamingTerminal::Completed);
                 Poll::Ready(None)
             }
             Poll::Pending => Poll::Pending,
@@ -167,7 +213,9 @@ impl Body for BootstrapStreamingBody {
 
 impl Drop for BootstrapStreamingBody {
     fn drop(&mut self) {
-        self.finish_backend_accounting();
+        if self.terminal.is_none() {
+            self.terminalize(BootstrapStreamingTerminal::UpstreamBodyFailed);
+        }
     }
 }
 
@@ -180,13 +228,15 @@ pub(in crate::quic_listener) struct BootstrapWritebackInput<'a> {
     pub(in crate::quic_listener) prepared_route: &'a BootstrapPreparedRoute,
     pub(in crate::quic_listener) dispatch_ctx: BootstrapDispatchCtx<'a>,
     pub(in crate::quic_listener) suppress_downstream_body: bool,
+    pub(in crate::quic_listener) request_mode: BootstrapRequestMode,
     pub(in crate::quic_listener) client_upgrade: Option<hyper::upgrade::OnUpgrade>,
 }
 
 pub(in crate::quic_listener) fn write_bootstrap_response(
     mut input: BootstrapWritebackInput<'_>,
-) -> Result<Response<BoxBody<Bytes, Infallible>>, hyper::Error> {
+) -> Result<BootstrapWritebackOutcome, hyper::Error> {
     let status = input.upstream_resp.status();
+    let response_mode = BootstrapResponseMode::from_request_mode(input.request_mode, status);
     let normalized_response = normalize_upstream_response(ResponseNormalizationInput {
         upstream: spooky_bridge::response::UpstreamResponseView {
             status,
@@ -202,8 +252,7 @@ pub(in crate::quic_listener) fn write_bootstrap_response(
             protocol: ResponseNormalizationProtocol::Http1,
             strip_connection_headers: true,
             allow_trailers: false,
-            preserve_upgrade: input.dispatch_ctx.is_websocket_upgrade
-                && status == StatusCode::SWITCHING_PROTOCOLS,
+            preserve_upgrade: matches!(response_mode, BootstrapResponseMode::WebsocketUpgrade),
         },
     });
     let upstream_content_length = input
@@ -243,8 +292,10 @@ pub(in crate::quic_listener) fn write_bootstrap_response(
                 normalized_response.emission.body,
                 ResponseBodyPolicy::Forward
             ),
-            exempt_from_body_size_cap: input.dispatch_ctx.is_websocket_upgrade
-                && status == StatusCode::SWITCHING_PROTOCOLS,
+            exempt_from_body_size_cap: matches!(
+                response_mode,
+                BootstrapResponseMode::WebsocketUpgrade
+            ),
         },
     );
     if matches!(
@@ -258,11 +309,14 @@ pub(in crate::quic_listener) fn write_bootstrap_response(
             input.prepared_route,
             input.dispatch_ctx.request.request_start,
         );
-        return Ok(Response::builder()
-            .status(StatusCode::SERVICE_UNAVAILABLE)
-            .header("alt-svc", &input.dispatch_ctx.request.runtime.alt_svc)
-            .body(boxed_full(Bytes::from_static(RESPONSE_BODY_TOO_LARGE_BODY)))
-            .unwrap_or_else(|_| Response::new(boxed_full(Bytes::from_static(b"error\n")))));
+        return Ok(BootstrapWritebackOutcome {
+            terminal: BootstrapTerminalOutcome::Rejected(BootstrapRejectionReason::Overloaded),
+            response: Response::builder()
+                .status(StatusCode::SERVICE_UNAVAILABLE)
+                .header("alt-svc", &input.dispatch_ctx.request.runtime.alt_svc)
+                .body(boxed_full(Bytes::from_static(RESPONSE_BODY_TOO_LARGE_BODY)))
+                .unwrap_or_else(|_| Response::new(boxed_full(Bytes::from_static(b"error\n")))),
+        });
     }
     observe_bootstrap_response_status(
         input.dispatch_ctx.request.runtime.metrics.as_ref(),
@@ -277,18 +331,19 @@ pub(in crate::quic_listener) fn write_bootstrap_response(
     }
     resp_builder = resp_builder.header("alt-svc", &input.dispatch_ctx.request.runtime.alt_svc);
 
-    if input.dispatch_ctx.is_websocket_upgrade
-        && input.upstream_resp.status() == StatusCode::SWITCHING_PROTOCOLS
-    {
-        return write_bootstrap_websocket_upgrade(
-            resp_builder,
-            &mut input.upstream_resp,
-            input.prepared_route,
-            input.dispatch_ctx.request.request_start,
-            &input.dispatch_ctx.request.runtime.alt_svc,
-            input.client_upgrade,
-            status,
-        );
+    if matches!(response_mode, BootstrapResponseMode::WebsocketUpgrade) {
+        return Ok(BootstrapWritebackOutcome {
+            terminal: BootstrapTerminalOutcome::AcceptedWebsocketUpgrade,
+            response: write_bootstrap_websocket_upgrade(
+                resp_builder,
+                &mut input.upstream_resp,
+                input.prepared_route,
+                input.dispatch_ctx.request.request_start,
+                &input.dispatch_ctx.request.runtime.alt_svc,
+                input.client_upgrade,
+                status,
+            )?,
+        });
     }
 
     let resp_body = if matches!(
@@ -320,7 +375,10 @@ pub(in crate::quic_listener) fn write_bootstrap_response(
         .boxed()
     };
 
-    Ok(resp_builder
-        .body(resp_body)
-        .unwrap_or_else(|_| Response::new(boxed_full(Bytes::new()))))
+    Ok(BootstrapWritebackOutcome {
+        terminal: BootstrapTerminalOutcome::AcceptedStandardResponse,
+        response: resp_builder
+            .body(resp_body)
+            .unwrap_or_else(|_| Response::new(boxed_full(Bytes::new()))),
+    })
 }

--- a/crates/edge/src/quic_listener/bootstrap/websocket.rs
+++ b/crates/edge/src/quic_listener/bootstrap/websocket.rs
@@ -13,7 +13,11 @@ use super::{
     dispatch::BootstrapDispatchInput,
     intake::bootstrap_error_response,
     outcome::{finish_bootstrap_backend_request_accounting, observe_bootstrap_dispatch_failure},
-    request::BootstrapPreparedRoute,
+    request::{
+        BootstrapBackendFailureReason, BootstrapLifecycleStage, BootstrapPreparedRoute,
+        BootstrapTerminalOutcome, BootstrapTerminalResponse, BootstrapTerminalResult,
+        BootstrapTimeoutReason,
+    },
 };
 use crate::quic_listener::protocol::is_websocket_upgrade_request;
 
@@ -45,12 +49,16 @@ pub(in crate::quic_listener) fn capture_bootstrap_websocket_flow(
 
 pub(in crate::quic_listener) async fn dispatch_bootstrap_websocket(
     input: BootstrapDispatchInput<'_>,
-) -> Result<Response<Incoming>, Response<BoxBody<Bytes, Infallible>>> {
+) -> BootstrapTerminalResult<Response<Incoming>> {
     if input.prepared_route.endpoint.scheme() != BackendScheme::Http {
-        return Err(bootstrap_error_response(
-            &input.dispatch_ctx.request.runtime.alt_svc,
-            StatusCode::BAD_GATEWAY,
-            b"websocket bootstrap requires http upstream\n",
+        return Err(BootstrapTerminalResponse::new(
+            BootstrapLifecycleStage::Dispatch,
+            BootstrapTerminalOutcome::BackendFailed(BootstrapBackendFailureReason::DispatchFailed),
+            bootstrap_error_response(
+                &input.dispatch_ctx.request.runtime.alt_svc,
+                StatusCode::BAD_GATEWAY,
+                b"websocket bootstrap requires http upstream\n",
+            ),
         ));
     }
 
@@ -58,10 +66,16 @@ pub(in crate::quic_listener) async fn dispatch_bootstrap_websocket(
     let upstream_path_uri = match Uri::try_from(input.dispatch_ctx.request_path) {
         Ok(uri) => uri,
         Err(_) => {
-            return Err(bootstrap_error_response(
-                &input.dispatch_ctx.request.runtime.alt_svc,
-                StatusCode::BAD_GATEWAY,
-                b"bad uri\n",
+            return Err(BootstrapTerminalResponse::new(
+                BootstrapLifecycleStage::Dispatch,
+                BootstrapTerminalOutcome::BackendFailed(
+                    BootstrapBackendFailureReason::RequestBuildFailed,
+                ),
+                bootstrap_error_response(
+                    &input.dispatch_ctx.request.runtime.alt_svc,
+                    StatusCode::BAD_GATEWAY,
+                    b"bad uri\n",
+                ),
             ));
         }
     };
@@ -92,17 +106,27 @@ pub(in crate::quic_listener) async fn dispatch_bootstrap_websocket(
         }
         Ok(Err(err)) => {
             warn!("Bootstrap WebSocket connect error: {}", err);
-            return Err(bootstrap_error_response(
-                &input.dispatch_ctx.request.runtime.alt_svc,
-                StatusCode::BAD_GATEWAY,
-                b"upstream error\n",
+            return Err(BootstrapTerminalResponse::new(
+                BootstrapLifecycleStage::Dispatch,
+                BootstrapTerminalOutcome::BackendFailed(
+                    BootstrapBackendFailureReason::DispatchFailed,
+                ),
+                bootstrap_error_response(
+                    &input.dispatch_ctx.request.runtime.alt_svc,
+                    StatusCode::BAD_GATEWAY,
+                    b"upstream error\n",
+                ),
             ));
         }
         Err(_) => {
-            return Err(bootstrap_error_response(
-                &input.dispatch_ctx.request.runtime.alt_svc,
-                StatusCode::GATEWAY_TIMEOUT,
-                b"upstream timeout\n",
+            return Err(BootstrapTerminalResponse::new(
+                BootstrapLifecycleStage::Dispatch,
+                BootstrapTerminalOutcome::TimedOut(BootstrapTimeoutReason::Upstream),
+                bootstrap_error_response(
+                    &input.dispatch_ctx.request.runtime.alt_svc,
+                    StatusCode::GATEWAY_TIMEOUT,
+                    b"upstream timeout\n",
+                ),
             ));
         }
     };
@@ -112,10 +136,16 @@ pub(in crate::quic_listener) async fn dispatch_bootstrap_websocket(
         Ok(v) => v,
         Err(err) => {
             warn!("Bootstrap WebSocket handshake setup failed: {}", err);
-            return Err(bootstrap_error_response(
-                &input.dispatch_ctx.request.runtime.alt_svc,
-                StatusCode::BAD_GATEWAY,
-                b"upstream error\n",
+            return Err(BootstrapTerminalResponse::new(
+                BootstrapLifecycleStage::Dispatch,
+                BootstrapTerminalOutcome::BackendFailed(
+                    BootstrapBackendFailureReason::DispatchFailed,
+                ),
+                bootstrap_error_response(
+                    &input.dispatch_ctx.request.runtime.alt_svc,
+                    StatusCode::BAD_GATEWAY,
+                    b"upstream error\n",
+                ),
             ));
         }
     };
@@ -140,10 +170,16 @@ pub(in crate::quic_listener) async fn dispatch_bootstrap_websocket(
                 StatusCode::BAD_GATEWAY,
                 &proxy_err,
             );
-            Err(bootstrap_error_response(
-                &input.dispatch_ctx.request.runtime.alt_svc,
-                StatusCode::BAD_GATEWAY,
-                b"upstream error\n",
+            Err(BootstrapTerminalResponse::new(
+                BootstrapLifecycleStage::Dispatch,
+                BootstrapTerminalOutcome::BackendFailed(
+                    BootstrapBackendFailureReason::DispatchFailed,
+                ),
+                bootstrap_error_response(
+                    &input.dispatch_ctx.request.runtime.alt_svc,
+                    StatusCode::BAD_GATEWAY,
+                    b"upstream error\n",
+                ),
             ))
         }
         Err(_) => {
@@ -155,10 +191,14 @@ pub(in crate::quic_listener) async fn dispatch_bootstrap_websocket(
                 StatusCode::GATEWAY_TIMEOUT,
                 &ProxyError::Timeout,
             );
-            Err(bootstrap_error_response(
-                &input.dispatch_ctx.request.runtime.alt_svc,
-                StatusCode::GATEWAY_TIMEOUT,
-                b"upstream timeout\n",
+            Err(BootstrapTerminalResponse::new(
+                BootstrapLifecycleStage::Dispatch,
+                BootstrapTerminalOutcome::TimedOut(BootstrapTimeoutReason::Upstream),
+                bootstrap_error_response(
+                    &input.dispatch_ctx.request.runtime.alt_svc,
+                    StatusCode::GATEWAY_TIMEOUT,
+                    b"upstream timeout\n",
+                ),
             ))
         }
     }

--- a/crates/edge/src/quic_listener/forwarding/auth.rs
+++ b/crates/edge/src/quic_listener/forwarding/auth.rs
@@ -30,7 +30,6 @@ pub(super) struct AuthStart {
     pub(super) rx: oneshot::Receiver<ExternalAuthResult>,
     pub(super) abort: AbortHandle,
     pub(super) deadline: Instant,
-    pub(super) fail_open: bool,
 }
 
 struct AuthHttpClient {
@@ -437,7 +436,6 @@ pub(super) fn start_external_auth_task(
         rx,
         abort: join.abort_handle(),
         deadline: Instant::now() + task_config.timeout,
-        fail_open: task_config.disposition.fail_open(),
     })
 }
 

--- a/crates/edge/src/quic_listener/forwarding/auth.rs
+++ b/crates/edge/src/quic_listener/forwarding/auth.rs
@@ -494,6 +494,7 @@ impl QUICListener {
                     req.response_status.unwrap_or(0)
                 );
                 Self::send_external_auth_decision_response(h3, quic, stream_id, &decision)?;
+                req.mark_terminal_outcome_recorded();
                 req.transition_to_terminal_with_cleanup(
                     TerminalReason::Rejected(RejectionReason::AuthDenied),
                     metrics,
@@ -530,6 +531,7 @@ impl QUICListener {
                     AdmissionOutcomeClass::Failed { timed_out: false },
                 );
                 Self::send_simple_response(h3, quic, stream_id, status, body)?;
+                req.mark_terminal_outcome_recorded();
                 req.transition_to_terminal_with_cleanup(
                     TerminalReason::Rejected(RejectionReason::AuthUnavailable),
                     metrics,
@@ -554,6 +556,7 @@ impl QUICListener {
                     AdmissionOutcomeClass::Failed { timed_out: true },
                 );
                 Self::send_simple_response(h3, quic, stream_id, status, body)?;
+                req.mark_terminal_outcome_recorded();
                 req.transition_to_terminal_with_cleanup(
                     TerminalReason::TimedOut(TimeoutReason::ExternalAuth),
                     metrics,

--- a/crates/edge/src/quic_listener/forwarding/auth.rs
+++ b/crates/edge/src/quic_listener/forwarding/auth.rs
@@ -20,7 +20,7 @@ use crate::runtime::connection::{
         AdmissionOutcomeClass, OutcomeBackendTarget, OutcomeRouteTarget, observe_admission_outcome,
     },
     request::PendingForward,
-    stream::RequestExecutionState,
+    stream::{RejectionReason, RequestExecutionState, TerminalReason, TimeoutReason},
 };
 
 const MAX_AUTH_BODY_BYTES: usize = 64 * 1024;
@@ -471,7 +471,6 @@ impl QUICListener {
             }
             ExternalAuthStateTransition::RejectedAuthDenied { decision } => {
                 req.response_status = Some(decision.status().as_u16());
-                req.discard_awaiting_auth_resources();
                 metrics.inc_policy_denied();
                 metrics.inc_external_auth_denied();
                 let _ = observe_admission_outcome(
@@ -495,6 +494,10 @@ impl QUICListener {
                     req.response_status.unwrap_or(0)
                 );
                 Self::send_external_auth_decision_response(h3, quic, stream_id, &decision)?;
+                req.transition_to_terminal_with_cleanup(
+                    TerminalReason::Rejected(RejectionReason::AuthDenied),
+                    metrics,
+                );
                 Ok(false)
             }
             ExternalAuthStateTransition::RejectedAuthUnavailable {
@@ -512,7 +515,6 @@ impl QUICListener {
                     );
                 }
                 req.response_status = Some(status.as_u16());
-                req.discard_awaiting_auth_resources();
                 let _ = observe_admission_outcome(
                     metrics,
                     OutcomeRouteTarget {
@@ -528,12 +530,15 @@ impl QUICListener {
                     AdmissionOutcomeClass::Failed { timed_out: false },
                 );
                 Self::send_simple_response(h3, quic, stream_id, status, body)?;
+                req.transition_to_terminal_with_cleanup(
+                    TerminalReason::Rejected(RejectionReason::AuthUnavailable),
+                    metrics,
+                );
                 Ok(false)
             }
             ExternalAuthStateTransition::TimedOutAuth { status, body } => {
                 metrics.inc_external_auth_timeout();
                 req.response_status = Some(status.as_u16());
-                req.discard_awaiting_auth_resources();
                 let _ = observe_admission_outcome(
                     metrics,
                     OutcomeRouteTarget {
@@ -549,6 +554,10 @@ impl QUICListener {
                     AdmissionOutcomeClass::Failed { timed_out: true },
                 );
                 Self::send_simple_response(h3, quic, stream_id, status, body)?;
+                req.transition_to_terminal_with_cleanup(
+                    TerminalReason::TimedOut(TimeoutReason::ExternalAuth),
+                    metrics,
+                );
                 Ok(false)
             }
         }

--- a/crates/edge/src/quic_listener/forwarding/auth.rs
+++ b/crates/edge/src/quic_listener/forwarding/auth.rs
@@ -452,21 +452,21 @@ impl QUICListener {
         shared_ctx: &ForwardingSharedCtx<'_>,
     ) -> Result<bool, quiche::h3::Error> {
         let metrics = shared_ctx.metrics.as_ref();
-        req.auth_result_rx = None;
-        if let Some(abort) = req.auth_abort.take() {
+        req.clear_auth_result_rx();
+        if let Some(abort) = req.take_auth_abort() {
             abort.abort();
         }
-        req.auth_deadline = None;
+        req.set_auth_deadline(None);
         let completion = evaluate_external_auth_completion(
             result,
-            ExternalAuthFailureDisposition::from_fail_open(req.auth_fail_open),
+            ExternalAuthFailureDisposition::from_fail_open(req.auth_fail_open()),
         );
         match completion {
             ExternalAuthCompletion::Allow {
                 request_header_mutations,
             } => {
                 metrics.inc_external_auth_allowed();
-                if let Some(pending_forward) = req.pending_forward.as_mut() {
+                if let Some(pending_forward) = req.pending_forward_mut() {
                     merge_auth_request_mutations(
                         &mut Arc::make_mut(pending_forward).auth_header_mutations,
                         request_header_mutations,
@@ -475,7 +475,7 @@ impl QUICListener {
                 Self::materialize_forward_after_auth(stream_id, req, h3, quic, exec_ctx, shared_ctx)
             }
             ExternalAuthCompletion::Respond(decision) => {
-                req.admission_state = StreamAdmissionState::Denied;
+                req.set_admission_state_legacy(StreamAdmissionState::Denied);
                 req.response_status = Some(decision.status().as_u16());
                 metrics.inc_policy_denied();
                 metrics.inc_external_auth_denied();
@@ -542,7 +542,7 @@ impl QUICListener {
                         );
                     }
                 }
-                req.admission_state = StreamAdmissionState::Denied;
+                req.set_admission_state_legacy(StreamAdmissionState::Denied);
                 req.response_status = Some(status.as_u16());
                 let _ = observe_admission_outcome(
                     metrics,

--- a/crates/edge/src/quic_listener/forwarding/auth.rs
+++ b/crates/edge/src/quic_listener/forwarding/auth.rs
@@ -10,18 +10,17 @@ use tokio::task::AbortHandle;
 use super::*;
 use crate::runtime::connection::{
     auth::{
-        ExternalAuthCompletion, ExternalAuthDecision, ExternalAuthDenyResponse,
-        ExternalAuthExecutionPolicy, ExternalAuthFailureDisposition, ExternalAuthResponseMetadata,
-        ExternalAuthResult, ExternalAuthTaskConfig, OidcAuthorizationCheck,
-        evaluate_external_auth_completion, merge_auth_request_mutations, oidc_audience_matches,
+        ExternalAuthDecision, ExternalAuthDenyResponse, ExternalAuthExecutionPolicy,
+        ExternalAuthResponseMetadata, ExternalAuthResult, ExternalAuthStateTransition,
+        ExternalAuthTaskConfig, OidcAuthorizationCheck, oidc_audience_matches,
         oidc_authorization_check, oidc_discovery_target, oidc_scope_satisfied,
-        validate_oidc_provider_metadata,
+        resolve_external_auth_state_transition, validate_oidc_provider_metadata,
     },
     outcome::{
         AdmissionOutcomeClass, OutcomeBackendTarget, OutcomeRouteTarget, observe_admission_outcome,
     },
     request::PendingForward,
-    stream::StreamAdmissionState,
+    stream::RequestExecutionState,
 };
 
 const MAX_AUTH_BODY_BYTES: usize = 64 * 1024;
@@ -450,31 +449,29 @@ impl QUICListener {
         shared_ctx: &ForwardingSharedCtx<'_>,
     ) -> Result<bool, quiche::h3::Error> {
         let metrics = shared_ctx.metrics.as_ref();
-        req.clear_auth_result_rx();
-        if let Some(abort) = req.take_auth_abort() {
-            abort.abort();
-        }
-        req.set_auth_deadline(None);
-        let completion = evaluate_external_auth_completion(
-            result,
-            ExternalAuthFailureDisposition::from_fail_open(req.auth_fail_open()),
-        );
-        match completion {
-            ExternalAuthCompletion::Allow {
+        let RequestExecutionState::AwaitingAuth(awaiting_auth) = &req.execution else {
+            Self::send_simple_response(
+                h3,
+                quic,
+                stream_id,
+                http::StatusCode::INTERNAL_SERVER_ERROR,
+                b"missing awaiting auth state\n",
+            )?;
+            return Ok(false);
+        };
+        let transition =
+            resolve_external_auth_state_transition(result, awaiting_auth.auth_disposition);
+        match transition {
+            ExternalAuthStateTransition::Admitted {
                 request_header_mutations,
             } => {
                 metrics.inc_external_auth_allowed();
-                if let Some(pending_forward) = req.pending_forward_mut() {
-                    merge_auth_request_mutations(
-                        &mut Arc::make_mut(pending_forward).auth_header_mutations,
-                        request_header_mutations,
-                    );
-                }
+                req.transition_awaiting_auth_to_dispatch_ready(request_header_mutations);
                 Self::materialize_forward_after_auth(stream_id, req, h3, quic, exec_ctx, shared_ctx)
             }
-            ExternalAuthCompletion::Respond(decision) => {
-                req.set_admission_state_legacy(StreamAdmissionState::Denied);
+            ExternalAuthStateTransition::RejectedAuthDenied { decision } => {
                 req.response_status = Some(decision.status().as_u16());
+                req.discard_awaiting_auth_resources();
                 metrics.inc_policy_denied();
                 metrics.inc_external_auth_denied();
                 let _ = observe_admission_outcome(
@@ -500,48 +497,22 @@ impl QUICListener {
                 Self::send_external_auth_decision_response(h3, quic, stream_id, &decision)?;
                 Ok(false)
             }
-            ExternalAuthCompletion::FailOpen { timed_out, error } => {
-                if timed_out {
-                    metrics.inc_external_auth_timeout();
-                    warn!(
-                        "request_id={} route={} external auth failed open: timeout",
-                        req.request_id,
-                        req.upstream_name.as_deref().unwrap_or("unrouted"),
-                    );
-                } else {
-                    metrics.inc_external_auth_error();
-                    if let Some(error) = error {
-                        warn!(
-                            "request_id={} route={} external auth failed open: {:?}",
-                            req.request_id,
-                            req.upstream_name.as_deref().unwrap_or("unrouted"),
-                            error
-                        );
-                    }
-                }
-                Self::materialize_forward_after_auth(stream_id, req, h3, quic, exec_ctx, shared_ctx)
-            }
-            ExternalAuthCompletion::Reject {
+            ExternalAuthStateTransition::RejectedAuthUnavailable {
                 status,
                 body,
-                timed_out,
                 error,
             } => {
-                if timed_out {
-                    metrics.inc_external_auth_timeout();
-                } else {
-                    metrics.inc_external_auth_error();
-                    if let Some(error) = &error {
-                        debug!(
-                            "request_id={} route={} external auth rejected after error: {:?}",
-                            req.request_id,
-                            req.upstream_name.as_deref().unwrap_or("unrouted"),
-                            error
-                        );
-                    }
+                metrics.inc_external_auth_error();
+                if let Some(error) = &error {
+                    debug!(
+                        "request_id={} route={} external auth rejected after error: {:?}",
+                        req.request_id,
+                        req.upstream_name.as_deref().unwrap_or("unrouted"),
+                        error
+                    );
                 }
-                req.set_admission_state_legacy(StreamAdmissionState::Denied);
                 req.response_status = Some(status.as_u16());
+                req.discard_awaiting_auth_resources();
                 let _ = observe_admission_outcome(
                     metrics,
                     OutcomeRouteTarget {
@@ -554,7 +525,28 @@ impl QUICListener {
                     }),
                     req.start.elapsed(),
                     status,
-                    AdmissionOutcomeClass::Failed { timed_out },
+                    AdmissionOutcomeClass::Failed { timed_out: false },
+                );
+                Self::send_simple_response(h3, quic, stream_id, status, body)?;
+                Ok(false)
+            }
+            ExternalAuthStateTransition::TimedOutAuth { status, body } => {
+                metrics.inc_external_auth_timeout();
+                req.response_status = Some(status.as_u16());
+                req.discard_awaiting_auth_resources();
+                let _ = observe_admission_outcome(
+                    metrics,
+                    OutcomeRouteTarget {
+                        route: req.upstream_name.as_deref().unwrap_or("unrouted"),
+                    },
+                    Some(OutcomeBackendTarget {
+                        upstream: req.upstream_name.as_deref().unwrap_or("unrouted"),
+                        backend_addr: req.backend_addr.as_deref(),
+                        backend_index: req.backend_index,
+                    }),
+                    req.start.elapsed(),
+                    status,
+                    AdmissionOutcomeClass::Failed { timed_out: true },
                 );
                 Self::send_simple_response(h3, quic, stream_id, status, body)?;
                 Ok(false)

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -19,37 +19,42 @@ pub(in crate::quic_listener) use self::resolve::RouteResolutionRequest as TestRo
 use super::*;
 use crate::runtime::connection::{
     outcome::{
-        BackendRequestFinishInput, OutcomeBackendTarget, OutcomeRouteTarget,
-        finish_backend_request_accounting, observe_admission_outcome, observe_proxy_error_outcome,
+        OutcomeBackendTarget, OutcomeRouteTarget, observe_admission_outcome,
+        observe_proxy_error_outcome,
     },
     request::PendingForward,
-    stream::{AdmissionPermits, StreamAdmissionState},
+    stream::{
+        AdmissionPermits, BackendFailureReason, RejectionReason, StreamAdmissionState, StreamPhase,
+        TerminalReason,
+    },
 };
 
-pub(super) fn abort_stream(req: &mut RequestEnvelope, metrics: &Metrics) -> StreamPhase {
-    let phase = req.phase();
-    if req.backend_request_started() && !req.backend_request_finished() {
-        finish_backend_request_accounting(BackendRequestFinishInput {
-            upstream_pool: req.upstream_pool.as_ref(),
-            backend_index: req.backend_index,
-            elapsed: req.start.elapsed(),
-            status: req.response_status.or(Some(503)),
-        });
-        req.set_backend_request_state(true, true);
+pub(super) fn terminalize_stream(
+    req: &mut RequestEnvelope,
+    reason: TerminalReason,
+    metrics: &Metrics,
+) -> StreamPhase {
+    req.transition_to_terminal_with_cleanup(reason, metrics)
+}
+
+pub(super) fn backend_failure_reason_for_proxy_error(err: &ProxyError) -> BackendFailureReason {
+    match err {
+        ProxyError::Timeout => BackendFailureReason::UpstreamTimeout,
+        ProxyError::Tls(_) => BackendFailureReason::UpstreamTls,
+        ProxyError::Transport(_) | ProxyError::Pool(_) => BackendFailureReason::UpstreamTransport,
+        ProxyError::Protocol(_) => BackendFailureReason::UpstreamProtocol,
+        ProxyError::Bridge(_) => BackendFailureReason::UpstreamBridge,
     }
-    if req.body_buf_bytes() > 0 {
-        metrics.release_request_buffer(req.body_buf_bytes());
-        req.set_body_buf_bytes(0);
+}
+
+pub(super) fn rejection_reason_for_status(status: http::StatusCode) -> RejectionReason {
+    match status {
+        http::StatusCode::PAYLOAD_TOO_LARGE => RejectionReason::RequestBodyTooLarge,
+        http::StatusCode::TOO_MANY_REQUESTS => RejectionReason::RateLimited,
+        http::StatusCode::SERVICE_UNAVAILABLE => RejectionReason::Overloaded,
+        http::StatusCode::BAD_REQUEST => RejectionReason::ValidationFailed,
+        _ => RejectionReason::ValidationFailed,
     }
-    req.body_buf_mut().clear();
-    req.clear_body_tx();
-    req.discard_awaiting_auth_resources();
-    req.clear_upstream_result_rx();
-    req.clear_response_chunk_rx();
-    req.set_pending_chunk(None);
-    req.clear_pending_forward();
-    req.clear_dispatch_permits();
-    phase
 }
 
 // Shared forwarding dependencies passed through extracted submodules.
@@ -250,6 +255,11 @@ impl QUICListener {
                 http::StatusCode::INTERNAL_SERVER_ERROR,
                 b"missing deferred forward snapshot\n",
             )?;
+            terminalize_stream(
+                req,
+                TerminalReason::Rejected(RejectionReason::ValidationFailed),
+                metrics,
+            );
             return Ok(false);
         };
         let Some(upstream_name) = req.upstream_name.clone() else {
@@ -269,6 +279,11 @@ impl QUICListener {
                 http::StatusCode::INTERNAL_SERVER_ERROR,
                 b"missing upstream route\n",
             )?;
+            terminalize_stream(
+                req,
+                TerminalReason::Rejected(RejectionReason::ValidationFailed),
+                metrics,
+            );
             return Ok(false);
         };
 
@@ -334,6 +349,11 @@ impl QUICListener {
                 resilience
                     .adaptive_admission
                     .observe(req.start.elapsed(), true);
+                terminalize_stream(
+                    req,
+                    TerminalReason::Rejected(RejectionReason::Overloaded),
+                    metrics,
+                );
                 return Ok(false);
             }
             crate::quic_listener::admission::PostAuthAdmissionExecution::Rejected(
@@ -368,6 +388,11 @@ impl QUICListener {
                         .adaptive_admission
                         .observe(req.start.elapsed(), true);
                 }
+                terminalize_stream(
+                    req,
+                    TerminalReason::Rejected(rejection_reason_for_status(decision.status)),
+                    metrics,
+                );
                 return Ok(false);
             }
         };
@@ -405,6 +430,11 @@ impl QUICListener {
                 http::StatusCode::BAD_GATEWAY,
                 b"unknown backend endpoint\n",
             )?;
+            terminalize_stream(
+                req,
+                TerminalReason::BackendFailed(BackendFailureReason::DispatchSpawnFailed),
+                metrics,
+            );
             return Ok(false);
         };
 
@@ -460,6 +490,11 @@ impl QUICListener {
                     resilience
                         .adaptive_admission
                         .observe(req.start.elapsed(), true);
+                    terminalize_stream(
+                        req,
+                        TerminalReason::Rejected(RejectionReason::ValidationFailed),
+                        metrics,
+                    );
                     return Ok(false);
                 }
             }
@@ -503,6 +538,11 @@ impl QUICListener {
                 resilience
                     .adaptive_admission
                     .observe(req.start.elapsed(), true);
+                terminalize_stream(
+                    req,
+                    TerminalReason::BackendFailed(BackendFailureReason::DispatchSpawnFailed),
+                    metrics,
+                );
                 return Ok(false);
             }
         };
@@ -768,7 +808,15 @@ impl QUICListener {
                         };
                         if !keep_stream {
                             if let Some(req) = connection.streams.get_mut(&stream_id) {
-                                abort_stream(req, &metrics);
+                                if !req.execution.is_terminal() {
+                                    terminalize_stream(
+                                        req,
+                                        TerminalReason::Cancelled(
+                                            CancellationReason::OperatorAbort,
+                                        ),
+                                        &metrics,
+                                    );
+                                }
                             }
                             connection.streams.remove(&stream_id);
                             continue;
@@ -905,7 +953,13 @@ impl QUICListener {
                                     b"request body not allowed for this request\n",
                                 )?;
                                 if let Some(req) = connection.streams.get_mut(&stream_id) {
-                                    abort_stream(req, &metrics);
+                                    terminalize_stream(
+                                        req,
+                                        TerminalReason::Rejected(
+                                            RejectionReason::RequestBodyNotAllowed,
+                                        ),
+                                        &metrics,
+                                    );
                                 }
                                 connection.streams.remove(&stream_id);
                                 resilience.adaptive_admission.observe(elapsed, true);
@@ -931,7 +985,13 @@ impl QUICListener {
                                     REQUEST_BODY_TOO_LARGE_BODY,
                                 )?;
                                 if let Some(req) = connection.streams.get_mut(&stream_id) {
-                                    abort_stream(req, &metrics);
+                                    terminalize_stream(
+                                        req,
+                                        TerminalReason::Rejected(
+                                            RejectionReason::RequestBodyTooLarge,
+                                        ),
+                                        &metrics,
+                                    );
                                 }
                                 connection.streams.remove(&stream_id);
                                 resilience.adaptive_admission.observe(elapsed, true);
@@ -971,7 +1031,11 @@ impl QUICListener {
                                     .adaptive_admission
                                     .observe(req.start.elapsed(), true);
                                 if let Some(req) = connection.streams.get_mut(&stream_id) {
-                                    abort_stream(req, &metrics);
+                                    terminalize_stream(
+                                        req,
+                                        TerminalReason::Rejected(RejectionReason::Overloaded),
+                                        &metrics,
+                                    );
                                 }
                                 connection.streams.remove(&stream_id);
                                 break;
@@ -1013,7 +1077,11 @@ impl QUICListener {
                                     .observe(req.start.elapsed(), true);
                             }
                             if let Some(req) = connection.streams.get_mut(&stream_id) {
-                                abort_stream(req, &metrics);
+                                terminalize_stream(
+                                    req,
+                                    TerminalReason::Rejected(RejectionReason::ValidationFailed),
+                                    &metrics,
+                                );
                             }
                             connection.streams.remove(&stream_id);
                             let _ = Self::send_simple_response(
@@ -1042,7 +1110,11 @@ impl QUICListener {
                 }
                 Ok((stream_id, quiche::h3::Event::Reset(error_code))) => {
                     if let Some(req) = connection.streams.get_mut(&stream_id) {
-                        let phase = abort_stream(req, &metrics);
+                        let phase = terminalize_stream(
+                            req,
+                            TerminalReason::Cancelled(CancellationReason::ClientReset),
+                            &metrics,
+                        );
                         debug!(
                             "stream {} reset by client (error_code={}, phase={:?}): resources released",
                             stream_id, error_code, phase

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -12,13 +12,12 @@ use http_body_util::Full;
 use spooky_config::config::ScopedRateLimitScope;
 use spooky_errors::ClassifiedUpstreamProxyError;
 
-use self::prepare::{PreparedRequest, StartedAuthRequest};
+use self::prepare::StartedRequestEnvelope;
 pub(in crate::quic_listener) use self::resolve::BootstrapResolutionInput;
 #[cfg(test)]
 pub(in crate::quic_listener) use self::resolve::RouteResolutionRequest as TestRouteResolutionRequest;
 use super::*;
 use crate::runtime::connection::{
-    auth::ExternalAuthFailureDisposition,
     outcome::{
         BackendRequestFinishInput, OutcomeBackendTarget, OutcomeRouteTarget,
         finish_backend_request_accounting, observe_admission_outcome, observe_proxy_error_outcome,
@@ -765,91 +764,19 @@ impl QUICListener {
                         request_start,
                         &metrics,
                         pre_auth,
+                        routing_transparency_enabled,
+                        routing_transparency_include_reason,
+                        backend_total_request_timeout,
                     )? {
                         Some(started_auth) => started_auth,
                         None => continue,
                     };
-                    let StartedAuthRequest {
-                        request:
-                            PreparedRequest {
-                                upstream_name,
-                                backend_addr,
-                                backend_index,
-                                upstream_pool,
-                                backend_lb,
-                                route_path_len,
-                                route_host_specific,
-                                route_reason,
-                                request_id,
-                                trace_id,
-                                span_id,
-                                traceparent,
-                                trace_span,
-                                bodyless_mode,
-                                request_fin_received,
-                                pending_forward,
-                                auth_fail_open: _,
-                            },
-                        auth_start,
-                        auth_requested,
+                    let StartedRequestEnvelope {
+                        envelope,
+                        should_materialize_forward,
                     } = started_auth;
-
-                    let (
-                        auth_result_rx,
-                        auth_abort,
-                        auth_deadline,
-                        auth_disposition,
-                        admission_state,
-                    ) = match auth_start {
-                        Some(start) => (
-                            Some(start.rx),
-                            Some(start.abort),
-                            Some(start.deadline),
-                            Some(ExternalAuthFailureDisposition::from_fail_open(
-                                start.fail_open,
-                            )),
-                            StreamAdmissionState::WaitingForAuth,
-                        ),
-                        None => (None, None, None, None, StreamAdmissionState::ReadyToForward),
-                    };
-                    connection.streams.insert(
-                        stream_id,
-                        RequestEnvelope::new_legacy(
-                            request_id,
-                            trace_id,
-                            span_id,
-                            traceparent,
-                            trace_span,
-                            method,
-                            path,
-                            authority,
-                            Some(backend_addr),
-                            Some(backend_index),
-                            Some(upstream_name),
-                            Some(route_reason),
-                            Some(route_path_len),
-                            Some(route_host_specific),
-                            Some(backend_lb),
-                            Some(upstream_pool),
-                            routing_transparency_enabled,
-                            routing_transparency_include_reason,
-                            request_start,
-                            request_start + backend_total_request_timeout,
-                            bodyless_mode,
-                            tunnel_mode,
-                            0,
-                            None,
-                            StreamPhase::ReceivingRequest,
-                            admission_state,
-                            request_fin_received,
-                            Some(pending_forward),
-                            auth_result_rx,
-                            auth_abort,
-                            auth_disposition,
-                            auth_deadline,
-                        ),
-                    );
-                    if !auth_requested {
+                    connection.streams.insert(stream_id, envelope);
+                    if should_materialize_forward {
                         let keep_stream = if let Some(req) = connection.streams.get_mut(&stream_id)
                         {
                             Self::materialize_forward_after_auth(

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -349,6 +349,8 @@ impl QUICListener {
                 resilience
                     .adaptive_admission
                     .observe(req.start.elapsed(), true);
+                req.set_terminal_overload_reason(Some(decision.reason.metrics_reason()));
+                req.mark_terminal_outcome_recorded();
                 terminalize_stream(
                     req,
                     TerminalReason::Rejected(RejectionReason::Overloaded),
@@ -388,6 +390,10 @@ impl QUICListener {
                         .adaptive_admission
                         .observe(req.start.elapsed(), true);
                 }
+                if let Some(reason) = decision.overload_reason {
+                    req.set_terminal_overload_reason(Some(reason.metrics_reason()));
+                }
+                req.mark_terminal_outcome_recorded();
                 terminalize_stream(
                     req,
                     TerminalReason::Rejected(rejection_reason_for_status(decision.status)),
@@ -1031,6 +1037,10 @@ impl QUICListener {
                                     .adaptive_admission
                                     .observe(req.start.elapsed(), true);
                                 if let Some(req) = connection.streams.get_mut(&stream_id) {
+                                    req.set_terminal_overload_reason(Some(
+                                        OverloadShedReason::RequestBufferCap,
+                                    ));
+                                    req.mark_terminal_outcome_recorded();
                                     terminalize_stream(
                                         req,
                                         TerminalReason::Rejected(RejectionReason::Overloaded),

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -24,7 +24,7 @@ use crate::runtime::connection::{
     },
     request::PendingForward,
     stream::{
-        AdmissionPermits, BackendFailureReason, RejectionReason, StreamAdmissionState, StreamPhase,
+        AdmissionPermits, BackendFailureReason, RejectionReason, StreamPhase,
         TerminalReason,
     },
 };
@@ -813,16 +813,14 @@ impl QUICListener {
                             false
                         };
                         if !keep_stream {
-                            if let Some(req) = connection.streams.get_mut(&stream_id) {
-                                if !req.execution.is_terminal() {
-                                    terminalize_stream(
-                                        req,
-                                        TerminalReason::Cancelled(
-                                            CancellationReason::OperatorAbort,
-                                        ),
-                                        &metrics,
-                                    );
-                                }
+                            if let Some(req) = connection.streams.get_mut(&stream_id)
+                                && !req.execution.is_terminal()
+                            {
+                                terminalize_stream(
+                                    req,
+                                    TerminalReason::Cancelled(CancellationReason::OperatorAbort),
+                                    &metrics,
+                                );
                             }
                             connection.streams.remove(&stream_id);
                             continue;
@@ -1109,11 +1107,6 @@ impl QUICListener {
                     if let Some(req) = connection.streams.get_mut(&stream_id) {
                         req.transition_request_body_finished();
                         let _ = Self::flush_request_buffer(req, &metrics);
-                        // Only move to AwaitingUpstream once auth has allowed the request
-                        // and an upstream task/body channel actually exists.
-                        if req.admission_state() == StreamAdmissionState::ReadyToForward {
-                            req.set_phase_legacy(StreamPhase::AwaitingUpstream);
-                        }
                         // Upstream polling and response dispatch are handled entirely
                         // by advance_streams_non_blocking, called unconditionally below.
                     }

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -18,6 +18,7 @@ pub(in crate::quic_listener) use self::resolve::BootstrapResolutionInput;
 pub(in crate::quic_listener) use self::resolve::RouteResolutionRequest as TestRouteResolutionRequest;
 use super::*;
 use crate::runtime::connection::{
+    auth::ExternalAuthFailureDisposition,
     outcome::{
         BackendRequestFinishInput, OutcomeBackendTarget, OutcomeRouteTarget,
         finish_backend_request_accounting, observe_admission_outcome, observe_proxy_error_outcome,
@@ -27,35 +28,32 @@ use crate::runtime::connection::{
 };
 
 pub(super) fn abort_stream(req: &mut RequestEnvelope, metrics: &Metrics) -> StreamPhase {
-    let phase = req.phase.clone();
-    if req.backend_request_started && !req.backend_request_finished {
+    let phase = req.phase();
+    if req.backend_request_started() && !req.backend_request_finished() {
         finish_backend_request_accounting(BackendRequestFinishInput {
             upstream_pool: req.upstream_pool.as_ref(),
             backend_index: req.backend_index,
             elapsed: req.start.elapsed(),
             status: req.response_status.or(Some(503)),
         });
-        req.backend_request_finished = true;
+        req.set_backend_request_state(true, true);
     }
-    if req.body_buf_bytes > 0 {
-        metrics.release_request_buffer(req.body_buf_bytes);
-        req.body_buf_bytes = 0;
+    if req.body_buf_bytes() > 0 {
+        metrics.release_request_buffer(req.body_buf_bytes());
+        req.set_body_buf_bytes(0);
     }
-    req.body_buf.clear();
-    req.body_tx = None;
-    req.auth_result_rx = None;
-    if let Some(abort) = req.auth_abort.take() {
+    req.body_buf_mut().clear();
+    req.clear_body_tx();
+    req.clear_auth_result_rx();
+    if let Some(abort) = req.take_auth_abort() {
         abort.abort();
     }
-    req.upstream_result_rx = None;
-    req.response_chunk_rx = None;
-    req.pending_chunk = None;
-    req.pending_forward = None;
-    req.auth_deadline = None;
-    req.global_inflight_permit = None;
-    req.upstream_inflight_permit = None;
-    req.adaptive_admission_permit = None;
-    req.route_queue_permit = None;
+    req.clear_upstream_result_rx();
+    req.clear_response_chunk_rx();
+    req.set_pending_chunk(None);
+    req.clear_pending_forward();
+    req.set_auth_deadline(None);
+    req.clear_dispatch_permits();
     phase
 }
 
@@ -240,7 +238,7 @@ impl QUICListener {
     ) -> Result<bool, quiche::h3::Error> {
         let metrics = shared_ctx.metrics.as_ref();
         let resilience = shared_ctx.resilience;
-        let Some(pending_forward) = req.pending_forward.as_ref().cloned() else {
+        let Some(pending_forward) = req.pending_forward().cloned() else {
             let _ = observe_proxy_error_outcome(
                 metrics,
                 OutcomeRouteTarget::UNROUTED,
@@ -525,26 +523,19 @@ impl QUICListener {
             }
         };
 
-        req.backend_request_started = true;
-        req.backend_request_finished = false;
-        req.body_tx = body_tx;
-        req.upstream_result_rx = Some(result_rx);
-        req.global_inflight_permit = Some(global_permit);
-        req.upstream_inflight_permit = Some(upstream_permit);
-        req.adaptive_admission_permit = Some(adaptive_permit);
-        req.route_queue_permit = Some(route_queue_permit);
-        req.admission_state = StreamAdmissionState::ReadyToForward;
-        req.phase = if req.request_fin_received {
-            StreamPhase::AwaitingUpstream
-        } else {
-            StreamPhase::ReceivingRequest
-        };
+        req.transition_to_dispatching(
+            body_tx,
+            result_rx,
+            global_permit,
+            upstream_permit,
+            adaptive_permit,
+            route_queue_permit,
+        );
         Self::flush_request_buffer(req, metrics);
-        if req.request_fin_received && req.body_buf.is_empty() {
-            req.body_tx = None;
-            req.phase = StreamPhase::AwaitingUpstream;
+        if req.request_fin_received() && req.body_buf().is_empty() {
+            req.clear_body_tx();
+            req.set_phase_legacy(StreamPhase::AwaitingUpstream);
         }
-        req.auth_abort = None;
         Ok(true)
     }
 
@@ -797,7 +788,7 @@ impl QUICListener {
                                 bodyless_mode,
                                 request_fin_received,
                                 pending_forward,
-                                auth_fail_open,
+                                auth_fail_open: _,
                             },
                         auth_start,
                         auth_requested,
@@ -807,27 +798,23 @@ impl QUICListener {
                         auth_result_rx,
                         auth_abort,
                         auth_deadline,
-                        auth_fail_open,
+                        auth_disposition,
                         admission_state,
                     ) = match auth_start {
                         Some(start) => (
                             Some(start.rx),
                             Some(start.abort),
                             Some(start.deadline),
-                            start.fail_open,
+                            Some(ExternalAuthFailureDisposition::from_fail_open(
+                                start.fail_open,
+                            )),
                             StreamAdmissionState::WaitingForAuth,
                         ),
-                        None => (
-                            None,
-                            None,
-                            None,
-                            auth_fail_open,
-                            StreamAdmissionState::ReadyToForward,
-                        ),
+                        None => (None, None, None, None, StreamAdmissionState::ReadyToForward),
                     };
                     connection.streams.insert(
                         stream_id,
-                        RequestEnvelope {
+                        RequestEnvelope::new_legacy(
                             request_id,
                             trace_id,
                             span_id,
@@ -836,47 +823,31 @@ impl QUICListener {
                             method,
                             path,
                             authority,
-                            body_tx: None,
-                            body_buf: std::collections::VecDeque::new(),
-                            body_buf_bytes: 0,
-                            body_bytes_received: 0,
-                            last_body_activity: request_start,
-                            backend_addr: Some(backend_addr),
-                            backend_index: Some(backend_index),
-                            upstream_name: Some(upstream_name),
-                            route_reason: Some(route_reason),
-                            route_path_len: Some(route_path_len),
-                            route_host_specific: Some(route_host_specific),
-                            backend_lb: Some(backend_lb),
-                            upstream_pool: Some(upstream_pool),
+                            Some(backend_addr),
+                            Some(backend_index),
+                            Some(upstream_name),
+                            Some(route_reason),
+                            Some(route_path_len),
+                            Some(route_host_specific),
+                            Some(backend_lb),
+                            Some(upstream_pool),
                             routing_transparency_enabled,
                             routing_transparency_include_reason,
-                            response_status: None,
-                            backend_request_started: false,
-                            backend_request_finished: false,
-                            global_inflight_permit: None,
-                            upstream_inflight_permit: None,
-                            adaptive_admission_permit: None,
-                            route_queue_permit: None,
-                            start: request_start,
-                            total_request_deadline: request_start + backend_total_request_timeout,
+                            request_start,
+                            request_start + backend_total_request_timeout,
                             bodyless_mode,
                             tunnel_mode,
-                            retry_count: 0,
-                            error_kind: None,
-                            pending_forward: Some(pending_forward),
-                            auth_result_rx,
-                            auth_abort,
-                            auth_fail_open,
-                            auth_deadline,
-                            phase: StreamPhase::ReceivingRequest,
+                            0,
+                            None,
+                            StreamPhase::ReceivingRequest,
                             admission_state,
                             request_fin_received,
-                            upstream_result_rx: None,
-                            response_chunk_rx: None,
-                            response_headers_sent: false,
-                            pending_chunk: None,
-                        },
+                            Some(pending_forward),
+                            auth_result_rx,
+                            auth_abort,
+                            auth_disposition,
+                            auth_deadline,
+                        ),
                     );
                     if !auth_requested {
                         let keep_stream = if let Some(req) = connection.streams.get_mut(&stream_id)
@@ -915,7 +886,7 @@ impl QUICListener {
                             let mut payload_too_large = None::<(String, Duration)>;
                             if let Some(req) = connection.streams.get_mut(&stream_id) {
                                 if read > 0 {
-                                    req.last_body_activity = Instant::now();
+                                    req.set_last_body_activity(Instant::now());
                                 }
                                 if req.bodyless_mode && read > 0 {
                                     reject_body_for_bodyless = Some((
@@ -935,9 +906,10 @@ impl QUICListener {
                                         },
                                         RequestBodyGuardrailInput {
                                             elapsed: req.start.elapsed(),
-                                            idle_for: Instant::now()
-                                                .saturating_duration_since(req.last_body_activity),
-                                            bytes_received: req.body_bytes_received,
+                                            idle_for: Instant::now().saturating_duration_since(
+                                                req.last_body_activity(),
+                                            ),
+                                            bytes_received: req.body_bytes_received(),
                                             buffered_bytes: 0,
                                             next_chunk_bytes: read,
                                             declared_content_length: None,
@@ -958,7 +930,7 @@ impl QUICListener {
                                             ));
                                         }
                                         Ok(next_state) => {
-                                            req.body_bytes_received = next_state.bytes_received;
+                                            req.set_body_bytes_received(next_state.bytes_received);
 
                                             for chunk_slice in
                                                 body_buf[..read].chunks(REQUEST_CHUNK_BYTES_LIMIT)
@@ -1154,17 +1126,17 @@ impl QUICListener {
                 },
                 Ok((stream_id, quiche::h3::Event::Finished)) => {
                     if let Some(req) = connection.streams.get_mut(&stream_id) {
-                        req.request_fin_received = true;
+                        req.set_request_fin_received(true);
 
                         Self::flush_request_buffer(req, &metrics);
                         // If buffer is now empty, drop body_tx to signal end-of-body.
-                        if req.body_buf.is_empty() {
-                            req.body_tx = None;
+                        if req.body_buf().is_empty() {
+                            req.clear_body_tx();
                         }
                         // Only move to AwaitingUpstream once auth has allowed the request
                         // and an upstream task/body channel actually exists.
-                        if req.admission_state == StreamAdmissionState::ReadyToForward {
-                            req.phase = StreamPhase::AwaitingUpstream;
+                        if req.admission_state() == StreamAdmissionState::ReadyToForward {
+                            req.set_phase_legacy(StreamPhase::AwaitingUpstream);
                         }
                         // Upstream polling and response dispatch are handled entirely
                         // by advance_streams_non_blocking, called unconditionally below.

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -43,15 +43,11 @@ pub(super) fn abort_stream(req: &mut RequestEnvelope, metrics: &Metrics) -> Stre
     }
     req.body_buf_mut().clear();
     req.clear_body_tx();
-    req.clear_auth_result_rx();
-    if let Some(abort) = req.take_auth_abort() {
-        abort.abort();
-    }
+    req.discard_awaiting_auth_resources();
     req.clear_upstream_result_rx();
     req.clear_response_chunk_rx();
     req.set_pending_chunk(None);
     req.clear_pending_forward();
-    req.set_auth_deadline(None);
     req.clear_dispatch_permits();
     phase
 }

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -408,9 +408,10 @@ impl QUICListener {
             return Ok(false);
         };
 
+        let request_mode = req.request_mode();
         let websocket_h1_tunnel = req.tunnel_mode == TunnelMode::Websocket
             && backend_endpoint.scheme() == BackendScheme::Http;
-        let (body_tx, websocket_tunnel_body_rx, request_body) = if req.bodyless_mode {
+        let (body_tx, websocket_tunnel_body_rx, request_body) = if request_mode.bodyless_mode() {
             (None, None, Some(BoxBody::new(Full::new(Bytes::new()))))
         } else if websocket_h1_tunnel {
             let (tx, rx) = mpsc::channel::<Bytes>(REQUEST_CHUNK_CHANNEL_CAPACITY);
@@ -509,10 +510,7 @@ impl QUICListener {
             pool.begin_request_for_accounting(backend_index);
         }
         req.transition_admitted_to_awaiting_upstream(body_tx, result_rx);
-        Self::flush_request_buffer(req, metrics);
-        if req.request_fin_received() && req.body_buf().is_empty() {
-            req.clear_body_tx();
-        }
+        let _ = Self::flush_request_buffer(req, metrics);
         Ok(true)
     }
 
@@ -793,7 +791,7 @@ impl QUICListener {
                                 if read > 0 {
                                     req.set_last_body_activity(Instant::now());
                                 }
-                                if req.bodyless_mode && read > 0 {
+                                if req.request_mode().bodyless_mode() && read > 0 {
                                     reject_body_for_bodyless = Some((
                                         req.upstream_name
                                             .clone()
@@ -1031,13 +1029,8 @@ impl QUICListener {
                 },
                 Ok((stream_id, quiche::h3::Event::Finished)) => {
                     if let Some(req) = connection.streams.get_mut(&stream_id) {
-                        req.set_request_fin_received(true);
-
-                        Self::flush_request_buffer(req, &metrics);
-                        // If buffer is now empty, drop body_tx to signal end-of-body.
-                        if req.body_buf().is_empty() {
-                            req.clear_body_tx();
-                        }
+                        req.transition_request_body_finished();
+                        let _ = Self::flush_request_buffer(req, &metrics);
                         // Only move to AwaitingUpstream once auth has allowed the request
                         // and an upstream task/body channel actually exists.
                         if req.admission_state() == StreamAdmissionState::ReadyToForward {

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -12,7 +12,7 @@ use http_body_util::Full;
 use spooky_config::config::ScopedRateLimitScope;
 use spooky_errors::ClassifiedUpstreamProxyError;
 
-use self::prepare::StartedRequestEnvelope;
+use self::prepare::{RequestFinalizationConfig, StartedRequestEnvelope};
 pub(in crate::quic_listener) use self::resolve::BootstrapResolutionInput;
 #[cfg(test)]
 pub(in crate::quic_listener) use self::resolve::RouteResolutionRequest as TestRouteResolutionRequest;
@@ -785,9 +785,11 @@ impl QUICListener {
                         request_start,
                         &metrics,
                         pre_auth,
-                        routing_transparency_enabled,
-                        routing_transparency_include_reason,
-                        backend_total_request_timeout,
+                        RequestFinalizationConfig {
+                            routing_transparency_enabled,
+                            routing_transparency_include_reason,
+                            backend_total_request_timeout,
+                        },
                     )? {
                         Some(started_auth) => started_auth,
                         None => continue,

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -24,8 +24,7 @@ use crate::runtime::connection::{
     },
     request::PendingForward,
     stream::{
-        AdmissionPermits, BackendFailureReason, RejectionReason, StreamPhase,
-        TerminalReason,
+        AdmissionPermits, BackendFailureReason, RejectionReason, StreamPhase, TerminalReason,
     },
 };
 

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -23,7 +23,7 @@ use crate::runtime::connection::{
         finish_backend_request_accounting, observe_admission_outcome, observe_proxy_error_outcome,
     },
     request::PendingForward,
-    stream::StreamAdmissionState,
+    stream::{AdmissionPermits, StreamAdmissionState},
 };
 
 pub(super) fn abort_stream(req: &mut RequestEnvelope, metrics: &Metrics) -> StreamPhase {
@@ -371,18 +371,18 @@ impl QUICListener {
                 return Ok(false);
             }
         };
+        req.transition_to_admitted(AdmissionPermits {
+            global: global_permit,
+            upstream: upstream_permit,
+            adaptive: adaptive_permit,
+            route_queue: route_queue_permit,
+        });
 
         let Some(backend_endpoint) = exec_ctx
             .backend_endpoints
             .get(pending_forward.backend_addr.as_ref())
             .cloned()
         else {
-            finish_backend_request_accounting(BackendRequestFinishInput {
-                upstream_pool: Some(&upstream_pool),
-                backend_index: Some(backend_index),
-                elapsed: req.start.elapsed(),
-                status: Some(503),
-            });
             let _ = observe_proxy_error_outcome(
                 metrics,
                 OutcomeRouteTarget {
@@ -433,12 +433,6 @@ impl QUICListener {
                 Ok(request) => Some(request),
                 Err(err) => {
                     let err_text = err.to_string();
-                    finish_backend_request_accounting(BackendRequestFinishInput {
-                        upstream_pool: Some(&upstream_pool),
-                        backend_index: Some(backend_index),
-                        elapsed: req.start.elapsed(),
-                        status: Some(503),
-                    });
                     let _ = observe_proxy_error_outcome(
                         metrics,
                         OutcomeRouteTarget {
@@ -481,12 +475,6 @@ impl QUICListener {
         ) {
             Ok(result_rx) => result_rx,
             Err(err) => {
-                finish_backend_request_accounting(BackendRequestFinishInput {
-                    upstream_pool: Some(&upstream_pool),
-                    backend_index: Some(backend_index),
-                    elapsed: req.start.elapsed(),
-                    status: Some(503),
-                });
                 let _ = observe_proxy_error_outcome(
                     metrics,
                     OutcomeRouteTarget {
@@ -517,19 +505,13 @@ impl QUICListener {
                 return Ok(false);
             }
         };
-
-        req.transition_to_dispatching(
-            body_tx,
-            result_rx,
-            global_permit,
-            upstream_permit,
-            adaptive_permit,
-            route_queue_permit,
-        );
+        if let Ok(pool) = upstream_pool.write() {
+            pool.begin_request_for_accounting(backend_index);
+        }
+        req.transition_admitted_to_awaiting_upstream(body_tx, result_rx);
         Self::flush_request_buffer(req, metrics);
         if req.request_fin_received() && req.body_buf().is_empty() {
             req.clear_body_tx();
-            req.set_phase_legacy(StreamPhase::AwaitingUpstream);
         }
         Ok(true)
     }

--- a/crates/edge/src/quic_listener/forwarding/prepare.rs
+++ b/crates/edge/src/quic_listener/forwarding/prepare.rs
@@ -321,7 +321,6 @@ impl QUICListener {
                 request_mode,
                 request_body,
                 request_body_runtime: RequestBodyRuntime {
-                    body_tx: None,
                     body_buf: VecDeque::new(),
                     body_buf_bytes: 0,
                     body_bytes_received: 0,

--- a/crates/edge/src/quic_listener/forwarding/prepare.rs
+++ b/crates/edge/src/quic_listener/forwarding/prepare.rs
@@ -2,16 +2,11 @@ use std::convert::Infallible;
 
 use http_body_util::Full;
 use spooky_config::runtime::RuntimeExternalAuth;
-use tracing::Span;
 
-use super::{
-    auth::{AuthStart, start_external_auth_task},
-    resolve::ForwardingResolvedTarget,
-    *,
-};
+use super::{auth::start_external_auth_task, resolve::ForwardingResolvedTarget, *};
 use crate::{
     quic_listener::admission::{
-        AdmissionPolicyDecision, admission_rejection_response,
+        AdmissionPolicyDecision, AdmissionRejectionResponse, admission_rejection_response,
         evaluate_forwarding_pre_admission_policy,
     },
     runtime::connection::{
@@ -23,39 +18,86 @@ use crate::{
             AdmissionOutcomeClass, OutcomeBackendTarget, OutcomeRouteTarget,
             observe_admission_outcome,
         },
-        request::PendingForward,
+        request::{IntakeExecutionSeed, PendingForward, RequestEnvelope},
+        stream::{
+            DispatchReadyState, RequestContext, RequestIntakeState, RequestMode, RoutingSnapshot,
+        },
     },
 };
 
-pub(super) struct PreparedRequest {
-    pub(super) upstream_name: String,
-    pub(super) backend_addr: String,
-    pub(super) backend_index: usize,
+pub(super) struct IntakeRequestCandidate {
+    pub(super) state: RequestIntakeState,
+}
+
+impl IntakeRequestCandidate {
+    fn request_id(&self) -> u64 {
+        self.state.context.request_id
+    }
+}
+
+pub(super) struct DispatchReadyCandidate {
+    pub(super) state: DispatchReadyState,
+    pub(super) routing: RoutingSnapshot,
     pub(super) upstream_pool: Arc<RwLock<UpstreamPool>>,
-    pub(super) backend_lb: String,
-    pub(super) route_path_len: usize,
-    pub(super) route_host_specific: bool,
-    pub(super) route_reason: String,
-    pub(super) request_id: u64,
-    pub(super) trace_id: Option<String>,
-    pub(super) span_id: Option<String>,
-    pub(super) traceparent: Option<String>,
-    pub(super) trace_span: Option<Span>,
-    pub(super) bodyless_mode: bool,
-    pub(super) request_fin_received: bool,
-    pub(super) pending_forward: Arc<PendingForward>,
-    pub(super) auth_fail_open: bool,
 }
 
-pub(super) struct PreAuthRequest {
-    pub(super) request: PreparedRequest,
-    pub(super) external_auth: Option<RuntimeExternalAuth>,
+impl DispatchReadyCandidate {
+    fn request_id(&self) -> u64 {
+        self.state.context.request_id
+    }
+
+    fn upstream_name(&self) -> &str {
+        &self.routing.upstream_name
+    }
+
+    fn backend_addr(&self) -> &str {
+        &self.routing.backend_addr
+    }
+
+    fn backend_index(&self) -> usize {
+        self.routing.backend_index
+    }
+
+    fn into_envelope(
+        self,
+        routing_transparency_enabled: bool,
+        routing_transparency_include_reason: bool,
+        execution: IntakeExecutionSeed,
+    ) -> RequestEnvelope {
+        RequestEnvelope::from_intake_legacy(
+            self.state.context,
+            self.routing,
+            self.upstream_pool,
+            self.state.request_mode,
+            self.state.request_body,
+            routing_transparency_enabled,
+            routing_transparency_include_reason,
+            0,
+            None,
+            execution,
+        )
+    }
 }
 
-pub(super) struct StartedAuthRequest {
-    pub(super) request: PreparedRequest,
-    pub(super) auth_start: Option<AuthStart>,
-    pub(super) auth_requested: bool,
+pub(super) struct ExternalAuthCandidate {
+    pub(super) request: DispatchReadyCandidate,
+    pub(super) external_auth: RuntimeExternalAuth,
+    pub(super) auth_disposition: ExternalAuthFailureDisposition,
+}
+
+pub(super) struct LocalRejectionCandidate {
+    pub(super) response: AdmissionRejectionResponse,
+}
+
+pub(super) enum PreAdmissionNextState {
+    LocallyRejected(LocalRejectionCandidate),
+    RequiresExternalAuth(ExternalAuthCandidate),
+    ReadyForPostAuthAdmission(DispatchReadyCandidate),
+}
+
+pub(super) struct StartedRequestEnvelope {
+    pub(super) envelope: RequestEnvelope,
+    pub(super) should_materialize_forward: bool,
 }
 
 impl PendingForward {
@@ -165,6 +207,88 @@ impl PendingForward {
 }
 
 impl QUICListener {
+    fn build_request_intake(
+        quic_trace_id: &str,
+        request_start: Instant,
+        method: &str,
+        path: &str,
+        authority: Option<&str>,
+        headers: &[quiche::h3::Header],
+        content_length: Option<usize>,
+        tunnel_mode: TunnelMode,
+        tracing_enabled: bool,
+    ) -> IntakeRequestCandidate {
+        let request_id = REQUEST_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let request_mode = RequestMode::from_intake(tunnel_mode, method, content_length);
+        let incoming_traceparent =
+            extract_header_value(headers, b"traceparent").and_then(parse_traceparent);
+        let trace_id = incoming_traceparent
+            .as_ref()
+            .map(|(trace_id, _)| trace_id.clone())
+            .or_else(|| tracing_enabled.then(|| generated_trace_id(quic_trace_id, request_id)));
+        let span_id = trace_id.as_ref().map(|_| generated_span_id(request_id));
+        let traceparent = trace_id
+            .as_ref()
+            .zip(span_id.as_ref())
+            .map(|(trace_id, span_id)| format!("00-{trace_id}-{span_id}-01"));
+        let trace_span = trace_id
+            .as_ref()
+            .zip(span_id.as_ref())
+            .map(|(trace_id, span_id)| {
+                info_span!(
+                    "spooky.request",
+                    request_id = request_id,
+                    trace_id = %trace_id,
+                    span_id = %span_id,
+                    method = %method,
+                    path = %path
+                )
+            });
+
+        IntakeRequestCandidate {
+            state: RequestIntakeState {
+                context: RequestContext {
+                    request_id,
+                    trace_id,
+                    span_id,
+                    traceparent,
+                    trace_span,
+                    method: method.to_string(),
+                    path: path.to_string(),
+                    authority: authority.map(str::to_string),
+                    start: request_start,
+                    total_request_deadline: request_start,
+                },
+                request_mode,
+                request_body: request_mode.initial_body_state(),
+            },
+        }
+    }
+
+    fn build_dispatch_ready_candidate(
+        intake: IntakeRequestCandidate,
+        routing: RoutingSnapshot,
+        upstream_pool: Arc<RwLock<UpstreamPool>>,
+        pending_forward: Arc<PendingForward>,
+    ) -> DispatchReadyCandidate {
+        let RequestIntakeState {
+            context,
+            request_mode,
+            request_body,
+        } = intake.state;
+        DispatchReadyCandidate {
+            state: DispatchReadyState {
+                context,
+                routing: routing.clone(),
+                request_mode,
+                request_body,
+                pending_forward,
+            },
+            routing,
+            upstream_pool,
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub(super) fn prepare_request_for_auth(
         stream_id: u64,
@@ -186,7 +310,18 @@ impl QUICListener {
         upstream_pools: &HashMap<String, Arc<RwLock<UpstreamPool>>>,
         metrics: &Metrics,
         resilience: &RuntimeResilience,
-    ) -> Result<Option<PreAuthRequest>, quiche::h3::Error> {
+    ) -> Result<Option<PreAdmissionNextState>, quiche::h3::Error> {
+        let intake = Self::build_request_intake(
+            quic_trace_id,
+            request_start,
+            method,
+            path,
+            authority,
+            headers,
+            content_length,
+            tunnel_mode,
+            tracing_enabled,
+        );
         let lb_header_lookup = |name: &str| {
             headers
                 .iter()
@@ -220,6 +355,15 @@ impl QUICListener {
                 backend_index,
                 backend_lb,
             }) => {
+                let routing = RoutingSnapshot {
+                    backend_addr: backend_addr.clone(),
+                    backend_index,
+                    upstream_name: upstream_name.clone(),
+                    route_reason: route_reason.clone(),
+                    route_path_len,
+                    route_host_specific,
+                    backend_lb: Some(backend_lb.clone()),
+                };
                 let admission = evaluate_forwarding_pre_admission_policy(
                     &upstream_policy,
                     Some(&lb_header_lookup),
@@ -278,8 +422,11 @@ impl QUICListener {
                             )?;
                             return Ok(None);
                         };
-                        Self::send_admission_rejection_response(h3, quic, stream_id, response)?;
-                        return Ok(None);
+                        return Ok(Some(PreAdmissionNextState::LocallyRejected(
+                            LocalRejectionCandidate {
+                                response: response.clone(),
+                            },
+                        )));
                     }
                     AdmissionPolicyDecision::RateLimited(decision) => {
                         metrics.inc_request_rate_limited();
@@ -315,8 +462,11 @@ impl QUICListener {
                             )?;
                             return Ok(None);
                         };
-                        Self::send_admission_rejection_response(h3, quic, stream_id, response)?;
-                        return Ok(None);
+                        return Ok(Some(PreAdmissionNextState::LocallyRejected(
+                            LocalRejectionCandidate {
+                                response: response.clone(),
+                            },
+                        )));
                     }
                     AdmissionPolicyDecision::Overloaded(decision) => {
                         let _ = observe_admission_outcome(
@@ -349,54 +499,22 @@ impl QUICListener {
                             )?;
                             return Ok(None);
                         };
-                        Self::send_admission_rejection_response(h3, quic, stream_id, response)?;
                         resilience
                             .adaptive_admission
                             .observe(request_start.elapsed(), true);
-                        return Ok(None);
+                        return Ok(Some(PreAdmissionNextState::LocallyRejected(
+                            LocalRejectionCandidate {
+                                response: response.clone(),
+                            },
+                        )));
                     }
                 }
 
-                let request_id = REQUEST_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
-                let incoming_traceparent =
-                    extract_header_value(headers, b"traceparent").and_then(parse_traceparent);
-                let trace_id = incoming_traceparent
-                    .as_ref()
-                    .map(|(trace_id, _)| trace_id.clone())
-                    .or_else(|| {
-                        tracing_enabled.then(|| generated_trace_id(quic_trace_id, request_id))
-                    });
-                let span_id = trace_id.as_ref().map(|_| generated_span_id(request_id));
-                let traceparent = trace_id
-                    .as_ref()
-                    .zip(span_id.as_ref())
-                    .map(|(trace_id, span_id)| format!("00-{trace_id}-{span_id}-01"));
-                let trace_span =
-                    trace_id
-                        .as_ref()
-                        .zip(span_id.as_ref())
-                        .map(|(trace_id, span_id)| {
-                            info_span!(
-                                "spooky.request",
-                                request_id = request_id,
-                                trace_id = %trace_id,
-                                span_id = %span_id,
-                                method = %method,
-                                path = %path
-                            )
-                        });
-                let bodyless_mode = !is_tunnel_mode(tunnel_mode)
-                    && is_bodyless_request_mode(method, content_length);
-                let request_fin_received = bodyless_mode;
                 let external_auth = upstream_policy.upstream_auth.external_auth.clone();
-                let auth_fail_open = external_auth
+                let auth_disposition = external_auth
                     .as_ref()
-                    .map(|auth| {
-                        ExternalAuthTaskConfig::from_external_auth(auth)
-                            .disposition
-                            .fail_open()
-                    })
-                    .unwrap_or(false);
+                    .map(|auth| ExternalAuthTaskConfig::from_external_auth(auth).disposition);
+                let request_id = intake.request_id();
                 let pending_forward = Arc::new(PendingForward {
                     method: Arc::<str>::from(method),
                     path: Arc::<str>::from(path),
@@ -411,35 +529,44 @@ impl QUICListener {
                     backend_lb: Some(Arc::<str>::from(backend_lb.as_str())),
                     client_addr: peer_address,
                     request_id,
-                    trace_id: trace_id.as_deref().map(Arc::<str>::from),
-                    span_id: span_id.as_deref().map(Arc::<str>::from),
-                    traceparent: traceparent.as_deref().map(Arc::<str>::from),
+                    trace_id: intake
+                        .state
+                        .context
+                        .trace_id
+                        .as_deref()
+                        .map(Arc::<str>::from),
+                    span_id: intake
+                        .state
+                        .context
+                        .span_id
+                        .as_deref()
+                        .map(Arc::<str>::from),
+                    traceparent: intake
+                        .state
+                        .context
+                        .traceparent
+                        .as_deref()
+                        .map(Arc::<str>::from),
                     host_policy: upstream_policy.host.0.clone(),
                     forwarded_header_policy: upstream_policy.forwarded_headers.0.clone(),
                     auth_header_mutations: Vec::new(),
                 });
+                let dispatch_ready = Self::build_dispatch_ready_candidate(
+                    intake,
+                    routing,
+                    upstream_pool,
+                    pending_forward,
+                );
 
-                Some(PreAuthRequest {
-                    request: PreparedRequest {
-                        upstream_name,
-                        backend_addr,
-                        backend_index,
-                        upstream_pool,
-                        backend_lb,
-                        route_path_len,
-                        route_host_specific,
-                        route_reason,
-                        request_id,
-                        trace_id,
-                        span_id,
-                        traceparent,
-                        trace_span,
-                        bodyless_mode,
-                        request_fin_received,
-                        pending_forward,
-                        auth_fail_open,
-                    },
-                    external_auth,
+                Some(match (external_auth, auth_disposition) {
+                    (Some(external_auth), Some(auth_disposition)) => {
+                        PreAdmissionNextState::RequiresExternalAuth(ExternalAuthCandidate {
+                            request: dispatch_ready,
+                            external_auth,
+                            auth_disposition,
+                        })
+                    }
+                    _ => PreAdmissionNextState::ReadyForPostAuthAdmission(dispatch_ready),
                 })
             }
             Err(err) => {
@@ -471,87 +598,134 @@ impl QUICListener {
         quic: &mut quiche::Connection,
         request_start: Instant,
         metrics: &Metrics,
-        pre_auth: PreAuthRequest,
-    ) -> Result<Option<StartedAuthRequest>, quiche::h3::Error> {
-        let PreAuthRequest {
-            request,
-            external_auth,
-        } = pre_auth;
-        let auth_fail_open = request.auth_fail_open;
-        let auth_start = if let Some(external_auth) = external_auth {
-            match start_external_auth_task(Arc::clone(&request.pending_forward), external_auth) {
-                Ok(start) => Some(start),
-                Err(err) => {
-                    match evaluate_external_auth_completion(
-                        Err(err),
-                        ExternalAuthFailureDisposition::from_fail_open(auth_fail_open),
-                    ) {
-                        ExternalAuthCompletion::FailOpen { timed_out, error } => {
-                            metrics.inc_external_auth_error();
-                            if timed_out {
-                                warn!(
-                                    "request_id={} route={} external auth startup failed open: timeout",
-                                    request.request_id, request.upstream_name
-                                );
-                            } else if let Some(error) = error {
-                                warn!(
-                                    "request_id={} route={} external auth startup failed open: {:?}",
-                                    request.request_id, request.upstream_name, error
-                                );
+        pre_auth: PreAdmissionNextState,
+        routing_transparency_enabled: bool,
+        routing_transparency_include_reason: bool,
+        backend_total_request_timeout: Duration,
+    ) -> Result<Option<StartedRequestEnvelope>, quiche::h3::Error> {
+        match pre_auth {
+            PreAdmissionNextState::LocallyRejected(rejection) => {
+                Self::send_admission_rejection_response(h3, quic, stream_id, &rejection.response)?;
+                Ok(None)
+            }
+            PreAdmissionNextState::ReadyForPostAuthAdmission(request) => {
+                let mut request = request;
+                request.state.context.total_request_deadline =
+                    request.state.context.start + backend_total_request_timeout;
+                let pending_forward = Arc::clone(&request.state.pending_forward);
+                Ok(Some(StartedRequestEnvelope {
+                    envelope: request.into_envelope(
+                        routing_transparency_enabled,
+                        routing_transparency_include_reason,
+                        IntakeExecutionSeed::ReadyForForwarding { pending_forward },
+                    ),
+                    should_materialize_forward: true,
+                }))
+            }
+            PreAdmissionNextState::RequiresExternalAuth(request) => {
+                let mut request = request;
+                request.request.state.context.total_request_deadline =
+                    request.request.state.context.start + backend_total_request_timeout;
+                let pending_forward = Arc::clone(&request.request.state.pending_forward);
+                let auth_disposition = request.auth_disposition;
+                let auth_start = match start_external_auth_task(
+                    pending_forward,
+                    request.external_auth,
+                ) {
+                    Ok(start) => Some(start),
+                    Err(err) => {
+                        match evaluate_external_auth_completion(Err(err), auth_disposition) {
+                            ExternalAuthCompletion::FailOpen { timed_out, error } => {
+                                metrics.inc_external_auth_error();
+                                if timed_out {
+                                    warn!(
+                                        "request_id={} route={} external auth startup failed open: timeout",
+                                        request.request.request_id(),
+                                        request.request.upstream_name()
+                                    );
+                                } else if let Some(error) = error {
+                                    warn!(
+                                        "request_id={} route={} external auth startup failed open: {:?}",
+                                        request.request.request_id(),
+                                        request.request.upstream_name(),
+                                        error
+                                    );
+                                }
+                                None
                             }
-                            None
-                        }
-                        ExternalAuthCompletion::Reject {
-                            status,
-                            body,
-                            timed_out,
-                            error,
-                        } => {
-                            metrics.inc_external_auth_error();
-                            let _ = observe_admission_outcome(
-                                metrics,
-                                OutcomeRouteTarget {
-                                    route: &request.upstream_name,
-                                },
-                                Some(OutcomeBackendTarget {
-                                    upstream: &request.upstream_name,
-                                    backend_addr: Some(request.backend_addr.as_str()),
-                                    backend_index: Some(request.backend_index),
-                                }),
-                                request_start.elapsed(),
+                            ExternalAuthCompletion::Reject {
                                 status,
-                                AdmissionOutcomeClass::Failed { timed_out },
-                            );
-                            if let Some(error) = error {
-                                error!(
-                                    "request_id={} route={} external auth startup failed: {:?}",
-                                    request.request_id, request.upstream_name, error
+                                body,
+                                timed_out,
+                                error,
+                            } => {
+                                metrics.inc_external_auth_error();
+                                let _ = observe_admission_outcome(
+                                    metrics,
+                                    OutcomeRouteTarget {
+                                        route: request.request.upstream_name(),
+                                    },
+                                    Some(OutcomeBackendTarget {
+                                        upstream: request.request.upstream_name(),
+                                        backend_addr: Some(request.request.backend_addr()),
+                                        backend_index: Some(request.request.backend_index()),
+                                    }),
+                                    request_start.elapsed(),
+                                    status,
+                                    AdmissionOutcomeClass::Failed { timed_out },
                                 );
-                            } else {
-                                error!(
-                                    "request_id={} route={} external auth startup failed",
-                                    request.request_id, request.upstream_name
-                                );
+                                if let Some(error) = error {
+                                    error!(
+                                        "request_id={} route={} external auth startup failed: {:?}",
+                                        request.request.request_id(),
+                                        request.request.upstream_name(),
+                                        error
+                                    );
+                                } else {
+                                    error!(
+                                        "request_id={} route={} external auth startup failed",
+                                        request.request.request_id(),
+                                        request.request.upstream_name()
+                                    );
+                                }
+                                Self::send_simple_response(h3, quic, stream_id, status, body)?;
+                                return Ok(None);
                             }
-                            Self::send_simple_response(h3, quic, stream_id, status, body)?;
-                            return Ok(None);
-                        }
-                        ExternalAuthCompletion::Allow { .. }
-                        | ExternalAuthCompletion::Respond(_) => {
-                            unreachable!("startup failure must resolve to fail-open or rejection")
+                            ExternalAuthCompletion::Allow { .. }
+                            | ExternalAuthCompletion::Respond(_) => {
+                                unreachable!(
+                                    "startup failure must resolve to fail-open or rejection"
+                                )
+                            }
                         }
                     }
-                }
+                };
+                let should_materialize_forward = auth_start.is_none();
+                let pending_forward = Arc::clone(&request.request.state.pending_forward);
+                let envelope = if let Some(start) = auth_start {
+                    request.request.into_envelope(
+                        routing_transparency_enabled,
+                        routing_transparency_include_reason,
+                        IntakeExecutionSeed::AwaitingAuth {
+                            pending_forward,
+                            auth_result_rx: start.rx,
+                            auth_abort: start.abort,
+                            auth_disposition,
+                            auth_deadline: start.deadline,
+                        },
+                    )
+                } else {
+                    request.request.into_envelope(
+                        routing_transparency_enabled,
+                        routing_transparency_include_reason,
+                        IntakeExecutionSeed::ReadyForForwarding { pending_forward },
+                    )
+                };
+                Ok(Some(StartedRequestEnvelope {
+                    envelope,
+                    should_materialize_forward,
+                }))
             }
-        } else {
-            None
-        };
-        let auth_requested = auth_start.is_some();
-
-        Ok(Some(StartedAuthRequest {
-            request,
-            auth_start,
-            auth_requested,
-        }))
+        }
     }
 }

--- a/crates/edge/src/quic_listener/forwarding/prepare.rs
+++ b/crates/edge/src/quic_listener/forwarding/prepare.rs
@@ -128,13 +128,33 @@ pub(super) struct LocalRejectionCandidate {
 
 pub(super) enum PreAdmissionNextState {
     LocallyRejected(LocalRejectionCandidate),
-    RequiresExternalAuth(ExternalAuthCandidate),
-    ReadyForPostAuthAdmission(DispatchReadyCandidate),
+    RequiresExternalAuth(Box<ExternalAuthCandidate>),
+    ReadyForPostAuthAdmission(Box<DispatchReadyCandidate>),
 }
 
 pub(super) struct StartedRequestEnvelope {
     pub(super) envelope: RequestEnvelope,
     pub(super) should_materialize_forward: bool,
+}
+
+/// The parsed HTTP request-line/header inputs needed to build a request intake.
+pub(super) struct IntakeRequestDescriptor<'a> {
+    pub(super) quic_trace_id: &'a str,
+    pub(super) request_start: Instant,
+    pub(super) method: &'a str,
+    pub(super) path: &'a str,
+    pub(super) authority: Option<&'a str>,
+    pub(super) headers: &'a [quiche::h3::Header],
+    pub(super) content_length: Option<usize>,
+    pub(super) tunnel_mode: TunnelMode,
+    pub(super) tracing_enabled: bool,
+}
+
+/// Request-scoped configuration applied when finalizing the request envelope.
+pub(super) struct RequestFinalizationConfig {
+    pub(super) routing_transparency_enabled: bool,
+    pub(super) routing_transparency_include_reason: bool,
+    pub(super) backend_total_request_timeout: Duration,
 }
 
 impl PendingForward {
@@ -244,17 +264,18 @@ impl PendingForward {
 }
 
 impl QUICListener {
-    fn build_request_intake(
-        quic_trace_id: &str,
-        request_start: Instant,
-        method: &str,
-        path: &str,
-        authority: Option<&str>,
-        headers: &[quiche::h3::Header],
-        content_length: Option<usize>,
-        tunnel_mode: TunnelMode,
-        tracing_enabled: bool,
-    ) -> IntakeRequestCandidate {
+    fn build_request_intake(descriptor: IntakeRequestDescriptor<'_>) -> IntakeRequestCandidate {
+        let IntakeRequestDescriptor {
+            quic_trace_id,
+            request_start,
+            method,
+            path,
+            authority,
+            headers,
+            content_length,
+            tunnel_mode,
+            tracing_enabled,
+        } = descriptor;
         let request_id = REQUEST_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
         let request_mode = RequestMode::from_intake(tunnel_mode, method, content_length);
         let incoming_traceparent =
@@ -356,7 +377,7 @@ impl QUICListener {
         metrics: &Metrics,
         resilience: &RuntimeResilience,
     ) -> Result<Option<PreAdmissionNextState>, quiche::h3::Error> {
-        let intake = Self::build_request_intake(
+        let intake = Self::build_request_intake(IntakeRequestDescriptor {
             quic_trace_id,
             request_start,
             method,
@@ -366,7 +387,7 @@ impl QUICListener {
             content_length,
             tunnel_mode,
             tracing_enabled,
-        );
+        });
         let lb_header_lookup = |name: &str| {
             headers
                 .iter()
@@ -605,13 +626,15 @@ impl QUICListener {
 
                 Some(match (external_auth, auth_disposition) {
                     (Some(external_auth), Some(auth_disposition)) => {
-                        PreAdmissionNextState::RequiresExternalAuth(ExternalAuthCandidate {
-                            request: dispatch_ready,
-                            external_auth,
-                            auth_disposition,
-                        })
+                        PreAdmissionNextState::RequiresExternalAuth(Box::new(
+                            ExternalAuthCandidate {
+                                request: dispatch_ready,
+                                external_auth,
+                                auth_disposition,
+                            },
+                        ))
                     }
-                    _ => PreAdmissionNextState::ReadyForPostAuthAdmission(dispatch_ready),
+                    _ => PreAdmissionNextState::ReadyForPostAuthAdmission(Box::new(dispatch_ready)),
                 })
             }
             Err(err) => {
@@ -644,17 +667,20 @@ impl QUICListener {
         request_start: Instant,
         metrics: &Metrics,
         pre_auth: PreAdmissionNextState,
-        routing_transparency_enabled: bool,
-        routing_transparency_include_reason: bool,
-        backend_total_request_timeout: Duration,
+        finalization: RequestFinalizationConfig,
     ) -> Result<Option<StartedRequestEnvelope>, quiche::h3::Error> {
+        let RequestFinalizationConfig {
+            routing_transparency_enabled,
+            routing_transparency_include_reason,
+            backend_total_request_timeout,
+        } = finalization;
         match pre_auth {
             PreAdmissionNextState::LocallyRejected(rejection) => {
                 Self::send_admission_rejection_response(h3, quic, stream_id, &rejection.response)?;
                 Ok(None)
             }
             PreAdmissionNextState::ReadyForPostAuthAdmission(request) => {
-                let mut request = request;
+                let mut request = *request;
                 request.state.context.total_request_deadline =
                     request.state.context.start + backend_total_request_timeout;
                 Ok(Some(StartedRequestEnvelope {
@@ -666,7 +692,7 @@ impl QUICListener {
                 }))
             }
             PreAdmissionNextState::RequiresExternalAuth(request) => {
-                let mut request = request;
+                let mut request = *request;
                 request.request.state.context.total_request_deadline =
                     request.request.state.context.start + backend_total_request_timeout;
                 let auth_disposition = request.auth_disposition;

--- a/crates/edge/src/quic_listener/forwarding/prepare.rs
+++ b/crates/edge/src/quic_listener/forwarding/prepare.rs
@@ -1,7 +1,8 @@
-use std::convert::Infallible;
+use std::{collections::VecDeque, convert::Infallible};
 
 use http_body_util::Full;
 use spooky_config::runtime::RuntimeExternalAuth;
+use tokio::{sync::oneshot, task::AbortHandle};
 
 use super::{auth::start_external_auth_task, resolve::ForwardingResolvedTarget, *};
 use crate::{
@@ -10,6 +11,7 @@ use crate::{
         evaluate_forwarding_pre_admission_policy,
     },
     runtime::connection::{
+        auth::ExternalAuthResult,
         auth::{
             ExternalAuthCompletion, ExternalAuthFailureDisposition, ExternalAuthTaskConfig,
             apply_auth_request_mutations, evaluate_external_auth_completion,
@@ -18,9 +20,10 @@ use crate::{
             AdmissionOutcomeClass, OutcomeBackendTarget, OutcomeRouteTarget,
             observe_admission_outcome,
         },
-        request::{IntakeExecutionSeed, PendingForward, RequestEnvelope},
+        request::{PendingForward, RequestEnvelope},
         stream::{
-            DispatchReadyState, RequestContext, RequestIntakeState, RequestMode, RoutingSnapshot,
+            AwaitingAuthState, DispatchReadyState, RequestBodyRuntime, RequestContext,
+            RequestIntakeState, RequestMode, RoutingSnapshot,
         },
     },
 };
@@ -58,23 +61,57 @@ impl DispatchReadyCandidate {
         self.routing.backend_index
     }
 
-    fn into_envelope(
+    fn into_dispatch_ready_envelope(
         self,
         routing_transparency_enabled: bool,
         routing_transparency_include_reason: bool,
-        execution: IntakeExecutionSeed,
     ) -> RequestEnvelope {
-        RequestEnvelope::from_intake_legacy(
-            self.state.context,
-            self.routing,
+        RequestEnvelope::from_dispatch_ready_state(
+            self.state,
             self.upstream_pool,
-            self.state.request_mode,
-            self.state.request_body,
             routing_transparency_enabled,
             routing_transparency_include_reason,
             0,
             None,
-            execution,
+        )
+    }
+
+    fn into_awaiting_auth_envelope(
+        self,
+        routing_transparency_enabled: bool,
+        routing_transparency_include_reason: bool,
+        auth_result_rx: oneshot::Receiver<ExternalAuthResult>,
+        auth_abort: AbortHandle,
+        auth_disposition: ExternalAuthFailureDisposition,
+        auth_deadline: Instant,
+    ) -> RequestEnvelope {
+        let DispatchReadyState {
+            context,
+            routing,
+            request_mode,
+            request_body,
+            request_body_runtime,
+            pending_forward,
+        } = self.state;
+
+        RequestEnvelope::from_awaiting_auth_state(
+            AwaitingAuthState {
+                context,
+                routing,
+                request_mode,
+                request_body,
+                request_body_runtime,
+                pending_forward,
+                auth_result_rx,
+                auth_abort,
+                auth_deadline,
+                auth_disposition,
+            },
+            self.upstream_pool,
+            routing_transparency_enabled,
+            routing_transparency_include_reason,
+            0,
+            None,
         )
     }
 }
@@ -276,12 +313,21 @@ impl QUICListener {
             request_mode,
             request_body,
         } = intake.state;
+        let last_body_activity = context.start;
         DispatchReadyCandidate {
             state: DispatchReadyState {
                 context,
                 routing: routing.clone(),
                 request_mode,
                 request_body,
+                request_body_runtime: RequestBodyRuntime {
+                    body_tx: None,
+                    body_buf: VecDeque::new(),
+                    body_buf_bytes: 0,
+                    body_bytes_received: 0,
+                    last_body_activity,
+                    request_fin_received: request_body.request_fin_received(),
+                },
                 pending_forward,
             },
             routing,
@@ -612,12 +658,10 @@ impl QUICListener {
                 let mut request = request;
                 request.state.context.total_request_deadline =
                     request.state.context.start + backend_total_request_timeout;
-                let pending_forward = Arc::clone(&request.state.pending_forward);
                 Ok(Some(StartedRequestEnvelope {
-                    envelope: request.into_envelope(
+                    envelope: request.into_dispatch_ready_envelope(
                         routing_transparency_enabled,
                         routing_transparency_include_reason,
-                        IntakeExecutionSeed::ReadyForForwarding { pending_forward },
                     ),
                     should_materialize_forward: true,
                 }))
@@ -626,8 +670,8 @@ impl QUICListener {
                 let mut request = request;
                 request.request.state.context.total_request_deadline =
                     request.request.state.context.start + backend_total_request_timeout;
-                let pending_forward = Arc::clone(&request.request.state.pending_forward);
                 let auth_disposition = request.auth_disposition;
+                let pending_forward = Arc::clone(&request.request.state.pending_forward);
                 let auth_start = match start_external_auth_task(
                     pending_forward,
                     request.external_auth,
@@ -701,24 +745,19 @@ impl QUICListener {
                     }
                 };
                 let should_materialize_forward = auth_start.is_none();
-                let pending_forward = Arc::clone(&request.request.state.pending_forward);
                 let envelope = if let Some(start) = auth_start {
-                    request.request.into_envelope(
+                    request.request.into_awaiting_auth_envelope(
                         routing_transparency_enabled,
                         routing_transparency_include_reason,
-                        IntakeExecutionSeed::AwaitingAuth {
-                            pending_forward,
-                            auth_result_rx: start.rx,
-                            auth_abort: start.abort,
-                            auth_disposition,
-                            auth_deadline: start.deadline,
-                        },
+                        start.rx,
+                        start.abort,
+                        auth_disposition,
+                        start.deadline,
                     )
                 } else {
-                    request.request.into_envelope(
+                    request.request.into_dispatch_ready_envelope(
                         routing_transparency_enabled,
                         routing_transparency_include_reason,
-                        IntakeExecutionSeed::ReadyForForwarding { pending_forward },
                     )
                 };
                 Ok(Some(StartedRequestEnvelope {

--- a/crates/edge/src/quic_listener/forwarding/response.rs
+++ b/crates/edge/src/quic_listener/forwarding/response.rs
@@ -15,6 +15,7 @@ use crate::runtime::connection::{
         ImmediateResponseStart, ResponseBodyPumpPlan, ResponseStartDecision, ResponseStartMetadata,
         ResponseStartObservation,
     },
+    stream::{BackendFailureReason, CompletionReason, ResponseEmissionState},
 };
 
 fn response_body_guardrail_error(decision: ResponseBodyGuardrailDecision) -> Option<ProxyError> {
@@ -940,7 +941,7 @@ impl QUICListener {
                     }
                 }
                 req.response_status = Some(metadata.status.as_u16());
-                req.transition_to_streaming_response(None, true, StreamPhase::Completed);
+                req.transition_streaming_to_completed(CompletionReason::ImmediateResponse);
                 Self::observe_response_start_transition(req, &observation, shared_ctx);
                 Ok(true)
             }
@@ -952,9 +953,9 @@ impl QUICListener {
                 Self::send_response_start_headers(h3, quic, stream_id, &metadata, false)?;
                 req.response_status = Some(metadata.status.as_u16());
                 req.transition_to_streaming_response(
-                    Some(response_chunk_rx),
-                    true,
-                    metadata.streaming_phase(),
+                    response_chunk_rx,
+                    ResponseEmissionState::HeadersSent,
+                    metadata.status,
                 );
                 Self::observe_response_start_transition(req, &observation, shared_ctx);
                 Ok(false)
@@ -971,9 +972,13 @@ impl QUICListener {
                 let chunk_rx = Self::spawn_response_body_pump(req, response_body, &metadata, pump);
                 req.response_status = Some(metadata.status.as_u16());
                 req.transition_to_streaming_response(
-                    Some(chunk_rx),
-                    metadata.response_headers_sent(),
-                    metadata.streaming_phase(),
+                    chunk_rx,
+                    if metadata.response_headers_sent() {
+                        ResponseEmissionState::HeadersSent
+                    } else {
+                        ResponseEmissionState::DeferredHeaders
+                    },
+                    metadata.status,
                 );
                 Self::observe_response_start_transition(req, &observation, shared_ctx);
                 Ok(false)
@@ -1005,7 +1010,9 @@ impl QUICListener {
                         Ok(c) => c,
                         Err(TryRecvError::Empty) => break,
                         Err(TryRecvError::Disconnected) => {
-                            req.set_phase_legacy(StreamPhase::Failed);
+                            req.transition_streaming_to_backend_failed(
+                                BackendFailureReason::ResponseStreamAborted,
+                            );
                             terminal = true;
                             break;
                         }
@@ -1024,7 +1031,7 @@ impl QUICListener {
                     }
                     match h3.send_response(quic, stream_id, &h3_headers, false) {
                         Ok(_) => {
-                            req.set_response_headers_sent(true);
+                            req.set_response_emission_state(ResponseEmissionState::HeadersSent);
                         }
                         Err(quiche::h3::Error::StreamBlocked) => {
                             req.set_pending_chunk(Some(ResponseChunk::Start { status, headers }));
@@ -1047,13 +1054,18 @@ impl QUICListener {
                             resilience
                                 .adaptive_admission
                                 .observe(req.start.elapsed(), true);
+                            req.transition_streaming_to_backend_failed(
+                                BackendFailureReason::ResponseWriteFailed,
+                            );
                             terminal = true;
                             break;
                         }
                     }
                 }
                 ResponseChunk::Data(data) => match h3.send_body(quic, stream_id, &data, false) {
-                    Ok(_) => {}
+                    Ok(_) => {
+                        req.set_response_emission_state(ResponseEmissionState::StreamingBody);
+                    }
                     Err(quiche::h3::Error::StreamBlocked) => {
                         req.set_pending_chunk(Some(ResponseChunk::Data(data)));
                         break;
@@ -1077,6 +1089,9 @@ impl QUICListener {
                         resilience
                             .adaptive_admission
                             .observe(req.start.elapsed(), true);
+                        req.transition_streaming_to_backend_failed(
+                            BackendFailureReason::ResponseWriteFailed,
+                        );
                         terminal = true;
                         break;
                     }
@@ -1087,7 +1102,9 @@ impl QUICListener {
                         h3_headers.push(quiche::h3::Header::new(name, value));
                     }
                     match h3.send_additional_headers(quic, stream_id, &h3_headers, false, false) {
-                        Ok(_) => {}
+                        Ok(_) => {
+                            req.set_response_emission_state(ResponseEmissionState::TrailersPending);
+                        }
                         Err(quiche::h3::Error::StreamBlocked) => {
                             req.set_pending_chunk(Some(ResponseChunk::Trailers { headers }));
                             break;
@@ -1111,6 +1128,9 @@ impl QUICListener {
                             resilience
                                 .adaptive_admission
                                 .observe(req.start.elapsed(), true);
+                            req.transition_streaming_to_backend_failed(
+                                BackendFailureReason::ResponseWriteFailed,
+                            );
                             terminal = true;
                             break;
                         }
@@ -1118,7 +1138,10 @@ impl QUICListener {
                 }
                 ResponseChunk::End => match h3.send_body(quic, stream_id, b"", true) {
                     Ok(_) => {
-                        req.set_phase_legacy(StreamPhase::Completed);
+                        req.set_response_emission_state(ResponseEmissionState::EndPending);
+                        req.transition_streaming_to_completed(
+                            CompletionReason::ResponseStreamFinished,
+                        );
                         terminal = true;
                         break;
                     }
@@ -1145,6 +1168,9 @@ impl QUICListener {
                         resilience
                             .adaptive_admission
                             .observe(req.start.elapsed(), true);
+                        req.transition_streaming_to_backend_failed(
+                            BackendFailureReason::ResponseWriteFailed,
+                        );
                         terminal = true;
                         break;
                     }
@@ -1169,7 +1195,6 @@ impl QUICListener {
                     } else {
                         let _ = h3.send_body(quic, stream_id, b"", true);
                     }
-                    req.set_phase_legacy(StreamPhase::Failed);
                     let upstream_name = routing_index.lookup(&req.path, req.authority.as_deref());
                     let upstream_pool = upstream_name.and_then(|n| upstream_pools.get(n));
                     if let (Some(addr), Some(idx), Some(classified)) = (
@@ -1293,6 +1318,9 @@ impl QUICListener {
                             }
                         }
                     }
+                    req.transition_streaming_to_backend_failed(
+                        BackendFailureReason::ResponseStreamAborted,
+                    );
                     terminal = true;
                     break;
                 }

--- a/crates/edge/src/quic_listener/forwarding/response.rs
+++ b/crates/edge/src/quic_listener/forwarding/response.rs
@@ -464,23 +464,24 @@ impl QUICListener {
         let resilience = shared_ctx.resilience;
         let routing_index = shared_ctx.routing_index;
         let upstream_pools = shared_ctx.upstream_pools;
-        let Some(rx) = &mut req.response_chunk_rx else {
-            return false;
-        };
-
         let mut terminal = false;
         loop {
-            let chunk = match req.pending_chunk.take() {
+            let chunk = match req.take_pending_chunk() {
                 Some(c) => c,
-                None => match rx.try_recv() {
-                    Ok(c) => c,
-                    Err(TryRecvError::Empty) => break,
-                    Err(TryRecvError::Disconnected) => {
-                        req.phase = StreamPhase::Failed;
-                        terminal = true;
-                        break;
+                None => {
+                    let Some(rx) = req.response_chunk_rx_mut() else {
+                        return false;
+                    };
+                    match rx.try_recv() {
+                        Ok(c) => c,
+                        Err(TryRecvError::Empty) => break,
+                        Err(TryRecvError::Disconnected) => {
+                            req.set_phase_legacy(StreamPhase::Failed);
+                            terminal = true;
+                            break;
+                        }
                     }
-                },
+                }
             };
             match chunk {
                 ResponseChunk::Start { status, headers } => {
@@ -494,10 +495,10 @@ impl QUICListener {
                     }
                     match h3.send_response(quic, stream_id, &h3_headers, false) {
                         Ok(_) => {
-                            req.response_headers_sent = true;
+                            req.set_response_headers_sent(true);
                         }
                         Err(quiche::h3::Error::StreamBlocked) => {
-                            req.pending_chunk = Some(ResponseChunk::Start { status, headers });
+                            req.set_pending_chunk(Some(ResponseChunk::Start { status, headers }));
                             break;
                         }
                         Err(err) => {
@@ -505,7 +506,7 @@ impl QUICListener {
                                 "HTTP/3 send_response protocol error on stream {}: {:?}",
                                 stream_id, err
                             );
-                            req.phase = StreamPhase::Failed;
+                            req.set_phase_legacy(StreamPhase::Failed);
                             metrics.inc_backend_error();
                             let _ = crate::runtime::connection::outcome::observe_status_outcome(
                                 metrics,
@@ -525,7 +526,7 @@ impl QUICListener {
                 ResponseChunk::Data(data) => match h3.send_body(quic, stream_id, &data, false) {
                     Ok(_) => {}
                     Err(quiche::h3::Error::StreamBlocked) => {
-                        req.pending_chunk = Some(ResponseChunk::Data(data));
+                        req.set_pending_chunk(Some(ResponseChunk::Data(data)));
                         break;
                     }
                     Err(err) => {
@@ -533,7 +534,7 @@ impl QUICListener {
                             "HTTP/3 send_body data protocol error on stream {}: {:?}",
                             stream_id, err
                         );
-                        req.phase = StreamPhase::Failed;
+                        req.set_phase_legacy(StreamPhase::Failed);
                         metrics.inc_backend_error();
                         let _ = crate::runtime::connection::outcome::observe_status_outcome(
                             metrics,
@@ -559,7 +560,7 @@ impl QUICListener {
                     match h3.send_additional_headers(quic, stream_id, &h3_headers, false, false) {
                         Ok(_) => {}
                         Err(quiche::h3::Error::StreamBlocked) => {
-                            req.pending_chunk = Some(ResponseChunk::Trailers { headers });
+                            req.set_pending_chunk(Some(ResponseChunk::Trailers { headers }));
                             break;
                         }
                         Err(err) => {
@@ -567,7 +568,7 @@ impl QUICListener {
                                 "HTTP/3 send_additional_headers protocol error on stream {}: {:?}",
                                 stream_id, err
                             );
-                            req.phase = StreamPhase::Failed;
+                            req.set_phase_legacy(StreamPhase::Failed);
                             metrics.inc_backend_error();
                             let _ = crate::runtime::connection::outcome::observe_status_outcome(
                                 metrics,
@@ -588,12 +589,12 @@ impl QUICListener {
                 }
                 ResponseChunk::End => match h3.send_body(quic, stream_id, b"", true) {
                     Ok(_) => {
-                        req.phase = StreamPhase::Completed;
+                        req.set_phase_legacy(StreamPhase::Completed);
                         terminal = true;
                         break;
                     }
                     Err(quiche::h3::Error::StreamBlocked) => {
-                        req.pending_chunk = Some(ResponseChunk::End);
+                        req.set_pending_chunk(Some(ResponseChunk::End));
                         break;
                     }
                     Err(err) => {
@@ -601,7 +602,7 @@ impl QUICListener {
                             "HTTP/3 send_body end protocol error on stream {}: {:?}",
                             stream_id, err
                         );
-                        req.phase = StreamPhase::Failed;
+                        req.set_phase_legacy(StreamPhase::Failed);
                         metrics.inc_backend_error();
                         let _ = crate::runtime::connection::outcome::observe_status_outcome(
                             metrics,
@@ -621,7 +622,7 @@ impl QUICListener {
                 },
                 ResponseChunk::Error(err) => {
                     let classified = classify_upstream_proxy_error(&err);
-                    if !req.response_headers_sent {
+                    if !req.response_headers_sent() {
                         let (status, body): (http::StatusCode, &[u8]) =
                             match (&err, classified.as_ref()) {
                                 (ProxyError::Pool(PoolError::BackendOverloaded(_)), _) => (
@@ -639,7 +640,7 @@ impl QUICListener {
                     } else {
                         let _ = h3.send_body(quic, stream_id, b"", true);
                     }
-                    req.phase = StreamPhase::Failed;
+                    req.set_phase_legacy(StreamPhase::Failed);
                     let upstream_name = routing_index.lookup(&req.path, req.authority.as_deref());
                     let upstream_pool = upstream_name.and_then(|n| upstream_pools.get(n));
                     if let (Some(addr), Some(idx), Some(classified)) = (

--- a/crates/edge/src/quic_listener/forwarding/response.rs
+++ b/crates/edge/src/quic_listener/forwarding/response.rs
@@ -954,6 +954,12 @@ impl QUICListener {
                 terminal,
                 observation,
             } => {
+                if let ResponseStartObservation::ProxyError {
+                    overload_reason, ..
+                } = &observation
+                {
+                    req.set_terminal_overload_reason(*overload_reason);
+                }
                 match terminal {
                     ImmediateResponseStart::NormalizedHeadersOnly => {
                         Self::send_response_start_headers(h3, quic, stream_id, &metadata, true)?;
@@ -969,6 +975,7 @@ impl QUICListener {
                     }
                 }
                 req.response_status = Some(metadata.status.as_u16());
+                req.mark_terminal_outcome_recorded();
                 req.transition_streaming_to_completed(CompletionReason::ImmediateResponse, metrics);
                 Self::observe_response_start_transition(req, &observation, shared_ctx);
                 Ok(true)

--- a/crates/edge/src/quic_listener/forwarding/response.rs
+++ b/crates/edge/src/quic_listener/forwarding/response.rs
@@ -6,37 +6,60 @@ use super::*;
 use crate::runtime::connection::{
     auth::ExternalAuthDecision,
     guardrails::{
-        ProgressiveEmissionPolicy, RESPONSE_BODY_TOO_LARGE_BODY, ResponseBodyGuardrailConfig,
-        ResponseBodyGuardrailDecision, ResponseBodyGuardrailInput,
+        BodyTimeoutKind, ProgressiveEmissionPolicy, RESPONSE_BODY_TOO_LARGE_BODY,
+        ResponseBodyGuardrailConfig, ResponseBodyGuardrailDecision, ResponseBodyGuardrailInput,
         checked_response_body_guardrails, is_unknown_length_response_prebuffer_reason,
         response_body_limit_reason, response_chunk_ranges,
     },
     response::{
-        ImmediateResponseStart, ResponseBodyPumpPlan, ResponseStartDecision, ResponseStartMetadata,
-        ResponseStartObservation,
+        ImmediateResponseStart, ResponseBodyPumpPlan, ResponseChunk, ResponseStartDecision,
+        ResponseStartMetadata, ResponseStartObservation,
     },
-    stream::{BackendFailureReason, CompletionReason, ResponseEmissionState},
+    stream::{BackendFailureReason, CompletionReason, ResponseEmissionState, TimeoutReason},
 };
 
-fn response_body_guardrail_error(decision: ResponseBodyGuardrailDecision) -> Option<ProxyError> {
+fn response_body_guardrail_chunk(decision: ResponseBodyGuardrailDecision) -> Option<ResponseChunk> {
     match decision {
         ResponseBodyGuardrailDecision::Continue { .. } => None,
-        ResponseBodyGuardrailDecision::Timeout { .. } => Some(ProxyError::Timeout),
+        ResponseBodyGuardrailDecision::Timeout {
+            kind: BodyTimeoutKind::Idle,
+        } => Some(ResponseChunk::Timeout(TimeoutReason::ResponseBodyIdle)),
+        ResponseBodyGuardrailDecision::Timeout {
+            kind: BodyTimeoutKind::Total,
+        } => Some(ResponseChunk::Timeout(TimeoutReason::ResponseBodyTotal)),
         ResponseBodyGuardrailDecision::Reject {
             kind: BodyLimitKind::BodySize,
-        } => Some(ProxyError::Pool(PoolError::BackendOverloaded(
-            response_body_limit_reason(BodyLimitKind::BodySize).into(),
+        } => Some(ResponseChunk::Error(ProxyError::Pool(
+            PoolError::BackendOverloaded(
+                response_body_limit_reason(BodyLimitKind::BodySize).into(),
+            ),
         ))),
         ResponseBodyGuardrailDecision::Reject {
             kind: BodyLimitKind::UnknownLengthPrebuffer,
-        } => Some(ProxyError::Pool(PoolError::BackendOverloaded(
-            response_body_limit_reason(BodyLimitKind::UnknownLengthPrebuffer).into(),
+        } => Some(ResponseChunk::Error(ProxyError::Pool(
+            PoolError::BackendOverloaded(
+                response_body_limit_reason(BodyLimitKind::UnknownLengthPrebuffer).into(),
+            ),
         ))),
-        ResponseBodyGuardrailDecision::Reject { .. } => {
-            Some(ProxyError::Pool(PoolError::BackendOverloaded(
+        ResponseBodyGuardrailDecision::Reject { .. } => Some(ResponseChunk::Error(
+            ProxyError::Pool(PoolError::BackendOverloaded(
                 response_body_limit_reason(BodyLimitKind::BufferedBody).into(),
-            )))
-        }
+            )),
+        )),
+    }
+}
+
+fn response_body_wait_timeout_reason(
+    guardrails: ResponseBodyGuardrailConfig,
+    body_started_at: tokio::time::Instant,
+    last_body_progress_at: tokio::time::Instant,
+) -> TimeoutReason {
+    if body_started_at.elapsed() >= guardrails.total_timeout {
+        TimeoutReason::ResponseBodyTotal
+    } else if last_body_progress_at.elapsed() >= guardrails.idle_timeout {
+        TimeoutReason::ResponseBodyIdle
+    } else {
+        TimeoutReason::ResponseBodyIdle
     }
 }
 
@@ -720,9 +743,9 @@ impl QUICListener {
                     Ok(evaluated) => evaluated.streaming,
                     other => {
                         if let Err(other) = other
-                            && let Some(err) = response_body_guardrail_error(other)
+                            && let Some(chunk) = response_body_guardrail_chunk(other)
                         {
-                            let _ = chunk_tx.send(ResponseChunk::Error(err)).await;
+                            let _ = chunk_tx.send(chunk).await;
                         }
                         return;
                     }
@@ -732,7 +755,11 @@ impl QUICListener {
                 match result {
                     Err(_elapsed) => {
                         let _ = chunk_tx
-                            .send(ResponseChunk::Error(ProxyError::Timeout))
+                            .send(ResponseChunk::Timeout(response_body_wait_timeout_reason(
+                                pump.guardrails,
+                                body_started_at,
+                                last_body_progress_at,
+                            )))
                             .await;
                         return;
                     }
@@ -760,9 +787,9 @@ impl QUICListener {
                                 Ok(evaluated) => evaluated,
                                 other => {
                                     if let Err(other) = other
-                                        && let Some(err) = response_body_guardrail_error(other)
+                                        && let Some(chunk) = response_body_guardrail_chunk(other)
                                     {
-                                        let _ = chunk_tx.send(ResponseChunk::Error(err)).await;
+                                        let _ = chunk_tx.send(chunk).await;
                                     }
                                     return;
                                 }
@@ -1329,6 +1356,37 @@ impl QUICListener {
                         BackendFailureReason::ResponseStreamAborted,
                         metrics,
                     );
+                    terminal = true;
+                    break;
+                }
+                ResponseChunk::Timeout(reason) => {
+                    metrics.inc_timeout();
+                    let _ = crate::runtime::connection::outcome::observe_proxy_error_outcome(
+                        metrics,
+                        Self::request_outcome_route_target(req),
+                        Self::request_outcome_backend_target(req),
+                        req.start.elapsed(),
+                        req.response_status
+                            .and_then(|status| http::StatusCode::from_u16(status).ok())
+                            .or(Some(http::StatusCode::SERVICE_UNAVAILABLE)),
+                        &ProxyError::Timeout,
+                        None,
+                    );
+                    if !req.response_headers_sent() {
+                        let _ = Self::send_simple_response(
+                            h3,
+                            quic,
+                            stream_id,
+                            http::StatusCode::SERVICE_UNAVAILABLE,
+                            b"upstream timeout\n",
+                        );
+                    } else {
+                        let _ = h3.send_body(quic, stream_id, b"", true);
+                    }
+                    resilience
+                        .adaptive_admission
+                        .observe(req.start.elapsed(), true);
+                    req.transition_streaming_to_timed_out(reason, metrics);
                     terminal = true;
                     break;
                 }

--- a/crates/edge/src/quic_listener/forwarding/response.rs
+++ b/crates/edge/src/quic_listener/forwarding/response.rs
@@ -52,12 +52,10 @@ fn response_body_guardrail_chunk(decision: ResponseBodyGuardrailDecision) -> Opt
 fn response_body_wait_timeout_reason(
     guardrails: ResponseBodyGuardrailConfig,
     body_started_at: tokio::time::Instant,
-    last_body_progress_at: tokio::time::Instant,
+    _last_body_progress_at: tokio::time::Instant,
 ) -> TimeoutReason {
     if body_started_at.elapsed() >= guardrails.total_timeout {
         TimeoutReason::ResponseBodyTotal
-    } else if last_body_progress_at.elapsed() >= guardrails.idle_timeout {
-        TimeoutReason::ResponseBodyIdle
     } else {
         TimeoutReason::ResponseBodyIdle
     }
@@ -1078,7 +1076,6 @@ impl QUICListener {
                                 "HTTP/3 send_response protocol error on stream {}: {:?}",
                                 stream_id, err
                             );
-                            req.set_phase_legacy(StreamPhase::Failed);
                             metrics.inc_backend_error();
                             let _ = crate::runtime::connection::outcome::observe_status_outcome(
                                 metrics,
@@ -1112,7 +1109,6 @@ impl QUICListener {
                             "HTTP/3 send_body data protocol error on stream {}: {:?}",
                             stream_id, err
                         );
-                        req.set_phase_legacy(StreamPhase::Failed);
                         metrics.inc_backend_error();
                         let _ = crate::runtime::connection::outcome::observe_status_outcome(
                             metrics,
@@ -1152,7 +1148,6 @@ impl QUICListener {
                                 "HTTP/3 send_additional_headers protocol error on stream {}: {:?}",
                                 stream_id, err
                             );
-                            req.set_phase_legacy(StreamPhase::Failed);
                             metrics.inc_backend_error();
                             let _ = crate::runtime::connection::outcome::observe_status_outcome(
                                 metrics,
@@ -1194,7 +1189,6 @@ impl QUICListener {
                             "HTTP/3 send_body end protocol error on stream {}: {:?}",
                             stream_id, err
                         );
-                        req.set_phase_legacy(StreamPhase::Failed);
                         metrics.inc_backend_error();
                         let _ = crate::runtime::connection::outcome::observe_status_outcome(
                             metrics,

--- a/crates/edge/src/quic_listener/forwarding/response.rs
+++ b/crates/edge/src/quic_listener/forwarding/response.rs
@@ -920,6 +920,7 @@ impl QUICListener {
         h3: &mut quiche::h3::Connection,
         shared_ctx: &ForwardingSharedCtx<'_>,
     ) -> Result<bool, ProxyError> {
+        let metrics = shared_ctx.metrics.as_ref();
         match decision {
             ResponseStartDecision::ImmediateTerminal {
                 metadata,
@@ -941,7 +942,7 @@ impl QUICListener {
                     }
                 }
                 req.response_status = Some(metadata.status.as_u16());
-                req.transition_streaming_to_completed(CompletionReason::ImmediateResponse);
+                req.transition_streaming_to_completed(CompletionReason::ImmediateResponse, metrics);
                 Self::observe_response_start_transition(req, &observation, shared_ctx);
                 Ok(true)
             }
@@ -1012,6 +1013,7 @@ impl QUICListener {
                         Err(TryRecvError::Disconnected) => {
                             req.transition_streaming_to_backend_failed(
                                 BackendFailureReason::ResponseStreamAborted,
+                                metrics,
                             );
                             terminal = true;
                             break;
@@ -1056,6 +1058,7 @@ impl QUICListener {
                                 .observe(req.start.elapsed(), true);
                             req.transition_streaming_to_backend_failed(
                                 BackendFailureReason::ResponseWriteFailed,
+                                metrics,
                             );
                             terminal = true;
                             break;
@@ -1091,6 +1094,7 @@ impl QUICListener {
                             .observe(req.start.elapsed(), true);
                         req.transition_streaming_to_backend_failed(
                             BackendFailureReason::ResponseWriteFailed,
+                            metrics,
                         );
                         terminal = true;
                         break;
@@ -1130,6 +1134,7 @@ impl QUICListener {
                                 .observe(req.start.elapsed(), true);
                             req.transition_streaming_to_backend_failed(
                                 BackendFailureReason::ResponseWriteFailed,
+                                metrics,
                             );
                             terminal = true;
                             break;
@@ -1141,6 +1146,7 @@ impl QUICListener {
                         req.set_response_emission_state(ResponseEmissionState::EndPending);
                         req.transition_streaming_to_completed(
                             CompletionReason::ResponseStreamFinished,
+                            metrics,
                         );
                         terminal = true;
                         break;
@@ -1170,6 +1176,7 @@ impl QUICListener {
                             .observe(req.start.elapsed(), true);
                         req.transition_streaming_to_backend_failed(
                             BackendFailureReason::ResponseWriteFailed,
+                            metrics,
                         );
                         terminal = true;
                         break;
@@ -1320,6 +1327,7 @@ impl QUICListener {
                     }
                     req.transition_streaming_to_backend_failed(
                         BackendFailureReason::ResponseStreamAborted,
+                        metrics,
                     );
                     terminal = true;
                     break;

--- a/crates/edge/src/quic_listener/forwarding/response.rs
+++ b/crates/edge/src/quic_listener/forwarding/response.rs
@@ -1,12 +1,217 @@
+use bytes::Bytes;
 use spooky_errors::{UpstreamProxyErrorKind, classify_upstream_proxy_error};
 use tokio::sync::mpsc::error::TryRecvError;
 
 use super::*;
 use crate::runtime::connection::{
-    auth::ExternalAuthDecision, guardrails::is_unknown_length_response_prebuffer_reason,
+    auth::ExternalAuthDecision,
+    guardrails::{
+        ProgressiveEmissionPolicy, RESPONSE_BODY_TOO_LARGE_BODY, ResponseBodyGuardrailConfig,
+        ResponseBodyGuardrailDecision, ResponseBodyGuardrailInput,
+        checked_response_body_guardrails, is_unknown_length_response_prebuffer_reason,
+        response_body_limit_reason, response_chunk_ranges,
+    },
+    response::{
+        ImmediateResponseStart, ResponseBodyPumpPlan, ResponseStartDecision, ResponseStartMetadata,
+        ResponseStartObservation,
+    },
 };
 
+fn response_body_guardrail_error(decision: ResponseBodyGuardrailDecision) -> Option<ProxyError> {
+    match decision {
+        ResponseBodyGuardrailDecision::Continue { .. } => None,
+        ResponseBodyGuardrailDecision::Timeout { .. } => Some(ProxyError::Timeout),
+        ResponseBodyGuardrailDecision::Reject {
+            kind: BodyLimitKind::BodySize,
+        } => Some(ProxyError::Pool(PoolError::BackendOverloaded(
+            response_body_limit_reason(BodyLimitKind::BodySize).into(),
+        ))),
+        ResponseBodyGuardrailDecision::Reject {
+            kind: BodyLimitKind::UnknownLengthPrebuffer,
+        } => Some(ProxyError::Pool(PoolError::BackendOverloaded(
+            response_body_limit_reason(BodyLimitKind::UnknownLengthPrebuffer).into(),
+        ))),
+        ResponseBodyGuardrailDecision::Reject { .. } => {
+            Some(ProxyError::Pool(PoolError::BackendOverloaded(
+                response_body_limit_reason(BodyLimitKind::BufferedBody).into(),
+            )))
+        }
+    }
+}
+
 impl QUICListener {
+    pub(super) fn prepare_response_start_decision(
+        req: &RequestEnvelope,
+        success: ForwardSuccess,
+        progress_config: &StreamProgressConfig,
+    ) -> ResponseStartDecision {
+        let (status, resp_headers, response_body, prebuilt_response_chunk_rx) = match success {
+            ForwardSuccess::Response {
+                status,
+                headers,
+                body,
+            } => (status, headers, Some(body), None),
+            ForwardSuccess::Tunnel {
+                status,
+                headers,
+                response_chunk_rx,
+            } => (status, headers, None, Some(response_chunk_rx)),
+        };
+        let request_mode = req.request_mode();
+        let tunnel_response = is_tunnel_response(req.tunnel_mode, status);
+        let response_body_mode = if tunnel_response {
+            ResponseBodyMode::TunnelSuccess
+        } else if request_mode.suppresses_response_body() {
+            ResponseBodyMode::HeadRequest
+        } else {
+            ResponseBodyMode::Normal
+        };
+        let upstream_content_length = resp_headers
+            .get(http::header::CONTENT_LENGTH)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<usize>().ok());
+        let normalized_response = normalize_upstream_response(ResponseNormalizationInput {
+            upstream: spooky_bridge::response::UpstreamResponseView {
+                status,
+                headers: &resp_headers,
+                trailers: None,
+            },
+            body_mode: response_body_mode,
+            constraints: ResponseProtocolConstraints {
+                protocol: ResponseNormalizationProtocol::Http3,
+                strip_connection_headers: true,
+                allow_trailers: true,
+                preserve_upgrade: false,
+            },
+        });
+        let body_forwarding_enabled = matches!(
+            normalized_response.emission.body,
+            ResponseBodyPolicy::Forward
+        );
+        let progressive_body_emission_allowed =
+            !normalized_response.emission.emit_end_stream_on_headers;
+        let response_guardrails = ResponseBodyGuardrailConfig {
+            idle_timeout: progress_config.backend_body_idle_timeout,
+            total_timeout: progress_config.backend_body_total_timeout,
+            max_body_bytes: progress_config.max_response_body_bytes,
+            unknown_length_prebuffer_bytes: progress_config.unknown_length_response_prebuffer_bytes,
+            chunk_bytes: RESPONSE_CHUNK_BYTES_LIMIT,
+        };
+        let preflight_guardrail = checked_response_body_guardrails(
+            response_guardrails,
+            ResponseBodyGuardrailInput {
+                elapsed: Duration::ZERO,
+                idle_for: Duration::ZERO,
+                bytes_received: 0,
+                prebuffered_bytes: 0,
+                next_chunk_bytes: 0,
+                declared_content_length: upstream_content_length,
+                headers_emitted: false,
+                progressive_emission_allowed: progressive_body_emission_allowed,
+                body_forwarding_enabled,
+                exempt_from_body_size_cap: tunnel_response,
+            },
+        );
+        if matches!(
+            preflight_guardrail,
+            Err(ResponseBodyGuardrailDecision::Reject {
+                kind: BodyLimitKind::BodySize,
+            })
+        ) {
+            return ResponseStartDecision::ImmediateTerminal {
+                metadata: ResponseStartMetadata {
+                    status: http::StatusCode::SERVICE_UNAVAILABLE,
+                    headers: Vec::new(),
+                    headers_deferred: false,
+                },
+                terminal: ImmediateResponseStart::SyntheticBody(RESPONSE_BODY_TOO_LARGE_BODY),
+                observation: ResponseStartObservation::ProxyError {
+                    status: http::StatusCode::SERVICE_UNAVAILABLE,
+                    error: ProxyError::Pool(PoolError::BackendOverloaded(
+                        "response prebuffer cap".into(),
+                    )),
+                    overload_reason: Some(OverloadShedReason::ResponsePrebufferCap),
+                },
+            };
+        }
+
+        let mut headers: Vec<(Vec<u8>, Vec<u8>)> = normalized_response
+            .head
+            .headers
+            .iter()
+            .map(|header| {
+                (
+                    header.name.as_str().as_bytes().to_vec(),
+                    header.value.as_bytes().to_vec(),
+                )
+            })
+            .collect();
+        headers.push((
+            b"alt-svc".to_vec(),
+            format!("h3=\":{}\"; ma=86400", progress_config.listen_port).into_bytes(),
+        ));
+
+        let defer_headers_until_body_validated = matches!(
+            preflight_guardrail,
+            Ok(crate::runtime::connection::guardrails::EvaluatedResponseBodyGuardrail {
+                streaming,
+                ..
+            }) if matches!(
+                streaming.emission,
+                ProgressiveEmissionPolicy::PrebufferUntilValidated
+            )
+        );
+        let observation = ResponseStartObservation::Status { status };
+
+        if normalized_response.emission.emit_end_stream_on_headers {
+            return ResponseStartDecision::ImmediateTerminal {
+                metadata: ResponseStartMetadata {
+                    status,
+                    headers,
+                    headers_deferred: false,
+                },
+                terminal: ImmediateResponseStart::NormalizedHeadersOnly,
+                observation,
+            };
+        }
+
+        if let Some(response_chunk_rx) = prebuilt_response_chunk_rx {
+            return ResponseStartDecision::StreamingPrebuilt {
+                metadata: ResponseStartMetadata {
+                    status,
+                    headers,
+                    headers_deferred: false,
+                },
+                response_chunk_rx,
+                observation,
+            };
+        }
+
+        let Some(response_body) = response_body else {
+            return ResponseStartDecision::BackendFailure(ProxyError::Transport(
+                "non-tunnel responses must carry an HTTP body stream".into(),
+            ));
+        };
+
+        ResponseStartDecision::StreamingBodyPump {
+            metadata: ResponseStartMetadata {
+                status,
+                headers,
+                headers_deferred: defer_headers_until_body_validated,
+            },
+            response_body,
+            pump: ResponseBodyPumpPlan {
+                guardrails: response_guardrails,
+                upstream_content_length,
+                body_forwarding_enabled,
+                progressive_emission_allowed: progressive_body_emission_allowed,
+                defer_headers_until_body_validated,
+                tunnel_response,
+            },
+            observation,
+        }
+    }
+
     /// Handle an already-resolved `ForwardResult`, applying health transitions
     /// and sending the H3 response.
     pub(super) fn handle_forward_result(
@@ -450,6 +655,330 @@ impl QUICListener {
                     &headers,
                 )
             }
+        }
+    }
+
+    fn send_response_start_headers(
+        h3: &mut quiche::h3::Connection,
+        quic: &mut quiche::Connection,
+        stream_id: u64,
+        metadata: &ResponseStartMetadata,
+        end_stream: bool,
+    ) -> Result<(), ProxyError> {
+        let mut h3_headers = Vec::with_capacity(metadata.headers.len() + 1);
+        h3_headers.push(quiche::h3::Header::new(
+            b":status",
+            metadata.status.as_str().as_bytes(),
+        ));
+        for (name, value) in &metadata.headers {
+            h3_headers.push(quiche::h3::Header::new(name, value));
+        }
+        h3.send_response(quic, stream_id, &h3_headers, end_stream)
+            .map_err(|err| {
+                ProxyError::Protocol(format!("failed to send HTTP/3 response headers: {:?}", err))
+            })
+    }
+
+    fn spawn_response_body_pump(
+        req: &RequestEnvelope,
+        response_body: hyper::body::Incoming,
+        metadata: &ResponseStartMetadata,
+        pump: ResponseBodyPumpPlan,
+    ) -> mpsc::Receiver<ResponseChunk> {
+        let (chunk_tx, chunk_rx) = mpsc::channel::<ResponseChunk>(RESPONSE_CHUNK_CHANNEL_CAPACITY);
+        let fail_tx = chunk_tx.clone();
+        let deferred_status = metadata.status;
+        let deferred_headers = metadata.headers.clone();
+        let fut = async move {
+            use http_body_util::BodyExt;
+
+            let mut body = response_body;
+            let body_started_at = tokio::time::Instant::now();
+            let mut last_body_progress_at = body_started_at;
+            let mut response_bytes_received: usize = 0;
+            let mut prebuffered_bytes: usize = 0;
+            let mut buffered_chunks: Vec<Bytes> = Vec::new();
+            let mut buffered_trailers: Option<Vec<(Vec<u8>, Vec<u8>)>> = None;
+            loop {
+                let wait_decision = checked_response_body_guardrails(
+                    pump.guardrails,
+                    ResponseBodyGuardrailInput {
+                        elapsed: body_started_at.elapsed(),
+                        idle_for: last_body_progress_at.elapsed(),
+                        bytes_received: response_bytes_received,
+                        prebuffered_bytes,
+                        next_chunk_bytes: 0,
+                        declared_content_length: pump.upstream_content_length,
+                        headers_emitted: !pump.defer_headers_until_body_validated,
+                        progressive_emission_allowed: pump.progressive_emission_allowed,
+                        body_forwarding_enabled: pump.body_forwarding_enabled,
+                        exempt_from_body_size_cap: pump.tunnel_response,
+                    },
+                );
+                let streaming = match wait_decision {
+                    Ok(evaluated) => evaluated.streaming,
+                    other => {
+                        if let Err(other) = other
+                            && let Some(err) = response_body_guardrail_error(other)
+                        {
+                            let _ = chunk_tx.send(ResponseChunk::Error(err)).await;
+                        }
+                        return;
+                    }
+                };
+                let frame_fut = BodyExt::frame(&mut body);
+                let result = tokio::time::timeout(streaming.wait_timeout, frame_fut).await;
+                match result {
+                    Err(_elapsed) => {
+                        let _ = chunk_tx
+                            .send(ResponseChunk::Error(ProxyError::Timeout))
+                            .await;
+                        return;
+                    }
+                    Ok(Some(Ok(f))) => match f.into_data() {
+                        Ok(data) => {
+                            if !data.is_empty() {
+                                last_body_progress_at = tokio::time::Instant::now();
+                            }
+                            let data_decision = checked_response_body_guardrails(
+                                pump.guardrails,
+                                ResponseBodyGuardrailInput {
+                                    elapsed: body_started_at.elapsed(),
+                                    idle_for: last_body_progress_at.elapsed(),
+                                    bytes_received: response_bytes_received,
+                                    prebuffered_bytes,
+                                    next_chunk_bytes: data.len(),
+                                    declared_content_length: pump.upstream_content_length,
+                                    headers_emitted: !pump.defer_headers_until_body_validated,
+                                    progressive_emission_allowed: pump.progressive_emission_allowed,
+                                    body_forwarding_enabled: pump.body_forwarding_enabled,
+                                    exempt_from_body_size_cap: pump.tunnel_response,
+                                },
+                            );
+                            let evaluated = match data_decision {
+                                Ok(evaluated) => evaluated,
+                                other => {
+                                    if let Err(other) = other
+                                        && let Some(err) = response_body_guardrail_error(other)
+                                    {
+                                        let _ = chunk_tx.send(ResponseChunk::Error(err)).await;
+                                    }
+                                    return;
+                                }
+                            };
+                            let streaming = evaluated.streaming;
+                            response_bytes_received = evaluated.next_state.bytes_received;
+                            prebuffered_bytes = evaluated.next_state.prebuffered_bytes;
+                            for (start, end) in
+                                response_chunk_ranges(data.len(), streaming.chunk_emission)
+                            {
+                                let chunk = data.slice(start..end);
+                                match streaming.emission {
+                                    ProgressiveEmissionPolicy::PrebufferUntilValidated => {
+                                        buffered_chunks.push(chunk);
+                                    }
+                                    ProgressiveEmissionPolicy::StreamProgressively => {
+                                        if chunk_tx.send(ResponseChunk::Data(chunk)).await.is_err()
+                                        {
+                                            return;
+                                        }
+                                    }
+                                    ProgressiveEmissionPolicy::SuppressBody => {}
+                                }
+                            }
+                        }
+                        Err(frame) => {
+                            if let Ok(trailers) = frame.into_trailers() {
+                                let trailer_headers = collect_h3_trailers(&trailers);
+                                if !trailer_headers.is_empty() {
+                                    if pump.defer_headers_until_body_validated {
+                                        buffered_trailers = Some(trailer_headers);
+                                    } else if chunk_tx
+                                        .send(ResponseChunk::Trailers {
+                                            headers: trailer_headers,
+                                        })
+                                        .await
+                                        .is_err()
+                                    {
+                                        return;
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    Ok(Some(Err(_))) => {
+                        let _ = chunk_tx
+                            .send(ResponseChunk::Error(ProxyError::Transport(
+                                "upstream body error".into(),
+                            )))
+                            .await;
+                        return;
+                    }
+                    Ok(None) => {
+                        if pump.defer_headers_until_body_validated {
+                            if chunk_tx
+                                .send(ResponseChunk::Start {
+                                    status: deferred_status,
+                                    headers: deferred_headers,
+                                })
+                                .await
+                                .is_err()
+                            {
+                                return;
+                            }
+                            for chunk in buffered_chunks {
+                                if chunk_tx.send(ResponseChunk::Data(chunk)).await.is_err() {
+                                    return;
+                                }
+                            }
+                        }
+                        if let Some(headers) = buffered_trailers
+                            && chunk_tx
+                                .send(ResponseChunk::Trailers { headers })
+                                .await
+                                .is_err()
+                        {
+                            return;
+                        }
+                        let _ = chunk_tx.send(ResponseChunk::End).await;
+                        return;
+                    }
+                }
+            }
+        };
+        let spawned = match req.trace_span.clone() {
+            Some(span) => spawn_async_task(fut.instrument(span), "body-pump"),
+            None => spawn_async_task(fut, "body-pump"),
+        };
+        if !spawned {
+            let _ = fail_tx.try_send(ResponseChunk::Error(ProxyError::Transport(
+                "runtime unavailable".into(),
+            )));
+        }
+        chunk_rx
+    }
+
+    fn observe_response_start_transition(
+        req: &RequestEnvelope,
+        observation: &ResponseStartObservation,
+        shared_ctx: &ForwardingSharedCtx<'_>,
+    ) {
+        let metrics = shared_ctx.metrics.as_ref();
+        let resilience = shared_ctx.resilience;
+        match observation {
+            ResponseStartObservation::Status { status } => {
+                if let (Some(addr), Some(idx)) = (&req.backend_addr, req.backend_index) {
+                    let _ = crate::runtime::connection::outcome::observe_backend_response_status_and_log(
+                        crate::runtime::connection::outcome::BackendHealthObservationInput {
+                            backend_addr: addr,
+                            backend_index: idx,
+                            upstream_pool: req.upstream_pool.as_ref(),
+                            status: *status,
+                        },
+                    );
+                }
+                let _ = crate::runtime::connection::outcome::observe_status_outcome(
+                    metrics,
+                    Self::request_outcome_route_target(req),
+                    Self::request_outcome_backend_target(req),
+                    req.start.elapsed(),
+                    *status,
+                );
+                resilience
+                    .adaptive_admission
+                    .observe(req.start.elapsed(), false);
+                Self::log_access(req, status.as_u16());
+            }
+            ResponseStartObservation::ProxyError {
+                status,
+                error,
+                overload_reason,
+            } => {
+                let _ = crate::runtime::connection::outcome::observe_proxy_error_outcome(
+                    metrics,
+                    Self::request_outcome_route_target(req),
+                    Self::request_outcome_backend_target(req),
+                    req.start.elapsed(),
+                    Some(*status),
+                    error,
+                    *overload_reason,
+                );
+                resilience
+                    .adaptive_admission
+                    .observe(req.start.elapsed(), true);
+                Self::log_access(req, status.as_u16());
+            }
+        }
+    }
+
+    pub(super) fn apply_response_start_decision(
+        stream_id: u64,
+        req: &mut RequestEnvelope,
+        decision: ResponseStartDecision,
+        quic: &mut quiche::Connection,
+        h3: &mut quiche::h3::Connection,
+        shared_ctx: &ForwardingSharedCtx<'_>,
+    ) -> Result<bool, ProxyError> {
+        match decision {
+            ResponseStartDecision::ImmediateTerminal {
+                metadata,
+                terminal,
+                observation,
+            } => {
+                match terminal {
+                    ImmediateResponseStart::NormalizedHeadersOnly => {
+                        Self::send_response_start_headers(h3, quic, stream_id, &metadata, true)?;
+                    }
+                    ImmediateResponseStart::SyntheticBody(body) => {
+                        Self::send_simple_response(h3, quic, stream_id, metadata.status, body)
+                            .map_err(|err| {
+                                ProxyError::Protocol(format!(
+                                    "failed to send terminal response: {:?}",
+                                    err
+                                ))
+                            })?;
+                    }
+                }
+                req.response_status = Some(metadata.status.as_u16());
+                req.transition_to_streaming_response(None, true, StreamPhase::Completed);
+                Self::observe_response_start_transition(req, &observation, shared_ctx);
+                Ok(true)
+            }
+            ResponseStartDecision::StreamingPrebuilt {
+                metadata,
+                response_chunk_rx,
+                observation,
+            } => {
+                Self::send_response_start_headers(h3, quic, stream_id, &metadata, false)?;
+                req.response_status = Some(metadata.status.as_u16());
+                req.transition_to_streaming_response(
+                    Some(response_chunk_rx),
+                    true,
+                    metadata.streaming_phase(),
+                );
+                Self::observe_response_start_transition(req, &observation, shared_ctx);
+                Ok(false)
+            }
+            ResponseStartDecision::StreamingBodyPump {
+                metadata,
+                response_body,
+                pump,
+                observation,
+            } => {
+                if !metadata.headers_deferred {
+                    Self::send_response_start_headers(h3, quic, stream_id, &metadata, false)?;
+                }
+                let chunk_rx = Self::spawn_response_body_pump(req, response_body, &metadata, pump);
+                req.response_status = Some(metadata.status.as_u16());
+                req.transition_to_streaming_response(
+                    Some(chunk_rx),
+                    metadata.response_headers_sent(),
+                    metadata.streaming_phase(),
+                );
+                Self::observe_response_start_transition(req, &observation, shared_ctx);
+                Ok(false)
+            }
+            ResponseStartDecision::BackendFailure(err) => Err(err),
         }
     }
 

--- a/crates/edge/src/quic_listener/forwarding/stream_progress.rs
+++ b/crates/edge/src/quic_listener/forwarding/stream_progress.rs
@@ -416,7 +416,9 @@ impl QUICListener {
                         };
                         if immediate_terminal {
                             if let Some(req) = streams.get_mut(&stream_id) {
-                                abort_stream(req, metrics);
+                                if !req.execution.is_terminal() {
+                                    abort_stream(req, metrics);
+                                }
                             }
                             streams.remove(&stream_id);
                             continue;
@@ -458,7 +460,9 @@ impl QUICListener {
 
             if terminal {
                 if let Some(req) = streams.get_mut(&stream_id) {
-                    abort_stream(req, metrics);
+                    if !req.execution.is_terminal() {
+                        abort_stream(req, metrics);
+                    }
                 }
                 streams.remove(&stream_id);
             }

--- a/crates/edge/src/quic_listener/forwarding/stream_progress.rs
+++ b/crates/edge/src/quic_listener/forwarding/stream_progress.rs
@@ -360,14 +360,14 @@ impl QUICListener {
                     false
                 };
                 if !keep_stream {
-                    if let Some(req) = streams.get_mut(&stream_id) {
-                        if !req.execution.is_terminal() {
-                            terminalize_stream(
-                                req,
-                                TerminalReason::Cancelled(CancellationReason::OperatorAbort),
-                                metrics,
-                            );
-                        }
+                    if let Some(req) = streams.get_mut(&stream_id)
+                        && !req.execution.is_terminal()
+                    {
+                        terminalize_stream(
+                            req,
+                            TerminalReason::Cancelled(CancellationReason::OperatorAbort),
+                            metrics,
+                        );
                     }
                     streams.remove(&stream_id);
                     continue;
@@ -447,16 +447,16 @@ impl QUICListener {
                             false
                         };
                         if immediate_terminal {
-                            if let Some(req) = streams.get_mut(&stream_id) {
-                                if !req.execution.is_terminal() {
-                                    terminalize_stream(
-                                        req,
-                                        TerminalReason::Completed(
-                                            CompletionReason::ImmediateResponse,
-                                        ),
-                                        metrics,
-                                    );
-                                }
+                            if let Some(req) = streams.get_mut(&stream_id)
+                                && !req.execution.is_terminal()
+                            {
+                                terminalize_stream(
+                                    req,
+                                    TerminalReason::Completed(
+                                        CompletionReason::ImmediateResponse,
+                                    ),
+                                    metrics,
+                                );
                             }
                             streams.remove(&stream_id);
                             continue;
@@ -506,14 +506,14 @@ impl QUICListener {
             };
 
             if terminal {
-                if let Some(req) = streams.get_mut(&stream_id) {
-                    if !req.execution.is_terminal() {
-                        terminalize_stream(
-                            req,
-                            TerminalReason::Cancelled(CancellationReason::OperatorAbort),
-                            metrics,
-                        );
-                    }
+                if let Some(req) = streams.get_mut(&stream_id)
+                    && !req.execution.is_terminal()
+                {
+                    terminalize_stream(
+                        req,
+                        TerminalReason::Cancelled(CancellationReason::OperatorAbort),
+                        metrics,
+                    );
                 }
                 streams.remove(&stream_id);
             }

--- a/crates/edge/src/quic_listener/forwarding/stream_progress.rs
+++ b/crates/edge/src/quic_listener/forwarding/stream_progress.rs
@@ -1,6 +1,5 @@
 use super::*;
 use crate::runtime::connection::{
-    auth::ExternalAuthResult,
     guardrails::{
         BodyLimitKind, BodyTimeoutKind, ProgressiveEmissionPolicy, RESPONSE_BODY_TOO_LARGE_BODY,
         RequestBodyGuardrailConfig, RequestBodyGuardrailDecision, RequestBodyGuardrailInput,
@@ -334,31 +333,9 @@ impl QUICListener {
                 }
             }
 
-            let auth_ready: Option<ExternalAuthResult> = if streams
-                .get(&stream_id)
-                .is_some_and(|req| req.admission_state() == StreamAdmissionState::WaitingForAuth)
-            {
-                if streams
-                    .get(&stream_id)
-                    .and_then(RequestEnvelope::auth_deadline)
-                    .is_some_and(|deadline| Instant::now() >= deadline)
-                {
-                    Some(Err(ProxyError::Timeout))
-                } else {
-                    streams
-                        .get_mut(&stream_id)
-                        .and_then(RequestEnvelope::auth_result_rx_mut)
-                        .and_then(|rx| match rx.try_recv() {
-                            Ok(result) => Some(result),
-                            Err(oneshot::error::TryRecvError::Empty) => None,
-                            Err(oneshot::error::TryRecvError::Closed) => Some(Err(
-                                ProxyError::Transport("external auth task dropped sender".into()),
-                            )),
-                        })
-                }
-            } else {
-                None
-            };
+            let auth_ready = streams
+                .get_mut(&stream_id)
+                .and_then(|req| req.poll_awaiting_auth_non_blocking(now));
 
             if let Some(auth_result) = auth_ready {
                 let keep_stream = if let Some(req) = streams.get_mut(&stream_id) {

--- a/crates/edge/src/quic_listener/forwarding/stream_progress.rs
+++ b/crates/edge/src/quic_listener/forwarding/stream_progress.rs
@@ -328,7 +328,7 @@ impl QUICListener {
                 if let Some(req) = streams.get_mut(&stream_id) {
                     terminalize_stream(
                         req,
-                        TerminalReason::TimedOut(TimeoutReason::TotalRequest),
+                        TerminalReason::TimedOut(req.total_request_timeout_reason()),
                         metrics,
                     );
                 }
@@ -462,7 +462,15 @@ impl QUICListener {
                         }
                     }
                     Err(err) => {
-                        let failure_reason = backend_failure_reason_for_proxy_error(&err);
+                        let terminal_reason = match &err {
+                            ProxyError::Timeout => streams.get(&stream_id).map_or(
+                                TerminalReason::TimedOut(TimeoutReason::AwaitingUpstream),
+                                |req| TerminalReason::TimedOut(req.upstream_timeout_reason()),
+                            ),
+                            other => TerminalReason::BackendFailed(
+                                backend_failure_reason_for_proxy_error(other),
+                            ),
+                        };
                         if let Some(req) = streams.get(&stream_id) {
                             if let Err(protocol_err) = Self::handle_forward_result(
                                 h3,
@@ -482,11 +490,7 @@ impl QUICListener {
                                 .observe(req.start.elapsed(), true);
                         }
                         if let Some(req) = streams.get_mut(&stream_id) {
-                            terminalize_stream(
-                                req,
-                                TerminalReason::BackendFailed(failure_reason),
-                                metrics,
-                            );
+                            terminalize_stream(req, terminal_reason, metrics);
                         }
                         streams.remove(&stream_id);
                         continue;

--- a/crates/edge/src/quic_listener/forwarding/stream_progress.rs
+++ b/crates/edge/src/quic_listener/forwarding/stream_progress.rs
@@ -8,6 +8,7 @@ use crate::runtime::connection::{
         evaluate_request_body_timeouts, response_body_limit_reason, response_chunk_ranges,
     },
     response::ForwardingPolicyTelemetry,
+    stream::RequestBodyState,
 };
 
 fn record_forwarding_policy_metrics(metrics: &Metrics, policy: &ForwardingPolicyTelemetry) {
@@ -96,6 +97,7 @@ impl QUICListener {
         };
         req.set_body_buf_bytes(next_state.buffered_bytes);
         req.body_buf_mut().push_back(chunk);
+        req.transition_request_body_buffered();
         Ok(())
     }
 
@@ -106,6 +108,10 @@ impl QUICListener {
         max_request_body_bytes: usize,
         request_buffer_global_cap_bytes: usize,
     ) -> Result<(), RequestBufferError> {
+        if !req.can_accept_request_body() {
+            return Ok(());
+        }
+
         if let Some(tx) = req.body_tx().cloned() {
             match tx.try_send(chunk) {
                 Ok(()) => Ok(()),
@@ -120,9 +126,9 @@ impl QUICListener {
                     if req.body_buf_bytes() > 0 {
                         metrics.release_request_buffer(req.body_buf_bytes());
                     }
-                    req.clear_body_tx();
                     req.body_buf_mut().clear();
                     req.set_body_buf_bytes(0);
+                    req.transition_request_body_forward_closed();
                     Ok(())
                 }
             }
@@ -140,9 +146,9 @@ impl QUICListener {
     pub(in crate::quic_listener) fn flush_request_buffer(
         req: &mut RequestEnvelope,
         metrics: &Metrics,
-    ) {
+    ) -> RequestBodyState {
         let Some(tx) = req.body_tx().cloned() else {
-            return;
+            return req.refresh_request_body_state();
         };
 
         loop {
@@ -165,11 +171,17 @@ impl QUICListener {
                     }
                     req.body_buf_mut().clear();
                     req.set_body_buf_bytes(0);
-                    req.clear_body_tx();
+                    req.transition_request_body_forward_closed();
                     break;
                 }
             }
         }
+
+        if req.should_close_request_body_forwarding() {
+            return req.transition_request_body_forward_closed();
+        }
+
+        req.refresh_request_body_state()
     }
 
     /// Advance all in-flight streams without blocking.
@@ -206,9 +218,7 @@ impl QUICListener {
         for stream_id in stream_ids {
             let now = Instant::now();
             if let Some(req) = streams.get(&stream_id)
-                && !req.request_fin_received()
-                && !req.bodyless_mode
-                && (req.phase() == StreamPhase::ReceivingRequest || req.body_tx().is_some())
+                && req.can_accept_request_body()
             {
                 let timeout_decision = evaluate_request_body_timeouts(
                     RequestBodyGuardrailConfig {
@@ -327,10 +337,7 @@ impl QUICListener {
             }
 
             if let Some(req) = streams.get_mut(&stream_id) {
-                Self::flush_request_buffer(req, metrics);
-                if req.request_fin_received() && req.body_buf().is_empty() {
-                    req.clear_body_tx();
-                }
+                let _ = Self::flush_request_buffer(req, metrics);
             }
 
             let auth_ready = streams

--- a/crates/edge/src/quic_listener/forwarding/stream_progress.rs
+++ b/crates/edge/src/quic_listener/forwarding/stream_progress.rs
@@ -74,8 +74,8 @@ impl QUICListener {
             RequestBodyGuardrailInput {
                 elapsed: Duration::ZERO,
                 idle_for: Duration::ZERO,
-                bytes_received: req.body_bytes_received,
-                buffered_bytes: req.body_buf_bytes,
+                bytes_received: req.body_bytes_received(),
+                buffered_bytes: req.body_buf_bytes(),
                 next_chunk_bytes: chunk_len,
                 declared_content_length: None,
                 exempt_from_body_size_cap: false,
@@ -95,8 +95,8 @@ impl QUICListener {
                 Ok(_) => unreachable!("handled Ok state before request buffer error mapping"),
             });
         };
-        req.body_buf_bytes = next_state.buffered_bytes;
-        req.body_buf.push_back(chunk);
+        req.set_body_buf_bytes(next_state.buffered_bytes);
+        req.body_buf_mut().push_back(chunk);
         Ok(())
     }
 
@@ -107,7 +107,7 @@ impl QUICListener {
         max_request_body_bytes: usize,
         request_buffer_global_cap_bytes: usize,
     ) -> Result<(), RequestBufferError> {
-        if let Some(tx) = &req.body_tx {
+        if let Some(tx) = req.body_tx().cloned() {
             match tx.try_send(chunk) {
                 Ok(()) => Ok(()),
                 Err(TrySendError::Full(chunk)) => Self::push_request_chunk(
@@ -118,12 +118,12 @@ impl QUICListener {
                     request_buffer_global_cap_bytes,
                 ),
                 Err(TrySendError::Closed(_chunk)) => {
-                    if req.body_buf_bytes > 0 {
-                        metrics.release_request_buffer(req.body_buf_bytes);
+                    if req.body_buf_bytes() > 0 {
+                        metrics.release_request_buffer(req.body_buf_bytes());
                     }
-                    req.body_tx = None;
-                    req.body_buf.clear();
-                    req.body_buf_bytes = 0;
+                    req.clear_body_tx();
+                    req.body_buf_mut().clear();
+                    req.set_body_buf_bytes(0);
                     Ok(())
                 }
             }
@@ -142,31 +142,31 @@ impl QUICListener {
         req: &mut RequestEnvelope,
         metrics: &Metrics,
     ) {
-        let Some(tx) = req.body_tx.as_ref() else {
+        let Some(tx) = req.body_tx().cloned() else {
             return;
         };
 
         loop {
-            let Some(chunk) = req.body_buf.pop_front() else {
+            let Some(chunk) = req.body_buf_mut().pop_front() else {
                 break;
             };
             let len = chunk.len();
             match tx.try_send(chunk) {
                 Ok(()) => {
-                    req.body_buf_bytes = req.body_buf_bytes.saturating_sub(len);
+                    req.set_body_buf_bytes(req.body_buf_bytes().saturating_sub(len));
                     metrics.release_request_buffer(len);
                 }
                 Err(TrySendError::Full(chunk)) => {
-                    req.body_buf.push_front(chunk);
+                    req.body_buf_mut().push_front(chunk);
                     break;
                 }
                 Err(TrySendError::Closed(_chunk)) => {
-                    if req.body_buf_bytes > 0 {
-                        metrics.release_request_buffer(req.body_buf_bytes);
+                    if req.body_buf_bytes() > 0 {
+                        metrics.release_request_buffer(req.body_buf_bytes());
                     }
-                    req.body_buf.clear();
-                    req.body_buf_bytes = 0;
-                    req.body_tx = None;
+                    req.body_buf_mut().clear();
+                    req.set_body_buf_bytes(0);
+                    req.clear_body_tx();
                     break;
                 }
             }
@@ -207,8 +207,8 @@ impl QUICListener {
         for stream_id in stream_ids {
             let now = Instant::now();
             if let Some(req) = streams.get(&stream_id)
-                && req.phase == StreamPhase::ReceivingRequest
-                && !req.request_fin_received
+                && req.phase() == StreamPhase::ReceivingRequest
+                && !req.request_fin_received()
                 && !req.bodyless_mode
             {
                 let timeout_decision = evaluate_request_body_timeouts(
@@ -223,9 +223,9 @@ impl QUICListener {
                     },
                     RequestBodyGuardrailInput {
                         elapsed: req.start.elapsed(),
-                        idle_for: now.saturating_duration_since(req.last_body_activity),
-                        bytes_received: req.body_bytes_received,
-                        buffered_bytes: req.body_buf_bytes,
+                        idle_for: now.saturating_duration_since(req.last_body_activity()),
+                        bytes_received: req.body_bytes_received(),
+                        buffered_bytes: req.body_buf_bytes(),
                         next_chunk_bytes: 0,
                         declared_content_length: None,
                         exempt_from_body_size_cap: false,
@@ -329,25 +329,25 @@ impl QUICListener {
 
             if let Some(req) = streams.get_mut(&stream_id) {
                 Self::flush_request_buffer(req, metrics);
-                if req.request_fin_received && req.body_buf.is_empty() {
-                    req.body_tx = None;
+                if req.request_fin_received() && req.body_buf().is_empty() {
+                    req.clear_body_tx();
                 }
             }
 
             let auth_ready: Option<ExternalAuthResult> = if streams
                 .get(&stream_id)
-                .is_some_and(|req| req.admission_state == StreamAdmissionState::WaitingForAuth)
+                .is_some_and(|req| req.admission_state() == StreamAdmissionState::WaitingForAuth)
             {
                 if streams
                     .get(&stream_id)
-                    .and_then(|req| req.auth_deadline)
+                    .and_then(RequestEnvelope::auth_deadline)
                     .is_some_and(|deadline| Instant::now() >= deadline)
                 {
                     Some(Err(ProxyError::Timeout))
                 } else {
                     streams
                         .get_mut(&stream_id)
-                        .and_then(|req| req.auth_result_rx.as_mut())
+                        .and_then(RequestEnvelope::auth_result_rx_mut)
                         .and_then(|rx| match rx.try_recv() {
                             Ok(result) => Some(result),
                             Err(oneshot::error::TryRecvError::Empty) => None,
@@ -389,7 +389,7 @@ impl QUICListener {
             let upstream_ready: Option<UpstreamResult> = if can_poll_upstream {
                 streams
                     .get_mut(&stream_id)
-                    .and_then(|req| req.upstream_result_rx.as_mut())
+                    .and_then(RequestEnvelope::upstream_result_rx_mut)
                     .and_then(|rx| match rx.try_recv() {
                         Ok(result) => Some(result),
                         Err(oneshot::error::TryRecvError::Empty) => None,
@@ -408,7 +408,7 @@ impl QUICListener {
                 record_forwarding_policy_metrics(metrics, &forward_result.policy);
 
                 if let Some(req) = streams.get_mut(&stream_id) {
-                    req.upstream_result_rx = None;
+                    req.clear_upstream_result_rx();
                     req.retry_count = forward_result.policy.retry.count;
                     req.error_kind = match &forward_result.forward {
                         Err(ProxyError::Timeout) => Some("timeout"),
@@ -656,17 +656,21 @@ impl QUICListener {
                                 }
                             }
                             if let Some(req) = streams.get_mut(&stream_id) {
-                                req.response_chunk_rx = None;
-                                req.response_headers_sent = true;
-                                req.phase = StreamPhase::Completed;
+                                req.transition_to_streaming_response(
+                                    None,
+                                    true,
+                                    StreamPhase::Completed,
+                                );
                                 req.response_status = Some(status.as_u16());
                             }
                             immediate_terminal = true;
                         } else if let Some(chunk_rx) = prebuilt_response_chunk_rx {
                             if let Some(req) = streams.get_mut(&stream_id) {
-                                req.response_chunk_rx = Some(chunk_rx);
-                                req.response_headers_sent = true;
-                                req.phase = StreamPhase::SendingResponse;
+                                req.transition_to_streaming_response(
+                                    Some(chunk_rx),
+                                    true,
+                                    StreamPhase::SendingResponse,
+                                );
                                 req.response_status = Some(status.as_u16());
                             }
                         } else {
@@ -878,9 +882,11 @@ impl QUICListener {
                             }
 
                             if let Some(req) = streams.get_mut(&stream_id) {
-                                req.response_chunk_rx = Some(chunk_rx);
-                                req.response_headers_sent = !defer_headers_until_body_validated;
-                                req.phase = StreamPhase::SendingResponse;
+                                req.transition_to_streaming_response(
+                                    Some(chunk_rx),
+                                    !defer_headers_until_body_validated,
+                                    StreamPhase::SendingResponse,
+                                );
                                 req.response_status = Some(status.as_u16());
                             }
                         }

--- a/crates/edge/src/quic_listener/forwarding/stream_progress.rs
+++ b/crates/edge/src/quic_listener/forwarding/stream_progress.rs
@@ -1,11 +1,8 @@
 use super::*;
 use crate::runtime::connection::{
     guardrails::{
-        BodyLimitKind, BodyTimeoutKind, ProgressiveEmissionPolicy, RESPONSE_BODY_TOO_LARGE_BODY,
-        RequestBodyGuardrailConfig, RequestBodyGuardrailDecision, RequestBodyGuardrailInput,
-        ResponseBodyGuardrailConfig, ResponseBodyGuardrailDecision, ResponseBodyGuardrailInput,
-        checked_request_body_ingress, checked_response_body_guardrails,
-        evaluate_request_body_timeouts, response_body_limit_reason, response_chunk_ranges,
+        BodyLimitKind, BodyTimeoutKind, RequestBodyGuardrailConfig, RequestBodyGuardrailDecision,
+        RequestBodyGuardrailInput, checked_request_body_ingress, evaluate_request_body_timeouts,
     },
     response::ForwardingPolicyTelemetry,
     stream::RequestBodyState,
@@ -26,28 +23,6 @@ fn record_forwarding_policy_metrics(metrics: &Metrics, policy: &ForwardingPolicy
     }
     if let Some(reason) = policy.retry.denial_reason {
         metrics.inc_retry_denied(reason);
-    }
-}
-
-fn response_body_guardrail_error(decision: ResponseBodyGuardrailDecision) -> Option<ProxyError> {
-    match decision {
-        ResponseBodyGuardrailDecision::Continue { .. } => None,
-        ResponseBodyGuardrailDecision::Timeout { .. } => Some(ProxyError::Timeout),
-        ResponseBodyGuardrailDecision::Reject {
-            kind: BodyLimitKind::BodySize,
-        } => Some(ProxyError::Pool(PoolError::BackendOverloaded(
-            response_body_limit_reason(BodyLimitKind::BodySize).into(),
-        ))),
-        ResponseBodyGuardrailDecision::Reject {
-            kind: BodyLimitKind::UnknownLengthPrebuffer,
-        } => Some(ProxyError::Pool(PoolError::BackendOverloaded(
-            response_body_limit_reason(BodyLimitKind::UnknownLengthPrebuffer).into(),
-        ))),
-        ResponseBodyGuardrailDecision::Reject { .. } => {
-            Some(ProxyError::Pool(PoolError::BackendOverloaded(
-                response_body_limit_reason(BodyLimitKind::BufferedBody).into(),
-            )))
-        }
     }
 }
 
@@ -406,499 +381,39 @@ impl QUICListener {
                 }
                 match forward_result.forward {
                     Ok(success) => {
-                        let (status, resp_headers, response_body, prebuilt_response_chunk_rx) =
-                            match success {
-                                ForwardSuccess::Response {
-                                    status,
-                                    headers,
-                                    body,
-                                } => (status, headers, Some(body), None),
-                                ForwardSuccess::Tunnel {
-                                    status,
-                                    headers,
-                                    response_chunk_rx,
-                                } => (status, headers, None, Some(response_chunk_rx)),
-                            };
-                        let suppress_downstream_body = streams
-                            .get(&stream_id)
-                            .is_some_and(|req| is_head_method(&req.method));
-                        let tunnel_response = streams
-                            .get(&stream_id)
-                            .is_some_and(|req| is_tunnel_response(req.tunnel_mode, status));
-                        let response_body_mode = if tunnel_response {
-                            ResponseBodyMode::TunnelSuccess
-                        } else if suppress_downstream_body {
-                            ResponseBodyMode::HeadRequest
+                        let decision = if let Some(req) = streams.get(&stream_id) {
+                            Self::prepare_response_start_decision(req, success, progress_config)
                         } else {
-                            ResponseBodyMode::Normal
-                        };
-                        let upstream_content_length = resp_headers
-                            .get(http::header::CONTENT_LENGTH)
-                            .and_then(|v| v.to_str().ok())
-                            .and_then(|v| v.parse::<usize>().ok());
-                        let normalized_response =
-                            normalize_upstream_response(ResponseNormalizationInput {
-                                upstream: spooky_bridge::response::UpstreamResponseView {
-                                    status,
-                                    headers: &resp_headers,
-                                    trailers: None,
-                                },
-                                body_mode: response_body_mode,
-                                constraints: ResponseProtocolConstraints {
-                                    protocol: ResponseNormalizationProtocol::Http3,
-                                    strip_connection_headers: true,
-                                    allow_trailers: true,
-                                    preserve_upgrade: false,
-                                },
-                            });
-                        let body_forwarding_enabled = matches!(
-                            normalized_response.emission.body,
-                            ResponseBodyPolicy::Forward
-                        );
-                        let progressive_body_emission_allowed =
-                            !normalized_response.emission.emit_end_stream_on_headers;
-                        let response_guardrails = ResponseBodyGuardrailConfig {
-                            idle_timeout: progress_config.backend_body_idle_timeout,
-                            total_timeout: progress_config.backend_body_total_timeout,
-                            max_body_bytes: progress_config.max_response_body_bytes,
-                            unknown_length_prebuffer_bytes: progress_config
-                                .unknown_length_response_prebuffer_bytes,
-                            chunk_bytes: RESPONSE_CHUNK_BYTES_LIMIT,
-                        };
-                        let preflight_guardrail = checked_response_body_guardrails(
-                            response_guardrails,
-                            ResponseBodyGuardrailInput {
-                                elapsed: Duration::ZERO,
-                                idle_for: Duration::ZERO,
-                                bytes_received: 0,
-                                prebuffered_bytes: 0,
-                                next_chunk_bytes: 0,
-                                declared_content_length: upstream_content_length,
-                                headers_emitted: false,
-                                progressive_emission_allowed: progressive_body_emission_allowed,
-                                body_forwarding_enabled,
-                                exempt_from_body_size_cap: tunnel_response,
-                            },
-                        );
-                        if matches!(
-                            preflight_guardrail,
-                            Err(ResponseBodyGuardrailDecision::Reject {
-                                kind: BodyLimitKind::BodySize,
-                            })
-                        ) {
-                            if let Some(req) = streams.get(&stream_id) {
-                                let _ = crate::runtime::connection::outcome::observe_proxy_error_outcome(
-                                    metrics,
-                                    crate::runtime::connection::outcome::OutcomeRouteTarget {
-                                        route: req.upstream_name.as_deref().unwrap_or("unrouted"),
-                                    },
-                                    Some(crate::runtime::connection::outcome::OutcomeBackendTarget {
-                                        upstream: req.upstream_name.as_deref().unwrap_or("unrouted"),
-                                        backend_addr: req.backend_addr.as_deref(),
-                                        backend_index: req.backend_index,
-                                    }),
-                                    req.start.elapsed(),
-                                    Some(http::StatusCode::SERVICE_UNAVAILABLE),
-                                    &ProxyError::Pool(PoolError::BackendOverloaded(
-                                        "response prebuffer cap".into(),
-                                    )),
-                                    Some(OverloadShedReason::ResponsePrebufferCap),
-                                );
-                                resilience
-                                    .adaptive_admission
-                                    .observe(req.start.elapsed(), true);
-                                warn!(
-                                    "request_id={} upstream declared content-length over cap ({} > {}) on stream {}",
-                                    req.request_id,
-                                    upstream_content_length.unwrap_or_default(),
-                                    progress_config.max_response_body_bytes,
-                                    stream_id
-                                );
-                                let _ = Self::send_simple_response(
-                                    h3,
-                                    quic,
-                                    stream_id,
-                                    http::StatusCode::SERVICE_UNAVAILABLE,
-                                    RESPONSE_BODY_TOO_LARGE_BODY,
-                                );
-                            }
-                            if let Some(req) = streams.get_mut(&stream_id) {
-                                abort_stream(req, metrics);
-                            }
-                            streams.remove(&stream_id);
                             continue;
-                        }
-                        let mut owned_h3_headers: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
-                        for header in &normalized_response.head.headers {
-                            owned_h3_headers.push((
-                                header.name.as_str().as_bytes().to_vec(),
-                                header.value.as_bytes().to_vec(),
-                            ));
-                        }
-                        owned_h3_headers.push((
-                            b"alt-svc".to_vec(),
-                            format!("h3=\":{}\"; ma=86400", progress_config.listen_port)
-                                .into_bytes(),
-                        ));
-
-                        let defer_headers_until_body_validated = matches!(
-                            preflight_guardrail,
-                            Ok(crate::runtime::connection::guardrails::EvaluatedResponseBodyGuardrail {
-                                streaming,
-                                ..
-                            })
-                                if matches!(
-                                    streaming.emission,
-                                    ProgressiveEmissionPolicy::PrebufferUntilValidated
-                                )
-                        );
-                        let immediate_end = normalized_response.emission.emit_end_stream_on_headers;
-                        let mut immediate_terminal = false;
-
-                        if !defer_headers_until_body_validated {
-                            let mut h3_headers = Vec::with_capacity(owned_h3_headers.len() + 1);
-                            h3_headers.push(quiche::h3::Header::new(
-                                b":status",
-                                normalized_response.head.status.as_str().as_bytes(),
-                            ));
-                            for (name, value) in &owned_h3_headers {
-                                h3_headers.push(quiche::h3::Header::new(name, value));
-                            }
-                            if let Err(err) =
-                                h3.send_response(quic, stream_id, &h3_headers, immediate_end)
-                            {
-                                if let Some(req) = streams.get(&stream_id) {
-                                    let protocol = ProxyError::Protocol(format!(
-                                        "failed to send HTTP/3 response headers: {:?}",
-                                        err
-                                    ));
+                        };
+                        let immediate_terminal = if let Some(req) = streams.get_mut(&stream_id) {
+                            match Self::apply_response_start_decision(
+                                stream_id, req, decision, quic, h3, shared_ctx,
+                            ) {
+                                Ok(immediate_terminal) => immediate_terminal,
+                                Err(err) => {
                                     if let Err(protocol_err) = Self::handle_forward_result(
                                         h3,
                                         quic,
                                         stream_id,
                                         req,
-                                        Err(protocol),
+                                        Err(err),
                                         shared_ctx,
                                     ) {
                                         error!(
-                                            "failed to emit protocol recovery response on stream {}: {:?}",
+                                            "failed to emit recoverable response-start error on stream {}: {:?}",
                                             stream_id, protocol_err
                                         );
                                     }
                                     resilience
                                         .adaptive_admission
                                         .observe(req.start.elapsed(), true);
+                                    true
                                 }
-                                if let Some(req) = streams.get_mut(&stream_id) {
-                                    abort_stream(req, metrics);
-                                }
-                                streams.remove(&stream_id);
-                                continue;
-                            }
-                        }
-
-                        if immediate_end {
-                            if defer_headers_until_body_validated {
-                                let mut h3_headers = Vec::with_capacity(owned_h3_headers.len() + 1);
-                                h3_headers.push(quiche::h3::Header::new(
-                                    b":status",
-                                    normalized_response.head.status.as_str().as_bytes(),
-                                ));
-                                for (name, value) in &owned_h3_headers {
-                                    h3_headers.push(quiche::h3::Header::new(name, value));
-                                }
-                                if let Err(err) =
-                                    h3.send_response(quic, stream_id, &h3_headers, true)
-                                {
-                                    if let Some(req) = streams.get(&stream_id) {
-                                        let protocol = ProxyError::Protocol(format!(
-                                            "failed to send HTTP/3 response headers: {:?}",
-                                            err
-                                        ));
-                                        if let Err(protocol_err) = Self::handle_forward_result(
-                                            h3,
-                                            quic,
-                                            stream_id,
-                                            req,
-                                            Err(protocol),
-                                            shared_ctx,
-                                        ) {
-                                            error!(
-                                                "failed to emit protocol recovery response on stream {}: {:?}",
-                                                stream_id, protocol_err
-                                            );
-                                        }
-                                        resilience
-                                            .adaptive_admission
-                                            .observe(req.start.elapsed(), true);
-                                    }
-                                    if let Some(req) = streams.get_mut(&stream_id) {
-                                        abort_stream(req, metrics);
-                                    }
-                                    streams.remove(&stream_id);
-                                    continue;
-                                }
-                            }
-                            if let Some(req) = streams.get_mut(&stream_id) {
-                                req.transition_to_streaming_response(
-                                    None,
-                                    true,
-                                    StreamPhase::Completed,
-                                );
-                                req.response_status = Some(status.as_u16());
-                            }
-                            immediate_terminal = true;
-                        } else if let Some(chunk_rx) = prebuilt_response_chunk_rx {
-                            if let Some(req) = streams.get_mut(&stream_id) {
-                                req.transition_to_streaming_response(
-                                    Some(chunk_rx),
-                                    true,
-                                    StreamPhase::SendingResponse,
-                                );
-                                req.response_status = Some(status.as_u16());
                             }
                         } else {
-                            let (chunk_tx, chunk_rx) =
-                                mpsc::channel::<ResponseChunk>(RESPONSE_CHUNK_CHANNEL_CAPACITY);
-                            let fail_tx = chunk_tx.clone();
-                            let deferred_status = status;
-                            let deferred_headers = owned_h3_headers.clone();
-                            let tunnel_mode = tunnel_response;
-                            let progressive_emission_allowed = progressive_body_emission_allowed;
-                            let fut = async move {
-                                use http_body_util::BodyExt;
-                                let Some(mut body) = response_body else {
-                                    let _ = chunk_tx
-                                        .send(ResponseChunk::Error(ProxyError::Transport(
-                                            "non-tunnel responses must carry an HTTP body stream"
-                                                .into(),
-                                        )))
-                                        .await;
-                                    return;
-                                };
-                                let body_started_at = tokio::time::Instant::now();
-                                let mut last_body_progress_at = body_started_at;
-                                let mut response_bytes_received: usize = 0;
-                                let mut prebuffered_bytes: usize = 0;
-                                let mut buffered_chunks: Vec<Bytes> = Vec::new();
-                                let mut buffered_trailers: Option<Vec<(Vec<u8>, Vec<u8>)>> = None;
-                                loop {
-                                    let wait_decision = checked_response_body_guardrails(
-                                        response_guardrails,
-                                        ResponseBodyGuardrailInput {
-                                            elapsed: body_started_at.elapsed(),
-                                            idle_for: last_body_progress_at.elapsed(),
-                                            bytes_received: response_bytes_received,
-                                            prebuffered_bytes,
-                                            next_chunk_bytes: 0,
-                                            declared_content_length: upstream_content_length,
-                                            headers_emitted: !defer_headers_until_body_validated,
-                                            progressive_emission_allowed,
-                                            body_forwarding_enabled,
-                                            exempt_from_body_size_cap: tunnel_mode,
-                                        },
-                                    );
-                                    let streaming = match wait_decision {
-                                        Ok(evaluated) => evaluated.streaming,
-                                        other => {
-                                            if let Err(other) = other
-                                                && let Some(err) =
-                                                    response_body_guardrail_error(other)
-                                            {
-                                                let _ =
-                                                    chunk_tx.send(ResponseChunk::Error(err)).await;
-                                            }
-                                            return;
-                                        }
-                                    };
-                                    let frame_fut = BodyExt::frame(&mut body);
-                                    let result =
-                                        tokio::time::timeout(streaming.wait_timeout, frame_fut)
-                                            .await;
-                                    match result {
-                                        Err(_elapsed) => {
-                                            let _ = chunk_tx
-                                                .send(ResponseChunk::Error(ProxyError::Timeout))
-                                                .await;
-                                            return;
-                                        }
-                                        Ok(Some(Ok(f))) => {
-                                            match f.into_data() {
-                                                Ok(data) => {
-                                                    if !data.is_empty() {
-                                                        last_body_progress_at =
-                                                            tokio::time::Instant::now();
-                                                    }
-                                                    let data_decision = checked_response_body_guardrails(
-                                                    response_guardrails,
-                                                    ResponseBodyGuardrailInput {
-                                                        elapsed: body_started_at.elapsed(),
-                                                        idle_for: last_body_progress_at.elapsed(),
-                                                        bytes_received: response_bytes_received,
-                                                        prebuffered_bytes,
-                                                        next_chunk_bytes: data.len(),
-                                                        declared_content_length: upstream_content_length,
-                                                        headers_emitted: !defer_headers_until_body_validated,
-                                                        progressive_emission_allowed,
-                                                        body_forwarding_enabled,
-                                                        exempt_from_body_size_cap: tunnel_mode,
-                                                    },
-                                                );
-                                                    let evaluated =
-                                                        match data_decision {
-                                                            Ok(evaluated) => evaluated,
-                                                            other => {
-                                                                if let Err(other) = other
-                                                            && let Some(err) =
-                                                                response_body_guardrail_error(other)
-                                                        {
-                                                            let _ = chunk_tx
-                                                                .send(ResponseChunk::Error(err))
-                                                                .await;
-                                                        }
-                                                                return;
-                                                            }
-                                                        };
-                                                    let streaming = evaluated.streaming;
-                                                    response_bytes_received =
-                                                        evaluated.next_state.bytes_received;
-                                                    prebuffered_bytes =
-                                                        evaluated.next_state.prebuffered_bytes;
-                                                    for (start, end) in response_chunk_ranges(
-                                                        data.len(),
-                                                        streaming.chunk_emission,
-                                                    ) {
-                                                        let chunk = data.slice(start..end);
-                                                        match streaming.emission {
-                                                        ProgressiveEmissionPolicy::PrebufferUntilValidated => {
-                                                            buffered_chunks.push(chunk);
-                                                        }
-                                                        ProgressiveEmissionPolicy::StreamProgressively => {
-                                                            if chunk_tx
-                                                                .send(ResponseChunk::Data(chunk))
-                                                                .await
-                                                                .is_err()
-                                                            {
-                                                                return;
-                                                            }
-                                                        }
-                                                        ProgressiveEmissionPolicy::SuppressBody => {}
-                                                    }
-                                                    }
-                                                }
-                                                Err(frame) => {
-                                                    if let Ok(trailers) = frame.into_trailers() {
-                                                        let trailer_headers =
-                                                            collect_h3_trailers(&trailers);
-                                                        if !trailer_headers.is_empty() {
-                                                            if defer_headers_until_body_validated {
-                                                                buffered_trailers =
-                                                                    Some(trailer_headers);
-                                                            } else if chunk_tx
-                                                                .send(ResponseChunk::Trailers {
-                                                                    headers: trailer_headers,
-                                                                })
-                                                                .await
-                                                                .is_err()
-                                                            {
-                                                                return;
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                        Ok(Some(Err(_))) => {
-                                            let _ = chunk_tx
-                                                .send(ResponseChunk::Error(ProxyError::Transport(
-                                                    "upstream body error".into(),
-                                                )))
-                                                .await;
-                                            return;
-                                        }
-                                        Ok(None) => {
-                                            if defer_headers_until_body_validated {
-                                                if chunk_tx
-                                                    .send(ResponseChunk::Start {
-                                                        status: deferred_status,
-                                                        headers: deferred_headers,
-                                                    })
-                                                    .await
-                                                    .is_err()
-                                                {
-                                                    return;
-                                                }
-                                                for chunk in buffered_chunks {
-                                                    if chunk_tx
-                                                        .send(ResponseChunk::Data(chunk))
-                                                        .await
-                                                        .is_err()
-                                                    {
-                                                        return;
-                                                    }
-                                                }
-                                            }
-                                            if let Some(headers) = buffered_trailers
-                                                && chunk_tx
-                                                    .send(ResponseChunk::Trailers { headers })
-                                                    .await
-                                                    .is_err()
-                                            {
-                                                return;
-                                            }
-                                            let _ = chunk_tx.send(ResponseChunk::End).await;
-                                            return;
-                                        }
-                                    }
-                                }
-                            };
-                            let request_span = streams
-                                .get(&stream_id)
-                                .and_then(|req| req.trace_span.clone());
-                            let spawned = match request_span {
-                                Some(span) => spawn_async_task(fut.instrument(span), "body-pump"),
-                                None => spawn_async_task(fut, "body-pump"),
-                            };
-                            if !spawned {
-                                let _ = fail_tx.try_send(ResponseChunk::Error(
-                                    ProxyError::Transport("runtime unavailable".into()),
-                                ));
-                            }
-
-                            if let Some(req) = streams.get_mut(&stream_id) {
-                                req.transition_to_streaming_response(
-                                    Some(chunk_rx),
-                                    !defer_headers_until_body_validated,
-                                    StreamPhase::SendingResponse,
-                                );
-                                req.response_status = Some(status.as_u16());
-                            }
-                        }
-
-                        if let Some(req) = streams.get(&stream_id) {
-                            if let (Some(addr), Some(idx)) = (&req.backend_addr, req.backend_index)
-                            {
-                                let _ = crate::runtime::connection::outcome::observe_backend_response_status_and_log(
-                                    crate::runtime::connection::outcome::BackendHealthObservationInput {
-                                        backend_addr: addr,
-                                        backend_index: idx,
-                                        upstream_pool: req.upstream_pool.as_ref(),
-                                        status,
-                                    },
-                                );
-                            }
-                            let _ = crate::runtime::connection::outcome::observe_status_outcome(
-                                metrics,
-                                Self::request_outcome_route_target(req),
-                                Self::request_outcome_backend_target(req),
-                                req.start.elapsed(),
-                                status,
-                            );
-                            resilience
-                                .adaptive_admission
-                                .observe(req.start.elapsed(), false);
-                            Self::log_access(req, status.as_u16());
-                        }
+                            false
+                        };
                         if immediate_terminal {
                             if let Some(req) = streams.get_mut(&stream_id) {
                                 abort_stream(req, metrics);

--- a/crates/edge/src/quic_listener/forwarding/stream_progress.rs
+++ b/crates/edge/src/quic_listener/forwarding/stream_progress.rs
@@ -206,9 +206,9 @@ impl QUICListener {
         for stream_id in stream_ids {
             let now = Instant::now();
             if let Some(req) = streams.get(&stream_id)
-                && req.phase() == StreamPhase::ReceivingRequest
                 && !req.request_fin_received()
                 && !req.bodyless_mode
+                && (req.phase() == StreamPhase::ReceivingRequest || req.body_tx().is_some())
             {
                 let timeout_decision = evaluate_request_body_timeouts(
                     RequestBodyGuardrailConfig {

--- a/crates/edge/src/quic_listener/forwarding/stream_progress.rs
+++ b/crates/edge/src/quic_listener/forwarding/stream_progress.rs
@@ -295,6 +295,7 @@ impl QUICListener {
                         .adaptive_admission
                         .observe(req.start.elapsed(), true);
                     if let Some(req) = streams.get_mut(&stream_id) {
+                        req.mark_terminal_outcome_recorded();
                         terminalize_stream(
                             req,
                             TerminalReason::TimedOut(TimeoutReason::RequestBodyIdle),

--- a/crates/edge/src/quic_listener/forwarding/stream_progress.rs
+++ b/crates/edge/src/quic_listener/forwarding/stream_progress.rs
@@ -452,9 +452,7 @@ impl QUICListener {
                             {
                                 terminalize_stream(
                                     req,
-                                    TerminalReason::Completed(
-                                        CompletionReason::ImmediateResponse,
-                                    ),
+                                    TerminalReason::Completed(CompletionReason::ImmediateResponse),
                                     metrics,
                                 );
                             }

--- a/crates/edge/src/quic_listener/forwarding/stream_progress.rs
+++ b/crates/edge/src/quic_listener/forwarding/stream_progress.rs
@@ -5,7 +5,7 @@ use crate::runtime::connection::{
         RequestBodyGuardrailInput, checked_request_body_ingress, evaluate_request_body_timeouts,
     },
     response::ForwardingPolicyTelemetry,
-    stream::RequestBodyState,
+    stream::{CompletionReason, RequestBodyState, TimeoutReason},
 };
 
 fn record_forwarding_policy_metrics(metrics: &Metrics, policy: &ForwardingPolicyTelemetry) {
@@ -49,7 +49,11 @@ impl QUICListener {
             RequestBodyGuardrailInput {
                 elapsed: Duration::ZERO,
                 idle_for: Duration::ZERO,
-                bytes_received: req.body_bytes_received(),
+                // The ingress path already advanced total bytes_received for this
+                // downstream read before chunk buffering begins. Subtract the
+                // current chunk here so total-body cap validation is not applied
+                // twice when backpressure forces buffering.
+                bytes_received: req.body_bytes_received().saturating_sub(chunk_len),
                 buffered_bytes: req.body_buf_bytes(),
                 next_chunk_bytes: chunk_len,
                 declared_content_length: None,
@@ -156,7 +160,16 @@ impl QUICListener {
             return req.transition_request_body_forward_closed();
         }
 
-        req.refresh_request_body_state()
+        let next = req.refresh_request_body_state();
+        if matches!(next, RequestBodyState::FinReceived) && req.body_tx().is_some() {
+            // A finished request can drain its last buffered chunk in this call.
+            // Close the upstream body sender immediately so the backend sees EOF
+            // without waiting for another progress pass that may never re-enter
+            // the request-body branch.
+            return req.transition_request_body_forward_closed();
+        }
+
+        next
     }
 
     /// Advance all in-flight streams without blocking.
@@ -239,7 +252,11 @@ impl QUICListener {
                         .adaptive_admission
                         .observe(req.start.elapsed(), true);
                     if let Some(req) = streams.get_mut(&stream_id) {
-                        abort_stream(req, metrics);
+                        terminalize_stream(
+                            req,
+                            TerminalReason::TimedOut(TimeoutReason::RequestBodyTotal),
+                            metrics,
+                        );
                     }
                     streams.remove(&stream_id);
                     continue;
@@ -278,7 +295,11 @@ impl QUICListener {
                         .adaptive_admission
                         .observe(req.start.elapsed(), true);
                     if let Some(req) = streams.get_mut(&stream_id) {
-                        abort_stream(req, metrics);
+                        terminalize_stream(
+                            req,
+                            TerminalReason::TimedOut(TimeoutReason::RequestBodyIdle),
+                            metrics,
+                        );
                     }
                     streams.remove(&stream_id);
                     continue;
@@ -305,7 +326,11 @@ impl QUICListener {
                     .adaptive_admission
                     .observe(req.start.elapsed(), true);
                 if let Some(req) = streams.get_mut(&stream_id) {
-                    abort_stream(req, metrics);
+                    terminalize_stream(
+                        req,
+                        TerminalReason::TimedOut(TimeoutReason::TotalRequest),
+                        metrics,
+                    );
                 }
                 streams.remove(&stream_id);
                 continue;
@@ -335,7 +360,13 @@ impl QUICListener {
                 };
                 if !keep_stream {
                     if let Some(req) = streams.get_mut(&stream_id) {
-                        abort_stream(req, metrics);
+                        if !req.execution.is_terminal() {
+                            terminalize_stream(
+                                req,
+                                TerminalReason::Cancelled(CancellationReason::OperatorAbort),
+                                metrics,
+                            );
+                        }
                     }
                     streams.remove(&stream_id);
                     continue;
@@ -417,7 +448,13 @@ impl QUICListener {
                         if immediate_terminal {
                             if let Some(req) = streams.get_mut(&stream_id) {
                                 if !req.execution.is_terminal() {
-                                    abort_stream(req, metrics);
+                                    terminalize_stream(
+                                        req,
+                                        TerminalReason::Completed(
+                                            CompletionReason::ImmediateResponse,
+                                        ),
+                                        metrics,
+                                    );
                                 }
                             }
                             streams.remove(&stream_id);
@@ -425,6 +462,7 @@ impl QUICListener {
                         }
                     }
                     Err(err) => {
+                        let failure_reason = backend_failure_reason_for_proxy_error(&err);
                         if let Some(req) = streams.get(&stream_id) {
                             if let Err(protocol_err) = Self::handle_forward_result(
                                 h3,
@@ -444,7 +482,11 @@ impl QUICListener {
                                 .observe(req.start.elapsed(), true);
                         }
                         if let Some(req) = streams.get_mut(&stream_id) {
-                            abort_stream(req, metrics);
+                            terminalize_stream(
+                                req,
+                                TerminalReason::BackendFailed(failure_reason),
+                                metrics,
+                            );
                         }
                         streams.remove(&stream_id);
                         continue;
@@ -461,7 +503,11 @@ impl QUICListener {
             if terminal {
                 if let Some(req) = streams.get_mut(&stream_id) {
                     if !req.execution.is_terminal() {
-                        abort_stream(req, metrics);
+                        terminalize_stream(
+                            req,
+                            TerminalReason::Cancelled(CancellationReason::OperatorAbort),
+                            metrics,
+                        );
                     }
                 }
                 streams.remove(&stream_id);

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -137,13 +137,14 @@ use forwarding::{ForwardingExecutionCtx, ForwardingSharedCtx, StreamProgressConf
 #[cfg(test)]
 use health_check::classify_active_health_check_response;
 pub(in crate::quic_listener) use protocol::{
-    can_poll_upstream_result, collect_h3_trailers, is_bodyless_request_mode, is_connect_method,
-    is_head_method, is_tunnel_mode, is_tunnel_response,
+    can_poll_upstream_result, collect_h3_trailers, is_connect_method, is_head_method,
+    is_tunnel_response,
 };
 #[cfg(test)]
 pub(in crate::quic_listener) use protocol::{
-    connection_header_tokens, is_connect_tunnel_response, should_strip_bootstrap_request_header,
-    should_strip_bootstrap_response_header, should_strip_h3_response_header,
+    connection_header_tokens, is_bodyless_request_mode, is_connect_tunnel_response,
+    should_strip_bootstrap_request_header, should_strip_bootstrap_response_header,
+    should_strip_h3_response_header,
 };
 pub use runtime_state::ListenerWorkerRuntimeState;
 pub(crate) use token_bucket::TokenBucket;

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -137,8 +137,7 @@ use forwarding::{ForwardingExecutionCtx, ForwardingSharedCtx, StreamProgressConf
 #[cfg(test)]
 use health_check::classify_active_health_check_response;
 pub(in crate::quic_listener) use protocol::{
-    can_poll_upstream_result, collect_h3_trailers, is_connect_method, is_head_method,
-    is_tunnel_response,
+    can_poll_upstream_result, collect_h3_trailers, is_connect_method, is_tunnel_response,
 };
 #[cfg(test)]
 pub(in crate::quic_listener) use protocol::{

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -84,7 +84,7 @@ use crate::{
             quic::{QuicConnection, QuicConnectionErrorSnapshot},
             request::RequestEnvelope,
             response::{ForwardResult, ForwardSuccess, ResponseChunk, UpstreamResult},
-            stream::{StreamAdmissionState, StreamPhase, TunnelMode},
+            stream::{StreamPhase, TunnelMode},
         },
         health::{HealthClassification, outcome_from_status},
         listener::QUICListener,

--- a/crates/edge/src/quic_listener/mod.rs
+++ b/crates/edge/src/quic_listener/mod.rs
@@ -84,7 +84,7 @@ use crate::{
             quic::{QuicConnection, QuicConnectionErrorSnapshot},
             request::RequestEnvelope,
             response::{ForwardResult, ForwardSuccess, ResponseChunk, UpstreamResult},
-            stream::{StreamPhase, TunnelMode},
+            stream::{CancellationReason, TerminalReason, TunnelMode},
         },
         health::{HealthClassification, outcome_from_status},
         listener::QUICListener,
@@ -133,7 +133,7 @@ pub(crate) use connection::purge_connection_routes;
 #[cfg(test)]
 use connection::resolve_primary_from_radix_prefix;
 pub(crate) use connection::{ConnectionRoutes, sweep_closed_connections};
-use forwarding::{ForwardingExecutionCtx, ForwardingSharedCtx, StreamProgressConfig, abort_stream};
+use forwarding::{ForwardingExecutionCtx, ForwardingSharedCtx, StreamProgressConfig};
 #[cfg(test)]
 use health_check::classify_active_health_check_response;
 pub(in crate::quic_listener) use protocol::{
@@ -604,7 +604,11 @@ impl QUICListener {
 
     fn release_connection_streams(connection: &mut QuicConnection, metrics: &Metrics) {
         for req in connection.streams.values_mut() {
-            abort_stream(req, metrics);
+            forwarding::terminalize_stream(
+                req,
+                TerminalReason::Cancelled(CancellationReason::ConnectionClosed),
+                metrics,
+            );
         }
         connection.streams.clear();
     }

--- a/crates/edge/src/quic_listener/protocol.rs
+++ b/crates/edge/src/quic_listener/protocol.rs
@@ -146,7 +146,7 @@ pub(in crate::quic_listener) fn is_connect_tunnel_response(
 }
 
 pub(in crate::quic_listener) fn can_poll_upstream_result(req: &RequestEnvelope) -> bool {
-    req.can_poll_upstream()
+    req.can_poll_upstream_result()
 }
 
 fn header_has_token(value: &http::HeaderValue, token: &str) -> bool {

--- a/crates/edge/src/quic_listener/protocol.rs
+++ b/crates/edge/src/quic_listener/protocol.rs
@@ -146,21 +146,7 @@ pub(in crate::quic_listener) fn is_connect_tunnel_response(
 }
 
 pub(in crate::quic_listener) fn can_poll_upstream_result(req: &RequestEnvelope) -> bool {
-    if req.admission_state() != StreamAdmissionState::ReadyToForward {
-        return false;
-    }
-
-    if is_tunnel_mode(req.tunnel_mode)
-        && (req.phase() == StreamPhase::ReceivingRequest
-            || req.phase() == StreamPhase::AwaitingUpstream)
-    {
-        return true;
-    }
-
-    req.phase() == StreamPhase::AwaitingUpstream
-        && req.request_fin_received()
-        && req.body_tx().is_none()
-        && req.body_buf().is_empty()
+    req.can_poll_upstream()
 }
 
 fn header_has_token(value: &http::HeaderValue, token: &str) -> bool {

--- a/crates/edge/src/quic_listener/protocol.rs
+++ b/crates/edge/src/quic_listener/protocol.rs
@@ -145,21 +145,21 @@ pub(in crate::quic_listener) fn is_connect_tunnel_response(
 }
 
 pub(in crate::quic_listener) fn can_poll_upstream_result(req: &RequestEnvelope) -> bool {
-    if req.admission_state != StreamAdmissionState::ReadyToForward {
+    if req.admission_state() != StreamAdmissionState::ReadyToForward {
         return false;
     }
 
     if is_tunnel_mode(req.tunnel_mode)
-        && (req.phase == StreamPhase::ReceivingRequest
-            || req.phase == StreamPhase::AwaitingUpstream)
+        && (req.phase() == StreamPhase::ReceivingRequest
+            || req.phase() == StreamPhase::AwaitingUpstream)
     {
         return true;
     }
 
-    req.phase == StreamPhase::AwaitingUpstream
-        && req.request_fin_received
-        && req.body_tx.is_none()
-        && req.body_buf.is_empty()
+    req.phase() == StreamPhase::AwaitingUpstream
+        && req.request_fin_received()
+        && req.body_tx().is_none()
+        && req.body_buf().is_empty()
 }
 
 fn header_has_token(value: &http::HeaderValue, token: &str) -> bool {

--- a/crates/edge/src/quic_listener/protocol.rs
+++ b/crates/edge/src/quic_listener/protocol.rs
@@ -117,6 +117,7 @@ pub(in crate::quic_listener) fn is_head_method(method: &str) -> bool {
     method.eq_ignore_ascii_case("HEAD")
 }
 
+#[cfg(test)]
 pub(in crate::quic_listener) fn is_bodyless_request_mode(
     method: &str,
     content_length: Option<usize>,

--- a/crates/edge/src/quic_listener/tests.rs
+++ b/crates/edge/src/quic_listener/tests.rs
@@ -1312,8 +1312,8 @@ fn connect_can_poll_upstream_before_request_fin() {
     let mut req = make_envelope(StreamPhase::ReceivingRequest);
     req.method = "CONNECT".to_string();
     req.tunnel_mode = crate::runtime::connection::stream::TunnelMode::Connect;
-    req.request_fin_received = false;
-    req.upstream_result_rx = Some(rx);
+    req.set_request_fin_received(false);
+    req.set_upstream_result_rx(Some(rx));
     assert!(can_poll_upstream_result(&req));
 }
 
@@ -1322,14 +1322,14 @@ fn non_connect_requires_request_completion_before_upstream_poll() {
     let (_tx, rx) = oneshot::channel::<crate::runtime::connection::response::UpstreamResult>();
     let mut req = make_envelope(StreamPhase::AwaitingUpstream);
     req.method = "GET".to_string();
-    req.request_fin_received = false;
-    req.upstream_result_rx = Some(rx);
+    req.set_request_fin_received(false);
+    req.set_upstream_result_rx(Some(rx));
     assert!(!can_poll_upstream_result(&req));
 
-    req.request_fin_received = true;
+    req.set_request_fin_received(true);
     assert!(can_poll_upstream_result(&req));
 
-    req.admission_state = StreamAdmissionState::WaitingForAuth;
+    req.set_admission_state_legacy(StreamAdmissionState::WaitingForAuth);
     assert!(!can_poll_upstream_result(&req));
 }
 
@@ -1902,56 +1902,41 @@ use crate::{
 };
 
 fn make_envelope(phase: StreamPhase) -> RequestEnvelope {
-    RequestEnvelope {
-        request_id: REQUEST_ID_COUNTER.fetch_add(1, Ordering::Relaxed),
-        trace_id: None,
-        span_id: None,
-        traceparent: None,
-        trace_span: None,
-        method: "GET".into(),
-        path: "/".into(),
-        authority: None,
-        body_tx: None,
-        body_buf: std::collections::VecDeque::new(),
-        body_buf_bytes: 0,
-        body_bytes_received: 0,
-        last_body_activity: Instant::now(),
-        backend_addr: None,
-        backend_index: None,
-        upstream_name: None,
-        route_reason: None,
-        route_path_len: None,
-        route_host_specific: None,
-        backend_lb: None,
-        upstream_pool: None,
-        routing_transparency_enabled: false,
-        routing_transparency_include_reason: false,
-        response_status: None,
-        backend_request_started: false,
-        backend_request_finished: false,
-        global_inflight_permit: None,
-        upstream_inflight_permit: None,
-        adaptive_admission_permit: None,
-        route_queue_permit: None,
-        start: Instant::now(),
-        total_request_deadline: Instant::now() + std::time::Duration::from_secs(30),
-        bodyless_mode: false,
-        retry_count: 0,
-        error_kind: None,
-        pending_forward: None,
-        auth_result_rx: None,
-        auth_abort: None,
-        auth_fail_open: false,
-        auth_deadline: None,
-        tunnel_mode: crate::runtime::connection::stream::TunnelMode::None,
+    let start = Instant::now();
+    RequestEnvelope::new_legacy(
+        REQUEST_ID_COUNTER.fetch_add(1, Ordering::Relaxed),
+        None,
+        None,
+        None,
+        None,
+        "GET".into(),
+        "/".into(),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        false,
+        false,
+        start,
+        start + std::time::Duration::from_secs(30),
+        false,
+        crate::runtime::connection::stream::TunnelMode::None,
+        0,
+        None,
         phase,
-        admission_state: StreamAdmissionState::ReadyToForward,
-        request_fin_received: false,
-        upstream_result_rx: None,
-        response_chunk_rx: None,
-        response_headers_sent: false,
-        pending_chunk: None,
-    }
+        StreamAdmissionState::ReadyToForward,
+        false,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
 }
 
 /// Path A: client reset before upstream response (ReceivingRequest phase).
@@ -1972,11 +1957,13 @@ fn abort_stream_receiving_request_releases_permits() {
     let (body_tx, body_rx) = mpsc::channel::<bytes::Bytes>(4);
 
     let mut req = make_envelope(StreamPhase::ReceivingRequest);
-    req.global_inflight_permit = Some(global_permit);
-    req.upstream_inflight_permit = Some(upstream_permit);
-    req.adaptive_admission_permit = Some(adaptive_permit);
-    req.route_queue_permit = Some(route_permit);
-    req.body_tx = Some(body_tx);
+    req.set_dispatch_permits(
+        Some(global_permit),
+        Some(upstream_permit),
+        Some(adaptive_permit),
+        Some(route_permit),
+    );
+    *req.body_tx_mut() = Some(body_tx);
 
     let phase = abort_stream(&mut req, &metrics);
 
@@ -1998,11 +1985,11 @@ fn abort_stream_receiving_request_releases_permits() {
     drop(body_rx); // safe to drop receiver — just checking channel is closed
 
     // All option fields cleared.
-    assert!(req.global_inflight_permit.is_none());
-    assert!(req.upstream_inflight_permit.is_none());
-    assert!(req.adaptive_admission_permit.is_none());
-    assert!(req.route_queue_permit.is_none());
-    assert!(req.body_tx.is_none());
+    assert!(!req.has_global_inflight_permit());
+    assert!(!req.has_upstream_inflight_permit());
+    assert!(!req.has_adaptive_admission_permit());
+    assert!(!req.has_route_queue_permit());
+    assert!(req.body_tx().is_none());
 }
 
 #[test]
@@ -2011,10 +1998,10 @@ fn abort_stream_waiting_for_auth_clears_async_auth_state() {
     let (auth_tx, auth_rx) =
         oneshot::channel::<crate::runtime::connection::auth::ExternalAuthResult>();
     let mut req = make_envelope(StreamPhase::ReceivingRequest);
-    req.admission_state = StreamAdmissionState::WaitingForAuth;
-    req.auth_result_rx = Some(auth_rx);
-    req.auth_deadline = Some(Instant::now() + std::time::Duration::from_secs(1));
-    req.pending_forward = Some(Arc::new(
+    req.set_admission_state_legacy(StreamAdmissionState::WaitingForAuth);
+    req.set_auth_result_rx(Some(auth_rx));
+    req.set_auth_deadline(Some(Instant::now() + std::time::Duration::from_secs(1)));
+    req.set_pending_forward(Some(Arc::new(
         crate::runtime::connection::request::PendingForward {
             method: Arc::<str>::from("POST"),
             path: Arc::<str>::from("/upload"),
@@ -2036,15 +2023,15 @@ fn abort_stream_waiting_for_auth_clears_async_auth_state() {
             forwarded_header_policy: Default::default(),
             auth_header_mutations: Vec::new(),
         },
-    ));
+    )));
 
     let phase = abort_stream(&mut req, &metrics);
 
     assert_eq!(phase, StreamPhase::ReceivingRequest);
-    assert!(req.auth_result_rx.is_none());
-    assert!(req.auth_abort.is_none());
-    assert!(req.auth_deadline.is_none());
-    assert!(req.pending_forward.is_none());
+    assert!(!req.has_auth_result_rx());
+    assert!(!req.has_auth_abort());
+    assert!(req.auth_deadline().is_none());
+    assert!(req.pending_forward().is_none());
     assert!(
         auth_tx
             .send(Ok(
@@ -2065,13 +2052,13 @@ fn abort_stream_awaiting_upstream_cancels_oneshot() {
         oneshot::channel::<crate::runtime::connection::response::UpstreamResult>();
 
     let mut req = make_envelope(StreamPhase::AwaitingUpstream);
-    req.upstream_result_rx = Some(result_rx);
+    req.set_upstream_result_rx(Some(result_rx));
 
     let phase = abort_stream(&mut req, &metrics);
 
     assert_eq!(phase, StreamPhase::AwaitingUpstream);
     assert!(
-        req.upstream_result_rx.is_none(),
+        !req.has_upstream_result_rx(),
         "oneshot receiver must be cleared"
     );
 
@@ -2096,20 +2083,19 @@ fn abort_stream_sending_response_closes_chunk_channel() {
         mpsc::channel::<crate::runtime::connection::response::ResponseChunk>(4);
 
     let mut req = make_envelope(StreamPhase::SendingResponse);
-    req.response_chunk_rx = Some(chunk_rx);
-    req.pending_chunk = Some(crate::runtime::connection::response::ResponseChunk::End);
+    req.set_response_chunk_rx(Some(chunk_rx));
+    req.set_pending_chunk(Some(
+        crate::runtime::connection::response::ResponseChunk::End,
+    ));
 
     let phase = abort_stream(&mut req, &metrics);
 
     assert_eq!(phase, StreamPhase::SendingResponse);
     assert!(
-        req.response_chunk_rx.is_none(),
+        !req.has_response_chunk_rx(),
         "chunk receiver must be cleared"
     );
-    assert!(
-        req.pending_chunk.is_none(),
-        "pending chunk must be discarded"
-    );
+    assert!(!req.has_pending_chunk(), "pending chunk must be discarded");
 
     // The body-pump task's sender should observe a closed channel.
     let send_result = chunk_tx.try_send(crate::runtime::connection::response::ResponseChunk::End);
@@ -2136,11 +2122,12 @@ fn abort_stream_upstream_error_releases_all_resources() {
         mpsc::channel::<crate::runtime::connection::response::ResponseChunk>(4);
 
     let mut req = make_envelope(StreamPhase::SendingResponse);
-    req.global_inflight_permit = Some(global_permit);
-    req.upstream_inflight_permit = Some(upstream_permit);
-    req.upstream_result_rx = Some(result_rx);
-    req.response_chunk_rx = Some(chunk_rx);
-    req.pending_chunk = Some(crate::runtime::connection::response::ResponseChunk::End);
+    req.set_dispatch_permits(Some(global_permit), Some(upstream_permit), None, None);
+    req.set_upstream_result_rx(Some(result_rx));
+    req.set_response_chunk_rx(Some(chunk_rx));
+    req.set_pending_chunk(Some(
+        crate::runtime::connection::response::ResponseChunk::End,
+    ));
 
     let phase = abort_stream(&mut req, &metrics);
 
@@ -2155,9 +2142,9 @@ fn abort_stream_upstream_error_releases_all_resources() {
         2,
         "upstream semaphore must be fully freed"
     );
-    assert!(req.upstream_result_rx.is_none());
-    assert!(req.response_chunk_rx.is_none());
-    assert!(req.pending_chunk.is_none());
+    assert!(!req.has_upstream_result_rx());
+    assert!(!req.has_response_chunk_rx());
+    assert!(!req.has_pending_chunk());
 
     // Body-pump task sender sees closed channel.
     assert!(
@@ -2176,7 +2163,7 @@ fn abort_stream_is_idempotent() {
     let permit = global_sem.clone().try_acquire_owned().unwrap();
 
     let mut req = make_envelope(StreamPhase::ReceivingRequest);
-    req.global_inflight_permit = Some(permit);
+    req.set_dispatch_permits(Some(permit), None, None, None);
 
     abort_stream(&mut req, &metrics);
     abort_stream(&mut req, &metrics); // second call must be a no-op

--- a/crates/edge/src/quic_listener/tests.rs
+++ b/crates/edge/src/quic_listener/tests.rs
@@ -38,7 +38,10 @@ use crate::{
             BodyLimitKind, ResponseBodyGuardrailConfig, ResponseBodyGuardrailDecision,
             ResponseBodyGuardrailInput, checked_response_body_guardrails,
         },
-        stream::StreamAdmissionState,
+        stream::{
+            AwaitingAuthState, RequestBodyRuntime, RequestBodyState, RequestExecutionState,
+            RequestMode, RoutingSnapshot, StreamAdmissionState,
+        },
     },
 };
 type RoutingMaps = (
@@ -1997,12 +2000,42 @@ fn abort_stream_waiting_for_auth_clears_async_auth_state() {
     let metrics = crate::Metrics::default();
     let (auth_tx, auth_rx) =
         oneshot::channel::<crate::runtime::connection::auth::ExternalAuthResult>();
+    let runtime = tokio::runtime::Runtime::new().expect("runtime");
+    let auth_task = runtime.spawn(async {});
     let mut req = make_envelope(StreamPhase::ReceivingRequest);
-    req.set_admission_state_legacy(StreamAdmissionState::WaitingForAuth);
-    req.set_auth_result_rx(Some(auth_rx));
-    req.set_auth_deadline(Some(Instant::now() + std::time::Duration::from_secs(1)));
-    req.set_pending_forward(Some(Arc::new(
-        crate::runtime::connection::request::PendingForward {
+    req.execution = RequestExecutionState::AwaitingAuth(AwaitingAuthState {
+        context: crate::runtime::connection::stream::RequestContext {
+            request_id: req.request_id,
+            trace_id: req.trace_id.clone(),
+            span_id: req.span_id.clone(),
+            traceparent: req.traceparent.clone(),
+            trace_span: req.trace_span.clone(),
+            method: req.method.clone(),
+            path: req.path.clone(),
+            authority: req.authority.clone(),
+            start: req.start,
+            total_request_deadline: req.total_request_deadline,
+        },
+        routing: RoutingSnapshot {
+            backend_addr: "http://127.0.0.1:8080".into(),
+            backend_index: 0,
+            upstream_name: "api".into(),
+            route_reason: "path_prefix".into(),
+            route_path_len: 7,
+            route_host_specific: false,
+            backend_lb: None,
+        },
+        request_mode: RequestMode::Normal,
+        request_body: RequestBodyState::Open,
+        request_body_runtime: RequestBodyRuntime {
+            body_tx: None,
+            body_buf: std::collections::VecDeque::new(),
+            body_buf_bytes: 0,
+            body_bytes_received: 0,
+            last_body_activity: req.start,
+            request_fin_received: false,
+        },
+        pending_forward: Arc::new(crate::runtime::connection::request::PendingForward {
             method: Arc::<str>::from("POST"),
             path: Arc::<str>::from("/upload"),
             authority: Some(Arc::<str>::from("example.com")),
@@ -2022,16 +2055,18 @@ fn abort_stream_waiting_for_auth_clears_async_auth_state() {
             host_policy: Default::default(),
             forwarded_header_policy: Default::default(),
             auth_header_mutations: Vec::new(),
-        },
-    )));
+        }),
+        auth_result_rx: auth_rx,
+        auth_abort: auth_task.abort_handle(),
+        auth_deadline: Instant::now() + std::time::Duration::from_secs(1),
+        auth_disposition:
+            crate::runtime::connection::auth::ExternalAuthFailureDisposition::FailClosed,
+    });
 
     let phase = abort_stream(&mut req, &metrics);
 
     assert_eq!(phase, StreamPhase::ReceivingRequest);
-    assert!(!req.has_auth_result_rx());
-    assert!(!req.has_auth_abort());
-    assert!(req.auth_deadline().is_none());
-    assert!(req.pending_forward().is_none());
+    assert_ne!(req.admission_state(), StreamAdmissionState::WaitingForAuth);
     assert!(
         auth_tx
             .send(Ok(

--- a/crates/edge/src/quic_listener/tests.rs
+++ b/crates/edge/src/quic_listener/tests.rs
@@ -45,8 +45,7 @@ use crate::{
         stream::{
             AdmissionPermits, AwaitingAuthState, DispatchReadyState, RequestBodyRuntime,
             RequestBodyState, RequestContext, RequestExecutionState, RequestMode,
-            ResponseEmissionState, RoutingSnapshot, StreamAdmissionState, StreamPhase,
-            TunnelMode,
+            ResponseEmissionState, RoutingSnapshot, StreamAdmissionState, StreamPhase, TunnelMode,
         },
     },
 };
@@ -1349,10 +1348,8 @@ fn non_connect_requires_request_completion_before_upstream_poll() {
         request_body: RequestBodyState::FinReceived,
         request_body_runtime: make_body_runtime(start, true),
         pending_forward: make_pending_forward("GET"),
-        auth_result_rx: oneshot::channel::<
-            crate::runtime::connection::auth::ExternalAuthResult,
-        >()
-        .1,
+        auth_result_rx: oneshot::channel::<crate::runtime::connection::auth::ExternalAuthResult>()
+            .1,
         auth_abort: tokio::runtime::Runtime::new()
             .expect("runtime")
             .spawn(async {})
@@ -2341,7 +2338,11 @@ fn abort_stream_sending_response_closes_chunk_channel() {
 
     let start = Instant::now();
     let mut req = make_awaiting_upstream_envelope(start, "GET", true);
-    req.transition_to_streaming_response(chunk_rx, ResponseEmissionState::HeadersSent, StatusCode::OK);
+    req.transition_to_streaming_response(
+        chunk_rx,
+        ResponseEmissionState::HeadersSent,
+        StatusCode::OK,
+    );
     req.set_pending_chunk(Some(
         crate::runtime::connection::response::ResponseChunk::End,
     ));
@@ -2393,8 +2394,14 @@ fn abort_stream_upstream_error_releases_all_resources() {
         },
     );
     req.transition_admitted_to_awaiting_upstream(None, oneshot::channel().1);
-    req.transition_to_streaming_response(chunk_rx, ResponseEmissionState::HeadersSent, StatusCode::OK);
-    req.set_pending_chunk(Some(crate::runtime::connection::response::ResponseChunk::End));
+    req.transition_to_streaming_response(
+        chunk_rx,
+        ResponseEmissionState::HeadersSent,
+        StatusCode::OK,
+    );
+    req.set_pending_chunk(Some(
+        crate::runtime::connection::response::ResponseChunk::End,
+    ));
 
     let phase = terminalize_stream(
         &mut req,

--- a/crates/edge/src/quic_listener/tests.rs
+++ b/crates/edge/src/quic_listener/tests.rs
@@ -23,12 +23,15 @@ use spooky_errors::{
 use tempfile::tempdir;
 
 use super::{
-    ConnectionRoutes, TokenBucket, abort_stream, can_poll_upstream_result,
-    classify_active_health_check_response, collect_h3_trailers, connection_header_tokens,
-    is_bodyless_request_mode, is_connect_tunnel_response, purge_connection_routes,
-    resolve_primary_from_radix_prefix, should_strip_bootstrap_request_header,
-    should_strip_bootstrap_response_header, should_strip_h3_response_header,
-    sweep_closed_connections,
+    ConnectionRoutes, TokenBucket, can_poll_upstream_result, classify_active_health_check_response,
+    collect_h3_trailers, connection_header_tokens, is_bodyless_request_mode,
+    is_connect_tunnel_response, purge_connection_routes, resolve_primary_from_radix_prefix,
+    should_strip_bootstrap_request_header, should_strip_bootstrap_response_header,
+    should_strip_h3_response_header, sweep_closed_connections,
+};
+use crate::quic_listener::forwarding::terminalize_stream;
+use crate::runtime::connection::stream::{
+    BackendFailureReason, CancellationReason, TerminalReason,
 };
 use crate::{
     REQUEST_ID_COUNTER,
@@ -1968,7 +1971,11 @@ fn abort_stream_receiving_request_releases_permits() {
     );
     *req.body_tx_mut() = Some(body_tx);
 
-    let phase = abort_stream(&mut req, &metrics);
+    let phase = terminalize_stream(
+        &mut req,
+        TerminalReason::Cancelled(CancellationReason::ClientReset),
+        &metrics,
+    );
 
     assert_eq!(phase, StreamPhase::ReceivingRequest);
 
@@ -2062,7 +2069,11 @@ fn abort_stream_waiting_for_auth_clears_async_auth_state() {
             crate::runtime::connection::auth::ExternalAuthFailureDisposition::FailClosed,
     });
 
-    let phase = abort_stream(&mut req, &metrics);
+    let phase = terminalize_stream(
+        &mut req,
+        TerminalReason::Cancelled(CancellationReason::ClientReset),
+        &metrics,
+    );
 
     assert_eq!(phase, StreamPhase::ReceivingRequest);
     assert_ne!(req.admission_state(), StreamAdmissionState::WaitingForAuth);
@@ -2088,7 +2099,11 @@ fn abort_stream_awaiting_upstream_cancels_oneshot() {
     let mut req = make_envelope(StreamPhase::AwaitingUpstream);
     req.set_upstream_result_rx(Some(result_rx));
 
-    let phase = abort_stream(&mut req, &metrics);
+    let phase = terminalize_stream(
+        &mut req,
+        TerminalReason::Cancelled(CancellationReason::ClientReset),
+        &metrics,
+    );
 
     assert_eq!(phase, StreamPhase::AwaitingUpstream);
     assert!(
@@ -2122,7 +2137,11 @@ fn abort_stream_sending_response_closes_chunk_channel() {
         crate::runtime::connection::response::ResponseChunk::End,
     ));
 
-    let phase = abort_stream(&mut req, &metrics);
+    let phase = terminalize_stream(
+        &mut req,
+        TerminalReason::Cancelled(CancellationReason::ClientReset),
+        &metrics,
+    );
 
     assert_eq!(phase, StreamPhase::SendingResponse);
     assert!(
@@ -2163,7 +2182,11 @@ fn abort_stream_upstream_error_releases_all_resources() {
         crate::runtime::connection::response::ResponseChunk::End,
     ));
 
-    let phase = abort_stream(&mut req, &metrics);
+    let phase = terminalize_stream(
+        &mut req,
+        TerminalReason::BackendFailed(BackendFailureReason::UpstreamTransport),
+        &metrics,
+    );
 
     assert_eq!(phase, StreamPhase::SendingResponse);
     assert_eq!(
@@ -2199,8 +2222,16 @@ fn abort_stream_is_idempotent() {
     let mut req = make_envelope(StreamPhase::ReceivingRequest);
     req.set_dispatch_permits(Some(permit), None, None, None);
 
-    abort_stream(&mut req, &metrics);
-    abort_stream(&mut req, &metrics); // second call must be a no-op
+    terminalize_stream(
+        &mut req,
+        TerminalReason::Cancelled(CancellationReason::ConnectionClosed),
+        &metrics,
+    );
+    terminalize_stream(
+        &mut req,
+        TerminalReason::Cancelled(CancellationReason::ConnectionClosed),
+        &metrics,
+    ); // second call must be a no-op
 
     assert_eq!(
         global_sem.available_permits(),

--- a/crates/edge/src/quic_listener/tests.rs
+++ b/crates/edge/src/quic_listener/tests.rs
@@ -1335,8 +1335,11 @@ fn non_connect_requires_request_completion_before_upstream_poll() {
 
     req.set_request_fin_received(true);
     if let RequestExecutionState::AwaitingUpstream(state) = &mut req.execution {
-        state.request_body = RequestBodyState::FinReceived;
         state.dispatch.body_tx = None;
+        // Request body forwarding is complete once FIN is received and the
+        // upstream body channel is closed; production reaches this via
+        // `from_runtime(fin, empty, no_tx)` == ClosedToUpstream.
+        state.request_body = RequestBodyState::ClosedToUpstream;
     }
     assert!(can_poll_upstream_result(&req));
 

--- a/crates/edge/src/quic_listener/tests.rs
+++ b/crates/edge/src/quic_listener/tests.rs
@@ -31,7 +31,7 @@ use super::{
 };
 use crate::quic_listener::forwarding::terminalize_stream;
 use crate::runtime::connection::stream::{
-    BackendFailureReason, CancellationReason, TerminalReason,
+    BackendFailureReason, CancellationReason, TerminalReason, TimeoutReason,
 };
 use crate::{
     REQUEST_ID_COUNTER,
@@ -1337,6 +1337,48 @@ fn non_connect_requires_request_completion_before_upstream_poll() {
 
     req.set_admission_state_legacy(StreamAdmissionState::WaitingForAuth);
     assert!(!can_poll_upstream_result(&req));
+}
+
+#[test]
+fn total_request_timeout_tracks_typed_execution_phase() {
+    let (_tx, rx) = oneshot::channel::<crate::runtime::connection::response::UpstreamResult>();
+    let mut req = make_envelope(StreamPhase::ReceivingRequest);
+    req.method = "GET".to_string();
+    req.set_request_fin_received(false);
+    assert_eq!(
+        req.total_request_timeout_reason(),
+        TimeoutReason::RequestBodyTotal
+    );
+
+    req.set_request_fin_received(true);
+    req.set_phase_legacy(StreamPhase::AwaitingUpstream);
+    req.set_upstream_result_rx(Some(rx));
+    assert_eq!(
+        req.total_request_timeout_reason(),
+        TimeoutReason::AwaitingUpstream
+    );
+
+    req.set_phase_legacy(StreamPhase::SendingResponse);
+    assert_eq!(
+        req.total_request_timeout_reason(),
+        TimeoutReason::ResponseBodyTotal
+    );
+}
+
+#[test]
+fn connect_total_request_timeout_prefers_awaiting_upstream_bucket() {
+    let (_tx, rx) = oneshot::channel::<crate::runtime::connection::response::UpstreamResult>();
+    let mut req = make_envelope(StreamPhase::ReceivingRequest);
+    req.method = "CONNECT".to_string();
+    req.tunnel_mode = crate::runtime::connection::stream::TunnelMode::Connect;
+    req.set_request_fin_received(false);
+    req.set_upstream_result_rx(Some(rx));
+
+    assert!(can_poll_upstream_result(&req));
+    assert_eq!(
+        req.total_request_timeout_reason(),
+        TimeoutReason::AwaitingUpstream
+    );
 }
 
 #[test]

--- a/crates/edge/src/quic_listener/tests.rs
+++ b/crates/edge/src/quic_listener/tests.rs
@@ -41,9 +41,12 @@ use crate::{
             BodyLimitKind, ResponseBodyGuardrailConfig, ResponseBodyGuardrailDecision,
             ResponseBodyGuardrailInput, checked_response_body_guardrails,
         },
+        request::{PendingForward, RequestEnvelope},
         stream::{
-            AwaitingAuthState, RequestBodyRuntime, RequestBodyState, RequestExecutionState,
-            RequestMode, RoutingSnapshot, StreamAdmissionState,
+            AdmissionPermits, AwaitingAuthState, DispatchReadyState, RequestBodyRuntime,
+            RequestBodyState, RequestContext, RequestExecutionState, RequestMode,
+            ResponseEmissionState, RoutingSnapshot, StreamAdmissionState, StreamPhase,
+            TunnelMode,
         },
     },
 };
@@ -1314,35 +1317,57 @@ fn bodyless_request_mode_only_applies_to_empty_get_and_head() {
 
 #[test]
 fn connect_can_poll_upstream_before_request_fin() {
-    let (_tx, rx) = oneshot::channel::<crate::runtime::connection::response::UpstreamResult>();
-    let mut req = make_envelope(StreamPhase::ReceivingRequest);
+    let mut req = make_awaiting_upstream_envelope(Instant::now(), "CONNECT", false);
     req.method = "CONNECT".to_string();
-    req.tunnel_mode = crate::runtime::connection::stream::TunnelMode::Connect;
+    req.tunnel_mode = TunnelMode::Connect;
     req.set_request_fin_received(false);
-    req.set_upstream_result_rx(Some(rx));
+    if let RequestExecutionState::AwaitingUpstream(state) = &mut req.execution {
+        state.request_mode = RequestMode::ConnectTunnel;
+    }
     assert!(can_poll_upstream_result(&req));
 }
 
 #[test]
 fn non_connect_requires_request_completion_before_upstream_poll() {
-    let (_tx, rx) = oneshot::channel::<crate::runtime::connection::response::UpstreamResult>();
-    let mut req = make_envelope(StreamPhase::AwaitingUpstream);
+    let mut req = make_awaiting_upstream_envelope(Instant::now(), "GET", false);
     req.method = "GET".to_string();
     req.set_request_fin_received(false);
-    req.set_upstream_result_rx(Some(rx));
     assert!(!can_poll_upstream_result(&req));
 
     req.set_request_fin_received(true);
+    if let RequestExecutionState::AwaitingUpstream(state) = &mut req.execution {
+        state.request_body = RequestBodyState::FinReceived;
+        state.dispatch.body_tx = None;
+    }
     assert!(can_poll_upstream_result(&req));
 
-    req.set_admission_state_legacy(StreamAdmissionState::WaitingForAuth);
+    let start = req.start;
+    req.execution = RequestExecutionState::AwaitingAuth(AwaitingAuthState {
+        context: make_request_context(start, "GET"),
+        routing: make_routing_snapshot(),
+        request_mode: RequestMode::Normal,
+        request_body: RequestBodyState::FinReceived,
+        request_body_runtime: make_body_runtime(start, true),
+        pending_forward: make_pending_forward("GET"),
+        auth_result_rx: oneshot::channel::<
+            crate::runtime::connection::auth::ExternalAuthResult,
+        >()
+        .1,
+        auth_abort: tokio::runtime::Runtime::new()
+            .expect("runtime")
+            .spawn(async {})
+            .abort_handle(),
+        auth_deadline: start + Duration::from_secs(1),
+        auth_disposition:
+            crate::runtime::connection::auth::ExternalAuthFailureDisposition::FailClosed,
+    });
     assert!(!can_poll_upstream_result(&req));
 }
 
 #[test]
 fn total_request_timeout_tracks_typed_execution_phase() {
-    let (_tx, rx) = oneshot::channel::<crate::runtime::connection::response::UpstreamResult>();
-    let mut req = make_envelope(StreamPhase::ReceivingRequest);
+    let start = Instant::now();
+    let mut req = make_dispatch_ready_envelope(start, "GET", false);
     req.method = "GET".to_string();
     req.set_request_fin_received(false);
     assert_eq!(
@@ -1350,15 +1375,13 @@ fn total_request_timeout_tracks_typed_execution_phase() {
         TimeoutReason::RequestBodyTotal
     );
 
-    req.set_request_fin_received(true);
-    req.set_phase_legacy(StreamPhase::AwaitingUpstream);
-    req.set_upstream_result_rx(Some(rx));
+    req = make_awaiting_upstream_envelope(start, "GET", true);
     assert_eq!(
         req.total_request_timeout_reason(),
         TimeoutReason::AwaitingUpstream
     );
 
-    req.set_phase_legacy(StreamPhase::SendingResponse);
+    req = make_streaming_envelope(start, StatusCode::OK, None);
     assert_eq!(
         req.total_request_timeout_reason(),
         TimeoutReason::ResponseBodyTotal
@@ -1367,12 +1390,13 @@ fn total_request_timeout_tracks_typed_execution_phase() {
 
 #[test]
 fn connect_total_request_timeout_prefers_awaiting_upstream_bucket() {
-    let (_tx, rx) = oneshot::channel::<crate::runtime::connection::response::UpstreamResult>();
-    let mut req = make_envelope(StreamPhase::ReceivingRequest);
+    let mut req = make_awaiting_upstream_envelope(Instant::now(), "CONNECT", false);
     req.method = "CONNECT".to_string();
-    req.tunnel_mode = crate::runtime::connection::stream::TunnelMode::Connect;
+    req.tunnel_mode = TunnelMode::Connect;
     req.set_request_fin_received(false);
-    req.set_upstream_result_rx(Some(rx));
+    if let RequestExecutionState::AwaitingUpstream(state) = &mut req.execution {
+        state.request_mode = RequestMode::ConnectTunnel;
+    }
 
     assert!(can_poll_upstream_result(&req));
     assert_eq!(
@@ -1944,47 +1968,193 @@ use std::time::Instant;
 
 use tokio::sync::{Semaphore, mpsc, oneshot};
 
-use crate::{
-    resilience::{adaptive_admission::AdaptiveAdmission, route_queue::RouteQueueLimiter},
-    runtime::connection::{request::RequestEnvelope, stream::StreamPhase},
-};
+use crate::resilience::{adaptive_admission::AdaptiveAdmission, route_queue::RouteQueueLimiter};
 
 fn make_envelope(phase: StreamPhase) -> RequestEnvelope {
     let start = Instant::now();
-    RequestEnvelope::new_legacy(
-        REQUEST_ID_COUNTER.fetch_add(1, Ordering::Relaxed),
-        None,
-        None,
-        None,
-        None,
-        "GET".into(),
-        "/".into(),
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        false,
-        false,
+    match phase {
+        StreamPhase::ReceivingRequest => make_dispatch_ready_envelope(start, "GET", false),
+        StreamPhase::AwaitingUpstream => make_awaiting_upstream_envelope(start, "GET", false),
+        StreamPhase::SendingResponse => make_streaming_envelope(start, StatusCode::OK, None),
+        StreamPhase::Completed | StreamPhase::Terminal => {
+            panic!("make_envelope is only defined for active execution phases")
+        }
+    }
+}
+
+fn make_request_context(start: Instant, method: &str) -> RequestContext {
+    RequestContext {
+        request_id: REQUEST_ID_COUNTER.fetch_add(1, Ordering::Relaxed),
+        trace_id: None,
+        span_id: None,
+        traceparent: None,
+        trace_span: None,
+        method: method.into(),
+        path: "/".into(),
+        authority: None,
         start,
-        start + std::time::Duration::from_secs(30),
-        false,
-        crate::runtime::connection::stream::TunnelMode::None,
-        0,
-        None,
-        phase,
-        StreamAdmissionState::ReadyToForward,
-        false,
-        None,
-        None,
-        None,
-        None,
-        None,
-    )
+        total_request_deadline: start + std::time::Duration::from_secs(30),
+    }
+}
+
+fn make_routing_snapshot() -> RoutingSnapshot {
+    RoutingSnapshot {
+        backend_addr: "http://127.0.0.1:8080".into(),
+        backend_index: 0,
+        upstream_name: "api".into(),
+        route_reason: "path_prefix".into(),
+        route_path_len: 1,
+        route_host_specific: false,
+        backend_lb: None,
+    }
+}
+
+fn make_pending_forward(method: &str) -> Arc<PendingForward> {
+    Arc::new(PendingForward {
+        method: Arc::<str>::from(method),
+        path: Arc::<str>::from("/"),
+        authority: None,
+        headers: Arc::new(vec![quiche::h3::Header::new(b":method", method.as_bytes())]),
+        upstream_name: Arc::<str>::from("api"),
+        route_reason: Arc::<str>::from("path_prefix"),
+        route_path_len: 1,
+        route_host_specific: false,
+        backend_addr: Arc::<str>::from("http://127.0.0.1:8080"),
+        backend_index: 0,
+        backend_lb: None,
+        client_addr: "127.0.0.1:443".parse().expect("client addr"),
+        request_id: 42,
+        trace_id: None,
+        span_id: None,
+        traceparent: None,
+        host_policy: Default::default(),
+        forwarded_header_policy: Default::default(),
+        auth_header_mutations: Vec::new(),
+    })
+}
+
+fn make_body_runtime(start: Instant, request_fin_received: bool) -> RequestBodyRuntime {
+    RequestBodyRuntime {
+        body_buf: std::collections::VecDeque::new(),
+        body_buf_bytes: 0,
+        body_bytes_received: 0,
+        last_body_activity: start,
+        request_fin_received,
+    }
+}
+
+fn make_test_permits() -> AdmissionPermits {
+    let global = Arc::new(Semaphore::new(1))
+        .try_acquire_owned()
+        .expect("global permit");
+    let upstream = Arc::new(Semaphore::new(1))
+        .try_acquire_owned()
+        .expect("upstream permit");
+    let adaptive = Arc::new(AdaptiveAdmission::new(false, 1, 100, 1, 1, 1000))
+        .try_acquire()
+        .expect("adaptive permit");
+    let route_queue = Arc::new(RouteQueueLimiter::new(100, 1000, Default::default()))
+        .try_acquire("test")
+        .expect("route permit");
+    AdmissionPermits {
+        global,
+        upstream,
+        adaptive,
+        route_queue,
+    }
+}
+
+fn make_dispatch_ready_envelope(
+    start: Instant,
+    method: &str,
+    request_fin_received: bool,
+) -> RequestEnvelope {
+    let context = make_request_context(start, method);
+    let routing = make_routing_snapshot();
+    RequestEnvelope {
+        request_id: context.request_id,
+        trace_id: context.trace_id.clone(),
+        span_id: context.span_id.clone(),
+        traceparent: context.traceparent.clone(),
+        trace_span: context.trace_span.clone(),
+        method: context.method.clone(),
+        path: context.path.clone(),
+        authority: context.authority.clone(),
+        backend_addr: Some(routing.backend_addr.clone()),
+        backend_index: Some(routing.backend_index),
+        upstream_name: Some(routing.upstream_name.clone()),
+        route_reason: Some(routing.route_reason.clone()),
+        route_path_len: Some(routing.route_path_len),
+        route_host_specific: Some(routing.route_host_specific),
+        backend_lb: routing.backend_lb.clone(),
+        upstream_pool: None,
+        routing_transparency_enabled: false,
+        routing_transparency_include_reason: false,
+        response_status: None,
+        start: context.start,
+        total_request_deadline: context.total_request_deadline,
+        bodyless_mode: false,
+        tunnel_mode: TunnelMode::None,
+        retry_count: 0,
+        error_kind: None,
+        terminal_overload_reason: None,
+        terminal_outcome_recorded: false,
+        execution: RequestExecutionState::DispatchReady(DispatchReadyState {
+            context,
+            routing,
+            request_mode: RequestMode::Normal,
+            request_body: if request_fin_received {
+                RequestBodyState::FinReceived
+            } else {
+                RequestBodyState::Open
+            },
+            request_body_runtime: make_body_runtime(start, request_fin_received),
+            pending_forward: make_pending_forward(method),
+        }),
+    }
+}
+
+fn make_admitted_envelope(start: Instant, permits: AdmissionPermits) -> RequestEnvelope {
+    let mut req = make_dispatch_ready_envelope(start, "GET", false);
+    req.transition_to_admitted(permits);
+    req
+}
+
+fn make_awaiting_upstream_envelope(
+    start: Instant,
+    method: &str,
+    request_fin_received: bool,
+) -> RequestEnvelope {
+    let mut req = make_admitted_envelope(start, make_test_permits());
+    req.method = method.into();
+    if let RequestExecutionState::Admitted(state) = &mut req.execution {
+        state.context.method = method.into();
+        state.request_mode = RequestMode::from_intake(TunnelMode::None, method, None);
+        state.pending_forward = make_pending_forward(method);
+        state.request_body = if request_fin_received {
+            RequestBodyState::FinReceived
+        } else {
+            RequestBodyState::Open
+        };
+        state.request_body_runtime.request_fin_received = request_fin_received;
+    }
+    let (_tx, rx) = oneshot::channel::<crate::runtime::connection::response::UpstreamResult>();
+    req.transition_admitted_to_awaiting_upstream(None, rx);
+    req
+}
+
+fn make_streaming_envelope(
+    start: Instant,
+    status: StatusCode,
+    pending_chunk: Option<crate::runtime::connection::response::ResponseChunk>,
+) -> RequestEnvelope {
+    let mut req = make_awaiting_upstream_envelope(start, "GET", true);
+    let (_tx, rx) = mpsc::channel::<crate::runtime::connection::response::ResponseChunk>(4);
+    req.transition_to_streaming_response(rx, ResponseEmissionState::HeadersSent, status);
+    if let Some(chunk) = pending_chunk {
+        req.set_pending_chunk(Some(chunk));
+    }
+    req
 }
 
 /// Path A: client reset before upstream response (ReceivingRequest phase).
@@ -2002,16 +2172,15 @@ fn abort_stream_receiving_request_releases_permits() {
     let adaptive_permit = adaptive.try_acquire().unwrap();
     let route_permit = route_limiter.try_acquire("test").unwrap();
 
-    let (body_tx, body_rx) = mpsc::channel::<bytes::Bytes>(4);
-
-    let mut req = make_envelope(StreamPhase::ReceivingRequest);
-    req.set_dispatch_permits(
-        Some(global_permit),
-        Some(upstream_permit),
-        Some(adaptive_permit),
-        Some(route_permit),
+    let mut req = make_admitted_envelope(
+        Instant::now(),
+        AdmissionPermits {
+            global: global_permit,
+            upstream: upstream_permit,
+            adaptive: adaptive_permit,
+            route_queue: route_permit,
+        },
     );
-    *req.body_tx_mut() = Some(body_tx);
 
     let phase = terminalize_stream(
         &mut req,
@@ -2033,15 +2202,11 @@ fn abort_stream_receiving_request_releases_permits() {
         "upstream semaphore must be freed"
     );
 
-    // body_tx dropped: body_rx should see the channel as disconnected.
-    drop(body_rx); // safe to drop receiver — just checking channel is closed
-
-    // All option fields cleared.
+    // All permit ownership should be released.
     assert!(!req.has_global_inflight_permit());
     assert!(!req.has_upstream_inflight_permit());
     assert!(!req.has_adaptive_admission_permit());
     assert!(!req.has_route_queue_permit());
-    assert!(req.body_tx().is_none());
 }
 
 #[test]
@@ -2138,8 +2303,9 @@ fn abort_stream_awaiting_upstream_cancels_oneshot() {
     let (result_tx, result_rx) =
         oneshot::channel::<crate::runtime::connection::response::UpstreamResult>();
 
-    let mut req = make_envelope(StreamPhase::AwaitingUpstream);
-    req.set_upstream_result_rx(Some(result_rx));
+    let start = Instant::now();
+    let mut req = make_admitted_envelope(start, make_test_permits());
+    req.transition_admitted_to_awaiting_upstream(None, result_rx);
 
     let phase = terminalize_stream(
         &mut req,
@@ -2173,8 +2339,9 @@ fn abort_stream_sending_response_closes_chunk_channel() {
     let (chunk_tx, chunk_rx) =
         mpsc::channel::<crate::runtime::connection::response::ResponseChunk>(4);
 
-    let mut req = make_envelope(StreamPhase::SendingResponse);
-    req.set_response_chunk_rx(Some(chunk_rx));
+    let start = Instant::now();
+    let mut req = make_awaiting_upstream_envelope(start, "GET", true);
+    req.transition_to_streaming_response(chunk_rx, ResponseEmissionState::HeadersSent, StatusCode::OK);
     req.set_pending_chunk(Some(
         crate::runtime::connection::response::ResponseChunk::End,
     ));
@@ -2211,18 +2378,23 @@ fn abort_stream_upstream_error_releases_all_resources() {
     let global_permit = global_sem.clone().try_acquire_owned().unwrap();
     let upstream_permit = upstream_sem.clone().try_acquire_owned().unwrap();
 
-    let (_result_tx, result_rx) =
-        oneshot::channel::<crate::runtime::connection::response::UpstreamResult>();
     let (chunk_tx, chunk_rx) =
         mpsc::channel::<crate::runtime::connection::response::ResponseChunk>(4);
 
-    let mut req = make_envelope(StreamPhase::SendingResponse);
-    req.set_dispatch_permits(Some(global_permit), Some(upstream_permit), None, None);
-    req.set_upstream_result_rx(Some(result_rx));
-    req.set_response_chunk_rx(Some(chunk_rx));
-    req.set_pending_chunk(Some(
-        crate::runtime::connection::response::ResponseChunk::End,
-    ));
+    let adaptive = Arc::new(AdaptiveAdmission::new(false, 1, 100, 1, 1, 1000));
+    let route_limiter = Arc::new(RouteQueueLimiter::new(100, 1000, Default::default()));
+    let mut req = make_admitted_envelope(
+        Instant::now(),
+        AdmissionPermits {
+            global: global_permit,
+            upstream: upstream_permit,
+            adaptive: adaptive.try_acquire().unwrap(),
+            route_queue: route_limiter.try_acquire("test").unwrap(),
+        },
+    );
+    req.transition_admitted_to_awaiting_upstream(None, oneshot::channel().1);
+    req.transition_to_streaming_response(chunk_rx, ResponseEmissionState::HeadersSent, StatusCode::OK);
+    req.set_pending_chunk(Some(crate::runtime::connection::response::ResponseChunk::End));
 
     let phase = terminalize_stream(
         &mut req,
@@ -2241,7 +2413,6 @@ fn abort_stream_upstream_error_releases_all_resources() {
         2,
         "upstream semaphore must be fully freed"
     );
-    assert!(!req.has_upstream_result_rx());
     assert!(!req.has_response_chunk_rx());
     assert!(!req.has_pending_chunk());
 
@@ -2260,9 +2431,18 @@ fn abort_stream_is_idempotent() {
     let metrics = crate::Metrics::default();
     let global_sem = Arc::new(Semaphore::new(1));
     let permit = global_sem.clone().try_acquire_owned().unwrap();
-
-    let mut req = make_envelope(StreamPhase::ReceivingRequest);
-    req.set_dispatch_permits(Some(permit), None, None, None);
+    let upstream_sem = Arc::new(Semaphore::new(1));
+    let adaptive = Arc::new(AdaptiveAdmission::new(false, 1, 100, 1, 1, 1000));
+    let route_limiter = Arc::new(RouteQueueLimiter::new(100, 1000, Default::default()));
+    let mut req = make_admitted_envelope(
+        Instant::now(),
+        AdmissionPermits {
+            global: permit,
+            upstream: upstream_sem.try_acquire_owned().unwrap(),
+            adaptive: adaptive.try_acquire().unwrap(),
+            route_queue: route_limiter.try_acquire("test").unwrap(),
+        },
+    );
 
     terminalize_stream(
         &mut req,

--- a/crates/edge/src/quic_listener/tests.rs
+++ b/crates/edge/src/quic_listener/tests.rs
@@ -2028,7 +2028,6 @@ fn abort_stream_waiting_for_auth_clears_async_auth_state() {
         request_mode: RequestMode::Normal,
         request_body: RequestBodyState::Open,
         request_body_runtime: RequestBodyRuntime {
-            body_tx: None,
             body_buf: std::collections::VecDeque::new(),
             body_buf_bytes: 0,
             body_bytes_received: 0,

--- a/crates/edge/src/runtime/connection/auth.rs
+++ b/crates/edge/src/runtime/connection/auth.rs
@@ -18,14 +18,6 @@ impl ExternalAuthFailureDisposition {
         }
     }
 
-    pub(crate) fn from_fail_open(fail_open: bool) -> Self {
-        if fail_open {
-            Self::FailOpen
-        } else {
-            Self::FailClosed
-        }
-    }
-
     pub(crate) fn fail_open(self) -> bool {
         matches!(self, Self::FailOpen)
     }
@@ -181,6 +173,24 @@ pub(crate) enum ExternalAuthCompletion {
     },
 }
 
+pub(crate) enum ExternalAuthStateTransition {
+    Admitted {
+        request_header_mutations: Vec<PendingHeaderMutation>,
+    },
+    RejectedAuthDenied {
+        decision: ExternalAuthDecision,
+    },
+    RejectedAuthUnavailable {
+        status: http::StatusCode,
+        body: &'static [u8],
+        error: Option<ProxyError>,
+    },
+    TimedOutAuth {
+        status: http::StatusCode,
+        body: &'static [u8],
+    },
+}
+
 impl ExternalAuthDecisionOutcome {
     fn from_result(
         result: ExternalAuthResult,
@@ -294,6 +304,41 @@ pub(crate) fn evaluate_external_auth_completion(
                 error: Some(error),
             },
             None => unreachable!("error outcome must resolve"),
+        },
+    }
+}
+
+pub(crate) fn resolve_external_auth_state_transition(
+    result: ExternalAuthResult,
+    disposition: ExternalAuthFailureDisposition,
+) -> ExternalAuthStateTransition {
+    match evaluate_external_auth_completion(result, disposition) {
+        ExternalAuthCompletion::Allow {
+            request_header_mutations,
+        } => ExternalAuthStateTransition::Admitted {
+            request_header_mutations,
+        },
+        ExternalAuthCompletion::Respond(decision) => {
+            ExternalAuthStateTransition::RejectedAuthDenied { decision }
+        }
+        ExternalAuthCompletion::FailOpen { .. } => ExternalAuthStateTransition::Admitted {
+            request_header_mutations: Vec::new(),
+        },
+        ExternalAuthCompletion::Reject {
+            status,
+            body,
+            timed_out: true,
+            ..
+        } => ExternalAuthStateTransition::TimedOutAuth { status, body },
+        ExternalAuthCompletion::Reject {
+            status,
+            body,
+            timed_out: false,
+            error,
+        } => ExternalAuthStateTransition::RejectedAuthUnavailable {
+            status,
+            body,
+            error,
         },
     }
 }

--- a/crates/edge/src/runtime/connection/outcome.rs
+++ b/crates/edge/src/runtime/connection/outcome.rs
@@ -415,6 +415,18 @@ pub(crate) fn finish_backend_request_accounting(input: BackendRequestFinishInput
     apply_backend_request_accounting(upstream_pool, backend_index, elapsed, status);
 }
 
+pub(crate) fn finalize_backend_request_cleanup(
+    input: BackendRequestFinishInput<'_>,
+    should_finalize: bool,
+) -> bool {
+    if should_finalize {
+        finish_backend_request_accounting(input);
+        true
+    } else {
+        false
+    }
+}
+
 pub(crate) fn observe_backend_response_status(
     input: BackendHealthObservationInput<'_>,
 ) -> Option<HealthTransition> {

--- a/crates/edge/src/runtime/connection/outcome.rs
+++ b/crates/edge/src/runtime/connection/outcome.rs
@@ -23,6 +23,9 @@ use crate::{
         },
         state::BackendIdentity,
     },
+    runtime::connection::stream::{
+        BackendFailureReason, RejectionReason, TerminalState, TimeoutReason,
+    },
 };
 
 fn emit_backend_health_transition(
@@ -375,6 +378,208 @@ pub(crate) fn observe_admission_outcome(
         elapsed,
         Some(status),
         classify_admission_outcome(outcome),
+    )
+}
+
+fn terminal_route_target(state: &TerminalState) -> OutcomeRouteTarget<'_> {
+    let routing = match state {
+        TerminalState::Completed(state) => state.snapshot.routing.as_ref(),
+        TerminalState::Cancelled(state) => state.snapshot.routing.as_ref(),
+        TerminalState::TimedOut(state) => state.snapshot.routing.as_ref(),
+        TerminalState::Rejected(state) => state.snapshot.routing.as_ref(),
+        TerminalState::BackendFailed(state) => state.snapshot.routing.as_ref(),
+    };
+    routing.map_or(OutcomeRouteTarget::UNROUTED, |routing| OutcomeRouteTarget {
+        route: &routing.upstream_name,
+    })
+}
+
+fn terminal_backend_target(state: &TerminalState) -> Option<OutcomeBackendTarget<'_>> {
+    let routing = match state {
+        TerminalState::Completed(state) => state.snapshot.routing.as_ref(),
+        TerminalState::Cancelled(state) => state.snapshot.routing.as_ref(),
+        TerminalState::TimedOut(state) => state.snapshot.routing.as_ref(),
+        TerminalState::Rejected(state) => state.snapshot.routing.as_ref(),
+        TerminalState::BackendFailed(state) => state.snapshot.routing.as_ref(),
+    }?;
+    Some(OutcomeBackendTarget {
+        upstream: &routing.upstream_name,
+        backend_addr: Some(&routing.backend_addr),
+        backend_index: Some(routing.backend_index),
+    })
+}
+
+fn terminal_elapsed(state: &TerminalState) -> Duration {
+    match state {
+        TerminalState::Completed(state) => state.snapshot.context.start.elapsed(),
+        TerminalState::Cancelled(state) => state.snapshot.context.start.elapsed(),
+        TerminalState::TimedOut(state) => state.snapshot.context.start.elapsed(),
+        TerminalState::Rejected(state) => state.snapshot.context.start.elapsed(),
+        TerminalState::BackendFailed(state) => state.snapshot.context.start.elapsed(),
+    }
+}
+
+fn infer_terminal_status(state: &TerminalState) -> Option<StatusCode> {
+    match state {
+        TerminalState::Completed(state) => state.snapshot.response_status,
+        TerminalState::Cancelled(state) => state.snapshot.response_status,
+        TerminalState::TimedOut(state) => {
+            state.snapshot.response_status.or(Some(match state.reason {
+                TimeoutReason::RequestBodyIdle
+                | TimeoutReason::RequestBodyTotal
+                | TimeoutReason::TotalRequest => StatusCode::REQUEST_TIMEOUT,
+                TimeoutReason::ExternalAuth
+                | TimeoutReason::AwaitingUpstream
+                | TimeoutReason::ResponseBodyIdle
+                | TimeoutReason::ResponseBodyTotal => StatusCode::GATEWAY_TIMEOUT,
+            }))
+        }
+        TerminalState::Rejected(state) => {
+            state.snapshot.response_status.or(Some(match state.reason {
+                RejectionReason::AuthDenied => StatusCode::UNAUTHORIZED,
+                RejectionReason::AuthUnavailable => StatusCode::SERVICE_UNAVAILABLE,
+                RejectionReason::ValidationFailed | RejectionReason::RequestBodyNotAllowed => {
+                    StatusCode::BAD_REQUEST
+                }
+                RejectionReason::RateLimited => StatusCode::TOO_MANY_REQUESTS,
+                RejectionReason::Overloaded | RejectionReason::ResponsePrebufferCap => {
+                    StatusCode::SERVICE_UNAVAILABLE
+                }
+                RejectionReason::RequestBodyTooLarge => StatusCode::PAYLOAD_TOO_LARGE,
+            }))
+        }
+        TerminalState::BackendFailed(state) => {
+            state.snapshot.response_status.or(Some(match state.reason {
+                BackendFailureReason::UpstreamTimeout => StatusCode::GATEWAY_TIMEOUT,
+                BackendFailureReason::DispatchSpawnFailed
+                | BackendFailureReason::UpstreamResultChannelDropped
+                | BackendFailureReason::UpstreamTransport
+                | BackendFailureReason::UpstreamProtocol
+                | BackendFailureReason::UpstreamTls
+                | BackendFailureReason::UpstreamBridge
+                | BackendFailureReason::ResponseWriteFailed
+                | BackendFailureReason::ResponseStreamAborted => StatusCode::BAD_GATEWAY,
+            }))
+        }
+    }
+}
+
+pub(crate) fn classify_terminal_outcome(state: &TerminalState) -> RequestOutcomeDecision {
+    match state {
+        TerminalState::Completed(state) if state.snapshot.overload_reason.is_some() => {
+            classify_admission_outcome(AdmissionOutcomeClass::OverloadShed {
+                reason: state.snapshot.overload_reason,
+            })
+        }
+        TerminalState::Completed(_) => infer_terminal_status(state)
+            .map(classify_status_outcome)
+            .unwrap_or(RequestOutcomeDecision {
+                route_outcome: CanonicalRouteOutcome::Success,
+                backend_outcome: CanonicalBackendOutcome::Success,
+                overload_reason: None,
+                health_effect: HealthEffectHint::Success,
+            }),
+        TerminalState::Cancelled(_) => infer_terminal_status(state)
+            .map(classify_status_outcome)
+            .unwrap_or(RequestOutcomeDecision {
+                route_outcome: CanonicalRouteOutcome::UpstreamFailure,
+                backend_outcome: CanonicalBackendOutcome::UpstreamFailure,
+                overload_reason: None,
+                health_effect: HealthEffectHint::None,
+            }),
+        TerminalState::TimedOut(_) => classify_proxy_error_outcome(&ProxyError::Timeout, None),
+        TerminalState::Rejected(state) => match state.reason {
+            RejectionReason::AuthDenied => {
+                classify_admission_outcome(AdmissionOutcomeClass::AuthDenied)
+            }
+            RejectionReason::RateLimited => {
+                classify_admission_outcome(AdmissionOutcomeClass::RateLimited)
+            }
+            RejectionReason::Overloaded | RejectionReason::ResponsePrebufferCap => {
+                classify_admission_outcome(AdmissionOutcomeClass::OverloadShed {
+                    reason: state.snapshot.overload_reason.or(
+                        if matches!(state.reason, RejectionReason::ResponsePrebufferCap) {
+                            Some(OverloadShedReason::ResponsePrebufferCap)
+                        } else {
+                            None
+                        },
+                    ),
+                })
+            }
+            RejectionReason::AuthUnavailable
+            | RejectionReason::ValidationFailed
+            | RejectionReason::RequestBodyNotAllowed
+            | RejectionReason::RequestBodyTooLarge => infer_terminal_status(
+                &TerminalState::Rejected(crate::runtime::connection::stream::RejectedState {
+                    reason: state.reason,
+                    snapshot: state.snapshot.clone(),
+                }),
+            )
+            .map(classify_status_outcome)
+            .unwrap_or(RequestOutcomeDecision {
+                route_outcome: CanonicalRouteOutcome::UpstreamFailure,
+                backend_outcome: CanonicalBackendOutcome::UpstreamFailure,
+                overload_reason: None,
+                health_effect: HealthEffectHint::None,
+            }),
+        },
+        TerminalState::BackendFailed(state) => match state.reason {
+            BackendFailureReason::UpstreamTimeout => RequestOutcomeDecision {
+                route_outcome: CanonicalRouteOutcome::Timeout,
+                backend_outcome: CanonicalBackendOutcome::Timeout,
+                overload_reason: None,
+                health_effect: HealthEffectHint::Failure {
+                    reason: HealthFailureReason::Timeout,
+                },
+            },
+            BackendFailureReason::UpstreamTls => RequestOutcomeDecision {
+                route_outcome: CanonicalRouteOutcome::UpstreamFailure,
+                backend_outcome: CanonicalBackendOutcome::UpstreamFailure,
+                overload_reason: None,
+                health_effect: HealthEffectHint::None,
+            },
+            BackendFailureReason::UpstreamBridge => RequestOutcomeDecision {
+                route_outcome: CanonicalRouteOutcome::UpstreamFailure,
+                backend_outcome: CanonicalBackendOutcome::UpstreamFailure,
+                overload_reason: None,
+                health_effect: HealthEffectHint::None,
+            },
+            BackendFailureReason::UpstreamProtocol => RequestOutcomeDecision {
+                route_outcome: CanonicalRouteOutcome::UpstreamFailure,
+                backend_outcome: CanonicalBackendOutcome::UpstreamFailure,
+                overload_reason: None,
+                health_effect: HealthEffectHint::Failure {
+                    reason: HealthFailureReason::Transport,
+                },
+            },
+            BackendFailureReason::UpstreamTransport
+            | BackendFailureReason::DispatchSpawnFailed
+            | BackendFailureReason::UpstreamResultChannelDropped
+            | BackendFailureReason::ResponseWriteFailed
+            | BackendFailureReason::ResponseStreamAborted => RequestOutcomeDecision {
+                route_outcome: CanonicalRouteOutcome::UpstreamFailure,
+                backend_outcome: CanonicalBackendOutcome::UpstreamFailure,
+                overload_reason: None,
+                health_effect: HealthEffectHint::Failure {
+                    reason: HealthFailureReason::Transport,
+                },
+            },
+        },
+    }
+}
+
+pub(crate) fn observe_terminal_request_outcome(
+    metrics: &Metrics,
+    state: &TerminalState,
+) -> RequestOutcomeDecision {
+    let status = infer_terminal_status(state);
+    observe_request_outcome(
+        metrics,
+        terminal_route_target(state),
+        terminal_backend_target(state),
+        terminal_elapsed(state),
+        status,
+        classify_terminal_outcome(state),
     )
 }
 

--- a/crates/edge/src/runtime/connection/request.rs
+++ b/crates/edge/src/runtime/connection/request.rs
@@ -20,25 +20,13 @@ use crate::{
         auth::{ExternalAuthFailureDisposition, ExternalAuthResult, PendingHeaderMutation},
         response::{ResponseChunk, UpstreamResult},
         stream::{
-            LegacyRequestLifecycle, RequestBodyRuntime, RequestBodyState, RequestContext,
-            RequestExecutionState, RequestMode, RoutingSnapshot, StreamAdmissionState, StreamPhase,
+            AwaitingAuthState, CancellationReason, CancelledState, DispatchReadyState,
+            LegacyRequestLifecycle, RequestBodyRuntime, RequestContext, RequestExecutionState,
+            RequestMode, StreamAdmissionState, StreamPhase, TerminalSnapshot, TerminalState,
             TunnelMode,
         },
     },
 };
-
-pub(crate) enum IntakeExecutionSeed {
-    AwaitingAuth {
-        pending_forward: Arc<PendingForward>,
-        auth_result_rx: oneshot::Receiver<ExternalAuthResult>,
-        auth_abort: AbortHandle,
-        auth_disposition: ExternalAuthFailureDisposition,
-        auth_deadline: Instant,
-    },
-    ReadyForForwarding {
-        pending_forward: Arc<PendingForward>,
-    },
-}
 
 pub struct RequestEnvelope {
     pub request_id: u64,
@@ -107,10 +95,10 @@ impl RequestEnvelope {
         admission_state: StreamAdmissionState,
         request_fin_received: bool,
         pending_forward: Option<Arc<PendingForward>>,
-        auth_result_rx: Option<oneshot::Receiver<ExternalAuthResult>>,
-        auth_abort: Option<AbortHandle>,
-        auth_disposition: Option<ExternalAuthFailureDisposition>,
-        auth_deadline: Option<Instant>,
+        _auth_result_rx: Option<oneshot::Receiver<ExternalAuthResult>>,
+        _auth_abort: Option<AbortHandle>,
+        _auth_disposition: Option<ExternalAuthFailureDisposition>,
+        _auth_deadline: Option<Instant>,
     ) -> Self {
         Self {
             request_id,
@@ -150,10 +138,6 @@ impl RequestEnvelope {
                     request_fin_received,
                 },
                 pending_forward,
-                auth_result_rx,
-                auth_abort,
-                auth_disposition,
-                auth_deadline,
                 backend_request_started: false,
                 backend_request_finished: false,
                 global_inflight_permit: None,
@@ -168,66 +152,39 @@ impl RequestEnvelope {
         }
     }
 
-    pub(crate) fn from_intake_legacy(
-        context: RequestContext,
-        routing: RoutingSnapshot,
+    pub(crate) fn from_dispatch_ready_state(
+        state: DispatchReadyState,
         upstream_pool: Arc<RwLock<UpstreamPool>>,
-        request_mode: RequestMode,
-        request_body: RequestBodyState,
         routing_transparency_enabled: bool,
         routing_transparency_include_reason: bool,
         retry_count: u8,
         error_kind: Option<&'static str>,
-        execution: IntakeExecutionSeed,
     ) -> Self {
-        let (
-            admission_state,
-            pending_forward,
-            auth_result_rx,
-            auth_abort,
-            auth_disposition,
-            auth_deadline,
-        ) = match execution {
-            IntakeExecutionSeed::AwaitingAuth {
-                pending_forward,
-                auth_result_rx,
-                auth_abort,
-                auth_disposition,
-                auth_deadline,
-            } => (
-                StreamAdmissionState::WaitingForAuth,
-                Some(pending_forward),
-                Some(auth_result_rx),
-                Some(auth_abort),
-                Some(auth_disposition),
-                Some(auth_deadline),
-            ),
-            IntakeExecutionSeed::ReadyForForwarding { pending_forward } => (
-                StreamAdmissionState::ReadyToForward,
-                Some(pending_forward),
-                None,
-                None,
-                None,
-                None,
-            ),
-        };
+        let DispatchReadyState {
+            context,
+            routing,
+            request_mode,
+            request_body: _,
+            request_body_runtime: _,
+            pending_forward: _,
+        } = &state;
 
         Self {
             request_id: context.request_id,
-            trace_id: context.trace_id,
-            span_id: context.span_id,
-            traceparent: context.traceparent,
-            trace_span: context.trace_span,
-            method: context.method,
-            path: context.path,
-            authority: context.authority,
-            backend_addr: Some(routing.backend_addr),
+            trace_id: context.trace_id.clone(),
+            span_id: context.span_id.clone(),
+            traceparent: context.traceparent.clone(),
+            trace_span: context.trace_span.clone(),
+            method: context.method.clone(),
+            path: context.path.clone(),
+            authority: context.authority.clone(),
+            backend_addr: Some(routing.backend_addr.clone()),
             backend_index: Some(routing.backend_index),
-            upstream_name: Some(routing.upstream_name),
-            route_reason: Some(routing.route_reason),
+            upstream_name: Some(routing.upstream_name.clone()),
+            route_reason: Some(routing.route_reason.clone()),
             route_path_len: Some(routing.route_path_len),
             route_host_specific: Some(routing.route_host_specific),
-            backend_lb: routing.backend_lb,
+            backend_lb: routing.backend_lb.clone(),
             upstream_pool: Some(upstream_pool),
             routing_transparency_enabled,
             routing_transparency_include_reason,
@@ -238,33 +195,58 @@ impl RequestEnvelope {
             tunnel_mode: request_mode.tunnel_mode(),
             retry_count,
             error_kind,
-            execution: RequestExecutionState::Legacy(LegacyRequestLifecycle {
-                phase: StreamPhase::ReceivingRequest,
-                admission_state,
-                request_body_runtime: RequestBodyRuntime {
-                    body_tx: None,
-                    body_buf: VecDeque::new(),
-                    body_buf_bytes: 0,
-                    body_bytes_received: 0,
-                    last_body_activity: context.start,
-                    request_fin_received: request_body.request_fin_received(),
-                },
-                pending_forward,
-                auth_result_rx,
-                auth_abort,
-                auth_disposition,
-                auth_deadline,
-                backend_request_started: false,
-                backend_request_finished: false,
-                global_inflight_permit: None,
-                upstream_inflight_permit: None,
-                adaptive_admission_permit: None,
-                route_queue_permit: None,
-                upstream_result_rx: None,
-                response_chunk_rx: None,
-                response_headers_sent: false,
-                pending_chunk: None,
-            }),
+            execution: RequestExecutionState::DispatchReady(state),
+        }
+    }
+
+    pub(crate) fn from_awaiting_auth_state(
+        state: AwaitingAuthState,
+        upstream_pool: Arc<RwLock<UpstreamPool>>,
+        routing_transparency_enabled: bool,
+        routing_transparency_include_reason: bool,
+        retry_count: u8,
+        error_kind: Option<&'static str>,
+    ) -> Self {
+        let AwaitingAuthState {
+            context,
+            routing,
+            request_mode,
+            request_body: _,
+            request_body_runtime: _,
+            pending_forward: _,
+            auth_result_rx: _,
+            auth_abort: _,
+            auth_deadline: _,
+            auth_disposition: _,
+        } = &state;
+
+        Self {
+            request_id: context.request_id,
+            trace_id: context.trace_id.clone(),
+            span_id: context.span_id.clone(),
+            traceparent: context.traceparent.clone(),
+            trace_span: context.trace_span.clone(),
+            method: context.method.clone(),
+            path: context.path.clone(),
+            authority: context.authority.clone(),
+            backend_addr: Some(routing.backend_addr.clone()),
+            backend_index: Some(routing.backend_index),
+            upstream_name: Some(routing.upstream_name.clone()),
+            route_reason: Some(routing.route_reason.clone()),
+            route_path_len: Some(routing.route_path_len),
+            route_host_specific: Some(routing.route_host_specific),
+            backend_lb: routing.backend_lb.clone(),
+            upstream_pool: Some(upstream_pool),
+            routing_transparency_enabled,
+            routing_transparency_include_reason,
+            response_status: None,
+            start: context.start,
+            total_request_deadline: context.total_request_deadline,
+            bodyless_mode: request_mode.bodyless_mode(),
+            tunnel_mode: request_mode.tunnel_mode(),
+            retry_count,
+            error_kind,
+            execution: RequestExecutionState::AwaitingAuth(state),
         }
     }
 
@@ -277,130 +259,112 @@ impl RequestEnvelope {
     }
 
     pub fn request_fin_received(&self) -> bool {
-        self.legacy().request_body_runtime.request_fin_received
+        self.request_body_runtime().request_fin_received
     }
 
     pub fn set_request_fin_received(&mut self, value: bool) {
-        self.legacy_mut().request_body_runtime.request_fin_received = value;
+        self.request_body_runtime_mut().request_fin_received = value;
     }
 
     pub fn body_tx(&self) -> Option<&mpsc::Sender<Bytes>> {
-        self.legacy().request_body_runtime.body_tx.as_ref()
+        self.request_body_runtime().body_tx.as_ref()
     }
 
     pub fn body_tx_mut(&mut self) -> &mut Option<mpsc::Sender<Bytes>> {
-        &mut self.legacy_mut().request_body_runtime.body_tx
+        &mut self.request_body_runtime_mut().body_tx
     }
 
     pub fn clear_body_tx(&mut self) {
-        self.legacy_mut().request_body_runtime.body_tx = None;
+        self.request_body_runtime_mut().body_tx = None;
     }
 
     pub fn body_buf(&self) -> &VecDeque<Bytes> {
-        &self.legacy().request_body_runtime.body_buf
+        &self.request_body_runtime().body_buf
     }
 
     pub fn body_buf_mut(&mut self) -> &mut VecDeque<Bytes> {
-        &mut self.legacy_mut().request_body_runtime.body_buf
+        &mut self.request_body_runtime_mut().body_buf
     }
 
     pub fn body_buf_bytes(&self) -> usize {
-        self.legacy().request_body_runtime.body_buf_bytes
+        self.request_body_runtime().body_buf_bytes
     }
 
     pub fn set_body_buf_bytes(&mut self, value: usize) {
-        self.legacy_mut().request_body_runtime.body_buf_bytes = value;
+        self.request_body_runtime_mut().body_buf_bytes = value;
     }
 
     pub fn body_bytes_received(&self) -> usize {
-        self.legacy().request_body_runtime.body_bytes_received
+        self.request_body_runtime().body_bytes_received
     }
 
     pub fn set_body_bytes_received(&mut self, value: usize) {
-        self.legacy_mut().request_body_runtime.body_bytes_received = value;
+        self.request_body_runtime_mut().body_bytes_received = value;
     }
 
     pub fn last_body_activity(&self) -> Instant {
-        self.legacy().request_body_runtime.last_body_activity
+        self.request_body_runtime().last_body_activity
     }
 
     pub fn set_last_body_activity(&mut self, value: Instant) {
-        self.legacy_mut().request_body_runtime.last_body_activity = value;
+        self.request_body_runtime_mut().last_body_activity = value;
     }
 
     pub fn pending_forward(&self) -> Option<&Arc<PendingForward>> {
-        self.legacy().pending_forward.as_ref()
+        match &self.execution {
+            RequestExecutionState::AwaitingAuth(state) => Some(&state.pending_forward),
+            RequestExecutionState::DispatchReady(state) => Some(&state.pending_forward),
+            RequestExecutionState::AwaitingUpstream(state) => Some(&state.pending_forward),
+            RequestExecutionState::Legacy(state) => state.pending_forward.as_ref(),
+            RequestExecutionState::Intake(_)
+            | RequestExecutionState::StreamingResponse(_)
+            | RequestExecutionState::Terminal(_) => None,
+        }
     }
 
     pub fn pending_forward_mut(&mut self) -> Option<&mut Arc<PendingForward>> {
-        self.legacy_mut().pending_forward.as_mut()
+        match &mut self.execution {
+            RequestExecutionState::AwaitingAuth(state) => Some(&mut state.pending_forward),
+            RequestExecutionState::DispatchReady(state) => Some(&mut state.pending_forward),
+            RequestExecutionState::AwaitingUpstream(state) => Some(&mut state.pending_forward),
+            RequestExecutionState::Legacy(state) => state.pending_forward.as_mut(),
+            RequestExecutionState::Intake(_)
+            | RequestExecutionState::StreamingResponse(_)
+            | RequestExecutionState::Terminal(_) => None,
+        }
     }
 
     pub fn clear_pending_forward(&mut self) {
-        self.legacy_mut().pending_forward = None;
+        match &mut self.execution {
+            RequestExecutionState::AwaitingAuth(_)
+            | RequestExecutionState::DispatchReady(_)
+            | RequestExecutionState::AwaitingUpstream(_)
+            | RequestExecutionState::Legacy(_) => {
+                self.set_pending_forward(None);
+            }
+            RequestExecutionState::Intake(_)
+            | RequestExecutionState::StreamingResponse(_)
+            | RequestExecutionState::Terminal(_) => {}
+        }
     }
 
-    pub(crate) fn auth_result_rx_mut(
+    pub(crate) fn poll_awaiting_auth_non_blocking(
         &mut self,
-    ) -> Option<&mut oneshot::Receiver<ExternalAuthResult>> {
-        self.legacy_mut().auth_result_rx.as_mut()
-    }
-
-    pub fn clear_auth_result_rx(&mut self) {
-        self.legacy_mut().auth_result_rx = None;
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn set_auth_result_rx(&mut self, rx: Option<oneshot::Receiver<ExternalAuthResult>>) {
-        self.legacy_mut().auth_result_rx = rx;
-    }
-
-    pub fn has_auth_result_rx(&self) -> bool {
-        self.legacy().auth_result_rx.is_some()
-    }
-
-    pub fn take_auth_abort(&mut self) -> Option<AbortHandle> {
-        self.legacy_mut().auth_abort.take()
-    }
-
-    pub fn clear_auth_abort(&mut self) {
-        self.legacy_mut().auth_abort = None;
-    }
-
-    pub fn set_auth_abort(&mut self, abort: Option<AbortHandle>) {
-        self.legacy_mut().auth_abort = abort;
-    }
-
-    pub fn has_auth_abort(&self) -> bool {
-        self.legacy().auth_abort.is_some()
-    }
-
-    pub fn auth_fail_open(&self) -> bool {
-        self.legacy()
-            .auth_disposition
-            .is_some_and(ExternalAuthFailureDisposition::fail_open)
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn set_auth_disposition(
-        &mut self,
-        disposition: Option<ExternalAuthFailureDisposition>,
-    ) {
-        self.legacy_mut().auth_disposition = disposition;
-    }
-
-    pub fn auth_deadline(&self) -> Option<Instant> {
-        self.legacy().auth_deadline
-    }
-
-    pub fn set_auth_deadline(&mut self, deadline: Option<Instant>) {
-        self.legacy_mut().auth_deadline = deadline;
+        now: Instant,
+    ) -> Option<ExternalAuthResult> {
+        match &mut self.execution {
+            RequestExecutionState::AwaitingAuth(state) => state.poll_non_blocking(now),
+            _ => None,
+        }
     }
 
     pub(crate) fn upstream_result_rx_mut(
         &mut self,
     ) -> Option<&mut oneshot::Receiver<UpstreamResult>> {
-        self.legacy_mut().upstream_result_rx.as_mut()
+        match &mut self.execution {
+            RequestExecutionState::Legacy(state) => state.upstream_result_rx.as_mut(),
+            _ => None,
+        }
     }
 
     #[allow(dead_code)]
@@ -409,11 +373,16 @@ impl RequestEnvelope {
     }
 
     pub fn clear_upstream_result_rx(&mut self) {
-        self.legacy_mut().upstream_result_rx = None;
+        if let RequestExecutionState::Legacy(state) = &mut self.execution {
+            state.upstream_result_rx = None;
+        }
     }
 
     pub(crate) fn response_chunk_rx_mut(&mut self) -> Option<&mut mpsc::Receiver<ResponseChunk>> {
-        self.legacy_mut().response_chunk_rx.as_mut()
+        match &mut self.execution {
+            RequestExecutionState::Legacy(state) => state.response_chunk_rx.as_mut(),
+            _ => None,
+        }
     }
 
     #[allow(dead_code)]
@@ -422,49 +391,94 @@ impl RequestEnvelope {
     }
 
     pub fn clear_response_chunk_rx(&mut self) {
-        self.legacy_mut().response_chunk_rx = None;
+        if let RequestExecutionState::Legacy(state) = &mut self.execution {
+            state.response_chunk_rx = None;
+        }
     }
 
     pub fn has_upstream_result_rx(&self) -> bool {
-        self.legacy().upstream_result_rx.is_some()
+        match &self.execution {
+            RequestExecutionState::Legacy(state) => state.upstream_result_rx.is_some(),
+            _ => false,
+        }
     }
 
     pub fn has_response_chunk_rx(&self) -> bool {
-        self.legacy().response_chunk_rx.is_some()
+        match &self.execution {
+            RequestExecutionState::Legacy(state) => state.response_chunk_rx.is_some(),
+            _ => false,
+        }
     }
 
     pub fn response_headers_sent(&self) -> bool {
-        self.legacy().response_headers_sent
+        match &self.execution {
+            RequestExecutionState::Legacy(state) => state.response_headers_sent,
+            _ => false,
+        }
     }
 
     pub fn set_response_headers_sent(&mut self, sent: bool) {
-        self.legacy_mut().response_headers_sent = sent;
+        if let RequestExecutionState::Legacy(state) = &mut self.execution {
+            state.response_headers_sent = sent;
+        }
     }
 
     pub(crate) fn take_pending_chunk(&mut self) -> Option<ResponseChunk> {
-        self.legacy_mut().pending_chunk.take()
+        match &mut self.execution {
+            RequestExecutionState::Legacy(state) => state.pending_chunk.take(),
+            RequestExecutionState::StreamingResponse(state) => state.pending_chunk.take(),
+            _ => None,
+        }
     }
 
     pub(crate) fn set_pending_chunk(&mut self, chunk: Option<ResponseChunk>) {
-        self.legacy_mut().pending_chunk = chunk;
+        match &mut self.execution {
+            RequestExecutionState::Legacy(state) => state.pending_chunk = chunk,
+            RequestExecutionState::StreamingResponse(state) => state.pending_chunk = chunk,
+            _ => {}
+        }
     }
 
     pub fn has_pending_chunk(&self) -> bool {
-        self.legacy().pending_chunk.is_some()
+        match &self.execution {
+            RequestExecutionState::Legacy(state) => state.pending_chunk.is_some(),
+            RequestExecutionState::StreamingResponse(state) => state.pending_chunk.is_some(),
+            _ => false,
+        }
     }
 
     pub fn backend_request_started(&self) -> bool {
-        self.legacy().backend_request_started
+        match &self.execution {
+            RequestExecutionState::Legacy(state) => state.backend_request_started,
+            RequestExecutionState::AwaitingUpstream(_)
+            | RequestExecutionState::StreamingResponse(_) => true,
+            _ => false,
+        }
     }
 
     pub fn backend_request_finished(&self) -> bool {
-        self.legacy().backend_request_finished
+        match &self.execution {
+            RequestExecutionState::Legacy(state) => state.backend_request_finished,
+            RequestExecutionState::AwaitingUpstream(state) => state.backend_accounting.finalized,
+            RequestExecutionState::StreamingResponse(state) => state.backend_accounting.finalized,
+            _ => false,
+        }
     }
 
     pub fn set_backend_request_state(&mut self, started: bool, finished: bool) {
-        let legacy = self.legacy_mut();
-        legacy.backend_request_started = started;
-        legacy.backend_request_finished = finished;
+        match &mut self.execution {
+            RequestExecutionState::Legacy(state) => {
+                state.backend_request_started = started;
+                state.backend_request_finished = finished;
+            }
+            RequestExecutionState::AwaitingUpstream(state) => {
+                state.backend_accounting.finalized = started && finished;
+            }
+            RequestExecutionState::StreamingResponse(state) => {
+                state.backend_accounting.finalized = started && finished;
+            }
+            _ => {}
+        }
     }
 
     pub fn set_dispatch_permits(
@@ -482,46 +496,48 @@ impl RequestEnvelope {
     }
 
     pub fn clear_dispatch_permits(&mut self) {
-        let legacy = self.legacy_mut();
-        legacy.global_inflight_permit = None;
-        legacy.upstream_inflight_permit = None;
-        legacy.adaptive_admission_permit = None;
-        legacy.route_queue_permit = None;
+        if let RequestExecutionState::Legacy(state) = &mut self.execution {
+            state.global_inflight_permit = None;
+            state.upstream_inflight_permit = None;
+            state.adaptive_admission_permit = None;
+            state.route_queue_permit = None;
+        }
     }
 
     pub fn has_global_inflight_permit(&self) -> bool {
-        self.legacy().global_inflight_permit.is_some()
+        match &self.execution {
+            RequestExecutionState::Legacy(state) => state.global_inflight_permit.is_some(),
+            RequestExecutionState::AwaitingUpstream(_)
+            | RequestExecutionState::StreamingResponse(_) => true,
+            _ => false,
+        }
     }
 
     pub fn has_upstream_inflight_permit(&self) -> bool {
-        self.legacy().upstream_inflight_permit.is_some()
+        match &self.execution {
+            RequestExecutionState::Legacy(state) => state.upstream_inflight_permit.is_some(),
+            RequestExecutionState::AwaitingUpstream(_)
+            | RequestExecutionState::StreamingResponse(_) => true,
+            _ => false,
+        }
     }
 
     pub fn has_adaptive_admission_permit(&self) -> bool {
-        self.legacy().adaptive_admission_permit.is_some()
+        match &self.execution {
+            RequestExecutionState::Legacy(state) => state.adaptive_admission_permit.is_some(),
+            RequestExecutionState::AwaitingUpstream(_)
+            | RequestExecutionState::StreamingResponse(_) => true,
+            _ => false,
+        }
     }
 
     pub fn has_route_queue_permit(&self) -> bool {
-        self.legacy().route_queue_permit.is_some()
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn transition_to_awaiting_auth(
-        &mut self,
-        pending_forward: Arc<PendingForward>,
-        auth_result_rx: oneshot::Receiver<ExternalAuthResult>,
-        auth_abort: AbortHandle,
-        auth_disposition: ExternalAuthFailureDisposition,
-        auth_deadline: Instant,
-    ) {
-        let legacy = self.legacy_mut();
-        legacy.phase = StreamPhase::ReceivingRequest;
-        legacy.admission_state = StreamAdmissionState::WaitingForAuth;
-        legacy.pending_forward = Some(pending_forward);
-        legacy.auth_result_rx = Some(auth_result_rx);
-        legacy.auth_abort = Some(auth_abort);
-        legacy.auth_disposition = Some(auth_disposition);
-        legacy.auth_deadline = Some(auth_deadline);
+        match &self.execution {
+            RequestExecutionState::Legacy(state) => state.route_queue_permit.is_some(),
+            RequestExecutionState::AwaitingUpstream(_)
+            | RequestExecutionState::StreamingResponse(_) => true,
+            _ => false,
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -535,27 +551,68 @@ impl RequestEnvelope {
         route_queue: RouteQueuePermit,
     ) {
         let should_await_upstream = self.request_fin_received() && self.body_buf().is_empty();
-        let legacy = self.legacy_mut();
-        legacy.backend_request_started = true;
-        legacy.backend_request_finished = false;
-        legacy.request_body_runtime.body_tx = body_tx;
-        legacy.upstream_result_rx = Some(upstream_result_rx);
-        legacy.global_inflight_permit = Some(global);
-        legacy.upstream_inflight_permit = Some(upstream);
-        legacy.adaptive_admission_permit = Some(adaptive);
-        legacy.route_queue_permit = Some(route_queue);
-        legacy.admission_state = StreamAdmissionState::ReadyToForward;
-        legacy.phase = if should_await_upstream {
-            StreamPhase::AwaitingUpstream
-        } else {
-            StreamPhase::ReceivingRequest
-        };
-        legacy.auth_abort = None;
-        legacy.auth_result_rx = None;
-        legacy.auth_disposition = None;
-        legacy.auth_deadline = None;
-        if should_await_upstream {
-            legacy.request_body_runtime.body_tx = None;
+        match &mut self.execution {
+            RequestExecutionState::Legacy(legacy) => {
+                legacy.backend_request_started = true;
+                legacy.backend_request_finished = false;
+                legacy.request_body_runtime.body_tx = body_tx;
+                legacy.upstream_result_rx = Some(upstream_result_rx);
+                legacy.global_inflight_permit = Some(global);
+                legacy.upstream_inflight_permit = Some(upstream);
+                legacy.adaptive_admission_permit = Some(adaptive);
+                legacy.route_queue_permit = Some(route_queue);
+                legacy.admission_state = StreamAdmissionState::ReadyToForward;
+                legacy.phase = if should_await_upstream {
+                    StreamPhase::AwaitingUpstream
+                } else {
+                    StreamPhase::ReceivingRequest
+                };
+                if should_await_upstream {
+                    legacy.request_body_runtime.body_tx = None;
+                }
+            }
+            RequestExecutionState::DispatchReady(state) => {
+                let mut request_body_runtime = std::mem::replace(
+                    &mut state.request_body_runtime,
+                    RequestBodyRuntime {
+                        body_tx: None,
+                        body_buf: VecDeque::new(),
+                        body_buf_bytes: 0,
+                        body_bytes_received: 0,
+                        last_body_activity: self.start,
+                        request_fin_received: true,
+                    },
+                );
+                request_body_runtime.body_tx = body_tx;
+                if should_await_upstream {
+                    request_body_runtime.body_tx = None;
+                }
+                let pending_forward = Some(Arc::clone(&state.pending_forward));
+                self.execution = RequestExecutionState::Legacy(LegacyRequestLifecycle {
+                    phase: if should_await_upstream {
+                        StreamPhase::AwaitingUpstream
+                    } else {
+                        StreamPhase::ReceivingRequest
+                    },
+                    admission_state: StreamAdmissionState::ReadyToForward,
+                    request_body_runtime,
+                    pending_forward,
+                    backend_request_started: true,
+                    backend_request_finished: false,
+                    global_inflight_permit: Some(global),
+                    upstream_inflight_permit: Some(upstream),
+                    adaptive_admission_permit: Some(adaptive),
+                    route_queue_permit: Some(route_queue),
+                    upstream_result_rx: Some(upstream_result_rx),
+                    response_chunk_rx: None,
+                    response_headers_sent: false,
+                    pending_chunk: None,
+                });
+            }
+            other => panic!(
+                "dispatch transition attempted from unsupported state {:?}",
+                std::mem::discriminant(other)
+            ),
         }
     }
 
@@ -587,17 +644,86 @@ impl RequestEnvelope {
     }
 
     pub fn set_pending_forward(&mut self, pending_forward: Option<Arc<PendingForward>>) {
-        self.legacy_mut().pending_forward = pending_forward;
+        match &mut self.execution {
+            RequestExecutionState::AwaitingAuth(state) => {
+                if let Some(pending_forward) = pending_forward {
+                    state.pending_forward = pending_forward;
+                }
+            }
+            RequestExecutionState::DispatchReady(state) => {
+                if let Some(pending_forward) = pending_forward {
+                    state.pending_forward = pending_forward;
+                }
+            }
+            RequestExecutionState::AwaitingUpstream(state) => {
+                if let Some(pending_forward) = pending_forward {
+                    state.pending_forward = pending_forward;
+                }
+            }
+            RequestExecutionState::Legacy(state) => {
+                state.pending_forward = pending_forward;
+            }
+            RequestExecutionState::Intake(_)
+            | RequestExecutionState::StreamingResponse(_)
+            | RequestExecutionState::Terminal(_) => {}
+        }
     }
 
-    fn legacy(&self) -> &LegacyRequestLifecycle {
-        match &self.execution {
-            RequestExecutionState::Legacy(state) => state,
-            other => panic!(
-                "legacy lifecycle access attempted after migration to {:?}",
-                std::mem::discriminant(other)
-            ),
+    pub(crate) fn transition_awaiting_auth_to_dispatch_ready<I>(&mut self, mutations: I)
+    where
+        I: IntoIterator<Item = PendingHeaderMutation>,
+    {
+        let state = match self.take_awaiting_auth_state() {
+            Some(state) => {
+                let mut state = state;
+                crate::runtime::connection::auth::merge_auth_request_mutations(
+                    &mut Arc::make_mut(&mut state.pending_forward).auth_header_mutations,
+                    mutations,
+                );
+                state
+            }
+            None => panic!("awaiting-auth transition attempted outside AwaitingAuth state"),
+        };
+        self.execution = RequestExecutionState::DispatchReady(DispatchReadyState {
+            context: state.context,
+            routing: state.routing,
+            request_mode: state.request_mode,
+            request_body: state.request_body,
+            request_body_runtime: state.request_body_runtime,
+            pending_forward: state.pending_forward,
+        });
+    }
+
+    pub(crate) fn take_awaiting_auth_state(&mut self) -> Option<AwaitingAuthState> {
+        let placeholder =
+            RequestExecutionState::Terminal(TerminalState::Cancelled(CancelledState {
+                reason: CancellationReason::OperatorAbort,
+                snapshot: self.terminal_snapshot(),
+            }));
+        match std::mem::replace(&mut self.execution, placeholder) {
+            RequestExecutionState::AwaitingAuth(state) => {
+                state.auth_abort.abort();
+                Some(state)
+            }
+            other => {
+                self.execution = other;
+                None
+            }
         }
+    }
+
+    pub(crate) fn discard_awaiting_auth_resources(&mut self) {
+        let Some(state) = self.take_awaiting_auth_state() else {
+            return;
+        };
+        self.execution = RequestExecutionState::DispatchReady(DispatchReadyState {
+            context: state.context,
+            routing: state.routing,
+            request_mode: state.request_mode,
+            request_body: state.request_body,
+            request_body_runtime: state.request_body_runtime,
+            pending_forward: state.pending_forward,
+        });
     }
 
     fn legacy_mut(&mut self) -> &mut LegacyRequestLifecycle {
@@ -607,6 +733,70 @@ impl RequestEnvelope {
                 "legacy lifecycle mutation attempted after migration to {:?}",
                 std::mem::discriminant(other)
             ),
+        }
+    }
+
+    fn request_body_runtime(&self) -> &RequestBodyRuntime {
+        match &self.execution {
+            RequestExecutionState::AwaitingAuth(state) => &state.request_body_runtime,
+            RequestExecutionState::DispatchReady(state) => &state.request_body_runtime,
+            RequestExecutionState::AwaitingUpstream(state) => &state.request_body_runtime,
+            RequestExecutionState::StreamingResponse(state) => &state.request_body_runtime,
+            RequestExecutionState::Legacy(state) => &state.request_body_runtime,
+            RequestExecutionState::Intake(_) | RequestExecutionState::Terminal(_) => {
+                panic!("request body runtime unavailable in current execution state")
+            }
+        }
+    }
+
+    fn request_body_runtime_mut(&mut self) -> &mut RequestBodyRuntime {
+        match &mut self.execution {
+            RequestExecutionState::AwaitingAuth(state) => &mut state.request_body_runtime,
+            RequestExecutionState::DispatchReady(state) => &mut state.request_body_runtime,
+            RequestExecutionState::AwaitingUpstream(state) => &mut state.request_body_runtime,
+            RequestExecutionState::StreamingResponse(state) => &mut state.request_body_runtime,
+            RequestExecutionState::Legacy(state) => &mut state.request_body_runtime,
+            RequestExecutionState::Intake(_) | RequestExecutionState::Terminal(_) => {
+                panic!("request body runtime mutation unavailable in current execution state")
+            }
+        }
+    }
+
+    fn terminal_snapshot(&self) -> TerminalSnapshot {
+        let routing = match &self.execution {
+            RequestExecutionState::AwaitingAuth(state) => Some(state.routing.clone()),
+            RequestExecutionState::DispatchReady(state) => Some(state.routing.clone()),
+            RequestExecutionState::AwaitingUpstream(state) => Some(state.routing.clone()),
+            RequestExecutionState::StreamingResponse(state) => Some(state.routing.clone()),
+            RequestExecutionState::Legacy(_) | RequestExecutionState::Intake(_) => None,
+            RequestExecutionState::Terminal(state) => match state {
+                TerminalState::Completed(state) => state.snapshot.routing.clone(),
+                TerminalState::Cancelled(state) => state.snapshot.routing.clone(),
+                TerminalState::TimedOut(state) => state.snapshot.routing.clone(),
+                TerminalState::Rejected(state) => state.snapshot.routing.clone(),
+                TerminalState::BackendFailed(state) => state.snapshot.routing.clone(),
+            },
+        };
+
+        TerminalSnapshot {
+            context: RequestContext {
+                request_id: self.request_id,
+                trace_id: self.trace_id.clone(),
+                span_id: self.span_id.clone(),
+                traceparent: self.traceparent.clone(),
+                trace_span: self.trace_span.clone(),
+                method: self.method.clone(),
+                path: self.path.clone(),
+                authority: self.authority.clone(),
+                start: self.start,
+                total_request_deadline: self.total_request_deadline,
+            },
+            routing,
+            request_mode: RequestMode::from_intake(self.tunnel_mode, &self.method, None),
+            response_status: self
+                .response_status
+                .and_then(|status| http::StatusCode::from_u16(status).ok()),
+            backend_accounting: None,
         }
     }
 }

--- a/crates/edge/src/runtime/connection/request.rs
+++ b/crates/edge/src/runtime/connection/request.rs
@@ -15,11 +15,14 @@ use tokio::{
 use tracing::Span;
 
 use crate::{
-    Metrics,
+    Metrics, OverloadShedReason,
     resilience::{adaptive_admission::AdaptivePermit, route_queue::RouteQueuePermit},
     runtime::connection::{
         auth::{ExternalAuthFailureDisposition, ExternalAuthResult, PendingHeaderMutation},
-        outcome::{BackendRequestFinishInput, finalize_backend_request_cleanup},
+        outcome::{
+            BackendRequestFinishInput, finalize_backend_request_cleanup,
+            observe_terminal_request_outcome,
+        },
         response::{ResponseChunk, UpstreamResult},
         stream::{
             AdmissionPermits, AdmittedState, AwaitingAuthState, AwaitingUpstreamState,
@@ -62,6 +65,8 @@ pub struct RequestEnvelope {
 
     pub retry_count: u8,
     pub error_kind: Option<&'static str>,
+    pub terminal_overload_reason: Option<OverloadShedReason>,
+    pub terminal_outcome_recorded: bool,
     pub execution: RequestExecutionState,
 }
 
@@ -131,6 +136,8 @@ impl RequestEnvelope {
             tunnel_mode,
             retry_count,
             error_kind,
+            terminal_overload_reason: None,
+            terminal_outcome_recorded: false,
             execution: RequestExecutionState::Legacy(LegacyRequestLifecycle {
                 phase,
                 admission_state,
@@ -155,6 +162,10 @@ impl RequestEnvelope {
                 pending_chunk: None,
             }),
         }
+    }
+
+    pub fn set_terminal_overload_reason(&mut self, reason: Option<OverloadShedReason>) {
+        self.terminal_overload_reason = reason;
     }
 
     pub(crate) fn from_dispatch_ready_state(
@@ -200,6 +211,8 @@ impl RequestEnvelope {
             tunnel_mode: request_mode.tunnel_mode(),
             retry_count,
             error_kind,
+            terminal_overload_reason: None,
+            terminal_outcome_recorded: false,
             execution: RequestExecutionState::DispatchReady(state),
         }
     }
@@ -251,8 +264,14 @@ impl RequestEnvelope {
             tunnel_mode: request_mode.tunnel_mode(),
             retry_count,
             error_kind,
+            terminal_overload_reason: None,
+            terminal_outcome_recorded: false,
             execution: RequestExecutionState::AwaitingAuth(state),
         }
+    }
+
+    pub fn mark_terminal_outcome_recorded(&mut self) {
+        self.terminal_outcome_recorded = true;
     }
 
     pub fn phase(&self) -> StreamPhase {
@@ -1108,6 +1127,11 @@ impl RequestEnvelope {
         }
 
         let snapshot = self.terminal_snapshot();
+        let terminal_state = reason.into_terminal_state(snapshot.clone());
+        if !self.terminal_outcome_recorded {
+            let _ = observe_terminal_request_outcome(metrics, &terminal_state);
+            self.terminal_outcome_recorded = true;
+        }
         let should_finalize_backend = self.execution.should_finalize_backend_accounting();
         let buffered_body_bytes = Self::buffered_request_body_bytes(&self.execution);
         let finalize_status = reason
@@ -1143,7 +1167,7 @@ impl RequestEnvelope {
             metrics.release_request_buffer(buffered_body_bytes);
         }
 
-        self.execution = RequestExecutionState::Terminal(reason.into_terminal_state(snapshot));
+        self.execution = RequestExecutionState::Terminal(terminal_state);
         prior_phase
     }
 
@@ -1238,6 +1262,7 @@ impl RequestEnvelope {
             response_status: self
                 .response_status
                 .and_then(|status| http::StatusCode::from_u16(status).ok()),
+            overload_reason: self.terminal_overload_reason,
             backend_accounting: match &self.execution {
                 RequestExecutionState::AwaitingUpstream(state) => {
                     Some(state.dispatch.backend_accounting)

--- a/crates/edge/src/runtime/connection/request.rs
+++ b/crates/edge/src/runtime/connection/request.rs
@@ -20,11 +20,25 @@ use crate::{
         auth::{ExternalAuthFailureDisposition, ExternalAuthResult, PendingHeaderMutation},
         response::{ResponseChunk, UpstreamResult},
         stream::{
-            LegacyRequestLifecycle, RequestBodyRuntime, RequestExecutionState,
-            StreamAdmissionState, StreamPhase, TunnelMode,
+            LegacyRequestLifecycle, RequestBodyRuntime, RequestBodyState, RequestContext,
+            RequestExecutionState, RequestMode, RoutingSnapshot, StreamAdmissionState, StreamPhase,
+            TunnelMode,
         },
     },
 };
+
+pub(crate) enum IntakeExecutionSeed {
+    AwaitingAuth {
+        pending_forward: Arc<PendingForward>,
+        auth_result_rx: oneshot::Receiver<ExternalAuthResult>,
+        auth_abort: AbortHandle,
+        auth_disposition: ExternalAuthFailureDisposition,
+        auth_deadline: Instant,
+    },
+    ReadyForForwarding {
+        pending_forward: Arc<PendingForward>,
+    },
+}
 
 pub struct RequestEnvelope {
     pub request_id: u64,
@@ -63,7 +77,7 @@ impl RequestEnvelope {
         self.request_id
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments, dead_code)]
     pub(crate) fn new_legacy(
         request_id: u64,
         trace_id: Option<String>,
@@ -134,6 +148,106 @@ impl RequestEnvelope {
                     body_bytes_received: 0,
                     last_body_activity: start,
                     request_fin_received,
+                },
+                pending_forward,
+                auth_result_rx,
+                auth_abort,
+                auth_disposition,
+                auth_deadline,
+                backend_request_started: false,
+                backend_request_finished: false,
+                global_inflight_permit: None,
+                upstream_inflight_permit: None,
+                adaptive_admission_permit: None,
+                route_queue_permit: None,
+                upstream_result_rx: None,
+                response_chunk_rx: None,
+                response_headers_sent: false,
+                pending_chunk: None,
+            }),
+        }
+    }
+
+    pub(crate) fn from_intake_legacy(
+        context: RequestContext,
+        routing: RoutingSnapshot,
+        upstream_pool: Arc<RwLock<UpstreamPool>>,
+        request_mode: RequestMode,
+        request_body: RequestBodyState,
+        routing_transparency_enabled: bool,
+        routing_transparency_include_reason: bool,
+        retry_count: u8,
+        error_kind: Option<&'static str>,
+        execution: IntakeExecutionSeed,
+    ) -> Self {
+        let (
+            admission_state,
+            pending_forward,
+            auth_result_rx,
+            auth_abort,
+            auth_disposition,
+            auth_deadline,
+        ) = match execution {
+            IntakeExecutionSeed::AwaitingAuth {
+                pending_forward,
+                auth_result_rx,
+                auth_abort,
+                auth_disposition,
+                auth_deadline,
+            } => (
+                StreamAdmissionState::WaitingForAuth,
+                Some(pending_forward),
+                Some(auth_result_rx),
+                Some(auth_abort),
+                Some(auth_disposition),
+                Some(auth_deadline),
+            ),
+            IntakeExecutionSeed::ReadyForForwarding { pending_forward } => (
+                StreamAdmissionState::ReadyToForward,
+                Some(pending_forward),
+                None,
+                None,
+                None,
+                None,
+            ),
+        };
+
+        Self {
+            request_id: context.request_id,
+            trace_id: context.trace_id,
+            span_id: context.span_id,
+            traceparent: context.traceparent,
+            trace_span: context.trace_span,
+            method: context.method,
+            path: context.path,
+            authority: context.authority,
+            backend_addr: Some(routing.backend_addr),
+            backend_index: Some(routing.backend_index),
+            upstream_name: Some(routing.upstream_name),
+            route_reason: Some(routing.route_reason),
+            route_path_len: Some(routing.route_path_len),
+            route_host_specific: Some(routing.route_host_specific),
+            backend_lb: routing.backend_lb,
+            upstream_pool: Some(upstream_pool),
+            routing_transparency_enabled,
+            routing_transparency_include_reason,
+            response_status: None,
+            start: context.start,
+            total_request_deadline: context.total_request_deadline,
+            bodyless_mode: request_mode.bodyless_mode(),
+            tunnel_mode: request_mode.tunnel_mode(),
+            retry_count,
+            error_kind,
+            execution: RequestExecutionState::Legacy(LegacyRequestLifecycle {
+                phase: StreamPhase::ReceivingRequest,
+                admission_state,
+                request_body_runtime: RequestBodyRuntime {
+                    body_tx: None,
+                    body_buf: VecDeque::new(),
+                    body_buf_bytes: 0,
+                    body_bytes_received: 0,
+                    last_body_activity: context.start,
+                    request_fin_received: request_body.request_fin_received(),
                 },
                 pending_forward,
                 auth_result_rx,

--- a/crates/edge/src/runtime/connection/request.rs
+++ b/crates/edge/src/runtime/connection/request.rs
@@ -20,10 +20,11 @@ use crate::{
         auth::{ExternalAuthFailureDisposition, ExternalAuthResult, PendingHeaderMutation},
         response::{ResponseChunk, UpstreamResult},
         stream::{
-            AwaitingAuthState, CancellationReason, CancelledState, DispatchReadyState,
-            LegacyRequestLifecycle, RequestBodyRuntime, RequestContext, RequestExecutionState,
-            RequestMode, StreamAdmissionState, StreamPhase, TerminalSnapshot, TerminalState,
-            TunnelMode,
+            AdmissionPermits, AdmittedState, AwaitingAuthState, AwaitingUpstreamState,
+            BackendAccountingState, BackendDispatchState, CancellationReason, CancelledState,
+            DispatchReadyState, LegacyRequestLifecycle, RequestBodyRuntime, RequestContext,
+            RequestExecutionState, RequestMode, ResponseEmissionState, ResponseStreamingState,
+            StreamAdmissionState, StreamPhase, TerminalSnapshot, TerminalState, TunnelMode,
         },
     },
 };
@@ -130,13 +131,13 @@ impl RequestEnvelope {
                 phase,
                 admission_state,
                 request_body_runtime: RequestBodyRuntime {
-                    body_tx: None,
                     body_buf: VecDeque::new(),
                     body_buf_bytes: 0,
                     body_bytes_received: 0,
                     last_body_activity: start,
                     request_fin_received,
                 },
+                body_tx: None,
                 pending_forward,
                 backend_request_started: false,
                 backend_request_finished: false,
@@ -267,15 +268,29 @@ impl RequestEnvelope {
     }
 
     pub fn body_tx(&self) -> Option<&mpsc::Sender<Bytes>> {
-        self.request_body_runtime().body_tx.as_ref()
+        match &self.execution {
+            RequestExecutionState::AwaitingUpstream(state) => state.dispatch.body_tx.as_ref(),
+            RequestExecutionState::Legacy(state) => state.body_tx.as_ref(),
+            _ => None,
+        }
     }
 
     pub fn body_tx_mut(&mut self) -> &mut Option<mpsc::Sender<Bytes>> {
-        &mut self.request_body_runtime_mut().body_tx
+        match &mut self.execution {
+            RequestExecutionState::Legacy(state) => &mut state.body_tx,
+            other => panic!(
+                "dispatch body channel mutation attempted outside legacy state {:?}",
+                std::mem::discriminant(other)
+            ),
+        }
     }
 
     pub fn clear_body_tx(&mut self) {
-        self.request_body_runtime_mut().body_tx = None;
+        match &mut self.execution {
+            RequestExecutionState::AwaitingUpstream(state) => state.dispatch.body_tx = None,
+            RequestExecutionState::Legacy(state) => state.body_tx = None,
+            _ => {}
+        }
     }
 
     pub fn body_buf(&self) -> &VecDeque<Bytes> {
@@ -314,6 +329,7 @@ impl RequestEnvelope {
         match &self.execution {
             RequestExecutionState::AwaitingAuth(state) => Some(&state.pending_forward),
             RequestExecutionState::DispatchReady(state) => Some(&state.pending_forward),
+            RequestExecutionState::Admitted(state) => Some(&state.pending_forward),
             RequestExecutionState::AwaitingUpstream(state) => Some(&state.pending_forward),
             RequestExecutionState::Legacy(state) => state.pending_forward.as_ref(),
             RequestExecutionState::Intake(_)
@@ -326,6 +342,7 @@ impl RequestEnvelope {
         match &mut self.execution {
             RequestExecutionState::AwaitingAuth(state) => Some(&mut state.pending_forward),
             RequestExecutionState::DispatchReady(state) => Some(&mut state.pending_forward),
+            RequestExecutionState::Admitted(state) => Some(&mut state.pending_forward),
             RequestExecutionState::AwaitingUpstream(state) => Some(&mut state.pending_forward),
             RequestExecutionState::Legacy(state) => state.pending_forward.as_mut(),
             RequestExecutionState::Intake(_)
@@ -338,6 +355,7 @@ impl RequestEnvelope {
         match &mut self.execution {
             RequestExecutionState::AwaitingAuth(_)
             | RequestExecutionState::DispatchReady(_)
+            | RequestExecutionState::Admitted(_)
             | RequestExecutionState::AwaitingUpstream(_)
             | RequestExecutionState::Legacy(_) => {
                 self.set_pending_forward(None);
@@ -362,6 +380,9 @@ impl RequestEnvelope {
         &mut self,
     ) -> Option<&mut oneshot::Receiver<UpstreamResult>> {
         match &mut self.execution {
+            RequestExecutionState::AwaitingUpstream(state) => {
+                Some(&mut state.dispatch.upstream_result_rx)
+            }
             RequestExecutionState::Legacy(state) => state.upstream_result_rx.as_mut(),
             _ => None,
         }
@@ -380,6 +401,7 @@ impl RequestEnvelope {
 
     pub(crate) fn response_chunk_rx_mut(&mut self) -> Option<&mut mpsc::Receiver<ResponseChunk>> {
         match &mut self.execution {
+            RequestExecutionState::StreamingResponse(state) => state.response_chunk_rx.as_mut(),
             RequestExecutionState::Legacy(state) => state.response_chunk_rx.as_mut(),
             _ => None,
         }
@@ -391,13 +413,20 @@ impl RequestEnvelope {
     }
 
     pub fn clear_response_chunk_rx(&mut self) {
-        if let RequestExecutionState::Legacy(state) = &mut self.execution {
-            state.response_chunk_rx = None;
+        match &mut self.execution {
+            RequestExecutionState::StreamingResponse(state) => {
+                state.response_chunk_rx = None;
+            }
+            RequestExecutionState::Legacy(state) => {
+                state.response_chunk_rx = None;
+            }
+            _ => {}
         }
     }
 
     pub fn has_upstream_result_rx(&self) -> bool {
         match &self.execution {
+            RequestExecutionState::AwaitingUpstream(_) => true,
             RequestExecutionState::Legacy(state) => state.upstream_result_rx.is_some(),
             _ => false,
         }
@@ -405,6 +434,7 @@ impl RequestEnvelope {
 
     pub fn has_response_chunk_rx(&self) -> bool {
         match &self.execution {
+            RequestExecutionState::StreamingResponse(state) => state.response_chunk_rx.is_some(),
             RequestExecutionState::Legacy(state) => state.response_chunk_rx.is_some(),
             _ => false,
         }
@@ -412,14 +442,27 @@ impl RequestEnvelope {
 
     pub fn response_headers_sent(&self) -> bool {
         match &self.execution {
+            RequestExecutionState::StreamingResponse(state) => {
+                !matches!(state.emission, ResponseEmissionState::DeferredHeaders)
+            }
             RequestExecutionState::Legacy(state) => state.response_headers_sent,
             _ => false,
         }
     }
 
     pub fn set_response_headers_sent(&mut self, sent: bool) {
-        if let RequestExecutionState::Legacy(state) = &mut self.execution {
-            state.response_headers_sent = sent;
+        match &mut self.execution {
+            RequestExecutionState::StreamingResponse(state) => {
+                state.emission = if sent {
+                    ResponseEmissionState::HeadersSent
+                } else {
+                    ResponseEmissionState::DeferredHeaders
+                };
+            }
+            RequestExecutionState::Legacy(state) => {
+                state.response_headers_sent = sent;
+            }
+            _ => {}
         }
     }
 
@@ -450,6 +493,7 @@ impl RequestEnvelope {
     pub fn backend_request_started(&self) -> bool {
         match &self.execution {
             RequestExecutionState::Legacy(state) => state.backend_request_started,
+            RequestExecutionState::Admitted(_) => false,
             RequestExecutionState::AwaitingUpstream(_)
             | RequestExecutionState::StreamingResponse(_) => true,
             _ => false,
@@ -459,7 +503,9 @@ impl RequestEnvelope {
     pub fn backend_request_finished(&self) -> bool {
         match &self.execution {
             RequestExecutionState::Legacy(state) => state.backend_request_finished,
-            RequestExecutionState::AwaitingUpstream(state) => state.backend_accounting.finalized,
+            RequestExecutionState::AwaitingUpstream(state) => {
+                state.dispatch.backend_accounting.finalized
+            }
             RequestExecutionState::StreamingResponse(state) => state.backend_accounting.finalized,
             _ => false,
         }
@@ -472,7 +518,7 @@ impl RequestEnvelope {
                 state.backend_request_finished = finished;
             }
             RequestExecutionState::AwaitingUpstream(state) => {
-                state.backend_accounting.finalized = started && finished;
+                state.dispatch.backend_accounting.finalized = started && finished;
             }
             RequestExecutionState::StreamingResponse(state) => {
                 state.backend_accounting.finalized = started && finished;
@@ -507,7 +553,8 @@ impl RequestEnvelope {
     pub fn has_global_inflight_permit(&self) -> bool {
         match &self.execution {
             RequestExecutionState::Legacy(state) => state.global_inflight_permit.is_some(),
-            RequestExecutionState::AwaitingUpstream(_)
+            RequestExecutionState::Admitted(_)
+            | RequestExecutionState::AwaitingUpstream(_)
             | RequestExecutionState::StreamingResponse(_) => true,
             _ => false,
         }
@@ -516,7 +563,8 @@ impl RequestEnvelope {
     pub fn has_upstream_inflight_permit(&self) -> bool {
         match &self.execution {
             RequestExecutionState::Legacy(state) => state.upstream_inflight_permit.is_some(),
-            RequestExecutionState::AwaitingUpstream(_)
+            RequestExecutionState::Admitted(_)
+            | RequestExecutionState::AwaitingUpstream(_)
             | RequestExecutionState::StreamingResponse(_) => true,
             _ => false,
         }
@@ -525,7 +573,8 @@ impl RequestEnvelope {
     pub fn has_adaptive_admission_permit(&self) -> bool {
         match &self.execution {
             RequestExecutionState::Legacy(state) => state.adaptive_admission_permit.is_some(),
-            RequestExecutionState::AwaitingUpstream(_)
+            RequestExecutionState::Admitted(_)
+            | RequestExecutionState::AwaitingUpstream(_)
             | RequestExecutionState::StreamingResponse(_) => true,
             _ => false,
         }
@@ -534,86 +583,92 @@ impl RequestEnvelope {
     pub fn has_route_queue_permit(&self) -> bool {
         match &self.execution {
             RequestExecutionState::Legacy(state) => state.route_queue_permit.is_some(),
-            RequestExecutionState::AwaitingUpstream(_)
+            RequestExecutionState::Admitted(_)
+            | RequestExecutionState::AwaitingUpstream(_)
             | RequestExecutionState::StreamingResponse(_) => true,
             _ => false,
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn transition_to_dispatching(
+    pub(crate) fn transition_to_admitted(&mut self, permits: AdmissionPermits) {
+        let snapshot = self.terminal_snapshot();
+        let state = match std::mem::replace(
+            &mut self.execution,
+            RequestExecutionState::Terminal(TerminalState::Cancelled(CancelledState {
+                reason: CancellationReason::OperatorAbort,
+                snapshot,
+            })),
+        ) {
+            RequestExecutionState::DispatchReady(state) => state,
+            other => {
+                self.execution = other;
+                panic!("admission transition attempted outside DispatchReady state");
+            }
+        };
+        self.execution = RequestExecutionState::Admitted(AdmittedState {
+            context: state.context,
+            routing: state.routing,
+            request_mode: state.request_mode,
+            request_body: state.request_body,
+            request_body_runtime: state.request_body_runtime,
+            pending_forward: state.pending_forward,
+            permits,
+        });
+    }
+
+    pub(crate) fn transition_admitted_to_awaiting_upstream(
         &mut self,
         body_tx: Option<mpsc::Sender<Bytes>>,
         upstream_result_rx: oneshot::Receiver<UpstreamResult>,
-        global: OwnedSemaphorePermit,
-        upstream: OwnedSemaphorePermit,
-        adaptive: AdaptivePermit,
-        route_queue: RouteQueuePermit,
     ) {
-        let should_await_upstream = self.request_fin_received() && self.body_buf().is_empty();
-        match &mut self.execution {
-            RequestExecutionState::Legacy(legacy) => {
-                legacy.backend_request_started = true;
-                legacy.backend_request_finished = false;
-                legacy.request_body_runtime.body_tx = body_tx;
-                legacy.upstream_result_rx = Some(upstream_result_rx);
-                legacy.global_inflight_permit = Some(global);
-                legacy.upstream_inflight_permit = Some(upstream);
-                legacy.adaptive_admission_permit = Some(adaptive);
-                legacy.route_queue_permit = Some(route_queue);
-                legacy.admission_state = StreamAdmissionState::ReadyToForward;
-                legacy.phase = if should_await_upstream {
-                    StreamPhase::AwaitingUpstream
-                } else {
-                    StreamPhase::ReceivingRequest
-                };
-                if should_await_upstream {
-                    legacy.request_body_runtime.body_tx = None;
-                }
+        let snapshot = self.terminal_snapshot();
+        let admitted = match std::mem::replace(
+            &mut self.execution,
+            RequestExecutionState::Terminal(TerminalState::Cancelled(CancelledState {
+                reason: CancellationReason::OperatorAbort,
+                snapshot,
+            })),
+        ) {
+            RequestExecutionState::Admitted(state) => state,
+            other => {
+                self.execution = other;
+                panic!("dispatch transition attempted outside Admitted state");
             }
-            RequestExecutionState::DispatchReady(state) => {
-                let mut request_body_runtime = std::mem::replace(
-                    &mut state.request_body_runtime,
-                    RequestBodyRuntime {
-                        body_tx: None,
-                        body_buf: VecDeque::new(),
-                        body_buf_bytes: 0,
-                        body_bytes_received: 0,
-                        last_body_activity: self.start,
-                        request_fin_received: true,
-                    },
-                );
-                request_body_runtime.body_tx = body_tx;
-                if should_await_upstream {
-                    request_body_runtime.body_tx = None;
-                }
-                let pending_forward = Some(Arc::clone(&state.pending_forward));
-                self.execution = RequestExecutionState::Legacy(LegacyRequestLifecycle {
-                    phase: if should_await_upstream {
-                        StreamPhase::AwaitingUpstream
-                    } else {
-                        StreamPhase::ReceivingRequest
-                    },
-                    admission_state: StreamAdmissionState::ReadyToForward,
-                    request_body_runtime,
-                    pending_forward,
-                    backend_request_started: true,
-                    backend_request_finished: false,
-                    global_inflight_permit: Some(global),
-                    upstream_inflight_permit: Some(upstream),
-                    adaptive_admission_permit: Some(adaptive),
-                    route_queue_permit: Some(route_queue),
-                    upstream_result_rx: Some(upstream_result_rx),
-                    response_chunk_rx: None,
-                    response_headers_sent: false,
-                    pending_chunk: None,
-                });
-            }
-            other => panic!(
-                "dispatch transition attempted from unsupported state {:?}",
-                std::mem::discriminant(other)
-            ),
-        }
+        };
+        let dispatch_body_tx = if admitted.request_body_runtime.request_fin_received
+            && admitted.request_body_runtime.body_buf.is_empty()
+        {
+            None
+        } else {
+            body_tx
+        };
+        let backend_accounting = BackendAccountingState {
+            response_status: None,
+            finalized: false,
+        };
+        let AdmittedState {
+            context,
+            routing,
+            request_mode,
+            request_body,
+            request_body_runtime,
+            pending_forward,
+            permits,
+        } = admitted;
+        self.execution = RequestExecutionState::AwaitingUpstream(AwaitingUpstreamState {
+            context,
+            routing,
+            request_mode,
+            request_body,
+            request_body_runtime,
+            pending_forward,
+            permits,
+            dispatch: BackendDispatchState {
+                body_tx: dispatch_body_tx,
+                upstream_result_rx,
+                backend_accounting,
+            },
+        });
     }
 
     pub(crate) fn transition_to_streaming_response(
@@ -622,10 +677,48 @@ impl RequestEnvelope {
         response_headers_sent: bool,
         phase: StreamPhase,
     ) {
-        let legacy = self.legacy_mut();
-        legacy.response_chunk_rx = response_chunk_rx;
-        legacy.response_headers_sent = response_headers_sent;
-        legacy.phase = phase;
+        let snapshot = self.terminal_snapshot();
+        match std::mem::replace(
+            &mut self.execution,
+            RequestExecutionState::Terminal(TerminalState::Cancelled(CancelledState {
+                reason: CancellationReason::OperatorAbort,
+                snapshot,
+            })),
+        ) {
+            RequestExecutionState::AwaitingUpstream(state) => {
+                self.execution = RequestExecutionState::StreamingResponse(ResponseStreamingState {
+                    context: state.context,
+                    routing: state.routing,
+                    request_mode: state.request_mode,
+                    request_body_runtime: state.request_body_runtime,
+                    permits: state.permits,
+                    response_status: self
+                        .response_status
+                        .and_then(|status| http::StatusCode::from_u16(status).ok())
+                        .unwrap_or(http::StatusCode::OK),
+                    emission: if !response_headers_sent {
+                        ResponseEmissionState::DeferredHeaders
+                    } else if phase == StreamPhase::Completed {
+                        ResponseEmissionState::EndPending
+                    } else {
+                        ResponseEmissionState::HeadersSent
+                    },
+                    response_chunk_rx,
+                    pending_chunk: None,
+                    backend_accounting: state.dispatch.backend_accounting,
+                });
+            }
+            RequestExecutionState::Legacy(mut legacy) => {
+                legacy.response_chunk_rx = response_chunk_rx;
+                legacy.response_headers_sent = response_headers_sent;
+                legacy.phase = phase;
+                self.execution = RequestExecutionState::Legacy(legacy);
+            }
+            other => {
+                self.execution = other;
+                panic!("streaming transition attempted from unsupported execution state");
+            }
+        }
     }
 
     pub fn transition_to_terminal(
@@ -636,11 +729,15 @@ impl RequestEnvelope {
     }
 
     pub fn set_phase_legacy(&mut self, phase: StreamPhase) {
-        self.legacy_mut().phase = phase;
+        if let RequestExecutionState::Legacy(state) = &mut self.execution {
+            state.phase = phase;
+        }
     }
 
     pub fn set_admission_state_legacy(&mut self, state: StreamAdmissionState) {
-        self.legacy_mut().admission_state = state;
+        if let RequestExecutionState::Legacy(legacy) = &mut self.execution {
+            legacy.admission_state = state;
+        }
     }
 
     pub fn set_pending_forward(&mut self, pending_forward: Option<Arc<PendingForward>>) {
@@ -651,6 +748,11 @@ impl RequestEnvelope {
                 }
             }
             RequestExecutionState::DispatchReady(state) => {
+                if let Some(pending_forward) = pending_forward {
+                    state.pending_forward = pending_forward;
+                }
+            }
+            RequestExecutionState::Admitted(state) => {
                 if let Some(pending_forward) = pending_forward {
                     state.pending_forward = pending_forward;
                 }
@@ -740,6 +842,7 @@ impl RequestEnvelope {
         match &self.execution {
             RequestExecutionState::AwaitingAuth(state) => &state.request_body_runtime,
             RequestExecutionState::DispatchReady(state) => &state.request_body_runtime,
+            RequestExecutionState::Admitted(state) => &state.request_body_runtime,
             RequestExecutionState::AwaitingUpstream(state) => &state.request_body_runtime,
             RequestExecutionState::StreamingResponse(state) => &state.request_body_runtime,
             RequestExecutionState::Legacy(state) => &state.request_body_runtime,
@@ -753,6 +856,7 @@ impl RequestEnvelope {
         match &mut self.execution {
             RequestExecutionState::AwaitingAuth(state) => &mut state.request_body_runtime,
             RequestExecutionState::DispatchReady(state) => &mut state.request_body_runtime,
+            RequestExecutionState::Admitted(state) => &mut state.request_body_runtime,
             RequestExecutionState::AwaitingUpstream(state) => &mut state.request_body_runtime,
             RequestExecutionState::StreamingResponse(state) => &mut state.request_body_runtime,
             RequestExecutionState::Legacy(state) => &mut state.request_body_runtime,
@@ -766,6 +870,7 @@ impl RequestEnvelope {
         let routing = match &self.execution {
             RequestExecutionState::AwaitingAuth(state) => Some(state.routing.clone()),
             RequestExecutionState::DispatchReady(state) => Some(state.routing.clone()),
+            RequestExecutionState::Admitted(state) => Some(state.routing.clone()),
             RequestExecutionState::AwaitingUpstream(state) => Some(state.routing.clone()),
             RequestExecutionState::StreamingResponse(state) => Some(state.routing.clone()),
             RequestExecutionState::Legacy(_) | RequestExecutionState::Intake(_) => None,
@@ -796,7 +901,13 @@ impl RequestEnvelope {
             response_status: self
                 .response_status
                 .and_then(|status| http::StatusCode::from_u16(status).ok()),
-            backend_accounting: None,
+            backend_accounting: match &self.execution {
+                RequestExecutionState::AwaitingUpstream(state) => {
+                    Some(state.dispatch.backend_accounting)
+                }
+                RequestExecutionState::StreamingResponse(state) => Some(state.backend_accounting),
+                _ => None,
+            },
         }
     }
 }

--- a/crates/edge/src/runtime/connection/request.rs
+++ b/crates/edge/src/runtime/connection/request.rs
@@ -8,9 +8,7 @@ use std::{
 use bytes::Bytes;
 use spooky_config::config::{ForwardedHeaderPolicy, UpstreamHostPolicy};
 use spooky_lb::upstream_pool::UpstreamPool;
-use tokio::{
-    sync::{mpsc, oneshot},
-};
+use tokio::sync::{mpsc, oneshot};
 use tracing::Span;
 
 use crate::{
@@ -218,16 +216,14 @@ impl RequestEnvelope {
             RequestExecutionState::DispatchReady(state) => state.request_body,
             RequestExecutionState::Admitted(state) => state.request_body,
             RequestExecutionState::AwaitingUpstream(state) => state.request_body,
-            RequestExecutionState::StreamingResponse(_) => {
-                RequestBodyState::from_runtime(
-                    self.request_body_runtime().request_fin_received,
-                    !self.request_body_runtime().body_buf.is_empty(),
-                    self.body_tx().is_some(),
-                )
-            }
-            RequestExecutionState::Terminal(state) => {
-                terminal_request_mode(state).initial_body_state().on_forward_closed()
-            }
+            RequestExecutionState::StreamingResponse(_) => RequestBodyState::from_runtime(
+                self.request_body_runtime().request_fin_received,
+                !self.request_body_runtime().body_buf.is_empty(),
+                self.body_tx().is_some(),
+            ),
+            RequestExecutionState::Terminal(state) => terminal_request_mode(state)
+                .initial_body_state()
+                .on_forward_closed(),
         }
     }
 
@@ -239,8 +235,7 @@ impl RequestEnvelope {
             RequestExecutionState::DispatchReady(state) => state.request_body = next,
             RequestExecutionState::Admitted(state) => state.request_body = next,
             RequestExecutionState::AwaitingUpstream(state) => state.request_body = next,
-            RequestExecutionState::StreamingResponse(_)
-            | RequestExecutionState::Terminal(_) => {}
+            RequestExecutionState::StreamingResponse(_) | RequestExecutionState::Terminal(_) => {}
         }
     }
 
@@ -413,8 +408,7 @@ impl RequestEnvelope {
         }
     }
 
-    pub fn clear_upstream_result_rx(&mut self) {
-    }
+    pub fn clear_upstream_result_rx(&mut self) {}
 
     pub(crate) fn response_chunk_rx_mut(&mut self) -> Option<&mut mpsc::Receiver<ResponseChunk>> {
         match &mut self.execution {
@@ -423,8 +417,7 @@ impl RequestEnvelope {
         }
     }
 
-    pub fn clear_response_chunk_rx(&mut self) {
-    }
+    pub fn clear_response_chunk_rx(&mut self) {}
 
     pub fn has_upstream_result_rx(&self) -> bool {
         matches!(&self.execution, RequestExecutionState::AwaitingUpstream(_))

--- a/crates/edge/src/runtime/connection/request.rs
+++ b/crates/edge/src/runtime/connection/request.rs
@@ -17,9 +17,12 @@ use tracing::Span;
 use crate::{
     resilience::{adaptive_admission::AdaptivePermit, route_queue::RouteQueuePermit},
     runtime::connection::{
-        auth::{ExternalAuthResult, PendingHeaderMutation},
+        auth::{ExternalAuthFailureDisposition, ExternalAuthResult, PendingHeaderMutation},
         response::{ResponseChunk, UpstreamResult},
-        stream::{StreamAdmissionState, StreamPhase, TunnelMode},
+        stream::{
+            LegacyRequestLifecycle, RequestBodyRuntime, RequestExecutionState,
+            StreamAdmissionState, StreamPhase, TunnelMode,
+        },
     },
 };
 
@@ -33,16 +36,6 @@ pub struct RequestEnvelope {
     pub method: String,
     pub path: String,
     pub authority: Option<String>,
-    /// Sender half of the body channel.  Dropping it signals end-of-body to hyper.
-    pub body_tx: Option<mpsc::Sender<Bytes>>,
-    /// Body chunks that arrived before the channel had capacity.
-    pub body_buf: VecDeque<Bytes>,
-    /// Current bytes held in `body_buf`.
-    pub body_buf_bytes: usize,
-    /// Total body bytes received on this stream (buffered + already forwarded).
-    pub body_bytes_received: usize,
-    /// Last observed request-body byte arrival time.
-    pub last_body_activity: Instant,
     /// Resolved backend address and index (for health marking on response).
     pub backend_addr: Option<String>,
     pub backend_index: Option<usize>,
@@ -55,12 +48,6 @@ pub struct RequestEnvelope {
     pub routing_transparency_enabled: bool,
     pub routing_transparency_include_reason: bool,
     pub response_status: Option<u16>,
-    pub backend_request_started: bool,
-    pub backend_request_finished: bool,
-    pub global_inflight_permit: Option<OwnedSemaphorePermit>,
-    pub upstream_inflight_permit: Option<OwnedSemaphorePermit>,
-    pub adaptive_admission_permit: Option<AdaptivePermit>,
-    pub route_queue_permit: Option<RouteQueuePermit>,
     pub start: Instant,
     pub total_request_deadline: Instant,
     pub bodyless_mode: bool,
@@ -68,36 +55,445 @@ pub struct RequestEnvelope {
 
     pub retry_count: u8,
     pub error_kind: Option<&'static str>,
-    /// Deferred request-building snapshot for async auth/admission handoff.
-    pub pending_forward: Option<Arc<PendingForward>>,
-    /// Receives the external auth decision once async auth completes.
-    pub(crate) auth_result_rx: Option<oneshot::Receiver<ExternalAuthResult>>,
-    /// Aborts the detached external auth task when the stream is cancelled.
-    pub auth_abort: Option<AbortHandle>,
-    /// Whether auth transport errors and timeouts should allow the request.
-    pub auth_fail_open: bool,
-    /// Deadline for the external auth decision, when auth is running asynchronously.
-    pub auth_deadline: Option<Instant>,
-
-    /// Current lifecycle phase of this stream.
-    pub phase: StreamPhase,
-    /// Current auth/admission state of this stream.
-    pub admission_state: StreamAdmissionState,
-    /// True once the client has sent FIN on the request stream.
-    pub request_fin_received: bool,
-    /// Receives the upstream H2 response (status, headers, body stream).
-    pub(crate) upstream_result_rx: Option<oneshot::Receiver<UpstreamResult>>,
-    /// Receives response body chunks to write back over QUIC.
-    pub(crate) response_chunk_rx: Option<mpsc::Receiver<ResponseChunk>>,
-    /// True once downstream response headers are emitted on this stream.
-    pub response_headers_sent: bool,
-    /// A chunk that could not be written due to QUIC send backpressure; retried next poll.
-    pub(crate) pending_chunk: Option<ResponseChunk>,
+    pub execution: RequestExecutionState,
 }
 
 impl RequestEnvelope {
     pub fn request_id(&self) -> u64 {
         self.request_id
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new_legacy(
+        request_id: u64,
+        trace_id: Option<String>,
+        span_id: Option<String>,
+        traceparent: Option<String>,
+        trace_span: Option<Span>,
+        method: String,
+        path: String,
+        authority: Option<String>,
+        backend_addr: Option<String>,
+        backend_index: Option<usize>,
+        upstream_name: Option<String>,
+        route_reason: Option<String>,
+        route_path_len: Option<usize>,
+        route_host_specific: Option<bool>,
+        backend_lb: Option<String>,
+        upstream_pool: Option<Arc<RwLock<UpstreamPool>>>,
+        routing_transparency_enabled: bool,
+        routing_transparency_include_reason: bool,
+        start: Instant,
+        total_request_deadline: Instant,
+        bodyless_mode: bool,
+        tunnel_mode: TunnelMode,
+        retry_count: u8,
+        error_kind: Option<&'static str>,
+        phase: StreamPhase,
+        admission_state: StreamAdmissionState,
+        request_fin_received: bool,
+        pending_forward: Option<Arc<PendingForward>>,
+        auth_result_rx: Option<oneshot::Receiver<ExternalAuthResult>>,
+        auth_abort: Option<AbortHandle>,
+        auth_disposition: Option<ExternalAuthFailureDisposition>,
+        auth_deadline: Option<Instant>,
+    ) -> Self {
+        Self {
+            request_id,
+            trace_id,
+            span_id,
+            traceparent,
+            trace_span,
+            method,
+            path,
+            authority,
+            backend_addr,
+            backend_index,
+            upstream_name,
+            route_reason,
+            route_path_len,
+            route_host_specific,
+            backend_lb,
+            upstream_pool,
+            routing_transparency_enabled,
+            routing_transparency_include_reason,
+            response_status: None,
+            start,
+            total_request_deadline,
+            bodyless_mode,
+            tunnel_mode,
+            retry_count,
+            error_kind,
+            execution: RequestExecutionState::Legacy(LegacyRequestLifecycle {
+                phase,
+                admission_state,
+                request_body_runtime: RequestBodyRuntime {
+                    body_tx: None,
+                    body_buf: VecDeque::new(),
+                    body_buf_bytes: 0,
+                    body_bytes_received: 0,
+                    last_body_activity: start,
+                    request_fin_received,
+                },
+                pending_forward,
+                auth_result_rx,
+                auth_abort,
+                auth_disposition,
+                auth_deadline,
+                backend_request_started: false,
+                backend_request_finished: false,
+                global_inflight_permit: None,
+                upstream_inflight_permit: None,
+                adaptive_admission_permit: None,
+                route_queue_permit: None,
+                upstream_result_rx: None,
+                response_chunk_rx: None,
+                response_headers_sent: false,
+                pending_chunk: None,
+            }),
+        }
+    }
+
+    pub fn phase(&self) -> StreamPhase {
+        self.execution.phase()
+    }
+
+    pub fn admission_state(&self) -> StreamAdmissionState {
+        self.execution.admission_state()
+    }
+
+    pub fn request_fin_received(&self) -> bool {
+        self.legacy().request_body_runtime.request_fin_received
+    }
+
+    pub fn set_request_fin_received(&mut self, value: bool) {
+        self.legacy_mut().request_body_runtime.request_fin_received = value;
+    }
+
+    pub fn body_tx(&self) -> Option<&mpsc::Sender<Bytes>> {
+        self.legacy().request_body_runtime.body_tx.as_ref()
+    }
+
+    pub fn body_tx_mut(&mut self) -> &mut Option<mpsc::Sender<Bytes>> {
+        &mut self.legacy_mut().request_body_runtime.body_tx
+    }
+
+    pub fn clear_body_tx(&mut self) {
+        self.legacy_mut().request_body_runtime.body_tx = None;
+    }
+
+    pub fn body_buf(&self) -> &VecDeque<Bytes> {
+        &self.legacy().request_body_runtime.body_buf
+    }
+
+    pub fn body_buf_mut(&mut self) -> &mut VecDeque<Bytes> {
+        &mut self.legacy_mut().request_body_runtime.body_buf
+    }
+
+    pub fn body_buf_bytes(&self) -> usize {
+        self.legacy().request_body_runtime.body_buf_bytes
+    }
+
+    pub fn set_body_buf_bytes(&mut self, value: usize) {
+        self.legacy_mut().request_body_runtime.body_buf_bytes = value;
+    }
+
+    pub fn body_bytes_received(&self) -> usize {
+        self.legacy().request_body_runtime.body_bytes_received
+    }
+
+    pub fn set_body_bytes_received(&mut self, value: usize) {
+        self.legacy_mut().request_body_runtime.body_bytes_received = value;
+    }
+
+    pub fn last_body_activity(&self) -> Instant {
+        self.legacy().request_body_runtime.last_body_activity
+    }
+
+    pub fn set_last_body_activity(&mut self, value: Instant) {
+        self.legacy_mut().request_body_runtime.last_body_activity = value;
+    }
+
+    pub fn pending_forward(&self) -> Option<&Arc<PendingForward>> {
+        self.legacy().pending_forward.as_ref()
+    }
+
+    pub fn pending_forward_mut(&mut self) -> Option<&mut Arc<PendingForward>> {
+        self.legacy_mut().pending_forward.as_mut()
+    }
+
+    pub fn clear_pending_forward(&mut self) {
+        self.legacy_mut().pending_forward = None;
+    }
+
+    pub(crate) fn auth_result_rx_mut(
+        &mut self,
+    ) -> Option<&mut oneshot::Receiver<ExternalAuthResult>> {
+        self.legacy_mut().auth_result_rx.as_mut()
+    }
+
+    pub fn clear_auth_result_rx(&mut self) {
+        self.legacy_mut().auth_result_rx = None;
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn set_auth_result_rx(&mut self, rx: Option<oneshot::Receiver<ExternalAuthResult>>) {
+        self.legacy_mut().auth_result_rx = rx;
+    }
+
+    pub fn has_auth_result_rx(&self) -> bool {
+        self.legacy().auth_result_rx.is_some()
+    }
+
+    pub fn take_auth_abort(&mut self) -> Option<AbortHandle> {
+        self.legacy_mut().auth_abort.take()
+    }
+
+    pub fn clear_auth_abort(&mut self) {
+        self.legacy_mut().auth_abort = None;
+    }
+
+    pub fn set_auth_abort(&mut self, abort: Option<AbortHandle>) {
+        self.legacy_mut().auth_abort = abort;
+    }
+
+    pub fn has_auth_abort(&self) -> bool {
+        self.legacy().auth_abort.is_some()
+    }
+
+    pub fn auth_fail_open(&self) -> bool {
+        self.legacy()
+            .auth_disposition
+            .is_some_and(ExternalAuthFailureDisposition::fail_open)
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn set_auth_disposition(
+        &mut self,
+        disposition: Option<ExternalAuthFailureDisposition>,
+    ) {
+        self.legacy_mut().auth_disposition = disposition;
+    }
+
+    pub fn auth_deadline(&self) -> Option<Instant> {
+        self.legacy().auth_deadline
+    }
+
+    pub fn set_auth_deadline(&mut self, deadline: Option<Instant>) {
+        self.legacy_mut().auth_deadline = deadline;
+    }
+
+    pub(crate) fn upstream_result_rx_mut(
+        &mut self,
+    ) -> Option<&mut oneshot::Receiver<UpstreamResult>> {
+        self.legacy_mut().upstream_result_rx.as_mut()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn set_upstream_result_rx(&mut self, rx: Option<oneshot::Receiver<UpstreamResult>>) {
+        self.legacy_mut().upstream_result_rx = rx;
+    }
+
+    pub fn clear_upstream_result_rx(&mut self) {
+        self.legacy_mut().upstream_result_rx = None;
+    }
+
+    pub(crate) fn response_chunk_rx_mut(&mut self) -> Option<&mut mpsc::Receiver<ResponseChunk>> {
+        self.legacy_mut().response_chunk_rx.as_mut()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn set_response_chunk_rx(&mut self, rx: Option<mpsc::Receiver<ResponseChunk>>) {
+        self.legacy_mut().response_chunk_rx = rx;
+    }
+
+    pub fn clear_response_chunk_rx(&mut self) {
+        self.legacy_mut().response_chunk_rx = None;
+    }
+
+    pub fn has_upstream_result_rx(&self) -> bool {
+        self.legacy().upstream_result_rx.is_some()
+    }
+
+    pub fn has_response_chunk_rx(&self) -> bool {
+        self.legacy().response_chunk_rx.is_some()
+    }
+
+    pub fn response_headers_sent(&self) -> bool {
+        self.legacy().response_headers_sent
+    }
+
+    pub fn set_response_headers_sent(&mut self, sent: bool) {
+        self.legacy_mut().response_headers_sent = sent;
+    }
+
+    pub(crate) fn take_pending_chunk(&mut self) -> Option<ResponseChunk> {
+        self.legacy_mut().pending_chunk.take()
+    }
+
+    pub(crate) fn set_pending_chunk(&mut self, chunk: Option<ResponseChunk>) {
+        self.legacy_mut().pending_chunk = chunk;
+    }
+
+    pub fn has_pending_chunk(&self) -> bool {
+        self.legacy().pending_chunk.is_some()
+    }
+
+    pub fn backend_request_started(&self) -> bool {
+        self.legacy().backend_request_started
+    }
+
+    pub fn backend_request_finished(&self) -> bool {
+        self.legacy().backend_request_finished
+    }
+
+    pub fn set_backend_request_state(&mut self, started: bool, finished: bool) {
+        let legacy = self.legacy_mut();
+        legacy.backend_request_started = started;
+        legacy.backend_request_finished = finished;
+    }
+
+    pub fn set_dispatch_permits(
+        &mut self,
+        global: Option<OwnedSemaphorePermit>,
+        upstream: Option<OwnedSemaphorePermit>,
+        adaptive: Option<AdaptivePermit>,
+        route_queue: Option<RouteQueuePermit>,
+    ) {
+        let legacy = self.legacy_mut();
+        legacy.global_inflight_permit = global;
+        legacy.upstream_inflight_permit = upstream;
+        legacy.adaptive_admission_permit = adaptive;
+        legacy.route_queue_permit = route_queue;
+    }
+
+    pub fn clear_dispatch_permits(&mut self) {
+        let legacy = self.legacy_mut();
+        legacy.global_inflight_permit = None;
+        legacy.upstream_inflight_permit = None;
+        legacy.adaptive_admission_permit = None;
+        legacy.route_queue_permit = None;
+    }
+
+    pub fn has_global_inflight_permit(&self) -> bool {
+        self.legacy().global_inflight_permit.is_some()
+    }
+
+    pub fn has_upstream_inflight_permit(&self) -> bool {
+        self.legacy().upstream_inflight_permit.is_some()
+    }
+
+    pub fn has_adaptive_admission_permit(&self) -> bool {
+        self.legacy().adaptive_admission_permit.is_some()
+    }
+
+    pub fn has_route_queue_permit(&self) -> bool {
+        self.legacy().route_queue_permit.is_some()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn transition_to_awaiting_auth(
+        &mut self,
+        pending_forward: Arc<PendingForward>,
+        auth_result_rx: oneshot::Receiver<ExternalAuthResult>,
+        auth_abort: AbortHandle,
+        auth_disposition: ExternalAuthFailureDisposition,
+        auth_deadline: Instant,
+    ) {
+        let legacy = self.legacy_mut();
+        legacy.phase = StreamPhase::ReceivingRequest;
+        legacy.admission_state = StreamAdmissionState::WaitingForAuth;
+        legacy.pending_forward = Some(pending_forward);
+        legacy.auth_result_rx = Some(auth_result_rx);
+        legacy.auth_abort = Some(auth_abort);
+        legacy.auth_disposition = Some(auth_disposition);
+        legacy.auth_deadline = Some(auth_deadline);
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn transition_to_dispatching(
+        &mut self,
+        body_tx: Option<mpsc::Sender<Bytes>>,
+        upstream_result_rx: oneshot::Receiver<UpstreamResult>,
+        global: OwnedSemaphorePermit,
+        upstream: OwnedSemaphorePermit,
+        adaptive: AdaptivePermit,
+        route_queue: RouteQueuePermit,
+    ) {
+        let should_await_upstream = self.request_fin_received() && self.body_buf().is_empty();
+        let legacy = self.legacy_mut();
+        legacy.backend_request_started = true;
+        legacy.backend_request_finished = false;
+        legacy.request_body_runtime.body_tx = body_tx;
+        legacy.upstream_result_rx = Some(upstream_result_rx);
+        legacy.global_inflight_permit = Some(global);
+        legacy.upstream_inflight_permit = Some(upstream);
+        legacy.adaptive_admission_permit = Some(adaptive);
+        legacy.route_queue_permit = Some(route_queue);
+        legacy.admission_state = StreamAdmissionState::ReadyToForward;
+        legacy.phase = if should_await_upstream {
+            StreamPhase::AwaitingUpstream
+        } else {
+            StreamPhase::ReceivingRequest
+        };
+        legacy.auth_abort = None;
+        legacy.auth_result_rx = None;
+        legacy.auth_disposition = None;
+        legacy.auth_deadline = None;
+        if should_await_upstream {
+            legacy.request_body_runtime.body_tx = None;
+        }
+    }
+
+    pub(crate) fn transition_to_streaming_response(
+        &mut self,
+        response_chunk_rx: Option<mpsc::Receiver<ResponseChunk>>,
+        response_headers_sent: bool,
+        phase: StreamPhase,
+    ) {
+        let legacy = self.legacy_mut();
+        legacy.response_chunk_rx = response_chunk_rx;
+        legacy.response_headers_sent = response_headers_sent;
+        legacy.phase = phase;
+    }
+
+    pub fn transition_to_terminal(
+        &mut self,
+        terminal: crate::runtime::connection::stream::TerminalState,
+    ) {
+        self.execution = RequestExecutionState::Terminal(terminal);
+    }
+
+    pub fn set_phase_legacy(&mut self, phase: StreamPhase) {
+        self.legacy_mut().phase = phase;
+    }
+
+    pub fn set_admission_state_legacy(&mut self, state: StreamAdmissionState) {
+        self.legacy_mut().admission_state = state;
+    }
+
+    pub fn set_pending_forward(&mut self, pending_forward: Option<Arc<PendingForward>>) {
+        self.legacy_mut().pending_forward = pending_forward;
+    }
+
+    fn legacy(&self) -> &LegacyRequestLifecycle {
+        match &self.execution {
+            RequestExecutionState::Legacy(state) => state,
+            other => panic!(
+                "legacy lifecycle access attempted after migration to {:?}",
+                std::mem::discriminant(other)
+            ),
+        }
+    }
+
+    fn legacy_mut(&mut self) -> &mut LegacyRequestLifecycle {
+        match &mut self.execution {
+            RequestExecutionState::Legacy(state) => state,
+            other => panic!(
+                "legacy lifecycle mutation attempted after migration to {:?}",
+                std::mem::discriminant(other)
+            ),
+        }
     }
 }
 

--- a/crates/edge/src/runtime/connection/request.rs
+++ b/crates/edge/src/runtime/connection/request.rs
@@ -21,11 +21,11 @@ use crate::{
         response::{ResponseChunk, UpstreamResult},
         stream::{
             AdmissionPermits, AdmittedState, AwaitingAuthState, AwaitingUpstreamState,
-            BackendAccountingState, BackendDispatchState, CancellationReason, CancelledState,
-            DispatchReadyState, LegacyRequestLifecycle, RequestBodyRuntime, RequestBodyState,
-            RequestContext, RequestExecutionState, RequestMode, ResponseEmissionState,
-            ResponseStreamingState, StreamAdmissionState, StreamPhase, TerminalSnapshot,
-            TerminalState, TunnelMode,
+            BackendAccountingState, BackendDispatchState, BackendFailureReason, CancellationReason,
+            CancelledState, CompletionReason, DispatchReadyState, LegacyRequestLifecycle,
+            RequestBodyRuntime, RequestBodyState, RequestContext, RequestExecutionState,
+            RequestMode, ResponseBackpressureState, ResponseEmissionState, ResponseStreamingState,
+            StreamAdmissionState, StreamPhase, TerminalSnapshot, TerminalState, TunnelMode,
         },
     },
 };
@@ -548,7 +548,7 @@ impl RequestEnvelope {
 
     pub(crate) fn response_chunk_rx_mut(&mut self) -> Option<&mut mpsc::Receiver<ResponseChunk>> {
         match &mut self.execution {
-            RequestExecutionState::StreamingResponse(state) => state.response_chunk_rx.as_mut(),
+            RequestExecutionState::StreamingResponse(state) => Some(&mut state.response_chunk_rx),
             RequestExecutionState::Legacy(state) => state.response_chunk_rx.as_mut(),
             _ => None,
         }
@@ -561,9 +561,6 @@ impl RequestEnvelope {
 
     pub fn clear_response_chunk_rx(&mut self) {
         match &mut self.execution {
-            RequestExecutionState::StreamingResponse(state) => {
-                state.response_chunk_rx = None;
-            }
             RequestExecutionState::Legacy(state) => {
                 state.response_chunk_rx = None;
             }
@@ -581,7 +578,7 @@ impl RequestEnvelope {
 
     pub fn has_response_chunk_rx(&self) -> bool {
         match &self.execution {
-            RequestExecutionState::StreamingResponse(state) => state.response_chunk_rx.is_some(),
+            RequestExecutionState::StreamingResponse(_) => true,
             RequestExecutionState::Legacy(state) => state.response_chunk_rx.is_some(),
             _ => false,
         }
@@ -616,7 +613,12 @@ impl RequestEnvelope {
     pub(crate) fn take_pending_chunk(&mut self) -> Option<ResponseChunk> {
         match &mut self.execution {
             RequestExecutionState::Legacy(state) => state.pending_chunk.take(),
-            RequestExecutionState::StreamingResponse(state) => state.pending_chunk.take(),
+            RequestExecutionState::StreamingResponse(state) => {
+                match std::mem::replace(&mut state.backpressure, ResponseBackpressureState::Ready) {
+                    ResponseBackpressureState::Ready => None,
+                    ResponseBackpressureState::Blocked(chunk) => Some(chunk),
+                }
+            }
             _ => None,
         }
     }
@@ -624,7 +626,12 @@ impl RequestEnvelope {
     pub(crate) fn set_pending_chunk(&mut self, chunk: Option<ResponseChunk>) {
         match &mut self.execution {
             RequestExecutionState::Legacy(state) => state.pending_chunk = chunk,
-            RequestExecutionState::StreamingResponse(state) => state.pending_chunk = chunk,
+            RequestExecutionState::StreamingResponse(state) => {
+                state.backpressure = match chunk {
+                    Some(chunk) => ResponseBackpressureState::Blocked(chunk),
+                    None => ResponseBackpressureState::Ready,
+                };
+            }
             _ => {}
         }
     }
@@ -632,8 +639,23 @@ impl RequestEnvelope {
     pub fn has_pending_chunk(&self) -> bool {
         match &self.execution {
             RequestExecutionState::Legacy(state) => state.pending_chunk.is_some(),
-            RequestExecutionState::StreamingResponse(state) => state.pending_chunk.is_some(),
+            RequestExecutionState::StreamingResponse(state) => {
+                matches!(state.backpressure, ResponseBackpressureState::Blocked(_))
+            }
             _ => false,
+        }
+    }
+
+    pub fn response_emission_state(&self) -> Option<ResponseEmissionState> {
+        match &self.execution {
+            RequestExecutionState::StreamingResponse(state) => Some(state.emission),
+            _ => None,
+        }
+    }
+
+    pub fn set_response_emission_state(&mut self, emission: ResponseEmissionState) {
+        if let RequestExecutionState::StreamingResponse(state) = &mut self.execution {
+            state.emission = emission;
         }
     }
 
@@ -825,9 +847,9 @@ impl RequestEnvelope {
 
     pub(crate) fn transition_to_streaming_response(
         &mut self,
-        response_chunk_rx: Option<mpsc::Receiver<ResponseChunk>>,
-        response_headers_sent: bool,
-        phase: StreamPhase,
+        response_chunk_rx: mpsc::Receiver<ResponseChunk>,
+        emission: ResponseEmissionState,
+        final_status: http::StatusCode,
     ) {
         let snapshot = self.terminal_snapshot();
         match std::mem::replace(
@@ -844,26 +866,18 @@ impl RequestEnvelope {
                     request_mode: state.request_mode,
                     request_body_runtime: state.request_body_runtime,
                     permits: state.permits,
-                    response_status: self
-                        .response_status
-                        .and_then(|status| http::StatusCode::from_u16(status).ok())
-                        .unwrap_or(http::StatusCode::OK),
-                    emission: if !response_headers_sent {
-                        ResponseEmissionState::DeferredHeaders
-                    } else if phase == StreamPhase::Completed {
-                        ResponseEmissionState::EndPending
-                    } else {
-                        ResponseEmissionState::HeadersSent
-                    },
+                    final_status,
+                    emission,
                     response_chunk_rx,
-                    pending_chunk: None,
+                    backpressure: ResponseBackpressureState::Ready,
                     backend_accounting: state.dispatch.backend_accounting,
                 });
             }
             RequestExecutionState::Legacy(mut legacy) => {
-                legacy.response_chunk_rx = response_chunk_rx;
-                legacy.response_headers_sent = response_headers_sent;
-                legacy.phase = phase;
+                legacy.response_chunk_rx = Some(response_chunk_rx);
+                legacy.response_headers_sent =
+                    !matches!(emission, ResponseEmissionState::DeferredHeaders);
+                legacy.phase = StreamPhase::SendingResponse;
                 self.execution = RequestExecutionState::Legacy(legacy);
             }
             other => {
@@ -871,6 +885,24 @@ impl RequestEnvelope {
                 panic!("streaming transition attempted from unsupported execution state");
             }
         }
+    }
+
+    pub(crate) fn transition_streaming_to_completed(&mut self, reason: CompletionReason) {
+        self.transition_to_terminal(TerminalState::Completed(
+            crate::runtime::connection::stream::CompletedState {
+                reason,
+                snapshot: self.terminal_snapshot(),
+            },
+        ));
+    }
+
+    pub(crate) fn transition_streaming_to_backend_failed(&mut self, reason: BackendFailureReason) {
+        self.transition_to_terminal(TerminalState::BackendFailed(
+            crate::runtime::connection::stream::BackendFailedState {
+                reason,
+                snapshot: self.terminal_snapshot(),
+            },
+        ));
     }
 
     pub fn transition_to_terminal(

--- a/crates/edge/src/runtime/connection/request.rs
+++ b/crates/edge/src/runtime/connection/request.rs
@@ -293,14 +293,34 @@ impl RequestEnvelope {
         match &self.execution {
             RequestExecutionState::AwaitingAuth(_) => TimeoutReason::ExternalAuth,
             RequestExecutionState::StreamingResponse(_) => TimeoutReason::ResponseBodyTotal,
-            RequestExecutionState::AwaitingUpstream(_)
-            | RequestExecutionState::DispatchReady(_)
-            | RequestExecutionState::Admitted(_) => TimeoutReason::AwaitingUpstream,
+            RequestExecutionState::AwaitingUpstream(state) => {
+                Self::pre_response_timeout_reason(state.request_mode, state.request_body)
+            }
+            RequestExecutionState::DispatchReady(state) => {
+                Self::pre_response_timeout_reason(state.request_mode, state.request_body)
+            }
+            RequestExecutionState::Admitted(state) => {
+                Self::pre_response_timeout_reason(state.request_mode, state.request_body)
+            }
             RequestExecutionState::Intake(_) => TimeoutReason::RequestBodyTotal,
             RequestExecutionState::Terminal(state) => match state {
                 TerminalState::TimedOut(state) => state.reason,
                 _ => TimeoutReason::TotalRequest,
             },
+        }
+    }
+
+    /// For pre-response states, requests still reading the client body time out
+    /// under the request-body bucket; once intake is complete (or for tunnels)
+    /// they time out under the await-upstream bucket.
+    fn pre_response_timeout_reason(
+        request_mode: RequestMode,
+        request_body: RequestBodyState,
+    ) -> TimeoutReason {
+        if request_mode.is_tunnel() || request_body.request_fin_received() {
+            TimeoutReason::AwaitingUpstream
+        } else {
+            TimeoutReason::RequestBodyTotal
         }
     }
 

--- a/crates/edge/src/runtime/connection/request.rs
+++ b/crates/edge/src/runtime/connection/request.rs
@@ -28,7 +28,7 @@ use crate::{
             RequestBodyRuntime, RequestBodyState, RequestContext, RequestExecutionState,
             RequestMode, ResponseBackpressureState, ResponseEmissionState, ResponseStreamingState,
             StreamAdmissionState, StreamPhase, TerminalReason, TerminalSnapshot, TerminalState,
-            TunnelMode,
+            TimeoutReason, TunnelMode,
         },
     },
 };
@@ -413,6 +413,96 @@ impl RequestEnvelope {
                     && self.request_body_state().forwarding_complete()
             }
             _ => self.execution.can_poll_upstream(),
+        }
+    }
+
+    pub fn can_poll_upstream_result(&self) -> bool {
+        match &self.execution {
+            RequestExecutionState::AwaitingUpstream(_) => {
+                self.has_upstream_result_rx() && self.execution.can_poll_upstream()
+            }
+            RequestExecutionState::Legacy(state) => {
+                if state.upstream_result_rx.is_none() {
+                    return false;
+                }
+
+                if state.admission_state != StreamAdmissionState::ReadyToForward {
+                    return false;
+                }
+
+                if self.request_mode().is_tunnel()
+                    && matches!(
+                        state.phase,
+                        StreamPhase::ReceivingRequest | StreamPhase::AwaitingUpstream
+                    )
+                {
+                    return true;
+                }
+
+                state.phase == StreamPhase::AwaitingUpstream
+                    && self.request_body_state().forwarding_complete()
+            }
+            _ => false,
+        }
+    }
+
+    pub fn total_request_timeout_reason(&self) -> TimeoutReason {
+        match &self.execution {
+            RequestExecutionState::AwaitingAuth(_) => TimeoutReason::ExternalAuth,
+            RequestExecutionState::StreamingResponse(_) => TimeoutReason::ResponseBodyTotal,
+            RequestExecutionState::AwaitingUpstream(_)
+            | RequestExecutionState::DispatchReady(_)
+            | RequestExecutionState::Admitted(_) => TimeoutReason::AwaitingUpstream,
+            RequestExecutionState::Intake(_) => TimeoutReason::RequestBodyTotal,
+            RequestExecutionState::Legacy(state) => {
+                if state.admission_state == StreamAdmissionState::WaitingForAuth {
+                    return TimeoutReason::ExternalAuth;
+                }
+
+                if self.has_response_chunk_rx() || state.phase == StreamPhase::SendingResponse {
+                    return TimeoutReason::ResponseBodyTotal;
+                }
+
+                // Tunnel requests become await-upstream work as soon as admission is
+                // complete; they should not inherit normal request-body timeout labels.
+                if self.request_mode().is_tunnel() && self.can_poll_upstream_result() {
+                    return TimeoutReason::AwaitingUpstream;
+                }
+
+                if self.can_poll_upstream_result() {
+                    return TimeoutReason::AwaitingUpstream;
+                }
+
+                if self.can_accept_request_body() {
+                    return TimeoutReason::RequestBodyTotal;
+                }
+
+                TimeoutReason::TotalRequest
+            }
+            RequestExecutionState::Terminal(state) => match state {
+                TerminalState::TimedOut(state) => state.reason,
+                _ => TimeoutReason::TotalRequest,
+            },
+        }
+    }
+
+    pub fn upstream_timeout_reason(&self) -> TimeoutReason {
+        match &self.execution {
+            RequestExecutionState::StreamingResponse(_) => TimeoutReason::ResponseBodyTotal,
+            RequestExecutionState::AwaitingUpstream(_)
+            | RequestExecutionState::DispatchReady(_)
+            | RequestExecutionState::Admitted(_)
+            | RequestExecutionState::AwaitingAuth(_) => TimeoutReason::AwaitingUpstream,
+            RequestExecutionState::Legacy(state) => {
+                if self.has_response_chunk_rx() || state.phase == StreamPhase::SendingResponse {
+                    TimeoutReason::ResponseBodyTotal
+                } else {
+                    TimeoutReason::AwaitingUpstream
+                }
+            }
+            RequestExecutionState::Intake(_) | RequestExecutionState::Terminal(_) => {
+                TimeoutReason::AwaitingUpstream
+            }
         }
     }
 
@@ -904,6 +994,14 @@ impl RequestEnvelope {
         metrics: &Metrics,
     ) {
         self.transition_to_terminal_with_cleanup(TerminalReason::BackendFailed(reason), metrics);
+    }
+
+    pub(crate) fn transition_streaming_to_timed_out(
+        &mut self,
+        reason: TimeoutReason,
+        metrics: &Metrics,
+    ) {
+        self.transition_to_terminal_with_cleanup(TerminalReason::TimedOut(reason), metrics);
     }
 
     pub fn transition_to_terminal(

--- a/crates/edge/src/runtime/connection/request.rs
+++ b/crates/edge/src/runtime/connection/request.rs
@@ -22,9 +22,10 @@ use crate::{
         stream::{
             AdmissionPermits, AdmittedState, AwaitingAuthState, AwaitingUpstreamState,
             BackendAccountingState, BackendDispatchState, CancellationReason, CancelledState,
-            DispatchReadyState, LegacyRequestLifecycle, RequestBodyRuntime, RequestContext,
-            RequestExecutionState, RequestMode, ResponseEmissionState, ResponseStreamingState,
-            StreamAdmissionState, StreamPhase, TerminalSnapshot, TerminalState, TunnelMode,
+            DispatchReadyState, LegacyRequestLifecycle, RequestBodyRuntime, RequestBodyState,
+            RequestContext, RequestExecutionState, RequestMode, ResponseEmissionState,
+            ResponseStreamingState, StreamAdmissionState, StreamPhase, TerminalSnapshot,
+            TerminalState, TunnelMode,
         },
     },
 };
@@ -260,11 +261,156 @@ impl RequestEnvelope {
     }
 
     pub fn request_fin_received(&self) -> bool {
-        self.request_body_runtime().request_fin_received
+        self.request_body_state().request_fin_received()
     }
 
     pub fn set_request_fin_received(&mut self, value: bool) {
         self.request_body_runtime_mut().request_fin_received = value;
+    }
+
+    pub fn request_mode(&self) -> RequestMode {
+        match &self.execution {
+            RequestExecutionState::Intake(state) => state.request_mode,
+            RequestExecutionState::AwaitingAuth(state) => state.request_mode,
+            RequestExecutionState::DispatchReady(state) => state.request_mode,
+            RequestExecutionState::Admitted(state) => state.request_mode,
+            RequestExecutionState::AwaitingUpstream(state) => state.request_mode,
+            RequestExecutionState::StreamingResponse(state) => state.request_mode,
+            RequestExecutionState::Terminal(state) => match state {
+                TerminalState::Completed(state) => state.snapshot.request_mode,
+                TerminalState::Cancelled(state) => state.snapshot.request_mode,
+                TerminalState::TimedOut(state) => state.snapshot.request_mode,
+                TerminalState::Rejected(state) => state.snapshot.request_mode,
+                TerminalState::BackendFailed(state) => state.snapshot.request_mode,
+            },
+            RequestExecutionState::Legacy(_) => {
+                RequestMode::from_legacy_flags(self.tunnel_mode, self.bodyless_mode)
+            }
+        }
+    }
+
+    pub fn request_body_state(&self) -> RequestBodyState {
+        match &self.execution {
+            RequestExecutionState::Intake(state) => state.request_body,
+            RequestExecutionState::AwaitingAuth(state) => state.request_body,
+            RequestExecutionState::DispatchReady(state) => state.request_body,
+            RequestExecutionState::Admitted(state) => state.request_body,
+            RequestExecutionState::AwaitingUpstream(state) => state.request_body,
+            RequestExecutionState::StreamingResponse(_) | RequestExecutionState::Legacy(_) => {
+                RequestBodyState::from_runtime(
+                    self.request_body_runtime().request_fin_received,
+                    !self.request_body_runtime().body_buf.is_empty(),
+                    self.body_tx().is_some(),
+                )
+            }
+            RequestExecutionState::Terminal(state) => match state {
+                TerminalState::Completed(state) => state
+                    .snapshot
+                    .request_mode
+                    .initial_body_state()
+                    .on_forward_closed(),
+                TerminalState::Cancelled(state) => state
+                    .snapshot
+                    .request_mode
+                    .initial_body_state()
+                    .on_forward_closed(),
+                TerminalState::TimedOut(state) => state
+                    .snapshot
+                    .request_mode
+                    .initial_body_state()
+                    .on_forward_closed(),
+                TerminalState::Rejected(state) => state
+                    .snapshot
+                    .request_mode
+                    .initial_body_state()
+                    .on_forward_closed(),
+                TerminalState::BackendFailed(state) => state
+                    .snapshot
+                    .request_mode
+                    .initial_body_state()
+                    .on_forward_closed(),
+            },
+        }
+    }
+
+    pub fn set_request_body_state(&mut self, next: RequestBodyState) {
+        self.request_body_runtime_mut().request_fin_received = next.request_fin_received();
+        match &mut self.execution {
+            RequestExecutionState::Intake(state) => state.request_body = next,
+            RequestExecutionState::AwaitingAuth(state) => state.request_body = next,
+            RequestExecutionState::DispatchReady(state) => state.request_body = next,
+            RequestExecutionState::Admitted(state) => state.request_body = next,
+            RequestExecutionState::AwaitingUpstream(state) => state.request_body = next,
+            RequestExecutionState::StreamingResponse(_)
+            | RequestExecutionState::Legacy(_)
+            | RequestExecutionState::Terminal(_) => {}
+        }
+    }
+
+    pub fn refresh_request_body_state(&mut self) -> RequestBodyState {
+        let next = RequestBodyState::from_runtime(
+            self.request_body_runtime().request_fin_received,
+            !self.request_body_runtime().body_buf.is_empty(),
+            self.body_tx().is_some(),
+        );
+        self.set_request_body_state(next);
+        next
+    }
+
+    pub fn transition_request_body_buffered(&mut self) -> RequestBodyState {
+        let next = self.request_body_state().on_buffered();
+        self.set_request_body_state(next);
+        next
+    }
+
+    pub fn transition_request_body_finished(&mut self) -> RequestBodyState {
+        let next = self.request_body_state().on_downstream_finished();
+        self.set_request_body_state(next);
+        next
+    }
+
+    pub fn transition_request_body_forward_closed(&mut self) -> RequestBodyState {
+        self.clear_body_tx();
+        self.refresh_request_body_state()
+    }
+
+    pub fn should_close_request_body_forwarding(&self) -> bool {
+        matches!(self.request_body_state(), RequestBodyState::FinReceived)
+            && self.body_buf().is_empty()
+            && self.body_tx().is_some()
+    }
+
+    pub fn can_accept_request_body(&self) -> bool {
+        match &self.execution {
+            RequestExecutionState::Legacy(state) => {
+                state.phase == StreamPhase::ReceivingRequest
+                    && self.request_body_state().can_accept_downstream_body()
+            }
+            _ => self.execution.can_accept_request_body(),
+        }
+    }
+
+    pub fn can_poll_upstream(&self) -> bool {
+        match &self.execution {
+            RequestExecutionState::Legacy(state) => {
+                if state.admission_state != StreamAdmissionState::ReadyToForward {
+                    return false;
+                }
+
+                if self.request_mode().is_tunnel()
+                    && matches!(
+                        state.phase,
+                        StreamPhase::ReceivingRequest | StreamPhase::AwaitingUpstream
+                    )
+                {
+                    return true;
+                }
+
+                state.phase == StreamPhase::AwaitingUpstream
+                    && self.request_body_state().forwarding_complete()
+            }
+            _ => self.execution.can_poll_upstream(),
+        }
     }
 
     pub fn body_tx(&self) -> Option<&mpsc::Sender<Bytes>> {
@@ -291,6 +437,7 @@ impl RequestEnvelope {
             RequestExecutionState::Legacy(state) => state.body_tx = None,
             _ => {}
         }
+        self.refresh_request_body_state();
     }
 
     pub fn body_buf(&self) -> &VecDeque<Bytes> {
@@ -650,11 +797,16 @@ impl RequestEnvelope {
             context,
             routing,
             request_mode,
-            request_body,
+            request_body: _,
             request_body_runtime,
             pending_forward,
             permits,
         } = admitted;
+        let request_body = RequestBodyState::from_runtime(
+            request_body_runtime.request_fin_received,
+            !request_body_runtime.body_buf.is_empty(),
+            dispatch_body_tx.is_some(),
+        );
         self.execution = RequestExecutionState::AwaitingUpstream(AwaitingUpstreamState {
             context,
             routing,

--- a/crates/edge/src/runtime/connection/request.rs
+++ b/crates/edge/src/runtime/connection/request.rs
@@ -284,7 +284,7 @@ impl RequestEnvelope {
                 TerminalState::BackendFailed(state) => state.snapshot.request_mode,
             },
             RequestExecutionState::Legacy(_) => {
-                RequestMode::from_legacy_flags(self.tunnel_mode, self.bodyless_mode)
+                RequestMode::from_legacy_flags(self.tunnel_mode, &self.method, self.bodyless_mode)
             }
         }
     }

--- a/crates/edge/src/runtime/connection/request.rs
+++ b/crates/edge/src/runtime/connection/request.rs
@@ -15,9 +15,11 @@ use tokio::{
 use tracing::Span;
 
 use crate::{
+    Metrics,
     resilience::{adaptive_admission::AdaptivePermit, route_queue::RouteQueuePermit},
     runtime::connection::{
         auth::{ExternalAuthFailureDisposition, ExternalAuthResult, PendingHeaderMutation},
+        outcome::{BackendRequestFinishInput, finalize_backend_request_cleanup},
         response::{ResponseChunk, UpstreamResult},
         stream::{
             AdmissionPermits, AdmittedState, AwaitingAuthState, AwaitingUpstreamState,
@@ -25,7 +27,8 @@ use crate::{
             CancelledState, CompletionReason, DispatchReadyState, LegacyRequestLifecycle,
             RequestBodyRuntime, RequestBodyState, RequestContext, RequestExecutionState,
             RequestMode, ResponseBackpressureState, ResponseEmissionState, ResponseStreamingState,
-            StreamAdmissionState, StreamPhase, TerminalSnapshot, TerminalState, TunnelMode,
+            StreamAdmissionState, StreamPhase, TerminalReason, TerminalSnapshot, TerminalState,
+            TunnelMode,
         },
     },
 };
@@ -887,22 +890,20 @@ impl RequestEnvelope {
         }
     }
 
-    pub(crate) fn transition_streaming_to_completed(&mut self, reason: CompletionReason) {
-        self.transition_to_terminal(TerminalState::Completed(
-            crate::runtime::connection::stream::CompletedState {
-                reason,
-                snapshot: self.terminal_snapshot(),
-            },
-        ));
+    pub(crate) fn transition_streaming_to_completed(
+        &mut self,
+        reason: CompletionReason,
+        metrics: &Metrics,
+    ) {
+        self.transition_to_terminal_with_cleanup(TerminalReason::Completed(reason), metrics);
     }
 
-    pub(crate) fn transition_streaming_to_backend_failed(&mut self, reason: BackendFailureReason) {
-        self.transition_to_terminal(TerminalState::BackendFailed(
-            crate::runtime::connection::stream::BackendFailedState {
-                reason,
-                snapshot: self.terminal_snapshot(),
-            },
-        ));
+    pub(crate) fn transition_streaming_to_backend_failed(
+        &mut self,
+        reason: BackendFailureReason,
+        metrics: &Metrics,
+    ) {
+        self.transition_to_terminal_with_cleanup(TerminalReason::BackendFailed(reason), metrics);
     }
 
     pub fn transition_to_terminal(
@@ -998,18 +999,54 @@ impl RequestEnvelope {
         }
     }
 
-    pub(crate) fn discard_awaiting_auth_resources(&mut self) {
-        let Some(state) = self.take_awaiting_auth_state() else {
-            return;
-        };
-        self.execution = RequestExecutionState::DispatchReady(DispatchReadyState {
-            context: state.context,
-            routing: state.routing,
-            request_mode: state.request_mode,
-            request_body: state.request_body,
-            request_body_runtime: state.request_body_runtime,
-            pending_forward: state.pending_forward,
-        });
+    pub(crate) fn transition_to_terminal_with_cleanup(
+        &mut self,
+        reason: TerminalReason,
+        metrics: &Metrics,
+    ) -> StreamPhase {
+        let prior_phase = self.phase();
+        if self.execution.is_terminal() {
+            return prior_phase;
+        }
+
+        let snapshot = self.terminal_snapshot();
+        let should_finalize_backend = self.execution.should_finalize_backend_accounting();
+        let buffered_body_bytes = Self::buffered_request_body_bytes(&self.execution);
+        let finalize_status = reason
+            .terminal_status(&snapshot)
+            .or(snapshot.response_status)
+            .map(|status| status.as_u16())
+            .or(Some(503));
+
+        let placeholder =
+            RequestExecutionState::Terminal(TerminalState::Cancelled(CancelledState {
+                reason: CancellationReason::OperatorAbort,
+                snapshot: snapshot.clone(),
+            }));
+        let prior_execution = std::mem::replace(&mut self.execution, placeholder);
+
+        if let RequestExecutionState::AwaitingAuth(state) = &prior_execution {
+            state.auth_abort.abort();
+        }
+
+        if should_finalize_backend {
+            let _ = finalize_backend_request_cleanup(
+                BackendRequestFinishInput {
+                    upstream_pool: self.upstream_pool.as_ref(),
+                    backend_index: self.backend_index,
+                    elapsed: self.start.elapsed(),
+                    status: finalize_status,
+                },
+                true,
+            );
+        }
+
+        if buffered_body_bytes > 0 {
+            metrics.release_request_buffer(buffered_body_bytes);
+        }
+
+        self.execution = RequestExecutionState::Terminal(reason.into_terminal_state(snapshot));
+        prior_phase
     }
 
     fn legacy_mut(&mut self) -> &mut LegacyRequestLifecycle {
@@ -1047,6 +1084,24 @@ impl RequestEnvelope {
             RequestExecutionState::Intake(_) | RequestExecutionState::Terminal(_) => {
                 panic!("request body runtime mutation unavailable in current execution state")
             }
+        }
+    }
+
+    fn buffered_request_body_bytes(execution: &RequestExecutionState) -> usize {
+        match execution {
+            RequestExecutionState::AwaitingAuth(state) => state.request_body_runtime.body_buf_bytes,
+            RequestExecutionState::DispatchReady(state) => {
+                state.request_body_runtime.body_buf_bytes
+            }
+            RequestExecutionState::Admitted(state) => state.request_body_runtime.body_buf_bytes,
+            RequestExecutionState::AwaitingUpstream(state) => {
+                state.request_body_runtime.body_buf_bytes
+            }
+            RequestExecutionState::StreamingResponse(state) => {
+                state.request_body_runtime.body_buf_bytes
+            }
+            RequestExecutionState::Legacy(state) => state.request_body_runtime.body_buf_bytes,
+            RequestExecutionState::Intake(_) | RequestExecutionState::Terminal(_) => 0,
         }
     }
 

--- a/crates/edge/src/runtime/connection/request.rs
+++ b/crates/edge/src/runtime/connection/request.rs
@@ -9,16 +9,14 @@ use bytes::Bytes;
 use spooky_config::config::{ForwardedHeaderPolicy, UpstreamHostPolicy};
 use spooky_lb::upstream_pool::UpstreamPool;
 use tokio::{
-    sync::{OwnedSemaphorePermit, mpsc, oneshot},
-    task::AbortHandle,
+    sync::{mpsc, oneshot},
 };
 use tracing::Span;
 
 use crate::{
     Metrics, OverloadShedReason,
-    resilience::{adaptive_admission::AdaptivePermit, route_queue::RouteQueuePermit},
     runtime::connection::{
-        auth::{ExternalAuthFailureDisposition, ExternalAuthResult, PendingHeaderMutation},
+        auth::{ExternalAuthResult, PendingHeaderMutation},
         outcome::{
             BackendRequestFinishInput, finalize_backend_request_cleanup,
             observe_terminal_request_outcome,
@@ -27,9 +25,9 @@ use crate::{
         stream::{
             AdmissionPermits, AdmittedState, AwaitingAuthState, AwaitingUpstreamState,
             BackendAccountingState, BackendDispatchState, BackendFailureReason, CancellationReason,
-            CancelledState, CompletionReason, DispatchReadyState, LegacyRequestLifecycle,
-            RequestBodyRuntime, RequestBodyState, RequestContext, RequestExecutionState,
-            RequestMode, ResponseBackpressureState, ResponseEmissionState, ResponseStreamingState,
+            CancelledState, CompletionReason, DispatchReadyState, RequestBodyRuntime,
+            RequestBodyState, RequestContext, RequestExecutionState, RequestMode,
+            ResponseBackpressureState, ResponseEmissionState, ResponseStreamingState,
             StreamAdmissionState, StreamPhase, TerminalReason, TerminalSnapshot, TerminalState,
             TimeoutReason, TunnelMode,
         },
@@ -73,95 +71,6 @@ pub struct RequestEnvelope {
 impl RequestEnvelope {
     pub fn request_id(&self) -> u64 {
         self.request_id
-    }
-
-    #[allow(clippy::too_many_arguments, dead_code)]
-    pub(crate) fn new_legacy(
-        request_id: u64,
-        trace_id: Option<String>,
-        span_id: Option<String>,
-        traceparent: Option<String>,
-        trace_span: Option<Span>,
-        method: String,
-        path: String,
-        authority: Option<String>,
-        backend_addr: Option<String>,
-        backend_index: Option<usize>,
-        upstream_name: Option<String>,
-        route_reason: Option<String>,
-        route_path_len: Option<usize>,
-        route_host_specific: Option<bool>,
-        backend_lb: Option<String>,
-        upstream_pool: Option<Arc<RwLock<UpstreamPool>>>,
-        routing_transparency_enabled: bool,
-        routing_transparency_include_reason: bool,
-        start: Instant,
-        total_request_deadline: Instant,
-        bodyless_mode: bool,
-        tunnel_mode: TunnelMode,
-        retry_count: u8,
-        error_kind: Option<&'static str>,
-        phase: StreamPhase,
-        admission_state: StreamAdmissionState,
-        request_fin_received: bool,
-        pending_forward: Option<Arc<PendingForward>>,
-        _auth_result_rx: Option<oneshot::Receiver<ExternalAuthResult>>,
-        _auth_abort: Option<AbortHandle>,
-        _auth_disposition: Option<ExternalAuthFailureDisposition>,
-        _auth_deadline: Option<Instant>,
-    ) -> Self {
-        Self {
-            request_id,
-            trace_id,
-            span_id,
-            traceparent,
-            trace_span,
-            method,
-            path,
-            authority,
-            backend_addr,
-            backend_index,
-            upstream_name,
-            route_reason,
-            route_path_len,
-            route_host_specific,
-            backend_lb,
-            upstream_pool,
-            routing_transparency_enabled,
-            routing_transparency_include_reason,
-            response_status: None,
-            start,
-            total_request_deadline,
-            bodyless_mode,
-            tunnel_mode,
-            retry_count,
-            error_kind,
-            terminal_overload_reason: None,
-            terminal_outcome_recorded: false,
-            execution: RequestExecutionState::Legacy(LegacyRequestLifecycle {
-                phase,
-                admission_state,
-                request_body_runtime: RequestBodyRuntime {
-                    body_buf: VecDeque::new(),
-                    body_buf_bytes: 0,
-                    body_bytes_received: 0,
-                    last_body_activity: start,
-                    request_fin_received,
-                },
-                body_tx: None,
-                pending_forward,
-                backend_request_started: false,
-                backend_request_finished: false,
-                global_inflight_permit: None,
-                upstream_inflight_permit: None,
-                adaptive_admission_permit: None,
-                route_queue_permit: None,
-                upstream_result_rx: None,
-                response_chunk_rx: None,
-                response_headers_sent: false,
-                pending_chunk: None,
-            }),
-        }
     }
 
     pub fn set_terminal_overload_reason(&mut self, reason: Option<OverloadShedReason>) {
@@ -298,16 +207,7 @@ impl RequestEnvelope {
             RequestExecutionState::Admitted(state) => state.request_mode,
             RequestExecutionState::AwaitingUpstream(state) => state.request_mode,
             RequestExecutionState::StreamingResponse(state) => state.request_mode,
-            RequestExecutionState::Terminal(state) => match state {
-                TerminalState::Completed(state) => state.snapshot.request_mode,
-                TerminalState::Cancelled(state) => state.snapshot.request_mode,
-                TerminalState::TimedOut(state) => state.snapshot.request_mode,
-                TerminalState::Rejected(state) => state.snapshot.request_mode,
-                TerminalState::BackendFailed(state) => state.snapshot.request_mode,
-            },
-            RequestExecutionState::Legacy(_) => {
-                RequestMode::from_legacy_flags(self.tunnel_mode, &self.method, self.bodyless_mode)
-            }
+            RequestExecutionState::Terminal(state) => terminal_request_mode(state),
         }
     }
 
@@ -318,40 +218,16 @@ impl RequestEnvelope {
             RequestExecutionState::DispatchReady(state) => state.request_body,
             RequestExecutionState::Admitted(state) => state.request_body,
             RequestExecutionState::AwaitingUpstream(state) => state.request_body,
-            RequestExecutionState::StreamingResponse(_) | RequestExecutionState::Legacy(_) => {
+            RequestExecutionState::StreamingResponse(_) => {
                 RequestBodyState::from_runtime(
                     self.request_body_runtime().request_fin_received,
                     !self.request_body_runtime().body_buf.is_empty(),
                     self.body_tx().is_some(),
                 )
             }
-            RequestExecutionState::Terminal(state) => match state {
-                TerminalState::Completed(state) => state
-                    .snapshot
-                    .request_mode
-                    .initial_body_state()
-                    .on_forward_closed(),
-                TerminalState::Cancelled(state) => state
-                    .snapshot
-                    .request_mode
-                    .initial_body_state()
-                    .on_forward_closed(),
-                TerminalState::TimedOut(state) => state
-                    .snapshot
-                    .request_mode
-                    .initial_body_state()
-                    .on_forward_closed(),
-                TerminalState::Rejected(state) => state
-                    .snapshot
-                    .request_mode
-                    .initial_body_state()
-                    .on_forward_closed(),
-                TerminalState::BackendFailed(state) => state
-                    .snapshot
-                    .request_mode
-                    .initial_body_state()
-                    .on_forward_closed(),
-            },
+            RequestExecutionState::Terminal(state) => {
+                terminal_request_mode(state).initial_body_state().on_forward_closed()
+            }
         }
     }
 
@@ -364,7 +240,6 @@ impl RequestEnvelope {
             RequestExecutionState::Admitted(state) => state.request_body = next,
             RequestExecutionState::AwaitingUpstream(state) => state.request_body = next,
             RequestExecutionState::StreamingResponse(_)
-            | RequestExecutionState::Legacy(_)
             | RequestExecutionState::Terminal(_) => {}
         }
     }
@@ -403,63 +278,17 @@ impl RequestEnvelope {
     }
 
     pub fn can_accept_request_body(&self) -> bool {
-        match &self.execution {
-            RequestExecutionState::Legacy(state) => {
-                state.phase == StreamPhase::ReceivingRequest
-                    && self.request_body_state().can_accept_downstream_body()
-            }
-            _ => self.execution.can_accept_request_body(),
-        }
+        self.execution.can_accept_request_body()
     }
 
     pub fn can_poll_upstream(&self) -> bool {
-        match &self.execution {
-            RequestExecutionState::Legacy(state) => {
-                if state.admission_state != StreamAdmissionState::ReadyToForward {
-                    return false;
-                }
-
-                if self.request_mode().is_tunnel()
-                    && matches!(
-                        state.phase,
-                        StreamPhase::ReceivingRequest | StreamPhase::AwaitingUpstream
-                    )
-                {
-                    return true;
-                }
-
-                state.phase == StreamPhase::AwaitingUpstream
-                    && self.request_body_state().forwarding_complete()
-            }
-            _ => self.execution.can_poll_upstream(),
-        }
+        self.execution.can_poll_upstream()
     }
 
     pub fn can_poll_upstream_result(&self) -> bool {
         match &self.execution {
             RequestExecutionState::AwaitingUpstream(_) => {
                 self.has_upstream_result_rx() && self.execution.can_poll_upstream()
-            }
-            RequestExecutionState::Legacy(state) => {
-                if state.upstream_result_rx.is_none() {
-                    return false;
-                }
-
-                if state.admission_state != StreamAdmissionState::ReadyToForward {
-                    return false;
-                }
-
-                if self.request_mode().is_tunnel()
-                    && matches!(
-                        state.phase,
-                        StreamPhase::ReceivingRequest | StreamPhase::AwaitingUpstream
-                    )
-                {
-                    return true;
-                }
-
-                state.phase == StreamPhase::AwaitingUpstream
-                    && self.request_body_state().forwarding_complete()
             }
             _ => false,
         }
@@ -473,31 +302,6 @@ impl RequestEnvelope {
             | RequestExecutionState::DispatchReady(_)
             | RequestExecutionState::Admitted(_) => TimeoutReason::AwaitingUpstream,
             RequestExecutionState::Intake(_) => TimeoutReason::RequestBodyTotal,
-            RequestExecutionState::Legacy(state) => {
-                if state.admission_state == StreamAdmissionState::WaitingForAuth {
-                    return TimeoutReason::ExternalAuth;
-                }
-
-                if self.has_response_chunk_rx() || state.phase == StreamPhase::SendingResponse {
-                    return TimeoutReason::ResponseBodyTotal;
-                }
-
-                // Tunnel requests become await-upstream work as soon as admission is
-                // complete; they should not inherit normal request-body timeout labels.
-                if self.request_mode().is_tunnel() && self.can_poll_upstream_result() {
-                    return TimeoutReason::AwaitingUpstream;
-                }
-
-                if self.can_poll_upstream_result() {
-                    return TimeoutReason::AwaitingUpstream;
-                }
-
-                if self.can_accept_request_body() {
-                    return TimeoutReason::RequestBodyTotal;
-                }
-
-                TimeoutReason::TotalRequest
-            }
             RequestExecutionState::Terminal(state) => match state {
                 TerminalState::TimedOut(state) => state.reason,
                 _ => TimeoutReason::TotalRequest,
@@ -512,13 +316,6 @@ impl RequestEnvelope {
             | RequestExecutionState::DispatchReady(_)
             | RequestExecutionState::Admitted(_)
             | RequestExecutionState::AwaitingAuth(_) => TimeoutReason::AwaitingUpstream,
-            RequestExecutionState::Legacy(state) => {
-                if self.has_response_chunk_rx() || state.phase == StreamPhase::SendingResponse {
-                    TimeoutReason::ResponseBodyTotal
-                } else {
-                    TimeoutReason::AwaitingUpstream
-                }
-            }
             RequestExecutionState::Intake(_) | RequestExecutionState::Terminal(_) => {
                 TimeoutReason::AwaitingUpstream
             }
@@ -528,26 +325,13 @@ impl RequestEnvelope {
     pub fn body_tx(&self) -> Option<&mpsc::Sender<Bytes>> {
         match &self.execution {
             RequestExecutionState::AwaitingUpstream(state) => state.dispatch.body_tx.as_ref(),
-            RequestExecutionState::Legacy(state) => state.body_tx.as_ref(),
             _ => None,
         }
     }
 
-    pub fn body_tx_mut(&mut self) -> &mut Option<mpsc::Sender<Bytes>> {
-        match &mut self.execution {
-            RequestExecutionState::Legacy(state) => &mut state.body_tx,
-            other => panic!(
-                "dispatch body channel mutation attempted outside legacy state {:?}",
-                std::mem::discriminant(other)
-            ),
-        }
-    }
-
     pub fn clear_body_tx(&mut self) {
-        match &mut self.execution {
-            RequestExecutionState::AwaitingUpstream(state) => state.dispatch.body_tx = None,
-            RequestExecutionState::Legacy(state) => state.body_tx = None,
-            _ => {}
+        if let RequestExecutionState::AwaitingUpstream(state) = &mut self.execution {
+            state.dispatch.body_tx = None;
         }
         self.refresh_request_body_state();
     }
@@ -590,7 +374,6 @@ impl RequestEnvelope {
             RequestExecutionState::DispatchReady(state) => Some(&state.pending_forward),
             RequestExecutionState::Admitted(state) => Some(&state.pending_forward),
             RequestExecutionState::AwaitingUpstream(state) => Some(&state.pending_forward),
-            RequestExecutionState::Legacy(state) => state.pending_forward.as_ref(),
             RequestExecutionState::Intake(_)
             | RequestExecutionState::StreamingResponse(_)
             | RequestExecutionState::Terminal(_) => None,
@@ -603,25 +386,9 @@ impl RequestEnvelope {
             RequestExecutionState::DispatchReady(state) => Some(&mut state.pending_forward),
             RequestExecutionState::Admitted(state) => Some(&mut state.pending_forward),
             RequestExecutionState::AwaitingUpstream(state) => Some(&mut state.pending_forward),
-            RequestExecutionState::Legacy(state) => state.pending_forward.as_mut(),
             RequestExecutionState::Intake(_)
             | RequestExecutionState::StreamingResponse(_)
             | RequestExecutionState::Terminal(_) => None,
-        }
-    }
-
-    pub fn clear_pending_forward(&mut self) {
-        match &mut self.execution {
-            RequestExecutionState::AwaitingAuth(_)
-            | RequestExecutionState::DispatchReady(_)
-            | RequestExecutionState::Admitted(_)
-            | RequestExecutionState::AwaitingUpstream(_)
-            | RequestExecutionState::Legacy(_) => {
-                self.set_pending_forward(None);
-            }
-            RequestExecutionState::Intake(_)
-            | RequestExecutionState::StreamingResponse(_)
-            | RequestExecutionState::Terminal(_) => {}
         }
     }
 
@@ -642,58 +409,29 @@ impl RequestEnvelope {
             RequestExecutionState::AwaitingUpstream(state) => {
                 Some(&mut state.dispatch.upstream_result_rx)
             }
-            RequestExecutionState::Legacy(state) => state.upstream_result_rx.as_mut(),
             _ => None,
         }
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn set_upstream_result_rx(&mut self, rx: Option<oneshot::Receiver<UpstreamResult>>) {
-        self.legacy_mut().upstream_result_rx = rx;
-    }
-
     pub fn clear_upstream_result_rx(&mut self) {
-        if let RequestExecutionState::Legacy(state) = &mut self.execution {
-            state.upstream_result_rx = None;
-        }
     }
 
     pub(crate) fn response_chunk_rx_mut(&mut self) -> Option<&mut mpsc::Receiver<ResponseChunk>> {
         match &mut self.execution {
             RequestExecutionState::StreamingResponse(state) => Some(&mut state.response_chunk_rx),
-            RequestExecutionState::Legacy(state) => state.response_chunk_rx.as_mut(),
             _ => None,
         }
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn set_response_chunk_rx(&mut self, rx: Option<mpsc::Receiver<ResponseChunk>>) {
-        self.legacy_mut().response_chunk_rx = rx;
-    }
-
     pub fn clear_response_chunk_rx(&mut self) {
-        match &mut self.execution {
-            RequestExecutionState::Legacy(state) => {
-                state.response_chunk_rx = None;
-            }
-            _ => {}
-        }
     }
 
     pub fn has_upstream_result_rx(&self) -> bool {
-        match &self.execution {
-            RequestExecutionState::AwaitingUpstream(_) => true,
-            RequestExecutionState::Legacy(state) => state.upstream_result_rx.is_some(),
-            _ => false,
-        }
+        matches!(&self.execution, RequestExecutionState::AwaitingUpstream(_))
     }
 
     pub fn has_response_chunk_rx(&self) -> bool {
-        match &self.execution {
-            RequestExecutionState::StreamingResponse(_) => true,
-            RequestExecutionState::Legacy(state) => state.response_chunk_rx.is_some(),
-            _ => false,
-        }
+        matches!(&self.execution, RequestExecutionState::StreamingResponse(_))
     }
 
     pub fn response_headers_sent(&self) -> bool {
@@ -701,30 +439,22 @@ impl RequestEnvelope {
             RequestExecutionState::StreamingResponse(state) => {
                 !matches!(state.emission, ResponseEmissionState::DeferredHeaders)
             }
-            RequestExecutionState::Legacy(state) => state.response_headers_sent,
             _ => false,
         }
     }
 
     pub fn set_response_headers_sent(&mut self, sent: bool) {
-        match &mut self.execution {
-            RequestExecutionState::StreamingResponse(state) => {
-                state.emission = if sent {
-                    ResponseEmissionState::HeadersSent
-                } else {
-                    ResponseEmissionState::DeferredHeaders
-                };
-            }
-            RequestExecutionState::Legacy(state) => {
-                state.response_headers_sent = sent;
-            }
-            _ => {}
+        if let RequestExecutionState::StreamingResponse(state) = &mut self.execution {
+            state.emission = if sent {
+                ResponseEmissionState::HeadersSent
+            } else {
+                ResponseEmissionState::DeferredHeaders
+            };
         }
     }
 
     pub(crate) fn take_pending_chunk(&mut self) -> Option<ResponseChunk> {
         match &mut self.execution {
-            RequestExecutionState::Legacy(state) => state.pending_chunk.take(),
             RequestExecutionState::StreamingResponse(state) => {
                 match std::mem::replace(&mut state.backpressure, ResponseBackpressureState::Ready) {
                     ResponseBackpressureState::Ready => None,
@@ -736,21 +466,16 @@ impl RequestEnvelope {
     }
 
     pub(crate) fn set_pending_chunk(&mut self, chunk: Option<ResponseChunk>) {
-        match &mut self.execution {
-            RequestExecutionState::Legacy(state) => state.pending_chunk = chunk,
-            RequestExecutionState::StreamingResponse(state) => {
-                state.backpressure = match chunk {
-                    Some(chunk) => ResponseBackpressureState::Blocked(chunk),
-                    None => ResponseBackpressureState::Ready,
-                };
-            }
-            _ => {}
+        if let RequestExecutionState::StreamingResponse(state) = &mut self.execution {
+            state.backpressure = match chunk {
+                Some(chunk) => ResponseBackpressureState::Blocked(chunk),
+                None => ResponseBackpressureState::Ready,
+            };
         }
     }
 
     pub fn has_pending_chunk(&self) -> bool {
         match &self.execution {
-            RequestExecutionState::Legacy(state) => state.pending_chunk.is_some(),
             RequestExecutionState::StreamingResponse(state) => {
                 matches!(state.backpressure, ResponseBackpressureState::Blocked(_))
             }
@@ -773,7 +498,6 @@ impl RequestEnvelope {
 
     pub fn backend_request_started(&self) -> bool {
         match &self.execution {
-            RequestExecutionState::Legacy(state) => state.backend_request_started,
             RequestExecutionState::Admitted(_) => false,
             RequestExecutionState::AwaitingUpstream(_)
             | RequestExecutionState::StreamingResponse(_) => true,
@@ -783,7 +507,6 @@ impl RequestEnvelope {
 
     pub fn backend_request_finished(&self) -> bool {
         match &self.execution {
-            RequestExecutionState::Legacy(state) => state.backend_request_finished,
             RequestExecutionState::AwaitingUpstream(state) => {
                 state.dispatch.backend_accounting.finalized
             }
@@ -794,10 +517,6 @@ impl RequestEnvelope {
 
     pub fn set_backend_request_state(&mut self, started: bool, finished: bool) {
         match &mut self.execution {
-            RequestExecutionState::Legacy(state) => {
-                state.backend_request_started = started;
-                state.backend_request_finished = finished;
-            }
             RequestExecutionState::AwaitingUpstream(state) => {
                 state.dispatch.backend_accounting.finalized = started && finished;
             }
@@ -808,67 +527,40 @@ impl RequestEnvelope {
         }
     }
 
-    pub fn set_dispatch_permits(
-        &mut self,
-        global: Option<OwnedSemaphorePermit>,
-        upstream: Option<OwnedSemaphorePermit>,
-        adaptive: Option<AdaptivePermit>,
-        route_queue: Option<RouteQueuePermit>,
-    ) {
-        let legacy = self.legacy_mut();
-        legacy.global_inflight_permit = global;
-        legacy.upstream_inflight_permit = upstream;
-        legacy.adaptive_admission_permit = adaptive;
-        legacy.route_queue_permit = route_queue;
-    }
-
-    pub fn clear_dispatch_permits(&mut self) {
-        if let RequestExecutionState::Legacy(state) = &mut self.execution {
-            state.global_inflight_permit = None;
-            state.upstream_inflight_permit = None;
-            state.adaptive_admission_permit = None;
-            state.route_queue_permit = None;
-        }
-    }
-
     pub fn has_global_inflight_permit(&self) -> bool {
-        match &self.execution {
-            RequestExecutionState::Legacy(state) => state.global_inflight_permit.is_some(),
+        matches!(
+            &self.execution,
             RequestExecutionState::Admitted(_)
-            | RequestExecutionState::AwaitingUpstream(_)
-            | RequestExecutionState::StreamingResponse(_) => true,
-            _ => false,
-        }
+                | RequestExecutionState::AwaitingUpstream(_)
+                | RequestExecutionState::StreamingResponse(_)
+        )
     }
 
     pub fn has_upstream_inflight_permit(&self) -> bool {
-        match &self.execution {
-            RequestExecutionState::Legacy(state) => state.upstream_inflight_permit.is_some(),
+        matches!(
+            &self.execution,
             RequestExecutionState::Admitted(_)
-            | RequestExecutionState::AwaitingUpstream(_)
-            | RequestExecutionState::StreamingResponse(_) => true,
-            _ => false,
-        }
+                | RequestExecutionState::AwaitingUpstream(_)
+                | RequestExecutionState::StreamingResponse(_)
+        )
     }
 
     pub fn has_adaptive_admission_permit(&self) -> bool {
-        match &self.execution {
-            RequestExecutionState::Legacy(state) => state.adaptive_admission_permit.is_some(),
+        matches!(
+            &self.execution,
             RequestExecutionState::Admitted(_)
-            | RequestExecutionState::AwaitingUpstream(_)
-            | RequestExecutionState::StreamingResponse(_) => true,
-            _ => false,
-        }
+                | RequestExecutionState::AwaitingUpstream(_)
+                | RequestExecutionState::StreamingResponse(_)
+        )
     }
 
     pub fn has_route_queue_permit(&self) -> bool {
-        match &self.execution {
-            RequestExecutionState::Legacy(state) => state.route_queue_permit.is_some(),
+        matches!(
+            &self.execution,
             RequestExecutionState::Admitted(_)
-            | RequestExecutionState::AwaitingUpstream(_)
-            | RequestExecutionState::StreamingResponse(_) => true,
-            _ => false,
-        }
+                | RequestExecutionState::AwaitingUpstream(_)
+                | RequestExecutionState::StreamingResponse(_)
+        )
     }
 
     pub(crate) fn transition_to_admitted(&mut self, permits: AdmissionPermits) {
@@ -985,13 +677,6 @@ impl RequestEnvelope {
                     backend_accounting: state.dispatch.backend_accounting,
                 });
             }
-            RequestExecutionState::Legacy(mut legacy) => {
-                legacy.response_chunk_rx = Some(response_chunk_rx);
-                legacy.response_headers_sent =
-                    !matches!(emission, ResponseEmissionState::DeferredHeaders);
-                legacy.phase = StreamPhase::SendingResponse;
-                self.execution = RequestExecutionState::Legacy(legacy);
-            }
             other => {
                 self.execution = other;
                 panic!("streaming transition attempted from unsupported execution state");
@@ -1028,49 +713,6 @@ impl RequestEnvelope {
         terminal: crate::runtime::connection::stream::TerminalState,
     ) {
         self.execution = RequestExecutionState::Terminal(terminal);
-    }
-
-    pub fn set_phase_legacy(&mut self, phase: StreamPhase) {
-        if let RequestExecutionState::Legacy(state) = &mut self.execution {
-            state.phase = phase;
-        }
-    }
-
-    pub fn set_admission_state_legacy(&mut self, state: StreamAdmissionState) {
-        if let RequestExecutionState::Legacy(legacy) = &mut self.execution {
-            legacy.admission_state = state;
-        }
-    }
-
-    pub fn set_pending_forward(&mut self, pending_forward: Option<Arc<PendingForward>>) {
-        match &mut self.execution {
-            RequestExecutionState::AwaitingAuth(state) => {
-                if let Some(pending_forward) = pending_forward {
-                    state.pending_forward = pending_forward;
-                }
-            }
-            RequestExecutionState::DispatchReady(state) => {
-                if let Some(pending_forward) = pending_forward {
-                    state.pending_forward = pending_forward;
-                }
-            }
-            RequestExecutionState::Admitted(state) => {
-                if let Some(pending_forward) = pending_forward {
-                    state.pending_forward = pending_forward;
-                }
-            }
-            RequestExecutionState::AwaitingUpstream(state) => {
-                if let Some(pending_forward) = pending_forward {
-                    state.pending_forward = pending_forward;
-                }
-            }
-            RequestExecutionState::Legacy(state) => {
-                state.pending_forward = pending_forward;
-            }
-            RequestExecutionState::Intake(_)
-            | RequestExecutionState::StreamingResponse(_)
-            | RequestExecutionState::Terminal(_) => {}
-        }
     }
 
     pub(crate) fn transition_awaiting_auth_to_dispatch_ready<I>(&mut self, mutations: I)
@@ -1171,25 +813,17 @@ impl RequestEnvelope {
         prior_phase
     }
 
-    fn legacy_mut(&mut self) -> &mut LegacyRequestLifecycle {
-        match &mut self.execution {
-            RequestExecutionState::Legacy(state) => state,
-            other => panic!(
-                "legacy lifecycle mutation attempted after migration to {:?}",
-                std::mem::discriminant(other)
-            ),
-        }
-    }
-
     fn request_body_runtime(&self) -> &RequestBodyRuntime {
         match &self.execution {
+            RequestExecutionState::Intake(_) => {
+                panic!("request body runtime unavailable in intake state")
+            }
             RequestExecutionState::AwaitingAuth(state) => &state.request_body_runtime,
             RequestExecutionState::DispatchReady(state) => &state.request_body_runtime,
             RequestExecutionState::Admitted(state) => &state.request_body_runtime,
             RequestExecutionState::AwaitingUpstream(state) => &state.request_body_runtime,
             RequestExecutionState::StreamingResponse(state) => &state.request_body_runtime,
-            RequestExecutionState::Legacy(state) => &state.request_body_runtime,
-            RequestExecutionState::Intake(_) | RequestExecutionState::Terminal(_) => {
+            RequestExecutionState::Terminal(_) => {
                 panic!("request body runtime unavailable in current execution state")
             }
         }
@@ -1197,13 +831,15 @@ impl RequestEnvelope {
 
     fn request_body_runtime_mut(&mut self) -> &mut RequestBodyRuntime {
         match &mut self.execution {
+            RequestExecutionState::Intake(_) => {
+                panic!("request body runtime mutation unavailable in intake state")
+            }
             RequestExecutionState::AwaitingAuth(state) => &mut state.request_body_runtime,
             RequestExecutionState::DispatchReady(state) => &mut state.request_body_runtime,
             RequestExecutionState::Admitted(state) => &mut state.request_body_runtime,
             RequestExecutionState::AwaitingUpstream(state) => &mut state.request_body_runtime,
             RequestExecutionState::StreamingResponse(state) => &mut state.request_body_runtime,
-            RequestExecutionState::Legacy(state) => &mut state.request_body_runtime,
-            RequestExecutionState::Intake(_) | RequestExecutionState::Terminal(_) => {
+            RequestExecutionState::Terminal(_) => {
                 panic!("request body runtime mutation unavailable in current execution state")
             }
         }
@@ -1222,7 +858,6 @@ impl RequestEnvelope {
             RequestExecutionState::StreamingResponse(state) => {
                 state.request_body_runtime.body_buf_bytes
             }
-            RequestExecutionState::Legacy(state) => state.request_body_runtime.body_buf_bytes,
             RequestExecutionState::Intake(_) | RequestExecutionState::Terminal(_) => 0,
         }
     }
@@ -1234,7 +869,7 @@ impl RequestEnvelope {
             RequestExecutionState::Admitted(state) => Some(state.routing.clone()),
             RequestExecutionState::AwaitingUpstream(state) => Some(state.routing.clone()),
             RequestExecutionState::StreamingResponse(state) => Some(state.routing.clone()),
-            RequestExecutionState::Legacy(_) | RequestExecutionState::Intake(_) => None,
+            RequestExecutionState::Intake(_) => None,
             RequestExecutionState::Terminal(state) => match state {
                 TerminalState::Completed(state) => state.snapshot.routing.clone(),
                 TerminalState::Cancelled(state) => state.snapshot.routing.clone(),
@@ -1271,6 +906,16 @@ impl RequestEnvelope {
                 _ => None,
             },
         }
+    }
+}
+
+fn terminal_request_mode(state: &TerminalState) -> RequestMode {
+    match state {
+        TerminalState::Completed(state) => state.snapshot.request_mode,
+        TerminalState::Cancelled(state) => state.snapshot.request_mode,
+        TerminalState::TimedOut(state) => state.snapshot.request_mode,
+        TerminalState::Rejected(state) => state.snapshot.request_mode,
+        TerminalState::BackendFailed(state) => state.snapshot.request_mode,
     }
 }
 

--- a/crates/edge/src/runtime/connection/response.rs
+++ b/crates/edge/src/runtime/connection/response.rs
@@ -7,10 +7,7 @@ use spooky_errors::{
 };
 use tokio::sync::mpsc;
 
-use crate::{
-    OverloadShedReason,
-    runtime::connection::{guardrails::ResponseBodyGuardrailConfig, stream::StreamPhase},
-};
+use crate::{OverloadShedReason, runtime::connection::guardrails::ResponseBodyGuardrailConfig};
 
 pub(crate) enum ForwardSuccess {
     Response {
@@ -85,10 +82,6 @@ pub(crate) struct ResponseStartMetadata {
 impl ResponseStartMetadata {
     pub(crate) fn response_headers_sent(&self) -> bool {
         !self.headers_deferred
-    }
-
-    pub(crate) fn streaming_phase(&self) -> StreamPhase {
-        StreamPhase::SendingResponse
     }
 }
 

--- a/crates/edge/src/runtime/connection/response.rs
+++ b/crates/edge/src/runtime/connection/response.rs
@@ -7,7 +7,10 @@ use spooky_errors::{
 };
 use tokio::sync::mpsc;
 
-use crate::{OverloadShedReason, runtime::connection::guardrails::ResponseBodyGuardrailConfig};
+use crate::{
+    OverloadShedReason,
+    runtime::connection::{guardrails::ResponseBodyGuardrailConfig, stream::TimeoutReason},
+};
 
 pub(crate) enum ForwardSuccess {
     Response {
@@ -70,6 +73,7 @@ pub(crate) enum ResponseChunk {
     },
     End,
     Error(ProxyError),
+    Timeout(TimeoutReason),
 }
 
 #[derive(Clone)]

--- a/crates/edge/src/runtime/connection/response.rs
+++ b/crates/edge/src/runtime/connection/response.rs
@@ -1,9 +1,16 @@
 use bytes::Bytes;
+use http::StatusCode;
+use hyper::body::Incoming;
 use spooky_errors::{
     HedgeOutcomeTelemetryReason, HedgeTriggerTelemetryReason, ProxyError,
     RetryAttemptTelemetryReason, RetryPolicyDenialReason,
 };
 use tokio::sync::mpsc;
+
+use crate::{
+    OverloadShedReason,
+    runtime::connection::{guardrails::ResponseBodyGuardrailConfig, stream::StreamPhase},
+};
 
 pub(crate) enum ForwardSuccess {
     Response {
@@ -66,6 +73,68 @@ pub(crate) enum ResponseChunk {
     },
     End,
     Error(ProxyError),
+}
+
+#[derive(Clone)]
+pub(crate) struct ResponseStartMetadata {
+    pub(crate) status: StatusCode,
+    pub(crate) headers: Vec<(Vec<u8>, Vec<u8>)>,
+    pub(crate) headers_deferred: bool,
+}
+
+impl ResponseStartMetadata {
+    pub(crate) fn response_headers_sent(&self) -> bool {
+        !self.headers_deferred
+    }
+
+    pub(crate) fn streaming_phase(&self) -> StreamPhase {
+        StreamPhase::SendingResponse
+    }
+}
+
+pub(crate) enum ImmediateResponseStart {
+    NormalizedHeadersOnly,
+    SyntheticBody(&'static [u8]),
+}
+
+pub(crate) struct ResponseBodyPumpPlan {
+    pub(crate) guardrails: ResponseBodyGuardrailConfig,
+    pub(crate) upstream_content_length: Option<usize>,
+    pub(crate) body_forwarding_enabled: bool,
+    pub(crate) progressive_emission_allowed: bool,
+    pub(crate) defer_headers_until_body_validated: bool,
+    pub(crate) tunnel_response: bool,
+}
+
+pub(crate) enum ResponseStartObservation {
+    Status {
+        status: StatusCode,
+    },
+    ProxyError {
+        status: StatusCode,
+        error: ProxyError,
+        overload_reason: Option<OverloadShedReason>,
+    },
+}
+
+pub(crate) enum ResponseStartDecision {
+    ImmediateTerminal {
+        metadata: ResponseStartMetadata,
+        terminal: ImmediateResponseStart,
+        observation: ResponseStartObservation,
+    },
+    StreamingPrebuilt {
+        metadata: ResponseStartMetadata,
+        response_chunk_rx: mpsc::Receiver<ResponseChunk>,
+        observation: ResponseStartObservation,
+    },
+    StreamingBodyPump {
+        metadata: ResponseStartMetadata,
+        response_body: Incoming,
+        pump: ResponseBodyPumpPlan,
+        observation: ResponseStartObservation,
+    },
+    BackendFailure(ProxyError),
 }
 
 #[derive(Debug, Clone, Copy, Default)]

--- a/crates/edge/src/runtime/connection/stream.rs
+++ b/crates/edge/src/runtime/connection/stream.rs
@@ -29,8 +29,8 @@ pub enum StreamPhase {
     SendingResponse,
     /// Stream finished cleanly.
     Completed,
-    /// Stream terminated with an error.
-    Failed,
+    /// Stream terminated.
+    Terminal,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -410,24 +410,6 @@ pub struct ResponseStreamingState {
     pub backend_accounting: BackendAccountingState,
 }
 
-pub struct LegacyRequestLifecycle {
-    pub phase: StreamPhase,
-    pub admission_state: StreamAdmissionState,
-    pub request_body_runtime: RequestBodyRuntime,
-    pub body_tx: Option<mpsc::Sender<Bytes>>,
-    pub pending_forward: Option<Arc<PendingForward>>,
-    pub backend_request_started: bool,
-    pub backend_request_finished: bool,
-    pub global_inflight_permit: Option<OwnedSemaphorePermit>,
-    pub upstream_inflight_permit: Option<OwnedSemaphorePermit>,
-    pub adaptive_admission_permit: Option<AdaptivePermit>,
-    pub route_queue_permit: Option<RouteQueuePermit>,
-    pub(crate) upstream_result_rx: Option<oneshot::Receiver<UpstreamResult>>,
-    pub(crate) response_chunk_rx: Option<mpsc::Receiver<ResponseChunk>>,
-    pub response_headers_sent: bool,
-    pub(crate) pending_chunk: Option<ResponseChunk>,
-}
-
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct TerminalSnapshot {
@@ -557,9 +539,6 @@ pub enum RequestExecutionState {
     Admitted(AdmittedState),
     AwaitingUpstream(AwaitingUpstreamState),
     StreamingResponse(ResponseStreamingState),
-    /// Migration shim used while handlers are incrementally rewritten away
-    /// from the legacy field-oriented request execution model.
-    Legacy(LegacyRequestLifecycle),
     Terminal(TerminalState),
 }
 
@@ -581,7 +560,6 @@ impl RequestExecutionState {
             Self::AwaitingUpstream(state) => state.dispatch.backend_accounting.should_finalize(),
             Self::StreamingResponse(state) => state.backend_accounting.should_finalize(),
             Self::Terminal(state) => state.should_finalize_backend_accounting(),
-            Self::Legacy(state) => state.backend_request_started && !state.backend_request_finished,
             Self::Intake(_)
             | Self::AwaitingAuth(_)
             | Self::DispatchReady(_)
@@ -596,10 +574,6 @@ impl RequestExecutionState {
             Self::DispatchReady(state) => state.request_body.can_accept_downstream_body(),
             Self::Admitted(state) => state.request_body.can_accept_downstream_body(),
             Self::AwaitingUpstream(state) => state.request_body.can_accept_downstream_body(),
-            Self::Legacy(state) => {
-                state.phase == StreamPhase::ReceivingRequest
-                    && !state.request_body_runtime.request_fin_received
-            }
             Self::StreamingResponse(_) | Self::Terminal(_) => false,
         }
     }
@@ -609,13 +583,12 @@ impl RequestExecutionState {
             Self::AwaitingUpstream(state) => {
                 state.request_mode.is_tunnel() || state.request_body.forwarding_complete()
             }
-            Self::Legacy(state) => state.admission_state == StreamAdmissionState::ReadyToForward,
             _ => false,
         }
     }
 
     pub fn can_emit_response(&self) -> bool {
-        matches!(self, Self::StreamingResponse(_) | Self::Legacy(_))
+        matches!(self, Self::StreamingResponse(_))
     }
 
     pub fn phase(&self) -> StreamPhase {
@@ -626,9 +599,8 @@ impl RequestExecutionState {
             | Self::Admitted(_) => StreamPhase::ReceivingRequest,
             Self::AwaitingUpstream(_) => StreamPhase::AwaitingUpstream,
             Self::StreamingResponse(_) => StreamPhase::SendingResponse,
-            Self::Legacy(state) => state.phase.clone(),
             Self::Terminal(TerminalState::Completed(_)) => StreamPhase::Completed,
-            Self::Terminal(_) => StreamPhase::Failed,
+            Self::Terminal(_) => StreamPhase::Terminal,
         }
     }
 
@@ -640,7 +612,6 @@ impl RequestExecutionState {
             | Self::AwaitingUpstream(_)
             | Self::StreamingResponse(_) => StreamAdmissionState::ReadyToForward,
             Self::Terminal(TerminalState::Rejected(_)) => StreamAdmissionState::Denied,
-            Self::Legacy(state) => state.admission_state.clone(),
             Self::Intake(_) | Self::Terminal(_) => StreamAdmissionState::ReadyToForward,
         }
     }

--- a/crates/edge/src/runtime/connection/stream.rs
+++ b/crates/edge/src/runtime/connection/stream.rs
@@ -1,3 +1,20 @@
+use std::{sync::Arc, time::Instant};
+
+use http::StatusCode;
+use tokio::{
+    sync::{OwnedSemaphorePermit, mpsc, oneshot},
+    task::AbortHandle,
+};
+
+use crate::{
+    resilience::{adaptive_admission::AdaptivePermit, route_queue::RouteQueuePermit},
+    runtime::connection::{
+        auth::{ExternalAuthFailureDisposition, ExternalAuthResult},
+        request::PendingForward,
+        response::{ResponseChunk, UpstreamResult},
+    },
+};
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StreamPhase {
     /// Still receiving request headers/body from the QUIC client.
@@ -27,4 +44,354 @@ pub enum TunnelMode {
     None,
     Connect,
     Websocket,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequestMode {
+    Normal,
+    HeadLike,
+    ConnectTunnel,
+    WebsocketTunnel,
+}
+
+#[allow(dead_code)]
+impl RequestMode {
+    pub fn is_tunnel(self) -> bool {
+        matches!(self, Self::ConnectTunnel | Self::WebsocketTunnel)
+    }
+
+    pub fn suppresses_response_body(self) -> bool {
+        matches!(self, Self::HeadLike)
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequestBodyState {
+    Open,
+    Buffered,
+    FinReceived,
+    ClosedToUpstream,
+}
+
+#[allow(dead_code)]
+impl RequestBodyState {
+    pub fn can_accept_downstream_body(self) -> bool {
+        matches!(self, Self::Open | Self::Buffered)
+    }
+
+    pub fn forwarding_complete(self) -> bool {
+        matches!(self, Self::ClosedToUpstream)
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResponseEmissionState {
+    DeferredHeaders,
+    HeadersSent,
+    StreamingBody,
+    TrailersPending,
+    EndPending,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompletionReason {
+    ResponseStreamFinished,
+    ImmediateResponse,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CancellationReason {
+    ClientReset,
+    ConnectionClosed,
+    OperatorAbort,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TimeoutReason {
+    RequestBodyIdle,
+    RequestBodyTotal,
+    ExternalAuth,
+    TotalRequest,
+    AwaitingUpstream,
+    ResponseBodyIdle,
+    ResponseBodyTotal,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RejectionReason {
+    AuthDenied,
+    AuthUnavailable,
+    ValidationFailed,
+    RateLimited,
+    Overloaded,
+    RequestBodyNotAllowed,
+    RequestBodyTooLarge,
+    ResponsePrebufferCap,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackendFailureReason {
+    DispatchSpawnFailed,
+    UpstreamResultChannelDropped,
+    UpstreamTimeout,
+    UpstreamTransport,
+    UpstreamProtocol,
+    UpstreamTls,
+    UpstreamBridge,
+    ResponseWriteFailed,
+    ResponseStreamAborted,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct RequestContext {
+    pub request_id: u64,
+    pub trace_id: Option<String>,
+    pub span_id: Option<String>,
+    pub traceparent: Option<String>,
+    pub method: String,
+    pub path: String,
+    pub authority: Option<String>,
+    pub start: Instant,
+    pub total_request_deadline: Instant,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct RoutingSnapshot {
+    pub backend_addr: String,
+    pub backend_index: usize,
+    pub upstream_name: String,
+    pub route_reason: String,
+    pub route_path_len: usize,
+    pub route_host_specific: bool,
+    pub backend_lb: Option<String>,
+}
+
+#[allow(dead_code)]
+pub struct RequestIntakeState {
+    pub context: RequestContext,
+    pub request_mode: RequestMode,
+    pub request_body: RequestBodyState,
+}
+
+#[allow(dead_code)]
+pub struct AuthWaitState {
+    pub context: RequestContext,
+    pub routing: RoutingSnapshot,
+    pub request_mode: RequestMode,
+    pub request_body: RequestBodyState,
+    pub pending_forward: Arc<PendingForward>,
+    pub auth_result_rx: oneshot::Receiver<ExternalAuthResult>,
+    pub auth_abort: AbortHandle,
+    pub auth_deadline: Instant,
+    pub auth_disposition: ExternalAuthFailureDisposition,
+}
+
+#[allow(dead_code)]
+pub struct DispatchReadyState {
+    pub context: RequestContext,
+    pub routing: RoutingSnapshot,
+    pub request_mode: RequestMode,
+    pub request_body: RequestBodyState,
+    pub pending_forward: Arc<PendingForward>,
+}
+
+#[allow(dead_code)]
+pub struct AdmissionPermits {
+    pub global: OwnedSemaphorePermit,
+    pub upstream: OwnedSemaphorePermit,
+    pub adaptive: AdaptivePermit,
+    pub route_queue: RouteQueuePermit,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BackendAccountingState {
+    pub response_status: Option<StatusCode>,
+    pub finalized: bool,
+}
+
+#[allow(dead_code)]
+impl BackendAccountingState {
+    pub fn should_finalize(self) -> bool {
+        !self.finalized
+    }
+}
+
+#[allow(dead_code)]
+pub struct AwaitingUpstreamState {
+    pub context: RequestContext,
+    pub routing: RoutingSnapshot,
+    pub request_mode: RequestMode,
+    pub request_body: RequestBodyState,
+    pub pending_forward: Arc<PendingForward>,
+    pub permits: AdmissionPermits,
+    pub upstream_result_rx: oneshot::Receiver<UpstreamResult>,
+    pub backend_accounting: BackendAccountingState,
+}
+
+#[allow(dead_code)]
+pub struct ResponseStreamingState {
+    pub context: RequestContext,
+    pub routing: RoutingSnapshot,
+    pub request_mode: RequestMode,
+    pub response_status: StatusCode,
+    pub emission: ResponseEmissionState,
+    pub response_chunk_rx: mpsc::Receiver<ResponseChunk>,
+    pub pending_chunk: Option<ResponseChunk>,
+    pub backend_accounting: BackendAccountingState,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct TerminalSnapshot {
+    pub context: RequestContext,
+    pub routing: Option<RoutingSnapshot>,
+    pub request_mode: RequestMode,
+    pub response_status: Option<StatusCode>,
+    pub backend_accounting: Option<BackendAccountingState>,
+}
+
+#[allow(dead_code)]
+pub struct CompletedState {
+    pub reason: CompletionReason,
+    pub snapshot: TerminalSnapshot,
+}
+
+#[allow(dead_code)]
+pub struct CancelledState {
+    pub reason: CancellationReason,
+    pub snapshot: TerminalSnapshot,
+}
+
+#[allow(dead_code)]
+pub struct TimedOutState {
+    pub reason: TimeoutReason,
+    pub snapshot: TerminalSnapshot,
+}
+
+#[allow(dead_code)]
+pub struct RejectedState {
+    pub reason: RejectionReason,
+    pub snapshot: TerminalSnapshot,
+}
+
+#[allow(dead_code)]
+pub struct BackendFailedState {
+    pub reason: BackendFailureReason,
+    pub snapshot: TerminalSnapshot,
+}
+
+#[allow(dead_code)]
+pub enum TerminalState {
+    Completed(CompletedState),
+    Cancelled(CancelledState),
+    TimedOut(TimedOutState),
+    Rejected(RejectedState),
+    BackendFailed(BackendFailedState),
+}
+
+#[allow(dead_code)]
+impl TerminalState {
+    pub fn terminal_status(&self) -> Option<StatusCode> {
+        match self {
+            Self::Completed(state) => state.snapshot.response_status,
+            Self::Cancelled(state) => state.snapshot.response_status,
+            Self::TimedOut(state) => state.snapshot.response_status,
+            Self::Rejected(state) => state.snapshot.response_status,
+            Self::BackendFailed(state) => state.snapshot.response_status,
+        }
+    }
+
+    pub fn should_finalize_backend_accounting(&self) -> bool {
+        match self {
+            Self::Completed(state) => state
+                .snapshot
+                .backend_accounting
+                .is_some_and(BackendAccountingState::should_finalize),
+            Self::Cancelled(state) => state
+                .snapshot
+                .backend_accounting
+                .is_some_and(BackendAccountingState::should_finalize),
+            Self::TimedOut(state) => state
+                .snapshot
+                .backend_accounting
+                .is_some_and(BackendAccountingState::should_finalize),
+            Self::Rejected(state) => state
+                .snapshot
+                .backend_accounting
+                .is_some_and(BackendAccountingState::should_finalize),
+            Self::BackendFailed(state) => state
+                .snapshot
+                .backend_accounting
+                .is_some_and(BackendAccountingState::should_finalize),
+        }
+    }
+}
+
+#[allow(dead_code)]
+pub enum RequestExecutionState {
+    Intake(RequestIntakeState),
+    AwaitingAuth(AuthWaitState),
+    DispatchReady(DispatchReadyState),
+    AwaitingUpstream(AwaitingUpstreamState),
+    StreamingResponse(ResponseStreamingState),
+    Terminal(TerminalState),
+}
+
+#[allow(dead_code)]
+impl RequestExecutionState {
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Terminal(_))
+    }
+
+    pub fn terminal_status(&self) -> Option<StatusCode> {
+        match self {
+            Self::Terminal(state) => state.terminal_status(),
+            _ => None,
+        }
+    }
+
+    pub fn should_finalize_backend_accounting(&self) -> bool {
+        match self {
+            Self::AwaitingUpstream(state) => state.backend_accounting.should_finalize(),
+            Self::StreamingResponse(state) => state.backend_accounting.should_finalize(),
+            Self::Terminal(state) => state.should_finalize_backend_accounting(),
+            Self::Intake(_) | Self::AwaitingAuth(_) | Self::DispatchReady(_) => false,
+        }
+    }
+
+    pub fn can_accept_request_body(&self) -> bool {
+        match self {
+            Self::Intake(state) => state.request_body.can_accept_downstream_body(),
+            Self::AwaitingAuth(state) => state.request_body.can_accept_downstream_body(),
+            Self::DispatchReady(state) => state.request_body.can_accept_downstream_body(),
+            Self::AwaitingUpstream(state) => {
+                state.request_mode.is_tunnel() && state.request_body.can_accept_downstream_body()
+            }
+            Self::StreamingResponse(_) | Self::Terminal(_) => false,
+        }
+    }
+
+    pub fn can_poll_upstream(&self) -> bool {
+        match self {
+            Self::AwaitingUpstream(state) => {
+                state.request_mode.is_tunnel() || state.request_body.forwarding_complete()
+            }
+            _ => false,
+        }
+    }
+
+    pub fn can_emit_response(&self) -> bool {
+        matches!(self, Self::StreamingResponse(_))
+    }
 }

--- a/crates/edge/src/runtime/connection/stream.rs
+++ b/crates/edge/src/runtime/connection/stream.rs
@@ -6,6 +6,7 @@ use tokio::{
     sync::{OwnedSemaphorePermit, mpsc, oneshot},
     task::AbortHandle,
 };
+use tracing::Span;
 
 use crate::{
     resilience::{adaptive_admission::AdaptivePermit, route_queue::RouteQueuePermit},
@@ -58,12 +59,51 @@ pub enum RequestMode {
 
 #[allow(dead_code)]
 impl RequestMode {
+    pub fn from_intake(
+        tunnel_mode: TunnelMode,
+        method: &str,
+        content_length: Option<usize>,
+    ) -> Self {
+        match tunnel_mode {
+            TunnelMode::Connect => Self::ConnectTunnel,
+            TunnelMode::Websocket => Self::WebsocketTunnel,
+            TunnelMode::None
+                if content_length.unwrap_or(0) == 0
+                    && (method.eq_ignore_ascii_case("GET")
+                        || method.eq_ignore_ascii_case("HEAD")) =>
+            {
+                Self::HeadLike
+            }
+            TunnelMode::None => Self::Normal,
+        }
+    }
+
     pub fn is_tunnel(self) -> bool {
         matches!(self, Self::ConnectTunnel | Self::WebsocketTunnel)
     }
 
     pub fn suppresses_response_body(self) -> bool {
         matches!(self, Self::HeadLike)
+    }
+
+    pub fn bodyless_mode(self) -> bool {
+        matches!(self, Self::HeadLike)
+    }
+
+    pub fn tunnel_mode(self) -> TunnelMode {
+        match self {
+            Self::Normal | Self::HeadLike => TunnelMode::None,
+            Self::ConnectTunnel => TunnelMode::Connect,
+            Self::WebsocketTunnel => TunnelMode::Websocket,
+        }
+    }
+
+    pub fn initial_body_state(self) -> RequestBodyState {
+        if self.bodyless_mode() {
+            RequestBodyState::FinReceived
+        } else {
+            RequestBodyState::Open
+        }
     }
 }
 
@@ -78,6 +118,10 @@ pub enum RequestBodyState {
 
 #[allow(dead_code)]
 impl RequestBodyState {
+    pub fn request_fin_received(self) -> bool {
+        matches!(self, Self::FinReceived | Self::ClosedToUpstream)
+    }
+
     pub fn can_accept_downstream_body(self) -> bool {
         matches!(self, Self::Open | Self::Buffered)
     }
@@ -158,6 +202,7 @@ pub struct RequestContext {
     pub trace_id: Option<String>,
     pub span_id: Option<String>,
     pub traceparent: Option<String>,
+    pub trace_span: Option<Span>,
     pub method: String,
     pub path: String,
     pub authority: Option<String>,

--- a/crates/edge/src/runtime/connection/stream.rs
+++ b/crates/edge/src/runtime/connection/stream.rs
@@ -53,6 +53,7 @@ pub enum TunnelMode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RequestMode {
     Normal,
+    Bodyless,
     HeadLike,
     ConnectTunnel,
     WebsocketTunnel,
@@ -60,11 +61,16 @@ pub enum RequestMode {
 
 #[allow(dead_code)]
 impl RequestMode {
-    pub fn from_legacy_flags(tunnel_mode: TunnelMode, bodyless_mode: bool) -> Self {
+    pub fn from_legacy_flags(tunnel_mode: TunnelMode, method: &str, bodyless_mode: bool) -> Self {
         match tunnel_mode {
             TunnelMode::Connect => Self::ConnectTunnel,
             TunnelMode::Websocket => Self::WebsocketTunnel,
-            TunnelMode::None if bodyless_mode => Self::HeadLike,
+            TunnelMode::None if bodyless_mode && method.eq_ignore_ascii_case("GET") => {
+                Self::Bodyless
+            }
+            TunnelMode::None if bodyless_mode && method.eq_ignore_ascii_case("HEAD") => {
+                Self::HeadLike
+            }
             TunnelMode::None => Self::Normal,
         }
     }
@@ -78,11 +84,14 @@ impl RequestMode {
             TunnelMode::Connect => Self::ConnectTunnel,
             TunnelMode::Websocket => Self::WebsocketTunnel,
             TunnelMode::None
-                if content_length.unwrap_or(0) == 0
-                    && (method.eq_ignore_ascii_case("GET")
-                        || method.eq_ignore_ascii_case("HEAD")) =>
+                if content_length.unwrap_or(0) == 0 && method.eq_ignore_ascii_case("HEAD") =>
             {
                 Self::HeadLike
+            }
+            TunnelMode::None
+                if content_length.unwrap_or(0) == 0 && method.eq_ignore_ascii_case("GET") =>
+            {
+                Self::Bodyless
             }
             TunnelMode::None => Self::Normal,
         }
@@ -97,12 +106,12 @@ impl RequestMode {
     }
 
     pub fn bodyless_mode(self) -> bool {
-        matches!(self, Self::HeadLike)
+        matches!(self, Self::Bodyless | Self::HeadLike)
     }
 
     pub fn tunnel_mode(self) -> TunnelMode {
         match self {
-            Self::Normal | Self::HeadLike => TunnelMode::None,
+            Self::Normal | Self::Bodyless | Self::HeadLike => TunnelMode::None,
             Self::ConnectTunnel => TunnelMode::Connect,
             Self::WebsocketTunnel => TunnelMode::Websocket,
         }

--- a/crates/edge/src/runtime/connection/stream.rs
+++ b/crates/edge/src/runtime/connection/stream.rs
@@ -10,6 +10,7 @@ use tokio::{
 use tracing::Span;
 
 use crate::{
+    OverloadShedReason,
     resilience::{adaptive_admission::AdaptivePermit, route_queue::RouteQueuePermit},
     runtime::connection::{
         auth::{ExternalAuthFailureDisposition, ExternalAuthResult},
@@ -434,6 +435,7 @@ pub struct TerminalSnapshot {
     pub routing: Option<RoutingSnapshot>,
     pub request_mode: RequestMode,
     pub response_status: Option<StatusCode>,
+    pub overload_reason: Option<OverloadShedReason>,
     pub backend_accounting: Option<BackendAccountingState>,
 }
 

--- a/crates/edge/src/runtime/connection/stream.rs
+++ b/crates/edge/src/runtime/connection/stream.rs
@@ -468,6 +468,39 @@ pub struct BackendFailedState {
 }
 
 #[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TerminalReason {
+    Completed(CompletionReason),
+    Cancelled(CancellationReason),
+    TimedOut(TimeoutReason),
+    Rejected(RejectionReason),
+    BackendFailed(BackendFailureReason),
+}
+
+#[allow(dead_code)]
+impl TerminalReason {
+    pub fn terminal_status(self, snapshot: &TerminalSnapshot) -> Option<StatusCode> {
+        snapshot.response_status
+    }
+
+    pub fn into_terminal_state(self, snapshot: TerminalSnapshot) -> TerminalState {
+        match self {
+            Self::Completed(reason) => {
+                TerminalState::Completed(CompletedState { reason, snapshot })
+            }
+            Self::Cancelled(reason) => {
+                TerminalState::Cancelled(CancelledState { reason, snapshot })
+            }
+            Self::TimedOut(reason) => TerminalState::TimedOut(TimedOutState { reason, snapshot }),
+            Self::Rejected(reason) => TerminalState::Rejected(RejectedState { reason, snapshot }),
+            Self::BackendFailed(reason) => {
+                TerminalState::BackendFailed(BackendFailedState { reason, snapshot })
+            }
+        }
+    }
+}
+
+#[allow(dead_code)]
 pub enum TerminalState {
     Completed(CompletedState),
     Cancelled(CancelledState),

--- a/crates/edge/src/runtime/connection/stream.rs
+++ b/crates/edge/src/runtime/connection/stream.rs
@@ -2,6 +2,7 @@ use std::{collections::VecDeque, sync::Arc, time::Instant};
 
 use bytes::Bytes;
 use http::StatusCode;
+use spooky_errors::ProxyError;
 use tokio::{
     sync::{OwnedSemaphorePermit, mpsc, oneshot},
     task::AbortHandle,
@@ -230,16 +231,33 @@ pub struct RequestIntakeState {
 }
 
 #[allow(dead_code)]
-pub struct AuthWaitState {
+pub struct AwaitingAuthState {
     pub context: RequestContext,
     pub routing: RoutingSnapshot,
     pub request_mode: RequestMode,
     pub request_body: RequestBodyState,
+    pub request_body_runtime: RequestBodyRuntime,
     pub pending_forward: Arc<PendingForward>,
     pub(crate) auth_result_rx: oneshot::Receiver<ExternalAuthResult>,
     pub auth_abort: AbortHandle,
     pub auth_deadline: Instant,
     pub(crate) auth_disposition: ExternalAuthFailureDisposition,
+}
+
+impl AwaitingAuthState {
+    pub(crate) fn poll_non_blocking(&mut self, now: Instant) -> Option<ExternalAuthResult> {
+        if now >= self.auth_deadline {
+            return Some(Err(ProxyError::Timeout));
+        }
+
+        match self.auth_result_rx.try_recv() {
+            Ok(result) => Some(result),
+            Err(oneshot::error::TryRecvError::Empty) => None,
+            Err(oneshot::error::TryRecvError::Closed) => Some(Err(ProxyError::Transport(
+                "external auth task dropped sender".into(),
+            ))),
+        }
+    }
 }
 
 #[allow(dead_code)]
@@ -248,6 +266,7 @@ pub struct DispatchReadyState {
     pub routing: RoutingSnapshot,
     pub request_mode: RequestMode,
     pub request_body: RequestBodyState,
+    pub request_body_runtime: RequestBodyRuntime,
     pub pending_forward: Arc<PendingForward>,
 }
 
@@ -314,10 +333,6 @@ pub struct LegacyRequestLifecycle {
     pub admission_state: StreamAdmissionState,
     pub request_body_runtime: RequestBodyRuntime,
     pub pending_forward: Option<Arc<PendingForward>>,
-    pub(crate) auth_result_rx: Option<oneshot::Receiver<ExternalAuthResult>>,
-    pub auth_abort: Option<AbortHandle>,
-    pub(crate) auth_disposition: Option<ExternalAuthFailureDisposition>,
-    pub auth_deadline: Option<Instant>,
     pub backend_request_started: bool,
     pub backend_request_finished: bool,
     pub global_inflight_permit: Option<OwnedSemaphorePermit>,
@@ -420,7 +435,7 @@ impl TerminalState {
 #[allow(dead_code)]
 pub enum RequestExecutionState {
     Intake(RequestIntakeState),
-    AwaitingAuth(AuthWaitState),
+    AwaitingAuth(AwaitingAuthState),
     DispatchReady(DispatchReadyState),
     AwaitingUpstream(AwaitingUpstreamState),
     StreamingResponse(ResponseStreamingState),

--- a/crates/edge/src/runtime/connection/stream.rs
+++ b/crates/edge/src/runtime/connection/stream.rs
@@ -60,6 +60,15 @@ pub enum RequestMode {
 
 #[allow(dead_code)]
 impl RequestMode {
+    pub fn from_legacy_flags(tunnel_mode: TunnelMode, bodyless_mode: bool) -> Self {
+        match tunnel_mode {
+            TunnelMode::Connect => Self::ConnectTunnel,
+            TunnelMode::Websocket => Self::WebsocketTunnel,
+            TunnelMode::None if bodyless_mode => Self::HeadLike,
+            TunnelMode::None => Self::Normal,
+        }
+    }
+
     pub fn from_intake(
         tunnel_mode: TunnelMode,
         method: &str,
@@ -119,6 +128,46 @@ pub enum RequestBodyState {
 
 #[allow(dead_code)]
 impl RequestBodyState {
+    pub fn from_runtime(
+        request_fin_received: bool,
+        has_buffered_body: bool,
+        forward_open: bool,
+    ) -> Self {
+        if forward_open {
+            if has_buffered_body {
+                Self::Buffered
+            } else if request_fin_received {
+                Self::FinReceived
+            } else {
+                Self::Open
+            }
+        } else if request_fin_received {
+            Self::ClosedToUpstream
+        } else if has_buffered_body {
+            Self::Buffered
+        } else {
+            Self::Open
+        }
+    }
+
+    pub fn on_buffered(self) -> Self {
+        match self {
+            Self::ClosedToUpstream => Self::ClosedToUpstream,
+            _ => Self::Buffered,
+        }
+    }
+
+    pub fn on_downstream_finished(self) -> Self {
+        match self {
+            Self::ClosedToUpstream => Self::ClosedToUpstream,
+            _ => Self::FinReceived,
+        }
+    }
+
+    pub fn on_forward_closed(self) -> Self {
+        Self::ClosedToUpstream
+    }
+
     pub fn request_fin_received(self) -> bool {
         matches!(self, Self::FinReceived | Self::ClosedToUpstream)
     }
@@ -495,9 +544,7 @@ impl RequestExecutionState {
             Self::AwaitingAuth(state) => state.request_body.can_accept_downstream_body(),
             Self::DispatchReady(state) => state.request_body.can_accept_downstream_body(),
             Self::Admitted(state) => state.request_body.can_accept_downstream_body(),
-            Self::AwaitingUpstream(state) => {
-                state.request_mode.is_tunnel() && state.request_body.can_accept_downstream_body()
-            }
+            Self::AwaitingUpstream(state) => state.request_body.can_accept_downstream_body(),
             Self::Legacy(state) => {
                 state.phase == StreamPhase::ReceivingRequest
                     && !state.request_body_runtime.request_fin_received

--- a/crates/edge/src/runtime/connection/stream.rs
+++ b/crates/edge/src/runtime/connection/stream.rs
@@ -1,5 +1,6 @@
-use std::{sync::Arc, time::Instant};
+use std::{collections::VecDeque, sync::Arc, time::Instant};
 
+use bytes::Bytes;
 use http::StatusCode;
 use tokio::{
     sync::{OwnedSemaphorePermit, mpsc, oneshot},
@@ -190,10 +191,10 @@ pub struct AuthWaitState {
     pub request_mode: RequestMode,
     pub request_body: RequestBodyState,
     pub pending_forward: Arc<PendingForward>,
-    pub auth_result_rx: oneshot::Receiver<ExternalAuthResult>,
+    pub(crate) auth_result_rx: oneshot::Receiver<ExternalAuthResult>,
     pub auth_abort: AbortHandle,
     pub auth_deadline: Instant,
-    pub auth_disposition: ExternalAuthFailureDisposition,
+    pub(crate) auth_disposition: ExternalAuthFailureDisposition,
 }
 
 #[allow(dead_code)]
@@ -203,6 +204,15 @@ pub struct DispatchReadyState {
     pub request_mode: RequestMode,
     pub request_body: RequestBodyState,
     pub pending_forward: Arc<PendingForward>,
+}
+
+pub struct RequestBodyRuntime {
+    pub body_tx: Option<mpsc::Sender<Bytes>>,
+    pub body_buf: VecDeque<Bytes>,
+    pub body_buf_bytes: usize,
+    pub body_bytes_received: usize,
+    pub last_body_activity: Instant,
+    pub request_fin_received: bool,
 }
 
 #[allow(dead_code)]
@@ -233,9 +243,10 @@ pub struct AwaitingUpstreamState {
     pub routing: RoutingSnapshot,
     pub request_mode: RequestMode,
     pub request_body: RequestBodyState,
+    pub request_body_runtime: RequestBodyRuntime,
     pub pending_forward: Arc<PendingForward>,
     pub permits: AdmissionPermits,
-    pub upstream_result_rx: oneshot::Receiver<UpstreamResult>,
+    pub(crate) upstream_result_rx: oneshot::Receiver<UpstreamResult>,
     pub backend_accounting: BackendAccountingState,
 }
 
@@ -244,11 +255,34 @@ pub struct ResponseStreamingState {
     pub context: RequestContext,
     pub routing: RoutingSnapshot,
     pub request_mode: RequestMode,
+    pub request_body_runtime: RequestBodyRuntime,
+    pub permits: AdmissionPermits,
     pub response_status: StatusCode,
     pub emission: ResponseEmissionState,
-    pub response_chunk_rx: mpsc::Receiver<ResponseChunk>,
-    pub pending_chunk: Option<ResponseChunk>,
+    pub(crate) response_chunk_rx: mpsc::Receiver<ResponseChunk>,
+    pub(crate) pending_chunk: Option<ResponseChunk>,
     pub backend_accounting: BackendAccountingState,
+}
+
+pub struct LegacyRequestLifecycle {
+    pub phase: StreamPhase,
+    pub admission_state: StreamAdmissionState,
+    pub request_body_runtime: RequestBodyRuntime,
+    pub pending_forward: Option<Arc<PendingForward>>,
+    pub(crate) auth_result_rx: Option<oneshot::Receiver<ExternalAuthResult>>,
+    pub auth_abort: Option<AbortHandle>,
+    pub(crate) auth_disposition: Option<ExternalAuthFailureDisposition>,
+    pub auth_deadline: Option<Instant>,
+    pub backend_request_started: bool,
+    pub backend_request_finished: bool,
+    pub global_inflight_permit: Option<OwnedSemaphorePermit>,
+    pub upstream_inflight_permit: Option<OwnedSemaphorePermit>,
+    pub adaptive_admission_permit: Option<AdaptivePermit>,
+    pub route_queue_permit: Option<RouteQueuePermit>,
+    pub(crate) upstream_result_rx: Option<oneshot::Receiver<UpstreamResult>>,
+    pub(crate) response_chunk_rx: Option<mpsc::Receiver<ResponseChunk>>,
+    pub response_headers_sent: bool,
+    pub(crate) pending_chunk: Option<ResponseChunk>,
 }
 
 #[allow(dead_code)]
@@ -345,6 +379,9 @@ pub enum RequestExecutionState {
     DispatchReady(DispatchReadyState),
     AwaitingUpstream(AwaitingUpstreamState),
     StreamingResponse(ResponseStreamingState),
+    /// Migration shim used while handlers are incrementally rewritten away
+    /// from the legacy field-oriented request execution model.
+    Legacy(LegacyRequestLifecycle),
     Terminal(TerminalState),
 }
 
@@ -366,6 +403,7 @@ impl RequestExecutionState {
             Self::AwaitingUpstream(state) => state.backend_accounting.should_finalize(),
             Self::StreamingResponse(state) => state.backend_accounting.should_finalize(),
             Self::Terminal(state) => state.should_finalize_backend_accounting(),
+            Self::Legacy(state) => state.backend_request_started && !state.backend_request_finished,
             Self::Intake(_) | Self::AwaitingAuth(_) | Self::DispatchReady(_) => false,
         }
     }
@@ -378,6 +416,10 @@ impl RequestExecutionState {
             Self::AwaitingUpstream(state) => {
                 state.request_mode.is_tunnel() && state.request_body.can_accept_downstream_body()
             }
+            Self::Legacy(state) => {
+                state.phase == StreamPhase::ReceivingRequest
+                    && !state.request_body_runtime.request_fin_received
+            }
             Self::StreamingResponse(_) | Self::Terminal(_) => false,
         }
     }
@@ -387,11 +429,37 @@ impl RequestExecutionState {
             Self::AwaitingUpstream(state) => {
                 state.request_mode.is_tunnel() || state.request_body.forwarding_complete()
             }
+            Self::Legacy(state) => state.admission_state == StreamAdmissionState::ReadyToForward,
             _ => false,
         }
     }
 
     pub fn can_emit_response(&self) -> bool {
-        matches!(self, Self::StreamingResponse(_))
+        matches!(self, Self::StreamingResponse(_) | Self::Legacy(_))
+    }
+
+    pub fn phase(&self) -> StreamPhase {
+        match self {
+            Self::Intake(_) | Self::AwaitingAuth(_) | Self::DispatchReady(_) => {
+                StreamPhase::ReceivingRequest
+            }
+            Self::AwaitingUpstream(_) => StreamPhase::AwaitingUpstream,
+            Self::StreamingResponse(_) => StreamPhase::SendingResponse,
+            Self::Legacy(state) => state.phase.clone(),
+            Self::Terminal(TerminalState::Completed(_)) => StreamPhase::Completed,
+            Self::Terminal(_) => StreamPhase::Failed,
+        }
+    }
+
+    pub fn admission_state(&self) -> StreamAdmissionState {
+        match self {
+            Self::AwaitingAuth(_) => StreamAdmissionState::WaitingForAuth,
+            Self::DispatchReady(_) | Self::AwaitingUpstream(_) | Self::StreamingResponse(_) => {
+                StreamAdmissionState::ReadyToForward
+            }
+            Self::Terminal(TerminalState::Rejected(_)) => StreamAdmissionState::Denied,
+            Self::Legacy(state) => state.admission_state.clone(),
+            Self::Intake(_) | Self::Terminal(_) => StreamAdmissionState::ReadyToForward,
+        }
     }
 }

--- a/crates/edge/src/runtime/connection/stream.rs
+++ b/crates/edge/src/runtime/connection/stream.rs
@@ -201,6 +201,13 @@ pub enum ResponseEmissionState {
 }
 
 #[allow(dead_code)]
+#[derive(Debug)]
+pub enum ResponseBackpressureState {
+    Ready,
+    Blocked(ResponseChunk),
+}
+
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CompletionReason {
     ResponseStreamFinished,
@@ -395,10 +402,10 @@ pub struct ResponseStreamingState {
     pub request_mode: RequestMode,
     pub request_body_runtime: RequestBodyRuntime,
     pub permits: AdmissionPermits,
-    pub response_status: StatusCode,
+    pub final_status: StatusCode,
     pub emission: ResponseEmissionState,
-    pub(crate) response_chunk_rx: Option<mpsc::Receiver<ResponseChunk>>,
-    pub(crate) pending_chunk: Option<ResponseChunk>,
+    pub(crate) response_chunk_rx: mpsc::Receiver<ResponseChunk>,
+    pub(crate) backpressure: ResponseBackpressureState,
     pub backend_accounting: BackendAccountingState,
 }
 

--- a/crates/edge/src/runtime/connection/stream.rs
+++ b/crates/edge/src/runtime/connection/stream.rs
@@ -271,7 +271,6 @@ pub struct DispatchReadyState {
 }
 
 pub struct RequestBodyRuntime {
-    pub body_tx: Option<mpsc::Sender<Bytes>>,
     pub body_buf: VecDeque<Bytes>,
     pub body_buf_bytes: usize,
     pub body_bytes_received: usize,
@@ -302,6 +301,24 @@ impl BackendAccountingState {
 }
 
 #[allow(dead_code)]
+pub struct BackendDispatchState {
+    pub body_tx: Option<mpsc::Sender<Bytes>>,
+    pub(crate) upstream_result_rx: oneshot::Receiver<UpstreamResult>,
+    pub backend_accounting: BackendAccountingState,
+}
+
+#[allow(dead_code)]
+pub struct AdmittedState {
+    pub context: RequestContext,
+    pub routing: RoutingSnapshot,
+    pub request_mode: RequestMode,
+    pub request_body: RequestBodyState,
+    pub request_body_runtime: RequestBodyRuntime,
+    pub pending_forward: Arc<PendingForward>,
+    pub permits: AdmissionPermits,
+}
+
+#[allow(dead_code)]
 pub struct AwaitingUpstreamState {
     pub context: RequestContext,
     pub routing: RoutingSnapshot,
@@ -310,8 +327,7 @@ pub struct AwaitingUpstreamState {
     pub request_body_runtime: RequestBodyRuntime,
     pub pending_forward: Arc<PendingForward>,
     pub permits: AdmissionPermits,
-    pub(crate) upstream_result_rx: oneshot::Receiver<UpstreamResult>,
-    pub backend_accounting: BackendAccountingState,
+    pub dispatch: BackendDispatchState,
 }
 
 #[allow(dead_code)]
@@ -323,7 +339,7 @@ pub struct ResponseStreamingState {
     pub permits: AdmissionPermits,
     pub response_status: StatusCode,
     pub emission: ResponseEmissionState,
-    pub(crate) response_chunk_rx: mpsc::Receiver<ResponseChunk>,
+    pub(crate) response_chunk_rx: Option<mpsc::Receiver<ResponseChunk>>,
     pub(crate) pending_chunk: Option<ResponseChunk>,
     pub backend_accounting: BackendAccountingState,
 }
@@ -332,6 +348,7 @@ pub struct LegacyRequestLifecycle {
     pub phase: StreamPhase,
     pub admission_state: StreamAdmissionState,
     pub request_body_runtime: RequestBodyRuntime,
+    pub body_tx: Option<mpsc::Sender<Bytes>>,
     pub pending_forward: Option<Arc<PendingForward>>,
     pub backend_request_started: bool,
     pub backend_request_finished: bool,
@@ -437,6 +454,7 @@ pub enum RequestExecutionState {
     Intake(RequestIntakeState),
     AwaitingAuth(AwaitingAuthState),
     DispatchReady(DispatchReadyState),
+    Admitted(AdmittedState),
     AwaitingUpstream(AwaitingUpstreamState),
     StreamingResponse(ResponseStreamingState),
     /// Migration shim used while handlers are incrementally rewritten away
@@ -460,11 +478,14 @@ impl RequestExecutionState {
 
     pub fn should_finalize_backend_accounting(&self) -> bool {
         match self {
-            Self::AwaitingUpstream(state) => state.backend_accounting.should_finalize(),
+            Self::AwaitingUpstream(state) => state.dispatch.backend_accounting.should_finalize(),
             Self::StreamingResponse(state) => state.backend_accounting.should_finalize(),
             Self::Terminal(state) => state.should_finalize_backend_accounting(),
             Self::Legacy(state) => state.backend_request_started && !state.backend_request_finished,
-            Self::Intake(_) | Self::AwaitingAuth(_) | Self::DispatchReady(_) => false,
+            Self::Intake(_)
+            | Self::AwaitingAuth(_)
+            | Self::DispatchReady(_)
+            | Self::Admitted(_) => false,
         }
     }
 
@@ -473,6 +494,7 @@ impl RequestExecutionState {
             Self::Intake(state) => state.request_body.can_accept_downstream_body(),
             Self::AwaitingAuth(state) => state.request_body.can_accept_downstream_body(),
             Self::DispatchReady(state) => state.request_body.can_accept_downstream_body(),
+            Self::Admitted(state) => state.request_body.can_accept_downstream_body(),
             Self::AwaitingUpstream(state) => {
                 state.request_mode.is_tunnel() && state.request_body.can_accept_downstream_body()
             }
@@ -500,9 +522,10 @@ impl RequestExecutionState {
 
     pub fn phase(&self) -> StreamPhase {
         match self {
-            Self::Intake(_) | Self::AwaitingAuth(_) | Self::DispatchReady(_) => {
-                StreamPhase::ReceivingRequest
-            }
+            Self::Intake(_)
+            | Self::AwaitingAuth(_)
+            | Self::DispatchReady(_)
+            | Self::Admitted(_) => StreamPhase::ReceivingRequest,
             Self::AwaitingUpstream(_) => StreamPhase::AwaitingUpstream,
             Self::StreamingResponse(_) => StreamPhase::SendingResponse,
             Self::Legacy(state) => state.phase.clone(),
@@ -514,9 +537,10 @@ impl RequestExecutionState {
     pub fn admission_state(&self) -> StreamAdmissionState {
         match self {
             Self::AwaitingAuth(_) => StreamAdmissionState::WaitingForAuth,
-            Self::DispatchReady(_) | Self::AwaitingUpstream(_) | Self::StreamingResponse(_) => {
-                StreamAdmissionState::ReadyToForward
-            }
+            Self::DispatchReady(_)
+            | Self::Admitted(_)
+            | Self::AwaitingUpstream(_)
+            | Self::StreamingResponse(_) => StreamAdmissionState::ReadyToForward,
             Self::Terminal(TerminalState::Rejected(_)) => StreamAdmissionState::Denied,
             Self::Legacy(state) => state.admission_state.clone(),
             Self::Intake(_) | Self::Terminal(_) => StreamAdmissionState::ReadyToForward,


### PR DESCRIPTION
## Summary

Replaces the edge data plane's field-oriented request handling — a flat
`RequestEnvelope` with ~40 loosely-coupled mutable fields and boolean flags —
with an explicit `RequestExecutionState` state machine. Each lifecycle stage
(intake → awaiting-auth → dispatch-ready → admitted → awaiting-upstream →
streaming-response → terminal) is now its own typed state carrying only the
data valid in that stage, with transitions and invariants enforced by the type
system rather than by convention.

The migration was done incrementally behind a `Legacy` shim so every commit
compiles and passes tests; the final commits remove the shim once all call
sites are moved onto the typed states.

## What changed

**Core state model (`runtime/connection/`)**
- `RequestExecutionState` enum with per-stage state structs (`RequestIntakeState`,
  `AwaitingAuthState`, `DispatchReadyState`, `AdmittedState`, `AwaitingUpstreamState`,
  `ResponseStreamingState`, `TerminalState`).
- `TerminalReason` / `TerminalSnapshot` unify terminal transitions with
  backend-accounting cleanup and centralized outcome observability
  (`observe_terminal_request_outcome`), including overload-reason plumbing.
- Response handling modeled explicitly: `ResponseStartDecision`,
  `ResponseBackpressureState`, and a `Bodyless` request mode split from `HeadLike`.
- Poll-gating, timeout-reason, and request-body-state logic centralized on the
  state model instead of being recomputed at call sites.

**Bootstrap TLS path (`quic_listener/bootstrap/`)**
- Parallel modeling for the non-QUIC listener: `BootstrapLifecycleStage`,
  `BootstrapTerminalOutcome`/`BootstrapTerminalResponse`/`BootstrapTerminalResult`,
  `BootstrapRequestMode`/`BootstrapResponseMode`, and streaming-body
  terminalization.

**Call sites (`quic_listener/`)**
- `forwarding/*`, `admission.rs`, `protocol.rs`, and `bootstrap/*` migrated to
  drive auth handoff, dispatch, poll gating, timeout decisions, and terminal
  handling through the state model.
- Legacy migration shim and its accessors removed once migration completed.

**Other**
- `perf`: request chunk channel capacity raised 8 → 64 (`d7e9262`).
- `style`: final `cargo fmt` pass.

## Notes for reviewers

- 26 commits, structured in pairs: each *state-model* commit is followed by its
  *call-site migration* commit, so they can be reviewed stage by stage.
- No behavioral change intended — this is a structural refactor. The one
  deliberate behavior change is the channel-capacity bump, isolated in its own
  commit.
- Net +2600 lines; much of `request.rs`/`stream.rs` growth is typed states and
  transition methods replacing scattered field mutation, with a large deletion
  at the end when the shim is removed.
