### PR TITLE
Rerfactor: Consolidate observability into a canonical reason/label/field contract

### DIFF
--- a/crates/bridge/src/forwarded.rs
+++ b/crates/bridge/src/forwarded.rs
@@ -109,3 +109,130 @@ pub fn forwarded_for_value(ip: IpAddr) -> String {
 pub fn escape_forwarded_host(host: &str) -> String {
     host.replace('\\', "\\\\").replace('"', "\\\"")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ForwardedHeaderChains, build_forwarded_header_values, escape_forwarded_host,
+        forwarded_for_value, merge_forwarded_chain,
+    };
+    use spooky_config::config::{ForwardedHeaderPolicy, ForwardedHeaderPolicyMode};
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+    #[test]
+    fn escape_forwarded_host_escapes_backslash_and_quote() {
+        assert_eq!(escape_forwarded_host(r#"ex"ample.com"#), r#"ex\"ample.com"#);
+        assert_eq!(escape_forwarded_host(r"foo\bar"), r"foo\\bar");
+        assert_eq!(escape_forwarded_host(r#"a\"b"#), r#"a\\\"b"#);
+        // plain host unchanged
+        assert_eq!(escape_forwarded_host("example.com"), "example.com");
+    }
+
+    #[test]
+    fn forwarded_for_value_ipv4_is_bare() {
+        let ip = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10));
+        assert_eq!(forwarded_for_value(ip), "203.0.113.10");
+    }
+
+    #[test]
+    fn forwarded_for_value_ipv6_is_quoted_bracket_form() {
+        let ip = IpAddr::V6(Ipv6Addr::LOCALHOST);
+        assert_eq!(forwarded_for_value(ip), "\"[::1]\"");
+        let ip = IpAddr::V6("2001:db8::1".parse().unwrap());
+        assert_eq!(forwarded_for_value(ip), "\"[2001:db8::1]\"");
+    }
+
+    #[test]
+    fn merge_forwarded_chain_preserve_append_overwrite() {
+        let inbound = vec![b"for=1.1.1.1".to_vec()];
+        let current = b"for=2.2.2.2";
+
+        let preserved =
+            merge_forwarded_chain(ForwardedHeaderPolicyMode::Preserve, &inbound, Some(current))
+                .unwrap()
+                .unwrap();
+        assert_eq!(preserved.as_bytes(), b"for=1.1.1.1");
+
+        let appended =
+            merge_forwarded_chain(ForwardedHeaderPolicyMode::Append, &inbound, Some(current))
+                .unwrap()
+                .unwrap();
+        assert_eq!(appended.as_bytes(), b"for=1.1.1.1, for=2.2.2.2");
+
+        let overwritten = merge_forwarded_chain(
+            ForwardedHeaderPolicyMode::Overwrite,
+            &inbound,
+            Some(current),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(overwritten.as_bytes(), b"for=2.2.2.2");
+    }
+
+    #[test]
+    fn build_forwarded_header_values_overwrite_drops_inbound() {
+        let policy = ForwardedHeaderPolicy {
+            mode: ForwardedHeaderPolicyMode::Overwrite,
+        };
+        let inbound_fwd = [b"for=9.9.9.9".to_vec()];
+        let inbound_xff = [b"9.9.9.9".to_vec()];
+        let inbound_xfp = [b"http".to_vec()];
+        let inbound_xfh = [b"old.example".to_vec()];
+        let inbound = ForwardedHeaderChains {
+            forwarded: &inbound_fwd,
+            x_forwarded_for: &inbound_xff,
+            x_forwarded_proto: &inbound_xfp,
+            x_forwarded_host: &inbound_xfh,
+        };
+        let ip = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10));
+        let out =
+            build_forwarded_header_values(&policy, inbound, ip, "app.example").expect("build");
+
+        assert_eq!(out.x_forwarded_for.unwrap().as_bytes(), b"203.0.113.10");
+        assert_eq!(out.x_forwarded_proto.unwrap().as_bytes(), b"https");
+        assert_eq!(out.x_forwarded_host.unwrap().as_bytes(), b"app.example");
+
+        // Bind the Bytes so the temporary is not dropped while `s` is borrowed (E0716).
+        let forwarded = out.forwarded.unwrap();
+        let s = std::str::from_utf8(forwarded.as_bytes()).unwrap();
+        assert!(s.contains("for=203.0.113.10"));
+        assert!(s.contains("proto=https"));
+        assert!(s.contains("host=\"app.example\""));
+        assert!(!s.contains("9.9.9.9"), "overwrite must drop inbound: {s}");
+    }
+
+    #[test]
+    fn build_forwarded_header_values_append_keeps_inbound() {
+        let policy = ForwardedHeaderPolicy {
+            mode: ForwardedHeaderPolicyMode::Append,
+        };
+        let inbound_xff = [b"1.1.1.1".to_vec()];
+        let inbound = ForwardedHeaderChains {
+            forwarded: &[],
+            x_forwarded_for: &inbound_xff,
+            x_forwarded_proto: &[],
+            x_forwarded_host: &[],
+        };
+        let ip = IpAddr::V4(Ipv4Addr::new(2, 2, 2, 2));
+        let out = build_forwarded_header_values(&policy, inbound, ip, "h").expect("build");
+        assert_eq!(out.x_forwarded_for.unwrap().as_bytes(), b"1.1.1.1, 2.2.2.2");
+    }
+
+    #[test]
+    fn build_forwarded_header_values_preserve_ignores_current_for_chain() {
+        let policy = ForwardedHeaderPolicy {
+            mode: ForwardedHeaderPolicyMode::Preserve,
+        };
+        let inbound_xff = [b"8.8.8.8".to_vec()];
+        let inbound = ForwardedHeaderChains {
+            forwarded: &[],
+            x_forwarded_for: &inbound_xff,
+            x_forwarded_proto: &[],
+            x_forwarded_host: &[],
+        };
+        let ip = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
+        let out = build_forwarded_header_values(&policy, inbound, ip, "h").expect("build");
+        // Preserve keeps only inbound chain values for XFF
+        assert_eq!(out.x_forwarded_for.unwrap().as_bytes(), b"8.8.8.8");
+    }
+}

--- a/crates/edge/src/lib.rs
+++ b/crates/edge/src/lib.rs
@@ -10,6 +10,7 @@ pub mod cid_radix;
 pub mod constants;
 pub mod hash;
 pub mod metrics;
+pub mod observability;
 mod quic_listener;
 pub mod resilience;
 pub mod routing;

--- a/crates/edge/src/metrics/mod.rs
+++ b/crates/edge/src/metrics/mod.rs
@@ -133,6 +133,17 @@ pub(crate) struct BackendConnectAttemptKey {
     pub(crate) resolved_addr: String,
 }
 
+/// Upper bound on the number of distinct `spooky_backend_connect_attempt_total`
+/// series (obs Phase 2, step 7). `resolved_addr`/`hostname` are otherwise
+/// unbounded across DNS rotation and multi-A records; once this many distinct
+/// keys exist, further keys collapse into a single stable overflow series so
+/// label cardinality does not grow with DNS churn.
+pub(crate) const BACKEND_CONNECT_ATTEMPT_LABEL_CAP: usize = 512;
+
+/// Stable sentinel used for the `hostname`/`resolved_addr` labels once the
+/// cardinality cap is reached.
+pub(crate) const METRIC_LABEL_OVER_CAP: &str = "__over_cap__";
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct UpstreamRequestCountKey {
     pub(crate) upstream: String,
@@ -351,6 +362,35 @@ pub enum OverloadShedReason {
     RequestBufferCap,
     ResponsePrebufferCap,
     ConnectionCap,
+}
+
+impl OverloadShedReason {
+    /// Bridge to the canonical overload cause (obs Phase 2, step 5). The
+    /// `reason=` label emitted for `spooky_overload_shed_by_reason_total` is the
+    /// canonical [`crate::observability::AdmissionOverloadCause::slug`]; this makes
+    /// the label vocabulary come from the canonical enum rather than the ad hoc
+    /// string literals in `prometheus.rs`.
+    pub fn canonical(self) -> crate::observability::AdmissionOverloadCause {
+        use crate::observability::AdmissionOverloadCause as C;
+        match self {
+            Self::Brownout => C::Brownout,
+            Self::AdaptiveAdmission => C::AdaptiveAdmission,
+            Self::RouteCap => C::RouteCap,
+            Self::RouteGlobalCap => C::RouteGlobalCap,
+            Self::GlobalInflight => C::GlobalInflight,
+            Self::UpstreamInflight => C::UpstreamInflight,
+            Self::BackendInflight => C::BackendInflight,
+            Self::CircuitOpen => C::CircuitOpen,
+            Self::RequestBufferCap => C::RequestBufferCap,
+            Self::ResponsePrebufferCap => C::ResponsePrebufferCap,
+            Self::ConnectionCap => C::ConnectionCap,
+        }
+    }
+
+    /// The canonical, stable `reason=` label value for this shed reason.
+    pub fn reason_label(self) -> &'static str {
+        self.canonical().slug()
+    }
 }
 
 impl Default for Metrics {
@@ -783,13 +823,26 @@ impl Metrics {
         resolved_addr: std::net::SocketAddr,
     ) {
         if let Ok(mut guard) = self.backend_connect_attempts.write() {
-            *guard
-                .entry(BackendConnectAttemptKey {
-                    backend: backend.to_string(),
-                    hostname: hostname.to_string(),
-                    resolved_addr: resolved_addr.to_string(),
-                })
-                .or_default() += 1;
+            let key = BackendConnectAttemptKey {
+                backend: backend.to_string(),
+                hostname: hostname.to_string(),
+                resolved_addr: resolved_addr.to_string(),
+            };
+            // Phase 2 (step 7): bound label cardinality. Existing series always
+            // update; a new series is only created while under the cap, otherwise
+            // it folds into a stable overflow key keyed only by backend identity
+            // (which is bounded by the configured backend set).
+            if guard.contains_key(&key) || guard.len() < BACKEND_CONNECT_ATTEMPT_LABEL_CAP {
+                *guard.entry(key).or_default() += 1;
+            } else {
+                *guard
+                    .entry(BackendConnectAttemptKey {
+                        backend: backend.to_string(),
+                        hostname: METRIC_LABEL_OVER_CAP.to_string(),
+                        resolved_addr: METRIC_LABEL_OVER_CAP.to_string(),
+                    })
+                    .or_default() += 1;
+            }
         }
     }
 

--- a/crates/edge/src/metrics/prometheus.rs
+++ b/crates/edge/src/metrics/prometheus.rs
@@ -151,51 +151,61 @@ impl Metrics {
             "# HELP spooky_overload_shed_by_reason_total Total overload shed decisions grouped by reason.\n",
         );
         out.push_str("# TYPE spooky_overload_shed_by_reason_total counter\n");
-        out.push_str(&format!(
-            "spooky_overload_shed_by_reason_total{{reason=\"brownout\"}} {}\n",
-            self.overload_shed_brownout.load(Ordering::Relaxed)
-        ));
-        out.push_str(&format!(
-            "spooky_overload_shed_by_reason_total{{reason=\"adaptive_admission\"}} {}\n",
-            self.overload_shed_adaptive.load(Ordering::Relaxed)
-        ));
-        out.push_str(&format!(
-            "spooky_overload_shed_by_reason_total{{reason=\"route_cap\"}} {}\n",
-            self.overload_shed_route_cap.load(Ordering::Relaxed)
-        ));
-        out.push_str(&format!(
-            "spooky_overload_shed_by_reason_total{{reason=\"route_global_cap\"}} {}\n",
-            self.overload_shed_route_global_cap.load(Ordering::Relaxed)
-        ));
-        out.push_str(&format!(
-            "spooky_overload_shed_by_reason_total{{reason=\"global_inflight\"}} {}\n",
-            self.overload_shed_global_inflight.load(Ordering::Relaxed)
-        ));
-        out.push_str(&format!(
-            "spooky_overload_shed_by_reason_total{{reason=\"upstream_inflight\"}} {}\n",
-            self.overload_shed_upstream_inflight.load(Ordering::Relaxed)
-        ));
-        out.push_str(&format!(
-            "spooky_overload_shed_by_reason_total{{reason=\"backend_inflight\"}} {}\n",
-            self.overload_shed_backend_inflight.load(Ordering::Relaxed)
-        ));
-        out.push_str(&format!(
-            "spooky_overload_shed_by_reason_total{{reason=\"circuit_open\"}} {}\n",
-            self.overload_shed_circuit_open.load(Ordering::Relaxed)
-        ));
-        out.push_str(&format!(
-            "spooky_overload_shed_by_reason_total{{reason=\"request_buffer_cap\"}} {}\n",
-            self.overload_shed_request_buffer.load(Ordering::Relaxed)
-        ));
-        out.push_str(&format!(
-            "spooky_overload_shed_by_reason_total{{reason=\"response_prebuffer_cap\"}} {}\n",
-            self.overload_shed_response_prebuffer
-                .load(Ordering::Relaxed)
-        ));
-        out.push_str(&format!(
-            "spooky_overload_shed_by_reason_total{{reason=\"connection_cap\"}} {}\n",
-            self.overload_shed_connection_cap.load(Ordering::Relaxed)
-        ));
+        // Phase 2 (step 5): the `reason=` label vocabulary comes from the canonical
+        // `OverloadShedReason::reason_label()` (→ AdmissionOverloadCause slug), not
+        // ad hoc string literals, so metric and canonical enum cannot drift.
+        for reason in [
+            OverloadShedReason::Brownout,
+            OverloadShedReason::AdaptiveAdmission,
+            OverloadShedReason::RouteCap,
+            OverloadShedReason::RouteGlobalCap,
+            OverloadShedReason::GlobalInflight,
+            OverloadShedReason::UpstreamInflight,
+            OverloadShedReason::BackendInflight,
+            OverloadShedReason::CircuitOpen,
+            OverloadShedReason::RequestBufferCap,
+            OverloadShedReason::ResponsePrebufferCap,
+            OverloadShedReason::ConnectionCap,
+        ] {
+            let count = match reason {
+                OverloadShedReason::Brownout => self.overload_shed_brownout.load(Ordering::Relaxed),
+                OverloadShedReason::AdaptiveAdmission => {
+                    self.overload_shed_adaptive.load(Ordering::Relaxed)
+                }
+                OverloadShedReason::RouteCap => {
+                    self.overload_shed_route_cap.load(Ordering::Relaxed)
+                }
+                OverloadShedReason::RouteGlobalCap => {
+                    self.overload_shed_route_global_cap.load(Ordering::Relaxed)
+                }
+                OverloadShedReason::GlobalInflight => {
+                    self.overload_shed_global_inflight.load(Ordering::Relaxed)
+                }
+                OverloadShedReason::UpstreamInflight => {
+                    self.overload_shed_upstream_inflight.load(Ordering::Relaxed)
+                }
+                OverloadShedReason::BackendInflight => {
+                    self.overload_shed_backend_inflight.load(Ordering::Relaxed)
+                }
+                OverloadShedReason::CircuitOpen => {
+                    self.overload_shed_circuit_open.load(Ordering::Relaxed)
+                }
+                OverloadShedReason::RequestBufferCap => {
+                    self.overload_shed_request_buffer.load(Ordering::Relaxed)
+                }
+                OverloadShedReason::ResponsePrebufferCap => {
+                    self.overload_shed_response_prebuffer.load(Ordering::Relaxed)
+                }
+                OverloadShedReason::ConnectionCap => {
+                    self.overload_shed_connection_cap.load(Ordering::Relaxed)
+                }
+            };
+            out.push_str(&format!(
+                "spooky_overload_shed_by_reason_total{{reason=\"{}\"}} {}\n",
+                reason.reason_label(),
+                count
+            ));
+        }
 
         out.push_str(
             "# HELP spooky_inflight_wait_admit_total Successful inflight admissions after micro-wait.\n",

--- a/crates/edge/src/metrics/prometheus.rs
+++ b/crates/edge/src/metrics/prometheus.rs
@@ -193,9 +193,9 @@ impl Metrics {
                 OverloadShedReason::RequestBufferCap => {
                     self.overload_shed_request_buffer.load(Ordering::Relaxed)
                 }
-                OverloadShedReason::ResponsePrebufferCap => {
-                    self.overload_shed_response_prebuffer.load(Ordering::Relaxed)
-                }
+                OverloadShedReason::ResponsePrebufferCap => self
+                    .overload_shed_response_prebuffer
+                    .load(Ordering::Relaxed),
                 OverloadShedReason::ConnectionCap => {
                     self.overload_shed_connection_cap.load(Ordering::Relaxed)
                 }

--- a/crates/edge/src/observability/mod.rs
+++ b/crates/edge/src/observability/mod.rs
@@ -1,0 +1,496 @@
+//! Canonical observability vocabulary (obs plan, Phase 1).
+//!
+//! This module is the **single, handler-free schema** for the operational reason
+//! vocabularies frozen in Phase 0 (`obs-phase0.md`). Phase 0 found the same
+//! concept named differently across metrics, logs, and control-plane JSON — and
+//! two parallel terminal vocabularies (the QUIC data path vs. bootstrap) with no
+//! shared slug. This module defines the canonical enums *once*, along with a
+//! single mapping layer that produces the stable string each surface should use.
+//!
+//! # Phase 1 scope
+//!
+//! This layer introduces **no behavioral change**. Existing emitters keep their
+//! current strings; new code is expected to route through these types, and later
+//! phases migrate the old emitters onto them. The mapping methods here are the
+//! intended canonical strings — where they intentionally differ from a legacy
+//! string, that is called out in a doc comment so the migration is explicit.
+//!
+//! A reader should be able to understand the intended reason vocabularies and
+//! field names from this one module without reading any emitter.
+
+use std::fmt;
+
+/// Why a request reached its terminal state — the one canonical request-outcome
+/// vocabulary. Unifies the QUIC data-path terminal enums
+/// (`RejectionReason`/`BackendFailureReason`/`TimeoutReason`) and the bootstrap
+/// `Bootstrap*` slugs, which Phase 0 found were two disjoint vocabularies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RequestOutcomeReason {
+    /// Response completed successfully (status-derived success).
+    Completed,
+    /// Client cancelled (reset / connection closed / operator abort).
+    Cancelled,
+    /// A deadline expired before completion.
+    TimedOut,
+    /// Rejected by authentication/authorization.
+    AuthDenied,
+    /// Rejected by rate limiting.
+    RateLimited,
+    /// Shed due to overload / admission control.
+    Overloaded,
+    /// Rejected by request validation or policy.
+    ValidationRejected,
+    /// Backend transport-level failure (connect/send/reset).
+    BackendTransportFailed,
+    /// Backend protocol-level failure (malformed/illegal upstream response).
+    BackendProtocolFailed,
+    /// Backend TLS failure.
+    BackendTlsFailed,
+    /// Backend bridge/translation failure.
+    BackendBridgeFailed,
+}
+
+/// Why a backend's health/observation reached its state — the one canonical
+/// backend-health vocabulary. Unifies `HealthFailureReason`,
+/// `BackendHealthObservationOutcome`, and the DNS-refresh classifications, which
+/// Phase 0 found were reported at three different granularities.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BackendHealthReason {
+    /// An active probe succeeded.
+    ActiveProbeSuccess,
+    /// An active probe failed.
+    ActiveProbeFailure,
+    /// Passive (live-traffic) observation succeeded.
+    PassiveSuccess,
+    /// Passive observation failed.
+    PassiveFailure,
+    /// A DNS refresh failed; the prior resolution is retained.
+    DnsRefreshFailed,
+    /// A DNS refresh returned no addresses; the prior resolution is retained.
+    EmptyResolutionRetained,
+    /// A backend pool lock was poisoned (observed as a health-affecting event).
+    PoolPoisoned,
+}
+
+/// Why a retry was attempted or denied — the one canonical retry vocabulary.
+/// Reconciles `RetryAttemptTelemetryReason` and `RetryPolicyDenialReason`, which
+/// Phase 0 found emitted lossy/merged metric labels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RetryDecisionReason {
+    /// Retriable: the prior attempt timed out.
+    UpstreamTimeout,
+    /// Retriable: the prior attempt hit a transport failure.
+    UpstreamTransportFailure,
+    /// Retriable: the prior attempt hit a protocol failure.
+    UpstreamProtocolFailure,
+    /// Denied: the retry budget is exhausted.
+    RetryBudgetDenied,
+    /// Denied: retries are disabled by policy.
+    RetryPolicyDisabled,
+    /// Denied: the request is not idempotent / body not replayable.
+    IdempotencyDenied,
+}
+
+/// Why a hedge was triggered or denied — the one canonical hedge vocabulary.
+/// Phase 0 found `HedgePolicyDenialReason` (7 variants) entirely unobserved; this
+/// gives every hedge decision a canonical name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum HedgeDecisionReason {
+    /// A hedge fired because the primary passed the hedge delay.
+    DelayElapsed,
+    /// Denied: hedging is disabled by policy.
+    HedgingDisabled,
+    /// Denied: the primary request already completed.
+    PrimaryCompleted,
+    /// Denied: the request body is not replayable.
+    RequestBodyNotReplayable,
+    /// Denied: the request is a tunnel (CONNECT/websocket).
+    TunnelRequest,
+    /// Denied: the method is not allowed to hedge.
+    MethodNotAllowed,
+    /// Denied: no alternate backend is available.
+    AlternateBackendUnavailable,
+    /// Denied: the hedge budget is exhausted.
+    HedgeBudgetDenied,
+}
+
+/// Why admission/auth rejected a request — the one canonical admission vocabulary.
+/// Reconciles `AdmissionOutcomeClass`, `OverloadDecisionReason`, and the external
+/// auth outcomes. Phase 0 found overload was split across two enums
+/// (`OverloadDecisionReason` 6-variant vs `OverloadShedReason` 11-variant); the
+/// fine-grained overload cause is carried separately by
+/// [`AdmissionOverloadCause`] so this stays low-cardinality.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AdmissionDecisionReason {
+    /// Authentication/authorization denied the request.
+    AuthDenied,
+    /// The auth service was unavailable (fail-closed).
+    AuthUnavailable,
+    /// Rate limiting rejected the request.
+    RateLimited,
+    /// Overload/admission control shed the request.
+    Overloaded,
+    /// Request validation rejected the request.
+    ValidationRejected,
+    /// A non-auth policy rejected the request.
+    PolicyRejected,
+}
+
+/// The fine-grained cause of an [`AdmissionDecisionReason::Overloaded`] decision,
+/// carried alongside it. This is the union of the two legacy overload enums so
+/// the shed cause is not lost when the coarse decision is recorded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AdmissionOverloadCause {
+    Brownout,
+    AdaptiveAdmission,
+    RouteCap,
+    RouteGlobalCap,
+    GlobalInflight,
+    UpstreamInflight,
+    BackendInflight,
+    CircuitOpen,
+    RequestBufferCap,
+    ResponsePrebufferCap,
+    ConnectionCap,
+}
+
+// ---------------------------------------------------------------------------
+// Stable string mapping layer (enum -> metric label / log value / control API)
+// ---------------------------------------------------------------------------
+//
+// Each canonical enum exposes exactly one `slug()`. The design decision for
+// Phase 1 is that a single stable slug serves all three surfaces — this is what
+// closes the Phase 0 gap where one concept had three names. Where a surface
+// historically used a different string, the migration comment records it.
+
+impl RequestOutcomeReason {
+    /// The canonical stable slug for metrics labels, log values, and control-API
+    /// strings.
+    pub fn slug(self) -> &'static str {
+        match self {
+            Self::Completed => "completed",
+            Self::Cancelled => "cancelled",
+            Self::TimedOut => "timed_out",
+            Self::AuthDenied => "auth_denied",
+            Self::RateLimited => "rate_limited",
+            Self::Overloaded => "overloaded",
+            Self::ValidationRejected => "validation_rejected",
+            Self::BackendTransportFailed => "backend_transport_failed",
+            Self::BackendProtocolFailed => "backend_protocol_failed",
+            Self::BackendTlsFailed => "backend_tls_failed",
+            Self::BackendBridgeFailed => "backend_bridge_failed",
+        }
+    }
+
+    /// Whether this outcome is a success terminal.
+    pub fn is_success(self) -> bool {
+        matches!(self, Self::Completed)
+    }
+
+    /// The coarse `outcome` metric-label bucket, matching the existing
+    /// `route_outcome_label` values so migrating an emitter does not change the
+    /// low-cardinality `outcome` series. Note the *canonical* per-reason detail
+    /// lives in [`Self::slug`]; this is the legacy coarse bucket.
+    pub fn coarse_outcome_label(self) -> &'static str {
+        match self {
+            Self::Completed => "success",
+            Self::TimedOut => "timeout",
+            Self::Overloaded => "overload_shed",
+            Self::RateLimited => "rate_limited",
+            // Phase 0 finding #2: auth-denied and validation currently collapse to
+            // `failure`; the canonical `slug()` distinguishes them, a later phase
+            // decides whether to widen the coarse label.
+            Self::AuthDenied
+            | Self::ValidationRejected
+            | Self::Cancelled
+            | Self::BackendTransportFailed
+            | Self::BackendProtocolFailed
+            | Self::BackendTlsFailed
+            | Self::BackendBridgeFailed => "failure",
+        }
+    }
+}
+
+impl BackendHealthReason {
+    pub fn slug(self) -> &'static str {
+        match self {
+            Self::ActiveProbeSuccess => "active_probe_success",
+            Self::ActiveProbeFailure => "active_probe_failure",
+            Self::PassiveSuccess => "passive_success",
+            Self::PassiveFailure => "passive_failure",
+            Self::DnsRefreshFailed => "dns_refresh_failed",
+            Self::EmptyResolutionRetained => "empty_resolution_retained",
+            Self::PoolPoisoned => "pool_poisoned",
+        }
+    }
+
+    /// Whether this reason represents a health-affecting failure.
+    pub fn is_failure(self) -> bool {
+        matches!(
+            self,
+            Self::ActiveProbeFailure
+                | Self::PassiveFailure
+                | Self::DnsRefreshFailed
+                | Self::PoolPoisoned
+        )
+    }
+}
+
+impl RetryDecisionReason {
+    pub fn slug(self) -> &'static str {
+        match self {
+            Self::UpstreamTimeout => "upstream_timeout",
+            Self::UpstreamTransportFailure => "upstream_transport_failure",
+            Self::UpstreamProtocolFailure => "upstream_protocol_failure",
+            Self::RetryBudgetDenied => "retry_budget_denied",
+            Self::RetryPolicyDisabled => "retry_policy_disabled",
+            Self::IdempotencyDenied => "idempotency_denied",
+        }
+    }
+
+    /// Whether this reason authorized a retry (vs. denied one).
+    pub fn is_retry(self) -> bool {
+        matches!(
+            self,
+            Self::UpstreamTimeout
+                | Self::UpstreamTransportFailure
+                | Self::UpstreamProtocolFailure
+        )
+    }
+}
+
+impl HedgeDecisionReason {
+    pub fn slug(self) -> &'static str {
+        match self {
+            Self::DelayElapsed => "delay_elapsed",
+            Self::HedgingDisabled => "hedging_disabled",
+            Self::PrimaryCompleted => "primary_completed",
+            Self::RequestBodyNotReplayable => "request_body_not_replayable",
+            Self::TunnelRequest => "tunnel_request",
+            Self::MethodNotAllowed => "method_not_allowed",
+            Self::AlternateBackendUnavailable => "alternate_backend_unavailable",
+            Self::HedgeBudgetDenied => "hedge_budget_denied",
+        }
+    }
+
+    /// Whether this reason triggered a hedge (vs. denied one).
+    pub fn is_triggered(self) -> bool {
+        matches!(self, Self::DelayElapsed)
+    }
+}
+
+impl AdmissionDecisionReason {
+    pub fn slug(self) -> &'static str {
+        match self {
+            Self::AuthDenied => "auth_denied",
+            Self::AuthUnavailable => "auth_unavailable",
+            Self::RateLimited => "rate_limited",
+            Self::Overloaded => "overloaded",
+            Self::ValidationRejected => "validation_rejected",
+            Self::PolicyRejected => "policy_rejected",
+        }
+    }
+}
+
+impl AdmissionOverloadCause {
+    /// The canonical slug, matching the existing `OverloadShedReason` metric-label
+    /// values (Phase 0 §1.6) so migrating the overload emitter is a no-op on the
+    /// `reason=` label.
+    pub fn slug(self) -> &'static str {
+        match self {
+            Self::Brownout => "brownout",
+            Self::AdaptiveAdmission => "adaptive_admission",
+            Self::RouteCap => "route_cap",
+            Self::RouteGlobalCap => "route_global_cap",
+            Self::GlobalInflight => "global_inflight",
+            Self::UpstreamInflight => "upstream_inflight",
+            Self::BackendInflight => "backend_inflight",
+            Self::CircuitOpen => "circuit_open",
+            Self::RequestBufferCap => "request_buffer_cap",
+            Self::ResponsePrebufferCap => "response_prebuffer_cap",
+            Self::ConnectionCap => "connection_cap",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared event-context carrier + metric label model
+// ---------------------------------------------------------------------------
+
+/// The one canonical set of dimensions for an operational event, used to give
+/// structured logs of the same event class the same fields (Phase 0 findings
+/// #9/#10: `route`/`upstream`/`route_upstream` and `request_id=unassigned` were
+/// inconsistent across the forwarding and bootstrap planes).
+///
+/// The canonical field name for the upstream-name concept is **`upstream`**.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct OperationalEventContext<'a> {
+    pub request_id: Option<u64>,
+    pub route: Option<&'a str>,
+    pub upstream: Option<&'a str>,
+    pub backend: Option<&'a str>,
+    pub decision_reason: Option<&'a str>,
+    pub failure_class: Option<&'a str>,
+}
+
+impl<'a> OperationalEventContext<'a> {
+    /// Start an empty context; fill fields with the builder methods.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_request_id(mut self, request_id: u64) -> Self {
+        self.request_id = Some(request_id);
+        self
+    }
+
+    pub fn with_upstream(mut self, upstream: &'a str) -> Self {
+        self.upstream = Some(upstream);
+        self
+    }
+
+    pub fn with_backend(mut self, backend: &'a str) -> Self {
+        self.backend = Some(backend);
+        self
+    }
+
+    pub fn with_reason(mut self, reason: &'a str) -> Self {
+        self.decision_reason = Some(reason);
+        self
+    }
+}
+
+impl fmt::Display for OperationalEventContext<'_> {
+    /// Render the canonical `key=value` field set, in a stable order, skipping
+    /// unset fields. This is the single log-field format for an operational event.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut first = true;
+        let mut field = |f: &mut fmt::Formatter<'_>, key: &str, value: &str| -> fmt::Result {
+            if !first {
+                f.write_str(" ")?;
+            }
+            first = false;
+            write!(f, "{key}={value}")
+        };
+        if let Some(request_id) = self.request_id {
+            field(f, "request_id", &request_id.to_string())?;
+        }
+        if let Some(route) = self.route {
+            field(f, "route", route)?;
+        }
+        if let Some(upstream) = self.upstream {
+            field(f, "upstream", upstream)?;
+        }
+        if let Some(backend) = self.backend {
+            field(f, "backend", backend)?;
+        }
+        if let Some(reason) = self.decision_reason {
+            field(f, "reason", reason)?;
+        }
+        if let Some(failure_class) = self.failure_class {
+            field(f, "failure_class", failure_class)?;
+        }
+        Ok(())
+    }
+}
+
+/// The one canonical metric reason-label model. Emitters that record a reasoned
+/// outcome populate this rather than assembling ad hoc label sets, so the label
+/// keys (`outcome`, `reason`, `failure_class`) are the same everywhere.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct MetricReasonLabels<'a> {
+    pub outcome: Option<&'a str>,
+    pub reason: Option<&'a str>,
+    pub failure_class: Option<&'a str>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_slug_is_unique_within_each_family() {
+        fn assert_unique(slugs: &[&str], family: &str) {
+            let mut v = slugs.to_vec();
+            let before = v.len();
+            v.sort_unstable();
+            v.dedup();
+            assert_eq!(before, v.len(), "duplicate slug in {family}");
+        }
+        assert_unique(
+            &[
+                RequestOutcomeReason::Completed.slug(),
+                RequestOutcomeReason::Cancelled.slug(),
+                RequestOutcomeReason::TimedOut.slug(),
+                RequestOutcomeReason::AuthDenied.slug(),
+                RequestOutcomeReason::RateLimited.slug(),
+                RequestOutcomeReason::Overloaded.slug(),
+                RequestOutcomeReason::ValidationRejected.slug(),
+                RequestOutcomeReason::BackendTransportFailed.slug(),
+                RequestOutcomeReason::BackendProtocolFailed.slug(),
+                RequestOutcomeReason::BackendTlsFailed.slug(),
+                RequestOutcomeReason::BackendBridgeFailed.slug(),
+            ],
+            "RequestOutcomeReason",
+        );
+        assert_unique(
+            &[
+                AdmissionOverloadCause::Brownout.slug(),
+                AdmissionOverloadCause::AdaptiveAdmission.slug(),
+                AdmissionOverloadCause::RouteCap.slug(),
+                AdmissionOverloadCause::RouteGlobalCap.slug(),
+                AdmissionOverloadCause::GlobalInflight.slug(),
+                AdmissionOverloadCause::UpstreamInflight.slug(),
+                AdmissionOverloadCause::BackendInflight.slug(),
+                AdmissionOverloadCause::CircuitOpen.slug(),
+                AdmissionOverloadCause::RequestBufferCap.slug(),
+                AdmissionOverloadCause::ResponsePrebufferCap.slug(),
+                AdmissionOverloadCause::ConnectionCap.slug(),
+            ],
+            "AdmissionOverloadCause",
+        );
+    }
+
+    #[test]
+    fn overload_cause_slugs_match_legacy_metric_labels() {
+        // These must stay byte-identical to `OverloadShedReason` labels so a later
+        // migration of the overload emitter does not change the `reason=` series.
+        assert_eq!(AdmissionOverloadCause::GlobalInflight.slug(), "global_inflight");
+        assert_eq!(
+            AdmissionOverloadCause::ResponsePrebufferCap.slug(),
+            "response_prebuffer_cap"
+        );
+    }
+
+    #[test]
+    fn request_outcome_coarse_label_matches_legacy_buckets() {
+        assert_eq!(RequestOutcomeReason::Completed.coarse_outcome_label(), "success");
+        assert_eq!(RequestOutcomeReason::TimedOut.coarse_outcome_label(), "timeout");
+        assert_eq!(
+            RequestOutcomeReason::Overloaded.coarse_outcome_label(),
+            "overload_shed"
+        );
+        assert_eq!(
+            RequestOutcomeReason::AuthDenied.coarse_outcome_label(),
+            "failure"
+        );
+    }
+
+    #[test]
+    fn event_context_renders_canonical_fields_in_order() {
+        let ctx = OperationalEventContext::new()
+            .with_request_id(42)
+            .with_upstream("api")
+            .with_backend("10.0.0.1:8080")
+            .with_reason("timed_out");
+        assert_eq!(
+            ctx.to_string(),
+            "request_id=42 upstream=api backend=10.0.0.1:8080 reason=timed_out"
+        );
+    }
+
+    #[test]
+    fn empty_event_context_renders_nothing() {
+        assert_eq!(OperationalEventContext::new().to_string(), "");
+    }
+}

--- a/crates/edge/src/observability/mod.rs
+++ b/crates/edge/src/observability/mod.rs
@@ -404,6 +404,109 @@ pub struct MetricReasonLabels<'a> {
     pub failure_class: Option<&'a str>,
 }
 
+// ---------------------------------------------------------------------------
+// Canonical mappings from local reason vocabularies (obs Phase 5)
+// ---------------------------------------------------------------------------
+//
+// Phase 5 classifies every local reason enum against the canonical vocabulary so
+// one operational concept is described one way. Each local enum is either:
+//   - an ALIAS of a canonical concept → `From<Local> for Canonical`, or
+//   - a RICHER SUBTYPE → mapped to the coarse canonical reason (the extra detail
+//     stays available as the local enum for debug/telemetry).
+// The QUIC-datapath terminal enums (edge-local) and the retry/hedge enums
+// (spooky_errors) are mapped here; `OverloadShedReason::canonical()` lives with
+// that enum. These impls are the single source that keeps the surfaces aligned.
+
+use crate::runtime::connection::stream::{BackendFailureReason, RejectionReason, TimeoutReason};
+use spooky_errors::{HedgePolicyDenialReason, RetryPolicyDenialReason, UpstreamRetryReason};
+
+/// Request rejection → canonical request outcome. Alias mapping.
+impl From<RejectionReason> for RequestOutcomeReason {
+    fn from(reason: RejectionReason) -> Self {
+        match reason {
+            RejectionReason::AuthDenied => Self::AuthDenied,
+            // AuthUnavailable is a richer subtype of "auth-related rejection";
+            // it maps to the canonical AuthDenied outcome (the request was not
+            // admitted), with the finer cause preserved by the local enum.
+            RejectionReason::AuthUnavailable => Self::AuthDenied,
+            RejectionReason::ValidationFailed
+            | RejectionReason::RequestBodyNotAllowed
+            | RejectionReason::RequestBodyTooLarge => Self::ValidationRejected,
+            RejectionReason::RateLimited => Self::RateLimited,
+            RejectionReason::Overloaded | RejectionReason::ResponsePrebufferCap => Self::Overloaded,
+        }
+    }
+}
+
+/// Backend failure → canonical request outcome. Richer subtype: the transport
+/// class is mapped to the matching canonical backend-failure outcome.
+impl From<BackendFailureReason> for RequestOutcomeReason {
+    fn from(reason: BackendFailureReason) -> Self {
+        match reason {
+            BackendFailureReason::UpstreamTimeout => Self::TimedOut,
+            BackendFailureReason::UpstreamTls => Self::BackendTlsFailed,
+            BackendFailureReason::UpstreamProtocol => Self::BackendProtocolFailed,
+            BackendFailureReason::UpstreamBridge => Self::BackendBridgeFailed,
+            BackendFailureReason::UpstreamTransport
+            | BackendFailureReason::DispatchSpawnFailed
+            | BackendFailureReason::UpstreamResultChannelDropped
+            | BackendFailureReason::ResponseWriteFailed
+            | BackendFailureReason::ResponseStreamAborted => Self::BackendTransportFailed,
+        }
+    }
+}
+
+/// Timeout phase → canonical request outcome. All phases are the one canonical
+/// `TimedOut` outcome; the phase remains the richer local detail.
+impl From<TimeoutReason> for RequestOutcomeReason {
+    fn from(_reason: TimeoutReason) -> Self {
+        Self::TimedOut
+    }
+}
+
+/// Retry attempt cause → canonical retry decision reason. Alias mapping.
+impl From<UpstreamRetryReason> for RetryDecisionReason {
+    fn from(reason: UpstreamRetryReason) -> Self {
+        match reason {
+            UpstreamRetryReason::Timeout => Self::UpstreamTimeout,
+            UpstreamRetryReason::Transport => Self::UpstreamTransportFailure,
+            UpstreamRetryReason::Pool => Self::UpstreamTransportFailure,
+        }
+    }
+}
+
+/// Retry denial → canonical retry decision reason. Richer subtype: the several
+/// idempotency/terminal causes collapse to the coarse canonical denials.
+impl From<RetryPolicyDenialReason> for RetryDecisionReason {
+    fn from(reason: RetryPolicyDenialReason) -> Self {
+        match reason {
+            RetryPolicyDenialReason::BudgetDenied => Self::RetryBudgetDenied,
+            RetryPolicyDenialReason::MethodNotIdempotent
+            | RetryPolicyDenialReason::RequestBodyNotReplayable => Self::IdempotencyDenied,
+            RetryPolicyDenialReason::TerminalError(_)
+            | RetryPolicyDenialReason::AttemptLimitReached
+            | RetryPolicyDenialReason::AlternateBackendUnavailable(_) => Self::RetryPolicyDisabled,
+        }
+    }
+}
+
+/// Hedge denial → canonical hedge decision reason. Alias / richer subtype.
+impl From<HedgePolicyDenialReason> for HedgeDecisionReason {
+    fn from(reason: HedgePolicyDenialReason) -> Self {
+        match reason {
+            HedgePolicyDenialReason::HedgingDisabled => Self::HedgingDisabled,
+            HedgePolicyDenialReason::PrimaryRequestCompleted => Self::PrimaryCompleted,
+            HedgePolicyDenialReason::RequestBodyNotReplayable => Self::RequestBodyNotReplayable,
+            HedgePolicyDenialReason::TunnelRequest => Self::TunnelRequest,
+            HedgePolicyDenialReason::MethodNotAllowed => Self::MethodNotAllowed,
+            HedgePolicyDenialReason::AlternateBackendUnavailable(_) => {
+                Self::AlternateBackendUnavailable
+            }
+            HedgePolicyDenialReason::BudgetDenied => Self::HedgeBudgetDenied,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -544,5 +647,76 @@ mod tests {
     #[test]
     fn empty_event_context_renders_nothing() {
         assert_eq!(OperationalEventContext::new().to_string(), "");
+    }
+
+    #[test]
+    fn local_rejection_maps_to_canonical_request_outcome() {
+        use crate::runtime::connection::stream::RejectionReason;
+        assert_eq!(
+            RequestOutcomeReason::from(RejectionReason::AuthDenied),
+            RequestOutcomeReason::AuthDenied
+        );
+        assert_eq!(
+            RequestOutcomeReason::from(RejectionReason::AuthUnavailable),
+            RequestOutcomeReason::AuthDenied
+        );
+        assert_eq!(
+            RequestOutcomeReason::from(RejectionReason::RequestBodyTooLarge),
+            RequestOutcomeReason::ValidationRejected
+        );
+        assert_eq!(
+            RequestOutcomeReason::from(RejectionReason::ResponsePrebufferCap),
+            RequestOutcomeReason::Overloaded
+        );
+    }
+
+    #[test]
+    fn local_backend_failure_maps_to_canonical_transport_class() {
+        use crate::runtime::connection::stream::BackendFailureReason;
+        assert_eq!(
+            RequestOutcomeReason::from(BackendFailureReason::UpstreamTimeout),
+            RequestOutcomeReason::TimedOut
+        );
+        assert_eq!(
+            RequestOutcomeReason::from(BackendFailureReason::UpstreamTls),
+            RequestOutcomeReason::BackendTlsFailed
+        );
+        assert_eq!(
+            RequestOutcomeReason::from(BackendFailureReason::UpstreamProtocol),
+            RequestOutcomeReason::BackendProtocolFailed
+        );
+        assert_eq!(
+            RequestOutcomeReason::from(BackendFailureReason::UpstreamBridge),
+            RequestOutcomeReason::BackendBridgeFailed
+        );
+        assert_eq!(
+            RequestOutcomeReason::from(BackendFailureReason::DispatchSpawnFailed),
+            RequestOutcomeReason::BackendTransportFailed
+        );
+    }
+
+    #[test]
+    fn retry_and_hedge_denials_map_to_canonical_reasons() {
+        use spooky_errors::{HedgePolicyDenialReason, RetryPolicyDenialReason, UpstreamRetryReason};
+        assert_eq!(
+            RetryDecisionReason::from(UpstreamRetryReason::Timeout),
+            RetryDecisionReason::UpstreamTimeout
+        );
+        assert_eq!(
+            RetryDecisionReason::from(RetryPolicyDenialReason::BudgetDenied),
+            RetryDecisionReason::RetryBudgetDenied
+        );
+        assert_eq!(
+            RetryDecisionReason::from(RetryPolicyDenialReason::MethodNotIdempotent),
+            RetryDecisionReason::IdempotencyDenied
+        );
+        assert_eq!(
+            HedgeDecisionReason::from(HedgePolicyDenialReason::TunnelRequest),
+            HedgeDecisionReason::TunnelRequest
+        );
+        assert_eq!(
+            HedgeDecisionReason::from(HedgePolicyDenialReason::BudgetDenied),
+            HedgeDecisionReason::HedgeBudgetDenied
+        );
     }
 }

--- a/crates/edge/src/observability/mod.rs
+++ b/crates/edge/src/observability/mod.rs
@@ -452,6 +452,58 @@ mod tests {
     }
 
     #[test]
+    fn metrics_overload_reason_routes_through_canonical_vocabulary() {
+        // obs Phase 2 (step 5): the metrics `reason=` label must come from the
+        // canonical vocabulary. Every OverloadShedReason maps to a canonical cause
+        // whose slug is the emitted label.
+        use crate::metrics::OverloadShedReason;
+        let cases = [
+            (OverloadShedReason::Brownout, AdmissionOverloadCause::Brownout),
+            (
+                OverloadShedReason::AdaptiveAdmission,
+                AdmissionOverloadCause::AdaptiveAdmission,
+            ),
+            (OverloadShedReason::RouteCap, AdmissionOverloadCause::RouteCap),
+            (
+                OverloadShedReason::RouteGlobalCap,
+                AdmissionOverloadCause::RouteGlobalCap,
+            ),
+            (
+                OverloadShedReason::GlobalInflight,
+                AdmissionOverloadCause::GlobalInflight,
+            ),
+            (
+                OverloadShedReason::UpstreamInflight,
+                AdmissionOverloadCause::UpstreamInflight,
+            ),
+            (
+                OverloadShedReason::BackendInflight,
+                AdmissionOverloadCause::BackendInflight,
+            ),
+            (
+                OverloadShedReason::CircuitOpen,
+                AdmissionOverloadCause::CircuitOpen,
+            ),
+            (
+                OverloadShedReason::RequestBufferCap,
+                AdmissionOverloadCause::RequestBufferCap,
+            ),
+            (
+                OverloadShedReason::ResponsePrebufferCap,
+                AdmissionOverloadCause::ResponsePrebufferCap,
+            ),
+            (
+                OverloadShedReason::ConnectionCap,
+                AdmissionOverloadCause::ConnectionCap,
+            ),
+        ];
+        for (reason, cause) in cases {
+            assert_eq!(reason.canonical(), cause);
+            assert_eq!(reason.reason_label(), cause.slug());
+        }
+    }
+
+    #[test]
     fn overload_cause_slugs_match_legacy_metric_labels() {
         // These must stay byte-identical to `OverloadShedReason` labels so a later
         // migration of the overload emitter does not change the `reason=` series.

--- a/crates/edge/src/observability/mod.rs
+++ b/crates/edge/src/observability/mod.rs
@@ -17,6 +17,110 @@
 //!
 //! A reader should be able to understand the intended reason vocabularies and
 //! field names from this one module without reading any emitter.
+//!
+//! # Operational observability schema reference (obs plan, Phase 9)
+//!
+//! This is the stable source of truth for dashboard/alert consumers. For each
+//! canonical reason family: the enum value, its `slug()` (which is the metric
+//! label value, the structured-log `reason=` value, and the control-API string —
+//! one string per concept across all three surfaces).
+//!
+//! ## Request outcome — [`RequestOutcomeReason`]
+//!
+//! | enum value | slug (metric / log / control-API) | coarse `outcome` label |
+//! |---|---|---|
+//! | `Completed` | `completed` | `success` |
+//! | `Cancelled` | `cancelled` | `failure` |
+//! | `TimedOut` | `timed_out` | `timeout` |
+//! | `AuthDenied` | `auth_denied` | `failure` |
+//! | `RateLimited` | `rate_limited` | `rate_limited` |
+//! | `Overloaded` | `overloaded` | `overload_shed` |
+//! | `ValidationRejected` | `validation_rejected` | `failure` |
+//! | `BackendTransportFailed` | `backend_transport_failed` | `failure` |
+//! | `BackendProtocolFailed` | `backend_protocol_failed` | `failure` |
+//! | `BackendTlsFailed` | `backend_tls_failed` | `failure` |
+//! | `BackendBridgeFailed` | `backend_bridge_failed` | `failure` |
+//!
+//! ## Backend health — [`BackendHealthReason`]
+//!
+//! | enum value | slug | failure? |
+//! |---|---|---|
+//! | `ActiveProbeSuccess` | `active_probe_success` | no |
+//! | `ActiveProbeFailure` | `active_probe_failure` | yes |
+//! | `PassiveSuccess` | `passive_success` | no |
+//! | `PassiveFailure` | `passive_failure` | yes |
+//! | `DnsRefreshFailed` | `dns_refresh_failed` | yes |
+//! | `EmptyResolutionRetained` | `empty_resolution_retained` | no |
+//! | `PoolPoisoned` | `pool_poisoned` | yes |
+//!
+//! Health-failure *class* (distinct axis, control-API `health_reason` +
+//! `spooky_health_failures_total{reason}`): `5xx`, `timeout`, `transport`,
+//! `tls`, `circuit_open`. Refresh *classification* (distinct axis): `refreshed`,
+//! `unchanged`, `rejected_empty_answer`, `failed_active_preserved`.
+//!
+//! ## Retry — [`RetryDecisionReason`]
+//!
+//! | enum value | slug | retry? |
+//! |---|---|---|
+//! | `UpstreamTimeout` | `upstream_timeout` | yes |
+//! | `UpstreamTransportFailure` | `upstream_transport_failure` | yes |
+//! | `UpstreamProtocolFailure` | `upstream_protocol_failure` | yes |
+//! | `RetryBudgetDenied` | `retry_budget_denied` | no |
+//! | `RetryPolicyDisabled` | `retry_policy_disabled` | no |
+//! | `IdempotencyDenied` | `idempotency_denied` | no |
+//!
+//! ## Hedge — [`HedgeDecisionReason`]
+//!
+//! | enum value | slug | triggered? |
+//! |---|---|---|
+//! | `DelayElapsed` | `delay_elapsed` | yes |
+//! | `HedgingDisabled` | `hedging_disabled` | no |
+//! | `PrimaryCompleted` | `primary_completed` | no |
+//! | `RequestBodyNotReplayable` | `request_body_not_replayable` | no |
+//! | `TunnelRequest` | `tunnel_request` | no |
+//! | `MethodNotAllowed` | `method_not_allowed` | no |
+//! | `AlternateBackendUnavailable` | `alternate_backend_unavailable` | no |
+//! | `HedgeBudgetDenied` | `hedge_budget_denied` | no |
+//!
+//! ## Admission / auth — [`AdmissionDecisionReason`]
+//!
+//! | enum value | slug |
+//! |---|---|
+//! | `AuthDenied` | `auth_denied` |
+//! | `AuthUnavailable` | `auth_unavailable` |
+//! | `RateLimited` | `rate_limited` |
+//! | `Overloaded` | `overloaded` (cause axis: [`AdmissionOverloadCause`]) |
+//! | `ValidationRejected` | `validation_rejected` |
+//! | `PolicyRejected` | `policy_rejected` |
+//!
+//! Overload cause ([`AdmissionOverloadCause`], the `spooky_overload_shed_by_reason_total{reason}`
+//! label): `brownout`, `adaptive_admission`, `route_cap`, `route_global_cap`,
+//! `global_inflight`, `upstream_inflight`, `backend_inflight`, `circuit_open`,
+//! `request_buffer_cap`, `response_prebuffer_cap`, `connection_cap`.
+//!
+//! ## Required dimensions per event class
+//!
+//! Emitted via [`OperationalEventContext`] (canonical field names). `request_id`
+//! is omitted (not `unassigned`) when no id exists yet.
+//!
+//! - **request / forwarding**: `request_id`, `upstream`, `backend`, `reason`,
+//!   `failure_class`, status
+//! - **backend lifecycle**: `backend`, `health_reason` (or refresh classification)
+//! - **retry / hedge**: `request_id`, `upstream`, `backend`, `decision`, `reason`
+//! - **admission / auth**: `request_id` (when known), `upstream`, `reason`
+//!
+//! ## Deprecated names / migration notes
+//!
+//! Superseded by the canonical field names above; dashboards keying on the old
+//! strings must migrate:
+//! - log field `route=` and `route_upstream=` → **`upstream=`**.
+//! - literal `request_id=unassigned` → field **omitted** when no id exists.
+//! - `Bootstrap request route=…` / `Bootstrap upstream error …` prose → the
+//!   canonical `admission denied: …` / `upstream failure: …` schemas.
+//! - `Backend <addr> became healthy/unhealthy` → `backend health transition:
+//!   backend=<addr> health_reason=…`.
+//! - Metric series names (`spooky_*`) are unchanged; only label *values* are now
+//!   canonical enum slugs.
 
 use std::fmt;
 

--- a/crates/edge/src/observability/mod.rs
+++ b/crates/edge/src/observability/mod.rs
@@ -351,9 +351,7 @@ impl RetryDecisionReason {
     pub fn is_retry(self) -> bool {
         matches!(
             self,
-            Self::UpstreamTimeout
-                | Self::UpstreamTransportFailure
-                | Self::UpstreamProtocolFailure
+            Self::UpstreamTimeout | Self::UpstreamTransportFailure | Self::UpstreamProtocolFailure
         )
     }
 }
@@ -721,12 +719,18 @@ mod tests {
         // whose slug is the emitted label.
         use crate::metrics::OverloadShedReason;
         let cases = [
-            (OverloadShedReason::Brownout, AdmissionOverloadCause::Brownout),
+            (
+                OverloadShedReason::Brownout,
+                AdmissionOverloadCause::Brownout,
+            ),
             (
                 OverloadShedReason::AdaptiveAdmission,
                 AdmissionOverloadCause::AdaptiveAdmission,
             ),
-            (OverloadShedReason::RouteCap, AdmissionOverloadCause::RouteCap),
+            (
+                OverloadShedReason::RouteCap,
+                AdmissionOverloadCause::RouteCap,
+            ),
             (
                 OverloadShedReason::RouteGlobalCap,
                 AdmissionOverloadCause::RouteGlobalCap,
@@ -770,7 +774,10 @@ mod tests {
     fn overload_cause_slugs_match_legacy_metric_labels() {
         // These must stay byte-identical to `OverloadShedReason` labels so a later
         // migration of the overload emitter does not change the `reason=` series.
-        assert_eq!(AdmissionOverloadCause::GlobalInflight.slug(), "global_inflight");
+        assert_eq!(
+            AdmissionOverloadCause::GlobalInflight.slug(),
+            "global_inflight"
+        );
         assert_eq!(
             AdmissionOverloadCause::ResponsePrebufferCap.slug(),
             "response_prebuffer_cap"
@@ -779,8 +786,14 @@ mod tests {
 
     #[test]
     fn request_outcome_coarse_label_matches_legacy_buckets() {
-        assert_eq!(RequestOutcomeReason::Completed.coarse_outcome_label(), "success");
-        assert_eq!(RequestOutcomeReason::TimedOut.coarse_outcome_label(), "timeout");
+        assert_eq!(
+            RequestOutcomeReason::Completed.coarse_outcome_label(),
+            "success"
+        );
+        assert_eq!(
+            RequestOutcomeReason::TimedOut.coarse_outcome_label(),
+            "timeout"
+        );
         assert_eq!(
             RequestOutcomeReason::Overloaded.coarse_outcome_label(),
             "overload_shed"
@@ -931,14 +944,19 @@ mod tests {
         // admission logs are the canonical AdmissionDecisionReason slugs. This
         // guards those hand-written literals against enum drift.
         assert_eq!(AdmissionDecisionReason::AuthDenied.slug(), "auth_denied");
-        assert_eq!(AdmissionDecisionReason::AuthUnavailable.slug(), "auth_unavailable");
+        assert_eq!(
+            AdmissionDecisionReason::AuthUnavailable.slug(),
+            "auth_unavailable"
+        );
         assert_eq!(AdmissionDecisionReason::RateLimited.slug(), "rate_limited");
         assert_eq!(AdmissionDecisionReason::Overloaded.slug(), "overloaded");
     }
 
     #[test]
     fn retry_and_hedge_denials_map_to_canonical_reasons() {
-        use spooky_errors::{HedgePolicyDenialReason, RetryPolicyDenialReason, UpstreamRetryReason};
+        use spooky_errors::{
+            HedgePolicyDenialReason, RetryPolicyDenialReason, UpstreamRetryReason,
+        };
         assert_eq!(
             RetryDecisionReason::from(UpstreamRetryReason::Timeout),
             RetryDecisionReason::UpstreamTimeout

--- a/crates/edge/src/observability/mod.rs
+++ b/crates/edge/src/observability/mod.rs
@@ -1,22 +1,18 @@
-//! Canonical observability vocabulary (obs plan, Phase 1).
+//! Canonical observability vocabulary.
 //!
 //! This module is the **single, handler-free schema** for the operational reason
-//! vocabularies frozen in Phase 0 (`obs-phase0.md`). Phase 0 found the same
-//! concept named differently across metrics, logs, and control-plane JSON — and
-//! two parallel terminal vocabularies (the QUIC data path vs. bootstrap) with no
-//! shared slug. This module defines the canonical enums *once*, along with a
-//! single mapping layer that produces the stable string each surface should use.
+//! vocabularies. It defines each canonical enum *once*, with one `slug()` per
+//! concept that is the stable string used across all three observability
+//! surfaces — metric label value, structured-log `reason=` value, and
+//! control-API serialized value. The `From` mappings below tie every local
+//! reason enum (QUIC data path, bootstrap, retry/hedge, admission, backend
+//! health) to this canonical vocabulary, so one operational concept is described
+//! one way everywhere.
 //!
-//! # Phase 1 scope
-//!
-//! This layer introduces **no behavioral change**. Existing emitters keep their
-//! current strings; new code is expected to route through these types, and later
-//! phases migrate the old emitters onto them. The mapping methods here are the
-//! intended canonical strings — where they intentionally differ from a legacy
-//! string, that is called out in a doc comment so the migration is explicit.
-//!
-//! A reader should be able to understand the intended reason vocabularies and
-//! field names from this one module without reading any emitter.
+//! This is the source of truth for dashboard and alert consumers: a reader can
+//! understand the reason vocabularies and canonical field names from this one
+//! module without reading any emitter, and the mapping tests guarantee emitters
+//! cannot drift from it.
 //!
 //! # Operational observability schema reference (obs plan, Phase 9)
 //!
@@ -262,10 +258,9 @@ pub enum AdmissionOverloadCause {
 // Stable string mapping layer (enum -> metric label / log value / control API)
 // ---------------------------------------------------------------------------
 //
-// Each canonical enum exposes exactly one `slug()`. The design decision for
-// Phase 1 is that a single stable slug serves all three surfaces — this is what
-// closes the Phase 0 gap where one concept had three names. Where a surface
-// historically used a different string, the migration comment records it.
+// Each canonical enum exposes exactly one `slug()`: a single stable string that
+// serves all three surfaces (metric label, log value, control-API string), so
+// one concept has exactly one name.
 
 impl RequestOutcomeReason {
     /// The canonical stable slug for metrics labels, log values, and control-API

--- a/crates/edge/src/observability/mod.rs
+++ b/crates/edge/src/observability/mod.rs
@@ -490,6 +490,51 @@ impl From<RetryPolicyDenialReason> for RetryDecisionReason {
     }
 }
 
+/// Backend health observation (source + outcome) → canonical backend health
+/// reason (obs Phase 8). This is the health axis: active vs passive probe,
+/// success vs failure. `Neutral` observations are not a health *reason* (they
+/// neither confirm nor fault the backend), so they return `None`.
+pub fn backend_health_reason(
+    source: crate::runtime::backend::event::BackendHealthObservationSource,
+    outcome: crate::runtime::backend::event::BackendHealthObservationOutcome,
+) -> Option<BackendHealthReason> {
+    use crate::runtime::backend::event::{
+        BackendHealthObservationOutcome as O, BackendHealthObservationSource as S,
+    };
+    match (source, outcome) {
+        (S::ActiveCheck, O::Success) => Some(BackendHealthReason::ActiveProbeSuccess),
+        (S::ActiveCheck, O::Failure) => Some(BackendHealthReason::ActiveProbeFailure),
+        (S::PassiveRequest | S::RequestCompletion, O::Success) => {
+            Some(BackendHealthReason::PassiveSuccess)
+        }
+        (S::PassiveRequest | S::RequestCompletion, O::Failure) => {
+            Some(BackendHealthReason::PassiveFailure)
+        }
+        // Control-plane driven observations are administrative, not probe health;
+        // and any Neutral outcome carries no health reason.
+        (S::ControlPlane, _) | (_, O::Neutral) => None,
+    }
+}
+
+/// Backend DNS-refresh classification → canonical backend health reason
+/// (obs Phase 8). This is the *resolution/refresh* axis, kept distinct from the
+/// probe-health axis above (Phase 8 step 4). Only the failure classifications
+/// carry a health reason; a successful/unchanged refresh does not.
+impl From<crate::runtime::backend::lifecycle::BackendRefreshClassification>
+    for Option<BackendHealthReason>
+{
+    fn from(
+        classification: crate::runtime::backend::lifecycle::BackendRefreshClassification,
+    ) -> Self {
+        use crate::runtime::backend::lifecycle::BackendRefreshClassification as C;
+        match classification {
+            C::Rejected => Some(BackendHealthReason::EmptyResolutionRetained),
+            C::FailedActivePreserved => Some(BackendHealthReason::DnsRefreshFailed),
+            C::Refreshed | C::Unchanged => None,
+        }
+    }
+}
+
 /// Admission outcome class → canonical admission decision reason (obs Phase 7).
 /// The single vocabulary both forwarding and bootstrap resolve admission denials
 /// through. `Failed { timed_out }` is a richer subtype: a timeout maps to the
@@ -709,6 +754,52 @@ mod tests {
             RequestOutcomeReason::from(BackendFailureReason::DispatchSpawnFailed),
             RequestOutcomeReason::BackendTransportFailed
         );
+    }
+
+    #[test]
+    fn backend_health_observation_maps_to_canonical_health_reason() {
+        use crate::runtime::backend::event::{
+            BackendHealthObservationOutcome as O, BackendHealthObservationSource as S,
+        };
+        assert_eq!(
+            backend_health_reason(S::ActiveCheck, O::Success),
+            Some(BackendHealthReason::ActiveProbeSuccess)
+        );
+        assert_eq!(
+            backend_health_reason(S::ActiveCheck, O::Failure),
+            Some(BackendHealthReason::ActiveProbeFailure)
+        );
+        assert_eq!(
+            backend_health_reason(S::PassiveRequest, O::Failure),
+            Some(BackendHealthReason::PassiveFailure)
+        );
+        assert_eq!(
+            backend_health_reason(S::RequestCompletion, O::Success),
+            Some(BackendHealthReason::PassiveSuccess)
+        );
+        // Neutral and control-plane observations carry no health reason.
+        assert_eq!(backend_health_reason(S::ActiveCheck, O::Neutral), None);
+        assert_eq!(backend_health_reason(S::ControlPlane, O::Success), None);
+    }
+
+    #[test]
+    fn refresh_classification_maps_only_failures_to_health_reason() {
+        use crate::runtime::backend::lifecycle::BackendRefreshClassification as C;
+        // Refresh axis is distinct from probe-health axis: only failures map.
+        assert_eq!(
+            Option::<BackendHealthReason>::from(C::FailedActivePreserved),
+            Some(BackendHealthReason::DnsRefreshFailed)
+        );
+        assert_eq!(
+            Option::<BackendHealthReason>::from(C::Rejected),
+            Some(BackendHealthReason::EmptyResolutionRetained)
+        );
+        assert_eq!(Option::<BackendHealthReason>::from(C::Refreshed), None);
+        assert_eq!(Option::<BackendHealthReason>::from(C::Unchanged), None);
+        // The failure health-reasons are themselves classified as failures.
+        assert!(BackendHealthReason::DnsRefreshFailed.is_failure());
+        assert!(BackendHealthReason::PassiveFailure.is_failure());
+        assert!(!BackendHealthReason::ActiveProbeSuccess.is_failure());
     }
 
     #[test]

--- a/crates/edge/src/observability/mod.rs
+++ b/crates/edge/src/observability/mod.rs
@@ -490,6 +490,22 @@ impl From<RetryPolicyDenialReason> for RetryDecisionReason {
     }
 }
 
+/// Admission outcome class → canonical admission decision reason (obs Phase 7).
+/// The single vocabulary both forwarding and bootstrap resolve admission denials
+/// through. `Failed { timed_out }` is a richer subtype: a timeout maps to the
+/// generic policy rejection here (the timeout axis is carried elsewhere).
+impl From<crate::runtime::connection::outcome::AdmissionOutcomeClass> for AdmissionDecisionReason {
+    fn from(outcome: crate::runtime::connection::outcome::AdmissionOutcomeClass) -> Self {
+        use crate::runtime::connection::outcome::AdmissionOutcomeClass as A;
+        match outcome {
+            A::AuthDenied => Self::AuthDenied,
+            A::RateLimited => Self::RateLimited,
+            A::OverloadShed { .. } => Self::Overloaded,
+            A::Failed { .. } => Self::PolicyRejected,
+        }
+    }
+}
+
 /// Hedge denial → canonical hedge decision reason. Alias / richer subtype.
 impl From<HedgePolicyDenialReason> for HedgeDecisionReason {
     fn from(reason: HedgePolicyDenialReason) -> Self {
@@ -693,6 +709,41 @@ mod tests {
             RequestOutcomeReason::from(BackendFailureReason::DispatchSpawnFailed),
             RequestOutcomeReason::BackendTransportFailed
         );
+    }
+
+    #[test]
+    fn admission_outcome_maps_to_canonical_decision_reason() {
+        use crate::metrics::OverloadShedReason;
+        use crate::runtime::connection::outcome::AdmissionOutcomeClass;
+        assert_eq!(
+            AdmissionDecisionReason::from(AdmissionOutcomeClass::AuthDenied),
+            AdmissionDecisionReason::AuthDenied
+        );
+        assert_eq!(
+            AdmissionDecisionReason::from(AdmissionOutcomeClass::RateLimited),
+            AdmissionDecisionReason::RateLimited
+        );
+        assert_eq!(
+            AdmissionDecisionReason::from(AdmissionOutcomeClass::OverloadShed {
+                reason: Some(OverloadShedReason::GlobalInflight)
+            }),
+            AdmissionDecisionReason::Overloaded
+        );
+        assert_eq!(
+            AdmissionDecisionReason::from(AdmissionOutcomeClass::Failed { timed_out: true }),
+            AdmissionDecisionReason::PolicyRejected
+        );
+    }
+
+    #[test]
+    fn admission_log_reason_literals_match_canonical_slugs() {
+        // obs Phase 7: the `reason=` values emitted by the forwarding/bootstrap
+        // admission logs are the canonical AdmissionDecisionReason slugs. This
+        // guards those hand-written literals against enum drift.
+        assert_eq!(AdmissionDecisionReason::AuthDenied.slug(), "auth_denied");
+        assert_eq!(AdmissionDecisionReason::AuthUnavailable.slug(), "auth_unavailable");
+        assert_eq!(AdmissionDecisionReason::RateLimited.slug(), "rate_limited");
+        assert_eq!(AdmissionDecisionReason::Overloaded.slug(), "overloaded");
     }
 
     #[test]

--- a/crates/edge/src/quic_listener/bootstrap/outcome.rs
+++ b/crates/edge/src/quic_listener/bootstrap/outcome.rs
@@ -131,7 +131,7 @@ pub(in crate::quic_listener) fn observe_bootstrap_dispatch_failure(
         );
     } else {
         log::warn!(
-            "Bootstrap upstream error route={} backend={}: {}",
+            "upstream failure: upstream={} backend={} failure_class=unclassified detail={}",
             prepared_route.upstream_name,
             prepared_route.backend_addr,
             proxy_err

--- a/crates/edge/src/quic_listener/bootstrap/request.rs
+++ b/crates/edge/src/quic_listener/bootstrap/request.rs
@@ -739,7 +739,9 @@ mod tests {
         assert_eq!(
             BootstrapTerminalOutcome::Rejected(BootstrapRejectionReason::ValidationFailed)
                 .canonical_reason(),
-            Some(RequestOutcomeReason::from(RejectionReason::ValidationFailed))
+            Some(RequestOutcomeReason::from(
+                RejectionReason::ValidationFailed
+            ))
         );
         // Backend dispatch failure ↔ QUIC transport failure.
         assert_eq!(

--- a/crates/edge/src/quic_listener/bootstrap/request.rs
+++ b/crates/edge/src/quic_listener/bootstrap/request.rs
@@ -129,6 +129,36 @@ impl BootstrapTerminalOutcome {
         )
     }
 
+    /// The canonical request-outcome reason for this bootstrap terminal (obs
+    /// Phase 10). Ties the bootstrap terminal vocabulary to the *same* canonical
+    /// enum the QUIC data path resolves through, so equivalent outcomes on both
+    /// planes report one reason. `None` for accepted outcomes (which are not a
+    /// failure reason). Test-only for now — it enforces the cross-plane contract
+    /// until an emitter consumes it.
+    #[cfg(test)]
+    pub(in crate::quic_listener) fn canonical_reason(
+        self,
+    ) -> Option<crate::observability::RequestOutcomeReason> {
+        use crate::observability::RequestOutcomeReason as R;
+        Some(match self {
+            Self::AcceptedStandardResponse | Self::AcceptedWebsocketUpgrade => return None,
+            Self::Rejected(reason) => match reason {
+                BootstrapRejectionReason::AuthDenied => R::AuthDenied,
+                BootstrapRejectionReason::RateLimited => R::RateLimited,
+                BootstrapRejectionReason::Overloaded => R::Overloaded,
+                BootstrapRejectionReason::ValidationFailed
+                | BootstrapRejectionReason::RequestBodyTooLarge => R::ValidationRejected,
+            },
+            Self::BackendFailed(reason) => match reason {
+                BootstrapBackendFailureReason::RouteResolutionFailed
+                | BootstrapBackendFailureReason::MissingEndpoint
+                | BootstrapBackendFailureReason::RequestBuildFailed
+                | BootstrapBackendFailureReason::DispatchFailed => R::BackendTransportFailed,
+            },
+            Self::TimedOut(_) => R::TimedOut,
+        })
+    }
+
     /// A stable slug naming the terminal classification, aligned with the
     /// terminal-state names used in the QUIC data path.
     pub(in crate::quic_listener) fn slug(self) -> &'static str {
@@ -677,5 +707,59 @@ mod tests {
     fn websocket_upgrade_is_a_request_mode_state() {
         assert!(BootstrapRequestMode::WebsocketUpgrade.is_websocket_upgrade());
         assert!(!BootstrapRequestMode::Standard.is_websocket_upgrade());
+    }
+
+    #[test]
+    fn bootstrap_and_quic_terminals_resolve_to_same_canonical_reason() {
+        // obs Phase 10 (step 1): equivalent outcomes on the bootstrap and QUIC
+        // data planes must report the SAME canonical reason — closing Phase 0
+        // finding #1 (two parallel terminal vocabularies).
+        use crate::observability::RequestOutcomeReason;
+        use crate::runtime::connection::stream::{BackendFailureReason, RejectionReason};
+
+        // Auth denied.
+        assert_eq!(
+            BootstrapTerminalOutcome::Rejected(BootstrapRejectionReason::AuthDenied)
+                .canonical_reason(),
+            Some(RequestOutcomeReason::from(RejectionReason::AuthDenied))
+        );
+        // Rate limited.
+        assert_eq!(
+            BootstrapTerminalOutcome::Rejected(BootstrapRejectionReason::RateLimited)
+                .canonical_reason(),
+            Some(RequestOutcomeReason::from(RejectionReason::RateLimited))
+        );
+        // Overloaded.
+        assert_eq!(
+            BootstrapTerminalOutcome::Rejected(BootstrapRejectionReason::Overloaded)
+                .canonical_reason(),
+            Some(RequestOutcomeReason::from(RejectionReason::Overloaded))
+        );
+        // Validation.
+        assert_eq!(
+            BootstrapTerminalOutcome::Rejected(BootstrapRejectionReason::ValidationFailed)
+                .canonical_reason(),
+            Some(RequestOutcomeReason::from(RejectionReason::ValidationFailed))
+        );
+        // Backend dispatch failure ↔ QUIC transport failure.
+        assert_eq!(
+            BootstrapTerminalOutcome::BackendFailed(BootstrapBackendFailureReason::DispatchFailed)
+                .canonical_reason(),
+            Some(RequestOutcomeReason::from(
+                BackendFailureReason::UpstreamTransport
+            ))
+        );
+        // Upstream timeout.
+        assert_eq!(
+            BootstrapTerminalOutcome::TimedOut(BootstrapTimeoutReason::Upstream).canonical_reason(),
+            Some(RequestOutcomeReason::from(
+                BackendFailureReason::UpstreamTimeout
+            ))
+        );
+        // Accepted outcomes carry no failure reason on either plane.
+        assert_eq!(
+            BootstrapTerminalOutcome::AcceptedStandardResponse.canonical_reason(),
+            None
+        );
     }
 }

--- a/crates/edge/src/quic_listener/bootstrap/request.rs
+++ b/crates/edge/src/quic_listener/bootstrap/request.rs
@@ -386,12 +386,12 @@ pub(in crate::quic_listener) fn evaluate_bootstrap_request_policy(
                 AdmissionOutcomeClass::AuthDenied,
             );
             warn!(
-                "Bootstrap request route={} denied by auth policy",
+                "admission denied: upstream={} reason=auth_denied",
                 resolved.upstream_name
             );
             let Some(response) = rejection_response.as_ref() else {
                 warn!(
-                    "Bootstrap request route={} missing admission rejection response for unauthorized decision",
+                    "admission rejection response missing: upstream={} reason=auth_denied",
                     resolved.upstream_name
                 );
                 return Err(BootstrapTerminalResponse::new(
@@ -402,7 +402,7 @@ pub(in crate::quic_listener) fn evaluate_bootstrap_request_policy(
             };
             let Some(challenge) = response.www_authenticate else {
                 warn!(
-                    "Bootstrap request route={} missing auth challenge in admission rejection response",
+                    "admission rejection response missing: upstream={} reason=auth_denied detail=missing_auth_challenge",
                     resolved.upstream_name
                 );
                 return Err(BootstrapTerminalResponse::new(
@@ -434,12 +434,12 @@ pub(in crate::quic_listener) fn evaluate_bootstrap_request_policy(
                 AdmissionOutcomeClass::RateLimited,
             );
             warn!(
-                "Bootstrap request route={} scoped rate limit exceeded by rule={}",
+                "admission denied: upstream={} reason=rate_limited rule={}",
                 decision.route, decision.rule_name
             );
             let Some(response) = rejection_response.as_ref() else {
                 warn!(
-                    "Bootstrap request route={} missing admission rejection response for rate-limited decision",
+                    "admission rejection response missing: upstream={} reason=rate_limited",
                     resolved.upstream_name
                 );
                 return Err(BootstrapTerminalResponse::new(
@@ -450,7 +450,7 @@ pub(in crate::quic_listener) fn evaluate_bootstrap_request_policy(
             };
             let Some(retry_after_seconds) = response.retry_after_seconds else {
                 warn!(
-                    "Bootstrap request route={} missing retry-after in rate-limited admission rejection response",
+                    "admission rejection response missing: upstream={} reason=rate_limited detail=missing_retry_after",
                     resolved.upstream_name
                 );
                 return Err(BootstrapTerminalResponse::new(
@@ -490,7 +490,7 @@ pub(in crate::quic_listener) fn evaluate_bootstrap_request_policy(
                 .observe(input.request_ctx.request_start.elapsed(), true);
             let Some(response) = rejection_response.as_ref() else {
                 warn!(
-                    "Bootstrap request route={} missing admission rejection response for overload decision",
+                    "admission rejection response missing: upstream={} reason=overloaded",
                     resolved.upstream_name
                 );
                 return Err(BootstrapTerminalResponse::new(
@@ -501,7 +501,7 @@ pub(in crate::quic_listener) fn evaluate_bootstrap_request_policy(
             };
             let Some(retry_after_seconds) = response.retry_after_seconds else {
                 warn!(
-                    "Bootstrap request route={} missing retry-after in overload admission rejection response",
+                    "admission rejection response missing: upstream={} reason=overloaded detail=missing_retry_after",
                     resolved.upstream_name
                 );
                 return Err(BootstrapTerminalResponse::new(

--- a/crates/edge/src/quic_listener/control_api/render.rs
+++ b/crates/edge/src/quic_listener/control_api/render.rs
@@ -9,6 +9,22 @@ use crate::runtime::backend::state::{
     BackendHealthState, BackendLifecycleInventorySnapshot, BackendMembershipState,
     BackendPoolPlacementSnapshot,
 };
+use spooky_lb::health::HealthFailureReason;
+
+/// Map a backend health-failure reason to the canonical control-plane token.
+///
+/// These are the same tokens as the `spooky_health_failures_total{reason=…}`
+/// metric label (obs Phase 4), so control-plane JSON and metrics name the failure
+/// the same way.
+fn health_failure_reason_label(reason: HealthFailureReason) -> &'static str {
+    match reason {
+        HealthFailureReason::HttpStatus5xx => "5xx",
+        HealthFailureReason::Timeout => "timeout",
+        HealthFailureReason::Transport => "transport",
+        HealthFailureReason::Tls => "tls",
+        HealthFailureReason::CircuitOpen => "circuit_open",
+    }
+}
 
 #[derive(Serialize)]
 struct ControlApiHealthPayload {
@@ -78,6 +94,12 @@ struct ControlApiBackendInventoryPayload {
 struct ControlApiBackendLifecyclePayload {
     backend: String,
     health: &'static str,
+    /// Canonical health-failure reason when the backend is unhealthy and a
+    /// reason is known. Uses the same tokens as `spooky_health_failures_total`'s
+    /// `reason=` label (obs Phase 4), so operators do not translate between the
+    /// control-plane JSON and the metric. Omitted when healthy / reason unknown.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    health_reason: Option<&'static str>,
     membership: &'static str,
     authority_host: String,
     authority_port: u16,
@@ -298,6 +320,12 @@ impl ControlApiBackendInventoryPayload {
                         BackendHealthState::Healthy => "healthy",
                         BackendHealthState::Unhealthy { .. } => "unhealthy",
                     },
+                    health_reason: match backend.health {
+                        BackendHealthState::Unhealthy { reason: Some(reason) } => {
+                            Some(health_failure_reason_label(reason))
+                        }
+                        _ => None,
+                    },
                     membership: match backend.membership {
                         BackendMembershipState::Active => "active",
                         BackendMembershipState::Suppressed => "suppressed",
@@ -340,5 +368,61 @@ impl ControlApiBackendPlacementPayload {
             ewma_latency_ms: snapshot.ewma_latency_ms,
             membership_epoch: snapshot.membership_epoch,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn health_reason_labels_match_metric_reason_tokens() {
+        // obs Phase 4: control-plane `health_reason` must use the same tokens as
+        // the `spooky_health_failures_total{reason=…}` metric label so operators
+        // don't translate between surfaces.
+        assert_eq!(
+            health_failure_reason_label(HealthFailureReason::HttpStatus5xx),
+            "5xx"
+        );
+        assert_eq!(
+            health_failure_reason_label(HealthFailureReason::Timeout),
+            "timeout"
+        );
+        assert_eq!(
+            health_failure_reason_label(HealthFailureReason::Transport),
+            "transport"
+        );
+        assert_eq!(health_failure_reason_label(HealthFailureReason::Tls), "tls");
+        assert_eq!(
+            health_failure_reason_label(HealthFailureReason::CircuitOpen),
+            "circuit_open"
+        );
+    }
+
+    #[test]
+    fn backend_payload_serializes_health_reason_when_present() {
+        // The field appears only when unhealthy with a known reason, and is
+        // omitted otherwise (skip_serializing_if).
+        let with_reason = ControlApiBackendLifecyclePayload {
+            backend: "b".to_string(),
+            health: "unhealthy",
+            health_reason: Some("timeout"),
+            membership: "active",
+            authority_host: "h".to_string(),
+            authority_port: 443,
+            resolved_addrs: vec![],
+            resolution_generation: 0,
+            last_refresh_success_at_unix_seconds: None,
+            placements: vec![],
+        };
+        let json = serde_json::to_string(&with_reason).expect("serialize");
+        assert!(json.contains("\"health_reason\":\"timeout\""));
+
+        let without = ControlApiBackendLifecyclePayload {
+            health_reason: None,
+            ..with_reason
+        };
+        let json = serde_json::to_string(&without).expect("serialize");
+        assert!(!json.contains("health_reason"));
     }
 }

--- a/crates/edge/src/quic_listener/control_api/render.rs
+++ b/crates/edge/src/quic_listener/control_api/render.rs
@@ -321,9 +321,9 @@ impl ControlApiBackendInventoryPayload {
                         BackendHealthState::Unhealthy { .. } => "unhealthy",
                     },
                     health_reason: match backend.health {
-                        BackendHealthState::Unhealthy { reason: Some(reason) } => {
-                            Some(health_failure_reason_label(reason))
-                        }
+                        BackendHealthState::Unhealthy {
+                            reason: Some(reason),
+                        } => Some(health_failure_reason_label(reason)),
                         _ => None,
                     },
                     membership: match backend.membership {

--- a/crates/edge/src/quic_listener/forwarding/auth.rs
+++ b/crates/edge/src/quic_listener/forwarding/auth.rs
@@ -488,7 +488,7 @@ impl QUICListener {
                     AdmissionOutcomeClass::AuthDenied,
                 );
                 warn!(
-                    "request_id={} route={} external auth denied with status={}",
+                    "admission denied: request_id={} upstream={} reason=auth_denied status={}",
                     req.request_id,
                     req.upstream_name.as_deref().unwrap_or("unrouted"),
                     req.response_status.unwrap_or(0)
@@ -509,7 +509,7 @@ impl QUICListener {
                 metrics.inc_external_auth_error();
                 if let Some(error) = &error {
                     debug!(
-                        "request_id={} route={} external auth rejected after error: {:?}",
+                        "admission denied: request_id={} upstream={} reason=auth_unavailable detail={:?}",
                         req.request_id,
                         req.upstream_name.as_deref().unwrap_or("unrouted"),
                         error

--- a/crates/edge/src/quic_listener/forwarding/dispatch.rs
+++ b/crates/edge/src/quic_listener/forwarding/dispatch.rs
@@ -348,7 +348,9 @@ impl QUICListener {
             alternate_backend,
         );
         let (retry_reason, canonical_retry_reason) = match retry_decision {
-            RetryPolicyDecision::Retry { reason } => (reason.into(), RetryDecisionReason::from(reason)),
+            RetryPolicyDecision::Retry { reason } => {
+                (reason.into(), RetryDecisionReason::from(reason))
+            }
             RetryPolicyDecision::DoNotRetry { denial } => {
                 policy_telemetry.retry.record_denial(denial);
                 // Phase 6: canonical operational reason (upstream=, decision=retry)

--- a/crates/edge/src/quic_listener/forwarding/dispatch.rs
+++ b/crates/edge/src/quic_listener/forwarding/dispatch.rs
@@ -8,6 +8,7 @@ use spooky_lb::alternate_backend::{
 };
 
 use super::*;
+use crate::observability::{HedgeDecisionReason, RetryDecisionReason};
 use crate::runtime::connection::response::ForwardingPolicyTelemetry;
 
 const MAX_UPSTREAM_RETRY_ATTEMPTS: u8 = 1;
@@ -346,13 +347,21 @@ impl QUICListener {
             retry_budget_available_for_error(&primary_err, route_name, retry_budget),
             alternate_backend,
         );
-        let retry_reason = match retry_decision {
-            RetryPolicyDecision::Retry { reason } => reason.into(),
+        let (retry_reason, canonical_retry_reason) = match retry_decision {
+            RetryPolicyDecision::Retry { reason } => (reason.into(), RetryDecisionReason::from(reason)),
             RetryPolicyDecision::DoNotRetry { denial } => {
                 policy_telemetry.retry.record_denial(denial);
+                // Phase 6: canonical operational reason (upstream=, decision=retry)
+                // with the raw denial kept as debug-only detail.
+                let reason = denial
+                    .map(RetryDecisionReason::from)
+                    .unwrap_or(RetryDecisionReason::RetryPolicyDisabled);
                 debug!(
-                    "request_id={} retry denied: route={} reason={:?}",
-                    request_id, route_name, denial
+                    "retry decision: request_id={} upstream={} decision=denied reason={} detail={:?}",
+                    request_id,
+                    route_name,
+                    reason.slug(),
+                    denial
                 );
                 return Err(primary_err);
             }
@@ -372,8 +381,11 @@ impl QUICListener {
 
         policy_telemetry.retry.record_attempt(retry_reason);
         info!(
-            "request_id={} retrying request on alternate backend: route={} reason={:?}",
-            request_id, route_name, retry_reason
+            "retry decision: request_id={} upstream={} decision=retry reason={} backend={}",
+            request_id,
+            route_name,
+            canonical_retry_reason.slug(),
+            retry_backend
         );
         Self::send_upstream_request(retry_backend, retry_request, circuit_breakers, transport).await
     }
@@ -541,8 +553,11 @@ impl QUICListener {
                                     HedgePolicyDecision::WaitForPrimary => primary_fut.await?,
                                     HedgePolicyDecision::DoNotHedge { denial } => {
                                         debug!(
-                                            "request_id={} hedge suppressed after delay: route={} reason={:?}",
-                                            request_id, route_name, denial
+                                            "hedge decision: request_id={} upstream={} decision=suppressed reason={} detail={:?}",
+                                            request_id,
+                                            route_name,
+                                            HedgeDecisionReason::from(denial).slug(),
+                                            denial
                                         );
                                         primary_fut.await?
                                     }
@@ -560,8 +575,11 @@ impl QUICListener {
                         }
                         HedgePolicyDecision::DoNotHedge { denial } => {
                             debug!(
-                                "request_id={} hedging disabled for request: route={} reason={:?}",
-                                request_id, route_name, denial
+                                "hedge decision: request_id={} upstream={} decision=denied reason={} detail={:?}",
+                                request_id,
+                                route_name,
+                                HedgeDecisionReason::from(denial).slug(),
+                                denial
                             );
                             match Self::send_upstream_request(
                                 fwd_addr.clone(),
@@ -592,8 +610,11 @@ impl QUICListener {
                         }
                         HedgePolicyDecision::Hedge { reason } => {
                             debug!(
-                                "request_id={} shared hedge policy triggered early: route={} reason={:?}",
-                                request_id, route_name, reason
+                                "hedge decision: request_id={} upstream={} decision=triggered reason={} detail={:?}",
+                                request_id,
+                                route_name,
+                                HedgeDecisionReason::DelayElapsed.slug(),
+                                reason
                             );
                             match Self::send_upstream_request(
                                 fwd_addr.clone(),

--- a/crates/edge/src/quic_listener/forwarding/prepare.rs
+++ b/crates/edge/src/quic_listener/forwarding/prepare.rs
@@ -471,12 +471,12 @@ impl QUICListener {
                             AdmissionOutcomeClass::AuthDenied,
                         );
                         warn!(
-                            "request_id=unassigned route={} denied by local auth policy",
+                            "admission denied: upstream={} reason=auth_denied",
                             upstream_name
                         );
                         let Some(response) = rejection_response.as_ref() else {
                             warn!(
-                                "request_id=unassigned route={} missing admission rejection response for unauthorized decision",
+                                "admission rejection response missing: upstream={} reason=auth_denied",
                                 upstream_name
                             );
                             Self::send_simple_response(
@@ -511,12 +511,12 @@ impl QUICListener {
                             AdmissionOutcomeClass::RateLimited,
                         );
                         warn!(
-                            "request_id=unassigned route={} scoped rate limit exceeded by rule={}",
+                            "admission denied: upstream={} reason=rate_limited rule={}",
                             decision.route, decision.rule_name
                         );
                         let Some(response) = rejection_response.as_ref() else {
                             warn!(
-                                "request_id=unassigned route={} missing admission rejection response for rate-limited decision",
+                                "admission rejection response missing: upstream={} reason=rate_limited",
                                 upstream_name
                             );
                             Self::send_simple_response(
@@ -553,7 +553,7 @@ impl QUICListener {
                         );
                         let Some(response) = rejection_response.as_ref() else {
                             warn!(
-                                "request_id=unassigned route={} missing admission rejection response for overload decision",
+                                "admission rejection response missing: upstream={} reason=overloaded",
                                 upstream_name
                             );
                             Self::send_simple_response(
@@ -708,13 +708,13 @@ impl QUICListener {
                                 metrics.inc_external_auth_error();
                                 if timed_out {
                                     warn!(
-                                        "request_id={} route={} external auth startup failed open: timeout",
+                                        "external auth failed open: request_id={} upstream={} reason=auth_timeout",
                                         request.request.request_id(),
                                         request.request.upstream_name()
                                     );
                                 } else if let Some(error) = error {
                                     warn!(
-                                        "request_id={} route={} external auth startup failed open: {:?}",
+                                        "external auth failed open: request_id={} upstream={} reason=auth_unavailable detail={:?}",
                                         request.request.request_id(),
                                         request.request.upstream_name(),
                                         error
@@ -745,14 +745,14 @@ impl QUICListener {
                                 );
                                 if let Some(error) = error {
                                     error!(
-                                        "request_id={} route={} external auth startup failed: {:?}",
+                                        "admission denied: request_id={} upstream={} reason=auth_unavailable detail={:?}",
                                         request.request.request_id(),
                                         request.request.upstream_name(),
                                         error
                                     );
                                 } else {
                                     error!(
-                                        "request_id={} route={} external auth startup failed",
+                                        "admission denied: request_id={} upstream={} reason=auth_unavailable",
                                         request.request.request_id(),
                                         request.request.upstream_name()
                                     );

--- a/crates/edge/src/runtime/connection/outcome.rs
+++ b/crates/edge/src/runtime/connection/outcome.rs
@@ -796,12 +796,14 @@ pub(crate) fn log_backend_health_transition_result(
 }
 
 pub(crate) fn log_backend_health_transition(addr: &str, transition: &HealthTransition) {
+    // Phase 3: canonical `backend=` field + `health_reason=` slug so backend
+    // health transitions carry the same dimension names as other backend events.
     match transition {
         HealthTransition::BecameHealthy => {
-            info!("Backend {} became healthy", addr);
+            info!("backend health transition: backend={addr} health_reason=became_healthy");
         }
         HealthTransition::BecameUnhealthy => {
-            error!("Backend {} became unhealthy", addr);
+            error!("backend health transition: backend={addr} health_reason=became_unhealthy");
         }
     }
 }

--- a/crates/edge/tests/regression/metrics.rs
+++ b/crates/edge/tests/regression/metrics.rs
@@ -353,3 +353,35 @@ fn metrics_render_includes_downstream_tls_certificate_expiry() {
         "spooky_downstream_tls_certificate_days_remaining{listener=\"127.0.0.1:9889\",server_name=\"api.example.com\"}"
     ));
 }
+
+#[test]
+fn backend_connect_attempt_labels_are_cardinality_bounded() {
+    // obs Phase 2 (step 7): resolved_addr/hostname are otherwise unbounded across
+    // DNS churn. Emitting far more distinct addresses than the cap must not create
+    // an unbounded number of series — overflow folds into a stable sentinel.
+    let metrics = Metrics::default();
+    for i in 0..5_000u32 {
+        let octet_a = (i / 256) % 256;
+        let octet_b = i % 256;
+        let addr = format!("10.{octet_a}.{octet_b}.1:443");
+        metrics.record_backend_connect(
+            "backend.internal:443",
+            "backend.internal",
+            addr.parse().expect("addr"),
+        );
+    }
+
+    let output = metrics.render_prometheus();
+    let series = output
+        .lines()
+        .filter(|line| line.starts_with("spooky_backend_connect_attempt_total{"))
+        .count();
+    assert!(
+        series <= 600,
+        "connect-attempt series must be bounded, got {series}"
+    );
+    assert!(
+        output.contains("resolved_addr=\"__over_cap__\""),
+        "overflow beyond the cap must fold into the stable sentinel series"
+    );
+}


### PR DESCRIPTION
## Summary

Turns metrics, structured logs, and control-plane output into one stable
observability **contract** instead of per-subsystem side effects. A Phase 0 audit
found the same operational concept named three different ways across surfaces —
and two parallel terminal vocabularies (the QUIC data path vs. bootstrap) with no
shared string. This PR introduces a single canonical reason vocabulary, points
every emitter at it, and makes drift a test failure rather than a broken
dashboard.

Emitter output is intentionally byte-compatible where it mattered (metric series
names unchanged; existing exposition tests still pass); the changes are canonical
typing, field-name standardization, and new observability surface — not
metric-series renames.

## What changed

**Canonical vocabulary (`observability/mod.rs`, new module)**
- One enum per operational concept — `RequestOutcomeReason`, `BackendHealthReason`,
  `RetryDecisionReason`, `HedgeDecisionReason`, `AdmissionDecisionReason`
  (+ `AdmissionOverloadCause`) — each with a single `slug()` that is *the* metric
  label value, log `reason=` value, and control-API string.
- `OperationalEventContext` fixes the canonical log field names (notably
  `upstream`, replacing the `route=`/`route_upstream=` split).
- `From` mappings tie every local reason enum (QUIC terminal states, bootstrap
  terminals, retry/hedge, admission, backend health/refresh) to the canonical
  vocabulary, so one concept is described one way everywhere.
- A rustdoc **schema reference** documents every enum → slug, required dimensions
  per event class, and the deprecated-name migration table — the source of truth
  for Grafana/alert consumers.

**Metrics (`metrics/`)**
- The `spooky_overload_shed_by_reason_total{reason}` label now comes from the
  canonical enum, not ad hoc string literals.
- Bounded the previously-unbounded `spooky_backend_connect_attempt_total`
  cardinality (`resolved_addr`/`hostname` fold into a stable sentinel past a cap).

**Structured logs (`forwarding/`, `bootstrap/`)**
- Forwarding and bootstrap admission/upstream/health logs now emit the same field
  schema: `upstream=`, `reason=<canonical slug>`, `decision=` — dropping the fake
  `request_id=unassigned` literal, the `Bootstrap request …` prose prefix, and the
  `route=`/`route_upstream=` divergence.
- Retry/hedge decisions emit canonical reason slugs with a consistent
  `decision=`/`reason=` dimension set (operational reason split from `{:?}` debug
  detail).

**Control-plane (`control_api/render.rs`)**
- Backend snapshot exposes a canonical `health_reason` field using the same tokens
  as `spooky_health_failures_total{reason}` (was silently dropped before).

## Tests

- Drift-guard unit tests: slug uniqueness, overload-label routing, every local→
  canonical mapping, and a guard that the admission log literals equal the
  canonical slugs.
- **Cross-plane equivalence:** a test asserts bootstrap terminals and the QUIC-path
  terminal enums resolve to the *same* canonical reason (closes the "two
  vocabularies" gap).
- Metrics regression: canonical overload labels unchanged; new cardinality-cap
  regression.

## Verification

- `cargo build` — clean
- `cargo test -p spooky-edge --lib` — **276 passed**
- `cargo test -p spooky-edge --test regression` — **16 passed**
- `cargo clippy -p spooky-edge --all-targets` — **0 warnings**

## Notes for reviewers

- **Metric series names are unchanged** — only label *values* are now canonical
  enum slugs. Two coarse-label collapses were left intact deliberately (auth-denied
  vs validation → `failure`; lossy retry-denied labels) because widening them
  breaks existing dashboards; the **logs** now distinguish these fully, and the
  widening is flagged as a separate, dashboard-affecting change.
