### PR TITLE
docs: align architecture, operations, and config docs with the post-refactor runtime model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Large runtime modules split into focused submodules: `quic_listener/mod.rs` → `bootstrap_tls`, `control_api/`, `forwarding`, `metrics_endpoint`, `tls_runtime`; `spooky/main.rs` → `app`, `listener_group`; `config/validator.rs` → `helpers`; `config/runtime.rs` → `listeners`, `upstreams`.
 - Integration tests extracted into per-subsystem modules (`h3_edge/`, `h3_bridge/protocol`, `lb/tests`, `control_api/tests`).
+- Phase 1 to Phase 3 refactor foundations completed across the main runtime layers: shared admission, route/backend resolution, LB key resolution, upstream error classification, canonical request/response shaping, external auth decision mapping, runtime generation ownership, backend lifecycle coordination, transport façade cleanup, and public API hardening.
+- `spooky-edge`, `spooky-config`, `spooky-bridge`, `spooky-transport`, and `spooky-lb` now expose narrower, more intentional façades; internal orchestration and protocol details were pushed back behind owning modules.
+- Control-plane, observability, backend lifecycle, and runtime reload flows now share canonical runtime views and reason vocabularies instead of relying on listener-local wiring or duplicated interpretation paths.
 
 ## [0.3.0-beta] - 2026-06-20
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Spooky
 
-Spooky is an HTTP/3 (QUIC) edge proxy and load balancer for HTTP/2 backends.
+Spooky is an HTTP/3 (QUIC) edge proxy and load balancer with native QUIC ingress, a bootstrap HTTP/1.1 and HTTP/2 compatibility path, and scheme-driven HTTP/1.1 or HTTP/2 upstream execution.
 
 ## Overview
 
-Modern clients increasingly expect HTTP/3 support, but most production backends still use HTTP/2. Spooky bridges this gap by:
+Modern clients increasingly expect HTTP/3 support, while production platforms still need compatibility with mixed client and backend environments. Spooky bridges that gap by:
 
 - Terminating QUIC connections with TLS 1.3
-- Converting HTTP/3 streams to HTTP/2 requests
+- Running HTTP/3 as the primary data-plane ingress with a bootstrap HTTP/1.1 and HTTP/2 ingress path
+- Converting canonical request flow into scheme-driven upstream HTTP/1.1 or HTTP/2 execution
 - Load balancing across backend pools with health checks
 - Supporting path and host-based routing
 - Enforcing bounded request/response memory with deterministic overload failures
@@ -225,10 +226,19 @@ See [release maturity](docs/release-maturity.md) for scope and GA exit criteria,
 
 ## Documentation
 
-- [Architecture Overview](docs/architecture.md)
+Start with the [docs index](docs/README.md).
+
+Recommended entrypoints:
+
+- [Architecture Overview](docs/architecture/overview.md)
+- [Edge Runtime Ownership](docs/architecture/edge-runtime.md)
+- [Request Lifecycle](docs/architecture/request-lifecycle.md)
+- [Transport Boundaries](docs/architecture/transport.md)
+- [Observability Contract](docs/architecture/observability-contract.md)
 - [Configuration Reference](docs/configuration/reference.md)
-- [TLS Setup Guide](docs/configuration/tls.md)
-- [Load Balancing Guide](docs/user-guide/load-balancing.md)
+- [Control Plane](docs/operations/control-plane.md)
+- [Reload and Drain](docs/operations/reload-and-drain.md)
+- [Metrics and Alerts](docs/operations/metrics-and-alerts.md)
 - [Production Deployment](docs/deployment/production.md)
 - [Troubleshooting](docs/troubleshooting/common-issues.md)
 

--- a/crates/bridge/src/forwarded.rs
+++ b/crates/bridge/src/forwarded.rs
@@ -111,12 +111,14 @@ pub fn escape_forwarded_host(host: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+    use spooky_config::config::{ForwardedHeaderPolicy, ForwardedHeaderPolicyMode};
+
     use super::{
         ForwardedHeaderChains, build_forwarded_header_values, escape_forwarded_host,
         forwarded_for_value, merge_forwarded_chain,
     };
-    use spooky_config::config::{ForwardedHeaderPolicy, ForwardedHeaderPolicyMode};
-    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
     #[test]
     fn escape_forwarded_host_escapes_backslash_and_quote() {

--- a/crates/config/src/runtime/upstreams.rs
+++ b/crates/config/src/runtime/upstreams.rs
@@ -649,6 +649,7 @@ fn is_valid_connect_authority(value: &str) -> bool {
 mod tests {
     use std::collections::HashMap;
 
+    use super::normalize_upstreams;
     use crate::{
         config::{
             ApiKeyAuth, Backend, Config, ExternalAuth, ExternalAuthFailureMode,
@@ -657,8 +658,6 @@ mod tests {
         },
         runtime::{RuntimeConfigError, RuntimePolicySet},
     };
-
-    use super::normalize_upstreams;
 
     fn upstream(host: Option<&str>, path_prefix: &str, method: Option<&str>) -> Upstream {
         Upstream {

--- a/crates/edge/src/observability/mod.rs
+++ b/crates/edge/src/observability/mod.rs
@@ -514,8 +514,9 @@ pub struct MetricReasonLabels<'a> {
 // (spooky_errors) are mapped here; `OverloadShedReason::canonical()` lives with
 // that enum. These impls are the single source that keeps the surfaces aligned.
 
-use crate::runtime::connection::stream::{BackendFailureReason, RejectionReason, TimeoutReason};
 use spooky_errors::{HedgePolicyDenialReason, RetryPolicyDenialReason, UpstreamRetryReason};
+
+use crate::runtime::connection::stream::{BackendFailureReason, RejectionReason, TimeoutReason};
 
 /// Request rejection → canonical request outcome. Alias mapping.
 impl From<RejectionReason> for RequestOutcomeReason {
@@ -916,8 +917,9 @@ mod tests {
 
     #[test]
     fn admission_outcome_maps_to_canonical_decision_reason() {
-        use crate::metrics::OverloadShedReason;
-        use crate::runtime::connection::outcome::AdmissionOutcomeClass;
+        use crate::{
+            metrics::OverloadShedReason, runtime::connection::outcome::AdmissionOutcomeClass,
+        };
         assert_eq!(
             AdmissionDecisionReason::from(AdmissionOutcomeClass::AuthDenied),
             AdmissionDecisionReason::AuthDenied
@@ -1026,10 +1028,11 @@ mod tests {
 
     #[test]
     fn retry_and_outcome_mappings_stay_aligned_but_distinct_by_failure_class() {
-        use crate::runtime::connection::stream::BackendFailureReason;
         use spooky_errors::{
             RetryPolicyDenialReason, UpstreamRetryReason, UpstreamTerminalErrorKind,
         };
+
+        use crate::runtime::connection::stream::BackendFailureReason;
 
         assert_eq!(
             RetryDecisionReason::from(UpstreamRetryReason::Transport),

--- a/crates/edge/src/quic_listener/bootstrap/dispatch.rs
+++ b/crates/edge/src/quic_listener/bootstrap/dispatch.rs
@@ -10,10 +10,10 @@ use super::{
     context::BootstrapDispatchCtx,
     intake::bootstrap_error_response,
     outcome::observe_bootstrap_dispatch_failure,
-    request::BootstrapPreparedRoute,
     request::{
-        BootstrapBackendFailureReason, BootstrapLifecycleStage, BootstrapTerminalOutcome,
-        BootstrapTerminalResponse, BootstrapTerminalResult, BootstrapTimeoutReason,
+        BootstrapBackendFailureReason, BootstrapLifecycleStage, BootstrapPreparedRoute,
+        BootstrapTerminalOutcome, BootstrapTerminalResponse, BootstrapTerminalResult,
+        BootstrapTimeoutReason,
     },
     websocket::dispatch_bootstrap_websocket,
 };

--- a/crates/edge/src/quic_listener/bootstrap/request.rs
+++ b/crates/edge/src/quic_listener/bootstrap/request.rs
@@ -632,7 +632,6 @@ pub(in crate::quic_listener) fn build_bootstrap_upstream_request(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::{collections::BTreeMap, sync::Arc};
 
     use quiche::h3::NameValue;
@@ -641,6 +640,7 @@ mod tests {
         runtime::{RuntimeAuthPolicy, RuntimeForwardedHeaderPolicy, RuntimeHostPolicy},
     };
 
+    use super::*;
     use crate::runtime::connection::request::PendingForward;
 
     #[test]
@@ -702,8 +702,10 @@ mod tests {
         // obs Phase 10 (step 1): equivalent outcomes on the bootstrap and QUIC
         // data planes must report the SAME canonical reason — closing Phase 0
         // finding #1 (two parallel terminal vocabularies).
-        use crate::observability::RequestOutcomeReason;
-        use crate::runtime::connection::stream::{BackendFailureReason, RejectionReason};
+        use crate::{
+            observability::RequestOutcomeReason,
+            runtime::connection::stream::{BackendFailureReason, RejectionReason},
+        };
 
         // Auth denied.
         assert_eq!(

--- a/crates/edge/src/quic_listener/control_api/reload.rs
+++ b/crates/edge/src/quic_listener/control_api/reload.rs
@@ -2,8 +2,10 @@ use bytes::Bytes;
 use http_body_util::Full;
 
 use super::*;
-use crate::runtime::bundle::{ActiveRuntimeGeneration, RuntimeBundleHandle};
-use crate::runtime::policy::{ReloadCompatibilityAuthority, TransitionRejection};
+use crate::runtime::{
+    bundle::{ActiveRuntimeGeneration, RuntimeBundleHandle},
+    policy::{ReloadCompatibilityAuthority, TransitionRejection},
+};
 
 pub(super) struct RuntimeReloadPlan {
     pub(super) next_runtime: RuntimeBundle,

--- a/crates/edge/src/quic_listener/control_api/render.rs
+++ b/crates/edge/src/quic_listener/control_api/render.rs
@@ -3,13 +3,13 @@ use std::collections::HashMap;
 use bytes::Bytes;
 use http_body_util::Full;
 use serde::Serialize;
+use spooky_lb::health::HealthFailureReason;
 
 use super::{state::ControlApiState, *};
 use crate::runtime::backend::state::{
     BackendHealthState, BackendLifecycleInventorySnapshot, BackendMembershipState,
     BackendPoolPlacementSnapshot,
 };
-use spooky_lb::health::HealthFailureReason;
 
 /// Map a backend health-failure reason to the canonical control-plane token.
 ///

--- a/crates/edge/src/quic_listener/forwarding/dispatch.rs
+++ b/crates/edge/src/quic_listener/forwarding/dispatch.rs
@@ -8,8 +8,10 @@ use spooky_lb::alternate_backend::{
 };
 
 use super::*;
-use crate::observability::{HedgeDecisionReason, RetryDecisionReason};
-use crate::runtime::connection::response::ForwardingPolicyTelemetry;
+use crate::{
+    observability::{HedgeDecisionReason, RetryDecisionReason},
+    runtime::connection::response::ForwardingPolicyTelemetry,
+};
 
 const MAX_UPSTREAM_RETRY_ATTEMPTS: u8 = 1;
 type UpstreamRequest = Request<BoxBody<Bytes, Infallible>>;

--- a/crates/edge/src/quic_listener/forwarding/prepare.rs
+++ b/crates/edge/src/quic_listener/forwarding/prepare.rs
@@ -11,10 +11,10 @@ use crate::{
         evaluate_forwarding_pre_admission_policy,
     },
     runtime::connection::{
-        auth::ExternalAuthResult,
         auth::{
-            ExternalAuthCompletion, ExternalAuthFailureDisposition, ExternalAuthTaskConfig,
-            apply_auth_request_mutations, evaluate_external_auth_completion,
+            ExternalAuthCompletion, ExternalAuthFailureDisposition, ExternalAuthResult,
+            ExternalAuthTaskConfig, apply_auth_request_mutations,
+            evaluate_external_auth_completion,
         },
         outcome::{
             AdmissionOutcomeClass, BackendOutcomeTarget, RouteOutcomeTarget,
@@ -796,7 +796,6 @@ impl QUICListener {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use bytes::Bytes;
     use http::header::HOST;
     use http_body_util::{Full, combinators::BoxBody};
@@ -806,6 +805,7 @@ mod tests {
     };
     use spooky_errors::{BridgeError, ProxyError};
 
+    use super::*;
     use crate::runtime::connection::auth::PendingHeaderMutation;
 
     fn empty_body() -> BoxBody<Bytes, Infallible> {

--- a/crates/edge/src/quic_listener/forwarding/response.rs
+++ b/crates/edge/src/quic_listener/forwarding/response.rs
@@ -1424,13 +1424,15 @@ impl QUICListener {
 
 #[cfg(test)]
 mod tests {
-    use crate::runtime::connection::auth::{
-        ExternalAuthChallengeResponse, ExternalAuthDenyResponse, ExternalAuthRedirectResponse,
-    };
     use quiche::h3::NameValue;
 
     use super::*;
-    use crate::quic_listener::admission::AdmissionRejectionResponse;
+    use crate::{
+        quic_listener::admission::AdmissionRejectionResponse,
+        runtime::connection::auth::{
+            ExternalAuthChallengeResponse, ExternalAuthDenyResponse, ExternalAuthRedirectResponse,
+        },
+    };
 
     fn header_value<'a>(headers: &'a [quiche::h3::Header], name: &[u8]) -> Option<&'a [u8]> {
         headers

--- a/crates/edge/src/quic_listener/tests.rs
+++ b/crates/edge/src/quic_listener/tests.rs
@@ -29,13 +29,10 @@ use super::{
     should_strip_bootstrap_request_header, should_strip_bootstrap_response_header,
     should_strip_h3_response_header, sweep_closed_connections,
 };
-use crate::quic_listener::forwarding::terminalize_stream;
-use crate::runtime::connection::stream::{
-    BackendFailureReason, CancellationReason, TerminalReason, TimeoutReason,
-};
 use crate::{
     REQUEST_ID_COUNTER,
     cid_radix::CidRadix,
+    quic_listener::forwarding::terminalize_stream,
     runtime::connection::{
         guardrails::{
             BodyLimitKind, ResponseBodyGuardrailConfig, ResponseBodyGuardrailDecision,
@@ -43,9 +40,10 @@ use crate::{
         },
         request::{PendingForward, RequestEnvelope},
         stream::{
-            AdmissionPermits, AwaitingAuthState, DispatchReadyState, RequestBodyRuntime,
-            RequestBodyState, RequestContext, RequestExecutionState, RequestMode,
-            ResponseEmissionState, RoutingSnapshot, StreamAdmissionState, StreamPhase, TunnelMode,
+            AdmissionPermits, AwaitingAuthState, BackendFailureReason, CancellationReason,
+            DispatchReadyState, RequestBodyRuntime, RequestBodyState, RequestContext,
+            RequestExecutionState, RequestMode, ResponseEmissionState, RoutingSnapshot,
+            StreamAdmissionState, StreamPhase, TerminalReason, TimeoutReason, TunnelMode,
         },
     },
 };

--- a/crates/edge/src/resilience/retry_budget.rs
+++ b/crates/edge/src/resilience/retry_budget.rs
@@ -82,8 +82,9 @@ impl RetryBudget {
 mod tests {
     use std::collections::HashMap;
 
-    use super::RetryBudget;
     use spooky_errors::RetryPolicyDenialReason;
+
+    use super::RetryBudget;
 
     #[test]
     fn allow_retry_denial_does_not_consume_retry_budget_counters() {

--- a/crates/edge/src/runtime/bundle.rs
+++ b/crates/edge/src/runtime/bundle.rs
@@ -262,16 +262,18 @@ mod tests {
     use std::{collections::HashMap, path::Path};
 
     use rcgen::{Certificate, CertificateParams, SanType};
+    use spooky_config::{
+        config::{
+            Backend, ClientAuth, Config as SpookyConfigConfig, Listen, LoadBalancing, Log, LogFile,
+            LogFormat, Observability, Performance, Resilience, RouteMatch, Security, Tls, Upstream,
+            UpstreamTls,
+        },
+        runtime::RuntimeConfig,
+    };
     use tempfile::tempdir;
 
     use super::*;
     use crate::runtime::listener::QUICListener;
-    use spooky_config::config::{
-        Backend, ClientAuth, Config as SpookyConfigConfig, Listen, LoadBalancing, Log, LogFile,
-        LogFormat, Observability, Performance, Resilience, RouteMatch, Security, Tls, Upstream,
-        UpstreamTls,
-    };
-    use spooky_config::runtime::RuntimeConfig;
 
     fn write_test_cert_for_name(dir: &Path, cert_name: &str, dns_name: &str) -> (String, String) {
         let mut params = CertificateParams::new(vec![dns_name.to_string()]);

--- a/crates/edge/src/runtime/connection/outcome.rs
+++ b/crates/edge/src/runtime/connection/outcome.rs
@@ -10,19 +10,19 @@ use spooky_lb::{HealthTransition, health::HealthFailureReason, upstream_pool::Up
 
 use crate::{
     Metrics, OverloadShedReason, RouteOutcome,
-    runtime::backend::{
-        event::{
-            BackendHealthObservation, BackendHealthObservationOutcome,
-            BackendHealthObservationSource, BackendRequestFeedback,
+    runtime::{
+        backend::{
+            event::{
+                BackendHealthObservation, BackendHealthObservationOutcome,
+                BackendHealthObservationSource, BackendRequestFeedback,
+            },
+            lifecycle::{
+                apply_backend_health_observation, apply_backend_request_accounting,
+                apply_backend_request_feedback,
+            },
+            state::BackendIdentity,
         },
-        lifecycle::{
-            apply_backend_health_observation, apply_backend_request_accounting,
-            apply_backend_request_feedback,
-        },
-        state::BackendIdentity,
-    },
-    runtime::connection::stream::{
-        BackendFailureReason, RejectionReason, TerminalState, TimeoutReason,
+        connection::stream::{BackendFailureReason, RejectionReason, TerminalState, TimeoutReason},
     },
 };
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,25 +16,55 @@ Spooky is an open-source HTTP/3 (QUIC) edge reverse proxy written in Rust that t
 | [Production Readiness](operations/production-readiness.md) | Canonical statement of what is production-ready today and what still blocks GA |
 | [Limitations](reference/limitations.md) | The current hard product limits, without marketing language |
 
-### Developer — understand the architecture, contribute
+### Architecture — understand the runtime and subsystem ownership
 
 | Document | What you'll find |
 |---|---|
 | [Architecture Overview](architecture/overview.md) | Design principles, data-plane topology, sharded ingress model |
 | [Component Breakdown](architecture/components.md) | Per-crate responsibilities, inter-crate boundaries, key types |
-| [Load Balancing](user-guide/load-balancing.md) | All six algorithms with characteristics, use-case guidance, and config examples |
-| [Contributing Guide](https://github.com/Supernova-Labs-Org/spooky/blob/master/CONTRIBUTING.md) | Dev setup, build commands, test matrix, PR conventions |
+| [Codebase Map](development/codebase-map.md) | Current crate/module map and where major logic lives |
+| [Development Invariants](development/invariants.md) | Core runtime invariants, ownership assumptions, and rules the code depends on |
+| [Public API Surface Inventory](public-api-surface-inventory.md) | Current canonical public surfaces, hidden internals, and remaining intentional exports |
 
-### Reference — config schema, API, benchmarks, changelog
+### Control Plane and Operations — runtime control, observability, and failure handling
+
+| Document | What you'll find |
+|---|---|
+| [API Overview](api/overview.md) | Metrics endpoint and control-plane HTTP surfaces at a high level |
+| [Control API Reference](reference/control-api-reference.md) | Endpoint-by-endpoint control API contract |
+| [Metrics Reference](reference/metrics-reference.md) | Metric names, labels, and exported runtime signals |
+| [Operations Overview](operations/overview.md) | Operator map for deployment, sizing, tuning, and failure handling |
+| [Runbook](operations/runbook.md) | Day-2 operational procedures and troubleshooting flow |
+| [Failure Modes](operations/failure-modes.md) | Expected degraded behaviors and what they mean operationally |
+| [Sizing and Capacity](operations/sizing-and-capacity.md) | Capacity planning and scaling guidance |
+
+### Protocol, traffic, and policy reference
+
+| Document | What you'll find |
+|---|---|
+| [Load Balancing](user-guide/load-balancing.md) | Current balancing strategies, selection behavior, and config examples |
+| [HTTP/3](protocols/http3.md) | HTTP/3 behavior and protocol-specific operational notes |
+| [QUIC](protocols/quic.md) | QUIC transport behavior, constraints, and terminology |
+| [Security Model](concepts/security-model.md) | Current trust boundaries, admin-plane assumptions, and missing security layers |
+| [Terminology](reference/terminology.md) | Canonical definitions for listener, upstream, backend, route, drain, and related terms |
+
+### Developer — contribute safely against the current architecture
+
+| Document | What you'll find |
+|---|---|
+| [Contributing Guide](https://github.com/Supernova-Labs-Org/spooky/blob/master/CONTRIBUTING.md) | Dev setup, build commands, test matrix, PR conventions |
+| [Development Overview](development/overview.md) | Contributor-oriented guide to working in the repo |
+| [Testing Strategy](development/testing-strategy.md) | Contract, regression, and parity test expectations |
+| [Benchmarking](development/benchmarking.md) | Benchmark crate, micro/macro suites, and regression-gate workflow |
+| [Adding Features](development/adding-features.md) | Expectations for new features against the current architecture |
+
+### Reference — schema, maturity, roadmap, and release state
 
 | Document | What you'll find |
 |---|---|
 | [Configuration Reference](configuration/reference.md) | Authoritative schema reference for every configuration block |
 | [Feature Matrix](reference/feature-matrix.md) | Strict feature-by-feature inventory of what is done, partial, and missing |
-| [Security Model](concepts/security-model.md) | Current trust boundaries, admin-plane assumptions, and missing security layers |
-| [Terminology](reference/terminology.md) | Canonical definitions for listener, upstream, backend, route, drain, and related terms |
-| [API Overview](api/overview.md) | Metrics endpoint, control API (health, ready, runtime), bearer auth |
-| [Benchmarking](development/benchmarking.md) | Benchmark crate, micro/macro suites, and regression-gate workflow |
+| [Reference Overview](reference/overview.md) | Index of the strict reference material and product limits |
 | [Roadmap](roadmap.md) | Planned features, GA exit criteria, known limitations |
 | [Changelog](changelog.md) | Version history with added, fixed, and changed entries |
 

--- a/docs/architecture/backend-lifecycle.md
+++ b/docs/architecture/backend-lifecycle.md
@@ -1,0 +1,255 @@
+# Backend Lifecycle
+
+This document explains how Spooky models backend resolution, health, pool placement, and request feedback as one lifecycle instead of several unrelated side effects.
+
+## Purpose
+
+Backend lifecycle state should be understandable as one pipeline:
+
+1. backend identity is defined
+2. resolution state is tracked
+3. pool membership exists in upstream pools
+4. health state changes from refresh, checks, and request feedback
+5. canonical snapshots are exposed to control-plane and observability surfaces
+
+The canonical implementation lives under:
+
+- `crates/edge/src/runtime/backend/`
+- `crates/edge/src/quic_listener/backend_resolution.rs`
+- `crates/edge/src/quic_listener/health_check.rs`
+- `crates/lb/src/upstream_pool.rs`
+
+## Ownership Boundary
+
+The key rule is:
+
+- `lb` owns balancing and per-pool request accounting substrate
+- `edge::runtime::backend` owns lifecycle state, lifecycle events, and lifecycle snapshots
+
+Listener request paths, health checks, and DNS refresh loops should emit typed lifecycle inputs rather than independently deciding backend state transitions in scattered places.
+
+## Core Concepts
+
+### Backend identity
+
+Backend identity is the stable key for lifecycle state.
+
+Today that identity is modeled by `BackendIdentity`, which is centered on the canonical backend address string.
+
+Identity is intentionally separate from mutable runtime properties such as:
+
+- resolved addresses
+- health state
+- membership state
+
+### Resolution state
+
+Resolution state is modeled by `BackendResolutionState`.
+
+It includes:
+
+- authority host
+- authority port
+- address kind such as hostname vs IP literal
+- current resolved socket addresses
+- last successful refresh time
+- refresh generation
+
+This is the canonical answer to “where does this backend currently resolve.”
+
+### Health state
+
+Health state is modeled by `BackendHealthState`.
+
+It can be:
+
+- `Unknown`
+- `Healthy`
+- `Unhealthy { reason }`
+
+The lifecycle layer uses shared health-failure reason vocabularies so passive failures, active health checks, and control-plane views describe failures consistently.
+
+### Membership state
+
+Membership state is modeled by `BackendMembershipState`.
+
+It describes whether the backend is:
+
+- active
+- suppressed
+- removed
+
+This keeps placement and availability distinct from name resolution and health.
+
+## Lifecycle State and Snapshots
+
+### Runtime lifecycle state
+
+`RuntimeBackendLifecycleState` groups:
+
+- identity
+- resolution
+- health
+- membership
+
+This is the canonical mutable lifecycle record for a backend.
+
+### Snapshots
+
+The lifecycle layer exposes snapshots for operator-facing and debugging surfaces:
+
+- `BackendLifecycleSnapshot`
+- `CanonicalBackendLifecycleSnapshot`
+- `BackendLifecycleInventorySnapshot`
+
+These are what control-plane and metrics-oriented surfaces should use instead of rebuilding backend state from several unrelated stores.
+
+`BackendLifecycleInventorySnapshot` also supports summary views such as total backends and healthy backends.
+
+## Backend Lifecycle Coordinator
+
+`BackendLifecycleCoordinator` is the unification point.
+
+Its responsibilities are:
+
+- expose backend lifecycle snapshots
+- apply DNS refresh outcomes
+- apply health observations
+- merge lifecycle state with upstream pool placement inventory
+
+In practice it is the place where contributors should look first when backend lifecycle ownership is unclear.
+
+## DNS Refresh Flow
+
+Hostname backends participate in DNS refresh lifecycle.
+
+The flow is:
+
+1. refresh loop performs lookup
+2. raw lookup result is passed to the lifecycle coordinator
+3. lifecycle applies refresh outcome to the resolution store
+4. lifecycle decides whether the backend resolution changed
+5. lifecycle coordinates client rotation behavior with transport
+6. lifecycle emits a canonical refresh classification
+
+Important cases are modeled explicitly:
+
+- updated addresses
+- unchanged addresses
+- empty answer retained previous addresses
+- lookup failed while preserving active addresses
+
+This is important operationally because a failed refresh should not silently erase the active resolution.
+
+## Health Observation Flow
+
+Active health checks and other health observations should not mutate pools inline from many places.
+
+The intended flow is:
+
+1. a scheduler or request path produces a `BackendHealthObservation`
+2. the observation states:
+   - source
+   - outcome
+   - optional reason
+3. lifecycle-owned application logic decides the health transition
+4. pool health state and lifecycle snapshot stay aligned
+
+Observation sources include:
+
+- active check
+- passive request
+- request completion
+- control plane
+
+This keeps the question “why did this backend become unhealthy” answerable from typed state rather than from log archaeology.
+
+## Request Feedback Flow
+
+Request completion also contributes lifecycle information.
+
+The shared request-feedback model is `BackendRequestFeedback`, which includes:
+
+- backend identity
+- elapsed time
+- optional status code
+- typed outcome
+
+Possible request-feedback outcomes are:
+
+- success
+- neutral
+- failure with optional health-failure reason
+
+The request path should emit feedback, and lifecycle application decides whether that feedback changes health state.
+
+This prevents forwarding code from mixing transport completion, health mutation, and accounting policy in one branch.
+
+## Pool Membership and Accounting
+
+Upstream pools remain the balancing/accounting substrate.
+
+They still own things such as:
+
+- backend indices
+- healthy flags inside a pool
+- active request counts
+- latency/accounting data used for balancing
+
+The lifecycle layer reads and applies against that substrate through narrow mutation and snapshot boundaries instead of letting arbitrary callers mutate pool health directly.
+
+## Canonical Inventory View
+
+For operator-facing surfaces, backend lifecycle must be visible as one inventory, not as several separate stores.
+
+The inventory view combines:
+
+- stable backend identity
+- resolution state
+- lifecycle health state
+- membership state
+- per-upstream placements
+
+That gives control-plane and observability surfaces one place to answer:
+
+- which backends exist
+- which backends are healthy
+- which upstreams currently place them
+- what addresses they resolve to
+- whether refresh state is current
+
+## What Request Paths Should Do
+
+Forwarding and bootstrap code should:
+
+- resolve which backend is being used
+- emit request accounting and request feedback
+- consume canonical lifecycle snapshots when needed
+
+They should not:
+
+- invent new backend health mutation logic
+- directly combine resolution store state with pool state for control-plane output
+- treat DNS refresh and health transitions as unrelated subsystems
+
+## Contributor Rules
+
+When adding lifecycle-related behavior:
+
+- put new resolution state or snapshot fields in `runtime/backend/state.rs`
+- put new lifecycle inputs in `runtime/backend/event.rs`
+- put new application logic in `runtime/backend/lifecycle.rs`
+- keep `health_check.rs` and `backend_resolution.rs` focused on orchestration and scheduling
+- keep `lb` focused on balancing substrate, not lifecycle orchestration
+
+## Mental Model
+
+Think about backend lifecycle this way:
+
+- identity tells you which backend
+- resolution tells you where it points
+- health tells you whether it should receive traffic
+- membership tells you whether it is still placed
+- the lifecycle coordinator owns how refresh, checks, and request feedback update that picture
+
+If a new feature changes backend state, it should most likely enter through the lifecycle layer rather than by adding another direct mutation path.

--- a/docs/architecture/bootstrap-vs-quic.md
+++ b/docs/architecture/bootstrap-vs-quic.md
@@ -1,0 +1,133 @@
+# Bootstrap vs QUIC
+
+This document explains the two ingress paths in `spooky-edge` and the intended boundary between them.
+
+## Short Version
+
+- QUIC is the main data-plane ingress path.
+- Bootstrap is a compatibility ingress path for HTTP/1.1 and HTTP/2.
+- Both paths should share the same policy, routing, transport, and observability layers.
+- They should differ mainly in ingress and egress mechanics.
+
+## Why Both Paths Exist
+
+Spooky is built around QUIC and HTTP/3 at the edge, but operators still need a compatibility path for environments that cannot enter over QUIC immediately.
+
+The bootstrap path exists so Spooky can:
+
+- accept HTTP/1.1 or HTTP/2 traffic where needed
+- support compatibility migration scenarios
+- preserve shared policy behavior while using different wire protocols at ingress
+
+Bootstrap is not meant to be a second independent runtime architecture.
+
+## QUIC Path
+
+The QUIC path is the primary ingress model.
+
+It owns:
+
+- UDP socket ingress
+- QUIC handshake and connection lifecycle
+- HTTP/3 stream handling
+- stream progression and chunk emission
+- QUIC-specific response writeback
+
+Most of this logic lives under `crates/edge/src/quic_listener/` and its forwarding/runtime modules.
+
+## Bootstrap Path
+
+The bootstrap path is the compatibility ingress model.
+
+It owns:
+
+- bootstrap listener startup
+- HTTP request intake and validation
+- websocket and upgrade follow-through
+- bootstrap-specific upstream dispatch glue
+- bootstrap response writeback
+
+Most of this logic now lives under `crates/edge/src/quic_listener/bootstrap/`.
+
+The bootstrap façade should stay thin and focused on compatibility mechanics.
+
+## Shared Layers Under Both Paths
+
+The two ingress paths should converge on the same internal policy layers as early as possible.
+
+That shared stack includes:
+
+- admission and pre-forward policy evaluation
+- route resolution and backend selection
+- load-balancing key resolution
+- external auth decision logic
+- canonical request building in `bridge`
+- transport execution in `transport`
+- canonical response normalization in `bridge`
+- streaming/body guardrail policy
+- retry and hedge policy
+- request/backend outcome recording
+- runtime generation and backend lifecycle state
+
+If a new policy exists only in QUIC or only in bootstrap, that is usually a design smell unless it is truly protocol-specific.
+
+## Where They Should Differ
+
+The paths are expected to differ in a few places.
+
+### Ingress mechanics
+
+QUIC owns packet, connection, and HTTP/3 stream handling.
+
+Bootstrap owns HTTP accept, request parsing, and upgrade mechanics.
+
+### Egress mechanics
+
+QUIC writes normalized responses back through HTTP/3 stream APIs.
+
+Bootstrap writes normalized responses back through HTTP/1.1 or HTTP/2 response handling and may need websocket upgrade follow-through.
+
+### Protocol-specific validation
+
+Some request and response validation is protocol-specific at the edge of the ingress path. That logic should stay local to the path that owns the protocol.
+
+## Where They Should Not Differ
+
+The following should remain shared and semantically identical:
+
+- auth allow/deny/challenge behavior
+- rate-limit and brownout behavior
+- route matching and upstream lookup
+- backend selection semantics
+- retry and hedge eligibility
+- backend health feedback
+- outcome reason vocabularies
+- metrics and logging dimensions
+
+If bootstrap and QUIC start producing different policy decisions for the same logical request, the shared layer is in the wrong place or one path has leaked local policy logic.
+
+## Code Ownership Guide
+
+Add code to bootstrap when the concern is compatibility-path specific, such as:
+
+- request intake differences
+- HTTP upgrade mechanics
+- bootstrap response writeback details
+
+Add code to shared layers when the concern is common policy or state, such as:
+
+- admission
+- auth decision mapping
+- routing and backend selection
+- request building
+- response normalization
+- guardrails
+- outcome recording
+
+Add code to transport when the concern is backend protocol execution, not ingress behavior.
+
+## Design Rule
+
+QUIC is the main data-plane path.
+
+Bootstrap should be treated as a compatibility wrapper around the same internal policy and execution model, not as an alternate architecture with its own independent decisions.

--- a/docs/architecture/edge-runtime.md
+++ b/docs/architecture/edge-runtime.md
@@ -1,0 +1,195 @@
+# Edge Runtime Ownership
+
+This document explains how `spooky-edge` is organized after the refactor work that split runtime ownership, listener orchestration, backend lifecycle management, and control-plane services into clearer boundaries.
+
+## Purpose
+
+`spooky-edge` is the data-plane crate for Spooky. It owns:
+
+- edge-facing runtime state
+- QUIC ingress and bootstrap compatibility ingress
+- request admission, routing, forwarding, and response emission orchestration
+- backend lifecycle coordination and health feedback
+- operator-facing services such as metrics, control API wiring, and watchdog coordination
+
+The important distinction is that `spooky-edge` no longer exposes its internal runtime mechanics directly. The crate root presents a narrow public surface, and most operational machinery lives behind internal subsystem modules.
+
+## Public Façade vs Internal Subsystems
+
+### Public crate façade
+
+The crate root in `crates/edge/src/lib.rs` is the public entrypoint for the rest of the workspace. It intentionally exposes only stable cross-crate surfaces such as:
+
+- shared metrics and observability reason vocabularies
+- runtime state entrypoints under `edge::runtime`
+- routing and resilience domain APIs
+- worker/runtime startup entrypoints that other crates need to boot the edge
+
+External callers should start from the crate root and `edge::runtime`, not from `quic_listener` internals.
+
+### Internal listener subsystem façade
+
+`crates/edge/src/quic_listener/mod.rs` is an internal subsystem façade. It owns:
+
+- listener startup and bind orchestration
+- worker lifecycle and shard runtime wiring
+- QUIC request ingress
+- bootstrap compatibility ingress
+- control-plane service startup glue
+- drain and shutdown coordination
+
+It is intentionally internal because it composes many lower-level modules that should not become part of the stable crate API.
+
+## Ownership Map
+
+### `edge::lib`
+
+Owns the public crate surface.
+
+Use it for:
+
+- stable re-exports
+- crate-level docs
+- public observability contracts
+
+Do not put request-path logic or runtime orchestration here.
+
+### `edge::runtime`
+
+Owns the runtime state model.
+
+This module is the stable place for:
+
+- runtime bundle and generation ownership
+- listener runtime state types
+- backend lifecycle state and coordination
+- shared runtime services
+- health and policy state that must survive beyond one request path
+
+`edge::runtime` should answer questions such as:
+
+- what is startup-owned
+- what is reloadable generation-owned state
+- what survives across runtime generations
+- what lifecycle state exists for a backend
+
+### `edge::quic_listener`
+
+Owns ingress/runtime orchestration, not durable runtime ownership.
+
+This subsystem should:
+
+- build listener execution contexts from runtime state
+- accept client traffic
+- translate ingress events into shared policy and transport calls
+- coordinate shutdown and worker lifecycle
+
+This subsystem should not become the long-term home of policy interpretation, backend lifecycle ownership, or transport-specific behavior.
+
+### `edge::watchdog`
+
+Owns watchdog coordination as an operator-facing service.
+
+This includes:
+
+- watchdog state and coordination loops
+- service-facing state views
+- operational safety checks that are not request hot-path logic
+
+### `edge::metrics` and observability vocabularies
+
+Own shared metrics storage plus the stable reason vocabularies used by:
+
+- admission decisions
+- retries and hedges
+- backend health transitions
+- route/request outcomes
+- overload and operational events
+
+These vocabularies matter because metrics, logs, and control-plane snapshots should describe the same events in the same terms.
+
+## Runtime Ownership Model
+
+At a high level, the runtime is split into three categories:
+
+### Startup-owned state
+
+This is fixed when the process or listener group starts and should not silently change during a runtime generation swap.
+
+Examples:
+
+- bound sockets and listener topology
+- worker layout and shard startup wiring
+- process-level startup services
+
+### Generation-owned state
+
+This is the active runtime configuration and derived state that can be replaced on reload.
+
+Examples:
+
+- routing index
+- upstream policies
+- listener runtime configs
+- admission and resilience policy snapshots
+- generation-scoped pools, semaphores, and backend maps
+
+### Long-lived shared services
+
+These survive across generation swaps and are shared by multiple services.
+
+Examples:
+
+- metrics
+- TLS reload stores
+- watchdog coordination
+- runtime bundle handle
+- long-lived resolution or transport service shells
+
+## Request-Path Ownership
+
+The request path is intentionally layered:
+
+1. Ingress mechanics live in `quic_listener`.
+2. Runtime-owned policy and lifecycle state live in `runtime`.
+3. Request building and response normalization live in `bridge`.
+4. Backend transport execution lives in `transport`.
+5. Balancing/accounting substrate lives in `lb`.
+
+That split matters because new features should extend the owning layer instead of recreating policy branches in listener code.
+
+## Control-Plane Ownership
+
+Admin and operator surfaces should depend on canonical runtime views, not on listener-local state.
+
+That includes:
+
+- control API snapshots
+- metrics endpoint rendering
+- watchdog coordination
+- reload/drain reporting
+
+If a control-plane service needs information, that information should come from the runtime bundle or shared service views, not from ad hoc listener internals.
+
+## Public vs Internal Rule of Thumb
+
+Make something public only if another crate needs it as a stable contract.
+
+Keep it internal if it is:
+
+- orchestration glue
+- module-local policy plumbing
+- listener mechanics
+- transport/protocol implementation detail
+- compatibility-path helper logic
+
+## Contributor Guidance
+
+When adding code:
+
+- put runtime ownership and reload semantics in `edge::runtime`
+- put ingress orchestration in `edge::quic_listener`
+- put operator services in `control_api`, `metrics`, or `watchdog`
+- keep the crate root limited to stable entrypoints and shared contracts
+
+If a change makes `quic_listener` smarter by embedding more policy or lifecycle ownership, it probably belongs somewhere else.

--- a/docs/architecture/observability-contract.md
+++ b/docs/architecture/observability-contract.md
@@ -1,0 +1,275 @@
+# Observability Contract
+
+This document defines the stable observability contract for Spooky after the refactor work that centralized reason vocabularies, outcome recording, backend lifecycle snapshots, and control-plane runtime views.
+
+## Purpose
+
+Spooky has three operator-facing observability surfaces:
+
+- Prometheus metrics
+- structured operational logs
+- control API runtime snapshots
+
+These surfaces should describe the same events using the same vocabulary.
+
+The source of truth for that vocabulary is:
+
+- `crates/edge/src/observability/mod.rs`
+
+This file defines the canonical enums, stable slugs, and field names that all emitters should use.
+
+## Contract Rule
+
+One operational concept should have:
+
+- one canonical enum value
+- one canonical slug string
+- one consistent meaning across metrics, logs, and control API payloads
+
+The contract exists to prevent drift such as:
+
+- one reason name in metrics
+- a different prose string in logs
+- a third serialized form in control-plane JSON
+
+## Canonical Reason Families
+
+The main canonical reason families are:
+
+- `RequestOutcomeReason`
+- `BackendHealthReason`
+- `RetryDecisionReason`
+- `HedgeDecisionReason`
+- `AdmissionDecisionReason`
+- `AdmissionOverloadCause`
+
+Each of these exposes a stable `slug()` used as the canonical external string.
+
+## Stable String Contract
+
+The canonical slug is the external operator contract.
+
+That means the slug should be treated as the stable value for:
+
+- metric label values
+- structured log `reason=` values
+- control API serialized fields
+
+Changing a slug is an observability contract change, not a cosmetic refactor.
+
+## Structured Log Field Contract
+
+Operational logs should use the canonical `OperationalEventContext` field set.
+
+The canonical fields are:
+
+- `request_id`
+- `route`
+- `upstream`
+- `backend`
+- `reason`
+- `failure_class`
+
+These fields are rendered in stable `key=value` form and unset fields are omitted.
+
+### Practical meaning
+
+- use `upstream` for route/upstream attribution in request-path events
+- use `backend` for selected backend identity
+- use `reason` for the canonical reason slug
+- use `failure_class` when a coarse outcome still needs finer transport or rejection detail
+
+Do not invent new ad hoc field keys for the same concept if the canonical field already exists.
+
+## Metric Label Contract
+
+Reasoned metric emitters should use the canonical label model:
+
+- `outcome`
+- `reason`
+- `failure_class`
+
+This contract is represented by `MetricReasonLabels`.
+
+### Meaning of the labels
+
+- `outcome` is the coarse terminal bucket such as success, failure, timeout, overload, or rate-limited
+- `reason` is the canonical reason slug
+- `failure_class` carries finer transport or rejection detail where needed
+
+This is what allows dashboards to compare:
+
+- route outcomes
+- backend failures
+- retries and hedges
+- admission denials
+
+without each emitter choosing different label semantics.
+
+## Control API Snapshot Contract
+
+The control API is not just an admin action surface. It is also a runtime introspection contract.
+
+The runtime snapshot should describe the current active generation and shared operational state using the same meaning as logs and metrics.
+
+Important snapshot areas include:
+
+- active generation id and config path
+- worker expectations
+- watchdog state
+- adaptive admission state
+- backend lifecycle inventory
+- coarse metrics summary
+- listener TLS inventory
+
+### Backend snapshot meanings
+
+Backend lifecycle payloads expose:
+
+- backend identity
+- health
+- `health_reason`
+- membership
+- authority host and port
+- resolved addresses
+- resolution generation
+- last successful refresh time
+- per-upstream placement details
+
+These fields should be interpreted as the canonical backend lifecycle view, not as a best-effort debug dump.
+
+## Runtime Snapshot Boundaries
+
+Control-plane surfaces should consume canonical runtime views, not listener-local state.
+
+That means runtime snapshot rendering should depend on:
+
+- the active runtime generation
+- shared runtime services
+- backend lifecycle inventory
+- watcher/coordinator state
+
+It should not reconstruct state by reaching into multiple unrelated listener internals.
+
+## Metrics vs Logs vs Control API
+
+These surfaces serve different operational jobs.
+
+### Metrics
+
+Metrics are for:
+
+- time-series alerting
+- SLO and capacity dashboards
+- rate and latency trends
+
+### Logs
+
+Logs are for:
+
+- event-level diagnosis
+- request-path and lifecycle debugging
+- understanding the exact reason a single action happened
+
+### Control API snapshots
+
+Control API snapshots are for:
+
+- current-state inspection
+- rollout verification
+- backend and watchdog status inspection
+- runtime-generation confirmation
+
+They should complement each other, not contradict each other.
+
+## Cardinality Rules
+
+The observability contract aims for stable, low-cardinality labels on default operational metrics.
+
+Use labeled metrics for:
+
+- upstream
+- backend
+- listener
+- protocol
+- canonical reason slugs
+
+Avoid introducing unbounded labels such as:
+
+- raw user IDs
+- arbitrary request paths
+- per-request trace tokens
+
+If a dimension is needed for debugging but not for alerting, prefer logs or control-plane snapshots over high-cardinality metrics.
+
+## Backend Lifecycle Observability
+
+Backend health and refresh behavior should be visible consistently across surfaces.
+
+Important canonical concepts include:
+
+- refresh classification
+- health-failure reason
+- membership state
+- placement state
+- client rotation behavior
+
+This lets operators answer:
+
+- did refresh fail or just return the same addresses
+- was a backend removed, suppressed, or merely unhealthy
+- did traffic continue on retained addresses after refresh failure
+
+## Request Outcome Observability
+
+Request outcome recording provides the canonical answer to:
+
+- did the request succeed
+- did it time out
+- was it rejected by policy
+- did backend transport/protocol/TLS fail
+- was it shed by overload controls
+
+This contract should be consistent for:
+
+- QUIC forwarding
+- bootstrap compatibility ingress
+- retries and hedges
+- admission and auth rejections
+
+## Reload and Runtime Observability
+
+Runtime generation changes should be visible through:
+
+- control API runtime generation fields
+- logs around generation swaps and rejection reasons
+- metrics that surface restart requests, degraded windows, and control-plane activity
+
+Operators should not have to infer whether a reload committed from unrelated side effects.
+
+## Contributor Rules
+
+When adding a new operational reason:
+
+- add it to the canonical observability vocabulary
+- give it one stable slug
+- map local enums into the canonical reason if the local enum is richer
+- reuse canonical field names in logs
+- reuse canonical label names in metrics
+- expose the same meaning in control-plane JSON where relevant
+
+Do not:
+
+- invent a new public reason string in one emitter only
+- log prose-only reasons that cannot be reconciled with metrics
+- serialize backend or request state under different names in different surfaces
+
+## Mental Model
+
+The observability contract is successful when an operator can look at:
+
+- a metric label
+- a log line
+- a control API field
+
+and know they are all describing the same event using the same vocabulary.

--- a/docs/architecture/request-lifecycle.md
+++ b/docs/architecture/request-lifecycle.md
@@ -1,0 +1,289 @@
+# Request Lifecycle
+
+This document describes the canonical request path through Spooky after the refactor work that split admission, auth, resolution, transport, normalization, streaming, and outcome recording into shared layers.
+
+## Purpose
+
+The request path should be understandable as one ordered flow:
+
+1. intake
+2. admission
+3. auth
+4. route resolution
+5. backend dispatch
+6. response normalization
+7. body streaming and guardrails
+8. outcome recording
+
+That flow should be shared conceptually across:
+
+- QUIC ingress
+- bootstrap compatibility ingress
+
+The two paths differ in ingress and egress mechanics, not in core policy meaning.
+
+## Main Ownership Boundaries
+
+### `edge::quic_listener`
+
+Owns ingress mechanics and request orchestration.
+
+It is responsible for:
+
+- accepting traffic
+- creating request envelopes
+- invoking shared policy layers in order
+- coordinating transport execution
+- writing results back to the client protocol
+
+### `edge::runtime::connection`
+
+Owns request-path shared policy and accounting helpers that are runtime concerns rather than ingress mechanics.
+
+This includes:
+
+- body guardrails
+- outcome classification and recording
+- stream terminal-state vocabulary
+
+### `bridge`
+
+Owns canonical request building and response normalization.
+
+It is responsible for:
+
+- upstream request construction
+- host and forwarded-header policy application
+- canonical response/header normalization
+- websocket and upgrade helper logic
+
+### `transport`
+
+Owns backend protocol execution.
+
+It is responsible for:
+
+- runtime-selected H1/H2 dispatch
+- connection reuse
+- transport-level timeouts
+- backend client rotation
+
+### `lb`
+
+Owns load-balancing substrate and pool accounting primitives.
+
+It is not where request-path orchestration should live.
+
+## Step 1: Intake
+
+The request path begins in an ingress-specific intake layer.
+
+### QUIC intake
+
+QUIC intake owns:
+
+- packet processing
+- QUIC connection lifecycle
+- HTTP/3 stream establishment
+- request envelope creation from stream headers and body chunks
+
+### Bootstrap intake
+
+Bootstrap intake owns:
+
+- HTTP request acceptance
+- method/path/authority extraction
+- compatibility-path validation
+- websocket upgrade detection
+
+By the end of intake, the system should have a canonical request envelope or request context, not a partially interpreted protocol object scattered across multiple branches.
+
+## Step 2: Admission
+
+Admission is the first shared policy gate.
+
+Admission covers:
+
+- local auth prerequisites where applicable
+- route-level policy rejection
+- scoped rate-limit decisions
+- brownout and overload shedding
+- permit acquisition and admission execution checks
+
+Admission should produce typed policy results, not direct response I/O decisions scattered across intake code.
+
+Both QUIC forwarding and bootstrap compatibility code should route these checks through the same admission layer.
+
+## Step 3: External Auth and Auth Decisions
+
+If external auth is configured, the request enters the shared auth-decision layer.
+
+This layer owns:
+
+- timeout handling
+- fail-open vs fail-closed policy
+- allow/deny/challenge/redirect mapping
+- allowlist filtering
+- header mutation validation and safety checks
+- OIDC helper checks where configured
+
+Ingress-specific code should only orchestrate the auth request and apply the shared decision result.
+
+## Step 4: Route Resolution and Backend Selection
+
+After admission and auth, the request enters the shared resolution pipeline.
+
+Resolution covers:
+
+- route matching
+- upstream lookup
+- load-balancing strategy selection
+- canonical load-balancing key extraction
+- backend selection
+- backend-selection logging and telemetry
+
+The result of this phase should be a typed resolved target, not a mix of route, upstream, and backend values reconstructed later by dispatch code.
+
+## Step 5: Request Building
+
+Once a backend is selected, ingress code shapes the request into the canonical bridge input.
+
+This phase covers:
+
+- method/path/authority transfer
+- body mode decisions
+- host policy application
+- forwarded-header policy application
+- websocket tunnel request shaping
+
+`bridge` owns the canonical request-building contract. Listener code should assemble inputs, not reimplement header policy.
+
+## Step 6: Backend Dispatch
+
+Backend dispatch means handing the canonical upstream request to transport.
+
+Edge-owned dispatch logic still owns:
+
+- retry and hedge orchestration
+- upstream inflight coordination
+- admission-related dispatch constraints
+- backend-target bookkeeping for observations
+
+But edge should not re-decide protocol execution details. At this point it should effectively say:
+
+- send this canonical request to this backend
+
+Transport decides how that backend is executed.
+
+## Step 7: Response Normalization
+
+When an upstream response arrives, it is normalized before downstream emission.
+
+This shared layer covers:
+
+- hop-by-hop header stripping
+- connection-token filtering
+- trailer normalization and conversion
+- content-length and content-type shaping
+- HEAD/bodyless/no-content behavior
+
+`bridge::response` is the canonical surface for this. QUIC and bootstrap should differ only in how they emit the normalized result downstream.
+
+## Step 8: Streaming and Guardrails
+
+After headers are normalized, response and request bodies continue under shared guardrail policy.
+
+This layer covers:
+
+- request body idle timeout
+- request total body timeout
+- response body idle timeout
+- response total streaming timeout
+- body size-cap enforcement
+- unknown-length prebuffer limits
+- chunk emission policy
+- progressive emission eligibility
+
+The guardrail layer lives in `edge::runtime::connection::guardrails`.
+
+Ingress-specific code owns:
+
+- polling
+- wakeups
+- channel and stream progression
+- actual downstream chunk emission mechanics
+
+It should not own the meaning of timeout and size-cap policy.
+
+## Step 9: Error Classification, Retry, and Hedge Policy
+
+When upstream execution fails or stalls, the request path uses shared classification and retry policy.
+
+This layer covers:
+
+- upstream error classification
+- retryability interpretation
+- retry denial reasons
+- hedge trigger and suppression rules
+- alternate backend selection
+- canonical telemetry reason vocabularies
+
+This allows forwarding code to orchestrate retries and hedges without owning raw error inspection logic itself.
+
+## Step 10: Outcome Recording
+
+Every terminal request path should flow through shared outcome recording.
+
+This covers:
+
+- route outcome classification
+- backend outcome classification
+- metrics recording
+- overload and rejection reason mapping
+- backend accounting hooks
+- backend health feedback hooks
+
+This is important because request paths should not each invent their own answer to “what happened.”
+
+## QUIC vs Bootstrap Differences
+
+Both paths should pass through the same policy layers in the same order.
+
+They intentionally differ only in:
+
+- ingress parsing and protocol setup
+- downstream response/writeback mechanics
+- websocket and upgrade mechanics on bootstrap
+- QUIC-specific stream progression details
+
+If a new policy exists only in one path, it usually belongs in a shared layer instead.
+
+## Contributor Rules
+
+When adding a new request-path feature:
+
+- put ingress mechanics in `quic_listener` or `bootstrap`
+- put shared policy in admission/auth/resolution/runtime layers
+- put canonical request/response shaping in `bridge`
+- put backend protocol execution in `transport`
+- put shared terminal observation and accounting in `runtime::connection::outcome`
+
+Do not:
+
+- add protocol-specific branching in edge when transport owns it
+- duplicate request header policy in listener code
+- classify terminal outcomes independently in multiple request paths
+
+## Mental Model
+
+The shortest correct model is:
+
+- ingress produces a canonical request context
+- shared policy decides whether and where it goes
+- bridge shapes it
+- transport executes it
+- bridge normalizes the result
+- guardrails constrain streaming
+- outcome recording tells the rest of the system what happened
+
+That is the data-plane contract contributors should preserve.

--- a/docs/architecture/runtime-generation.md
+++ b/docs/architecture/runtime-generation.md
@@ -1,0 +1,233 @@
+# Runtime Generation Model
+
+This document explains how `spooky-edge` owns live runtime state, how reloads replace that state, and how workers and control-plane services are expected to read it.
+
+## Purpose
+
+The runtime generation model exists to answer three questions clearly:
+
+- what is fixed at startup
+- what can change on reload
+- what must survive across reloads
+
+The canonical implementation lives under:
+
+- `crates/edge/src/runtime/bundle.rs`
+- `crates/edge/src/runtime/generation.rs`
+- `crates/edge/src/runtime/shared_state.rs`
+- `crates/edge/src/runtime/tasks.rs`
+
+## Ownership Classes
+
+The runtime is intentionally split into three ownership classes.
+
+### Startup-owned state
+
+Startup-owned state is established once for the process and must not change while the process keeps running.
+
+Examples:
+
+- config path
+- non-reloadable logging sink configuration
+
+This state is represented by `StartupOwnedRuntimeState`.
+
+If a reload would require changing startup-owned state, it should be rejected as restart-required rather than silently applied.
+
+### Generation-owned state
+
+Generation-owned state is the live, reloadable runtime snapshot used by workers and operator surfaces.
+
+Examples:
+
+- listener runtime configs
+- routing index
+- upstream policies
+- backend endpoint maps
+- backend health-check definitions
+- per-upstream pools and inflight semaphores
+- resilience and admission state
+- generation-scoped background task registry
+
+This state is represented by `RuntimeGenerationState`.
+
+When a reload is committed, this is the state that gets replaced.
+
+### Long-lived shared services
+
+Long-lived shared services are the services the data plane reaches through the active generation but which are not modeled as per-request state.
+
+Examples:
+
+- metrics
+- listener TLS reload store
+- upstream transport pool shell
+- backend lifecycle coordinator
+- backend resolution store
+- watchdog coordinator
+- shared DNS resolver
+
+This state is represented by `RuntimeSharedServices`.
+
+Some of these services are rebuilt from config on reload, while others are deliberately carried forward so in-flight operational state survives the swap.
+
+## Core Types
+
+### `RuntimeBundle`
+
+`RuntimeBundle` is the canonical published unit of runtime state. It contains:
+
+- generation number
+- startup-owned state
+- runtime config snapshot
+- shared runtime state
+
+This is the boundary between assembly time and live execution time.
+
+### `SharedRuntimeState`
+
+`SharedRuntimeState` groups:
+
+- `RuntimeSharedServices`
+- `RuntimeGenerationState`
+
+This gives workers and service surfaces one stable handoff point without exposing the internal reload planner.
+
+### `RuntimeGenerationView`
+
+`RuntimeGenerationView` is the canonical read-only view for callers that need the active runtime state without caring about swap mechanics.
+
+It bundles:
+
+- generation id
+- startup-owned state
+- runtime config
+- shared services
+- generation-owned state
+
+Listener workers, metrics rendering, control-plane surfaces, and bootstrap compatibility code should prefer a generation view over reaching into internal storage directly.
+
+### `RuntimeBundleHandle`
+
+`RuntimeBundleHandle` is the active-generation publisher and read interface.
+
+Its responsibilities are:
+
+- expose the current active generation
+- provide stable read helpers such as `current_view()` and `with_current_view(...)`
+- gate reload commits against lifecycle phase
+- atomically replace the active bundle
+- retire the previous generation's generation-scoped tasks
+
+## Read Path
+
+The intended read path is:
+
+1. caller obtains `RuntimeBundleHandle`
+2. caller asks for `current_view()` or `with_current_view(...)`
+3. caller reads runtime state through `RuntimeGenerationView`
+
+Callers should not manually reconstruct active runtime state by following ad hoc chains through listener-local fields.
+
+This keeps control-plane, listener, and metrics code aligned on the same active generation contract.
+
+## Reload Flow
+
+At a high level, reload follows this sequence:
+
+1. build a new runtime bundle from the new config
+2. carry forward any process-scoped shared services that must survive reload
+3. validate that startup-owned state did not change in a reload-illegal way
+4. stage generation-owned state and generation-scoped tasks
+5. atomically replace the active bundle in `RuntimeBundleHandle`
+6. retire the previous generation's generation task registry
+
+The critical point is that readers only ever observe whole bundles. There is no partial in-place mutation of the live generation.
+
+## Bundle Replacement Semantics
+
+Bundle replacement is intentionally narrow.
+
+### What replacement changes
+
+- generation-owned runtime state
+- the active runtime config snapshot
+- any shared services that are intentionally rebuilt with the generation
+
+### What replacement must not silently change
+
+- startup-owned state
+- process identity assumptions
+- restart-required ownership domains
+
+### What survives replacement
+
+- readers holding the old `Arc<RuntimeBundle>` until they finish
+- process-scoped services that are explicitly carried forward
+- operational lifecycle phase state shared through the handle
+
+## Task Ownership
+
+Generation-scoped background tasks belong to `RuntimeTaskRegistry` inside `RuntimeGenerationState`.
+
+That means:
+
+- tasks are owned by the generation that created them
+- retiring old generation tasks happens in one place during bundle replacement
+- task retirement should not be scattered across unrelated reload callers
+
+This avoids ambiguous ownership over which generation is responsible for stopping background work.
+
+## Lifecycle Gating
+
+Reload is not allowed in every process phase.
+
+`RuntimeBundleHandle` owns the runtime lifecycle gate and rejects reload commits once drain or shutdown has begun.
+
+That matters because it prevents:
+
+- installing a fresh generation during shutdown
+- racing reload and drain into inconsistent state
+- forcing leaf callers to implement their own shutdown/reload conflict logic
+
+## Startup, Reload, and Shutdown Roles
+
+### Startup path
+
+Startup assembles the first runtime bundle and publishes generation 0 or generation 1 as the initial active state.
+
+### Reload path
+
+Reload prepares a complete next generation and swaps the bundle if lifecycle gating and validation allow it.
+
+### Shutdown and drain path
+
+Drain and shutdown do not mutate the active generation in place to express policy changes. They move lifecycle phase forward and let listener/control-plane services react accordingly.
+
+## Contributor Rules
+
+When adding code:
+
+- put new reloadable runtime state in `RuntimeGenerationState`
+- put fixed process-start state in `StartupOwnedRuntimeState`
+- put shared services in `RuntimeSharedServices`
+- expose read access through `RuntimeGenerationView`
+- keep bundle replacement in `RuntimeBundleHandle`
+
+Do not:
+
+- add new ad hoc active-runtime lookup paths
+- let listener code invent its own startup-vs-reload fallback rules
+- spread generation-task retirement across multiple modules
+
+## Mental Model
+
+The simplest way to think about the runtime is:
+
+- `RuntimeBundle` is what the process is currently serving
+- `RuntimeBundleHandle` decides which bundle is live
+- startup-owned state defines what cannot change without restart
+- generation-owned state defines what reload replaces
+- shared services define what the running process keeps reaching through
+
+If a contributor can answer those questions for a new piece of state, it will land in the right part of the runtime model.

--- a/docs/architecture/transport.md
+++ b/docs/architecture/transport.md
@@ -1,0 +1,203 @@
+# Transport Boundary
+
+This document explains what the transport layer owns, what it deliberately hides, and where `edge` should stop reasoning about H1/H2 backend details.
+
+## Purpose
+
+The transport refactor established one rule:
+
+- `edge` owns request orchestration
+- `transport` owns backend protocol execution
+
+Callers should depend on a canonical transport façade, not on protocol-specific pools or client behavior.
+
+## Canonical Transport Surface
+
+The main façade is:
+
+- `crates/transport/src/transport_pool.rs`
+
+`UpstreamTransportPool` is the transport contract that the rest of the system should use.
+
+Its surface is intentionally transport-shaped:
+
+- execute a canonical upstream request
+- rotate a backend client when refresh or lifecycle logic requires it
+- build the runtime transport pool from interpreted runtime config
+
+This is the place where backend protocol choice becomes a resolved runtime concern.
+
+## What Transport Owns
+
+Transport owns the parts of backend execution that should not leak into request orchestration code.
+
+### Runtime-selected protocol dispatch
+
+Transport decides whether a backend runs over:
+
+- HTTP/1.1
+- HTTP/2
+
+That mapping is resolved from runtime config and hidden behind the transport façade.
+
+### Connection reuse
+
+Transport owns:
+
+- per-backend reusable clients
+- idle connection reuse
+- protocol-specific pool behavior
+
+Callers should not know how reuse differs internally between H1 and H2.
+
+### Transport-level timeout application
+
+Transport owns:
+
+- connect-level timeout behavior
+- execution timeout around backend send operations
+- protocol/client-level timeout handling that belongs to transport execution
+
+Edge still owns higher-level request lifecycle deadlines and streaming deadlines.
+
+### Client rotation
+
+Transport owns backend client rotation when:
+
+- DNS refresh changes the effective backend resolution
+- lifecycle code asks transport to rotate or recreate the backend client
+
+The result is exposed as a canonical transport rotation result instead of protocol-specific return shapes.
+
+## What Edge Owns
+
+Edge should still own the policy and orchestration around transport.
+
+That includes:
+
+- request preparation
+- admission
+- auth
+- route and backend selection
+- retry and hedge policy
+- request streaming orchestration
+- response emission
+- outcome recording
+
+Edge should not own how a chosen backend gets executed as H1 or H2.
+
+## Internal Transport Structure
+
+The transport façade hides the protocol-specific implementation modules.
+
+Internally, transport still has:
+
+- H1 client and H1 pool logic
+- H2 client and H2 pool logic
+- backend transport entry resolution
+
+But those are implementation details behind the façade, not surfaces for higher-level orchestration.
+
+## H1/H2 Hiding
+
+The goal is not to pretend H1 and H2 are identical on the wire. The goal is to prevent those differences from leaking upward into the wrong layer.
+
+Higher-level code should not branch because:
+
+- H1 acquires or rotates clients one way
+- H2 does it another way
+- one protocol has a slightly different pool surface
+
+Those differences should be absorbed inside transport so `edge` only consumes canonical outcomes.
+
+## Request Execution Flow
+
+The intended execution flow is:
+
+1. edge resolves the backend target
+2. edge builds a canonical upstream request
+3. edge calls transport with backend identity plus request
+4. transport chooses the internal backend transport entry
+5. transport dispatches to H1 or H2 pool/client behavior
+6. transport maps protocol-specific failures into canonical transport errors
+7. edge consumes the result through shared error classification and retry policy
+
+This keeps execution flow readable from the outside while still allowing protocol-specific implementation internally.
+
+## Runtime Interpretation Boundary
+
+The runtime/config layer interprets raw config into canonical runtime transport policy.
+
+Transport then consumes that interpreted policy and builds the internal execution topology.
+
+That means:
+
+- raw config parsing is not transport's job
+- route-level backend selection is not transport's job
+- protocol realization from runtime backend transport kind is transport's job
+
+## Timeout Ownership Split
+
+The clean split is:
+
+### Transport owns
+
+- connection and client execution timeouts
+- protocol-execution timeout application
+
+### Edge owns
+
+- end-to-end request lifecycle deadlines
+- body streaming and idle guardrails
+- admission and inflight waiting deadlines where policy requires them
+
+If a timeout only exists because of the backend protocol execution path, it probably belongs in transport.
+
+## DNS Refresh and Client Rotation
+
+Backend DNS refresh and lifecycle logic may decide that transport clients should rotate.
+
+That decision should not require callers to know:
+
+- how H1 rotates clients
+- how H2 rotates clients
+- whether one protocol exposes generation movement differently
+
+Transport should expose one canonical rotation result so lifecycle code can reason in transport-neutral terms.
+
+## Error Mapping Boundary
+
+Transport is responsible for mapping protocol/pool execution failures into canonical transport-facing errors.
+
+Shared upstream error classification then interprets those errors for:
+
+- retryability
+- health-failure mapping
+- metrics/logging reason mapping
+
+This keeps transport from owning request policy while also keeping edge from digging into protocol implementation details.
+
+## Contributor Rules
+
+When adding code:
+
+- put H1/H2 protocol behavior in transport protocol modules
+- keep `transport_pool.rs` as the façade
+- keep edge-side dispatch protocol-neutral
+- expose canonical results when transport behavior matters to callers
+
+Do not:
+
+- add direct H1/H2 branching in forwarding or bootstrap code unless the concern is purely ingress compatibility
+- leak protocol-specific helper types upward as public contracts
+- make lifecycle or retry logic inspect protocol internals directly
+
+## Mental Model
+
+The simplest correct model is:
+
+- edge decides whether to send
+- transport decides how to send
+- shared error and outcome layers decide what the send meant
+
+If a change breaks that separation, it likely belongs in a different layer.

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -17,6 +17,7 @@ This page covers:
 - precedence and normalization rules
 - validation behavior
 - runtime meaning of major knobs
+- the boundary between raw YAML input and runtime-normalized policy objects
 
 Default coverage now lives on [Configuration Defaults](defaults.md) so the full inventory can stay centralized and easier to audit against the code.
 
@@ -29,6 +30,49 @@ This page does not change the current product behavior:
   restart.
 - certificate reload (`POST /admin/runtime/reload-certs`) covers new handshakes only
 - backend transport is scheme-driven: `https://` backends use HTTP/2, `http://` backends use HTTP/1.1
+
+## Raw Config vs Runtime Interpretation
+
+Spooky now has a clearer split between:
+
+- raw configuration schema loaded from YAML
+- normalized runtime configuration consumed by the rest of the system
+
+The raw schema is defined by the `config` module and is what this page documents field-by-field.
+
+The runtime model is defined by `crates/config/src/runtime.rs` and the domain interpreters under `crates/config/src/runtime/policies/`. Downstream crates should depend on that runtime model, not on the raw YAML shape.
+
+### Canonical runtime boundary
+
+The important runtime outputs are:
+
+- `RuntimeConfig`
+- `RuntimePolicySet`
+- `RuntimeListenerPolicySet`
+- `RuntimeUpstream`
+- `RuntimeBackendEndpoint`
+- `RuntimeLoadBalancingPolicy`
+- `RuntimeAdmissionPolicy`
+- `RuntimeAuthPolicy`
+- `RuntimeTransportPolicy`
+- `RuntimeTimeoutPolicy`
+
+These types are the validated, normalized forms that `edge`, `transport`, and `lb` actually execute against.
+
+### What normalization means in practice
+
+Normalization is where Spooky resolves and validates things such as:
+
+- listener selection precedence between `listen` and `listeners`
+- per-upstream override precedence over global defaults
+- trimming and rejection of empty strings where fields must be meaningful
+- route host and method canonicalization
+- backend endpoint parsing and transport-kind derivation
+- timeout conversion from raw millisecond fields into runtime `Duration`s
+- cross-field validation for limits, inflight caps, and watchdog/retry policy
+- route, auth, admission, backend, and load-balancing policy shaping
+
+If the raw YAML is accepted, the rest of the system should not need to reinterpret those rules again.
 
 ## Reading This Reference
 
@@ -106,6 +150,155 @@ Precedence and interpretation rules:
 4. Per-upstream load-balancing settings override the top-level `load_balancing` fallback.
 5. Certificate reload updates listener TLS material for future handshakes; it does not rewrite the already-running route or upstream model.
 
+## Runtime Interpretation Domains
+
+The runtime interpreter is now decomposed by policy domain. That split is important because it defines where runtime behavior is shaped and validated.
+
+### Listener and listener-TLS interpretation
+
+The listener interpreter resolves:
+
+- whether `listen` or `listeners[]` is authoritative
+- listener source identity
+- listener bind conflicts
+- default TLS identity and SNI identities
+- listener-scoped TLS reload inventory
+
+This produces runtime listener types such as:
+
+- `RuntimeListener`
+- `RuntimeListenerTls`
+- `ListenerRuntimeConfig`
+
+### Timeout interpretation
+
+Timeout interpretation converts raw timeout fields into the canonical runtime timeout policy:
+
+- backend request timeout
+- backend connect timeout
+- backend body idle and total timeouts
+- shutdown drain timeout
+- client body idle timeout
+- backend DNS refresh interval
+- QUIC idle timeout
+
+Cross-field ordering is validated here rather than by data-plane callers.
+
+### Transport interpretation
+
+Transport interpretation shapes:
+
+- worker and control-plane thread counts
+- shard layout
+- queue capacities
+- UDP buffer sizing
+- inflight limits
+- backend connection reuse policy
+- DNS refresh enablement
+- body-size and prebuffer limits
+
+This produces:
+
+- `RuntimeTransportPolicy`
+- `RuntimeConnectionLimits`
+- `RuntimeBackendConnectionPolicy`
+
+### Auth interpretation
+
+Auth interpretation shapes:
+
+- API key auth policy
+- JWT auth policy
+- external auth policy
+- external auth failure mode
+- external auth request-header shaping
+
+This produces runtime auth types such as:
+
+- `RuntimeAuthPolicy`
+- `RuntimeApiKeyAuth`
+- `RuntimeJwtAuth`
+- `RuntimeExternalAuth`
+
+### Admission and rate-limit interpretation
+
+Admission interpretation shapes:
+
+- brownout policy
+- overload and route queue policy
+- scoped rate-limit rules
+- watchdog-related admission policy
+
+This produces:
+
+- `RuntimeAdmissionPolicy`
+- `RuntimeRateLimitPolicy`
+- `RuntimeScopedRateLimitPolicy`
+- `RuntimeBrownoutPolicy`
+
+### Backend interpretation
+
+Backend interpretation shapes:
+
+- canonical backend endpoint
+- authority host and port
+- hostname vs IP-literal classification
+- runtime backend transport kind
+- backend TLS policy
+- backend DNS policy
+- backend health-check policy
+
+This produces:
+
+- `RuntimeBackendEndpoint`
+- `RuntimeBackendTlsPolicy`
+- `RuntimeBackendDnsPolicy`
+- `RuntimeBackendHealthCheck`
+
+### Load-balancing interpretation
+
+Load-balancing interpretation shapes:
+
+- canonical strategy
+- request-key extraction spec
+- alternate-backend behavior
+
+This produces:
+
+- `RuntimeLoadBalancingPolicy`
+- `RuntimeLoadBalancingStrategy`
+- `RuntimeRequestKeySpec`
+
+### Resilience and watchdog interpretation
+
+Resilience interpretation shapes:
+
+- retry budget policy
+- hedge policy
+- circuit breaker policy
+- watchdog runtime policy
+
+This produces:
+
+- `RuntimeRetryBudgetPolicy`
+- `RuntimeHedgingPolicy`
+- `RuntimeCircuitBreakerPolicy`
+- `RuntimeWatchdogPolicy`
+
+## How To Read Field Semantics
+
+For each setting on this page, keep the following distinction in mind:
+
+- raw schema semantics tell you what can be written in YAML
+- runtime semantics tell you what the interpreter will actually execute after normalization
+
+Examples:
+
+- a backend address string is raw input; `RuntimeBackendEndpoint` is the executed form
+- a timeout field in milliseconds is raw input; `RuntimeTimeoutPolicy` is the executed form
+- a `load_balancing.key` string is raw input; `RuntimeRequestKeySpec` is the executed form
+- auth and admission nested objects are raw input; `RuntimeAuthPolicy` and `RuntimeAdmissionPolicy` are the executed forms
+
 ## Production-Safe Defaults
 
 The configuration model is intentionally safe-by-default in several important areas:
@@ -145,9 +338,21 @@ Configuration schema version.
 
 Server listening configuration. Defines the protocol, address, and port for incoming client connections. Used as the single listener when `listeners` is absent or empty.
 
+Runtime interpretation:
+
+- lowered into `RuntimeListener` plus `RuntimeListenerTls`
+- then wrapped into `ListenerRuntimeConfig` with normalized timeout and transport policy
+- ignored for runtime listener selection when `listeners[]` is non-empty
+
 ### listeners
 
 Optional multi-listener array. When set, overrides the top-level `listen` block. Each entry is an independent listener with its own address, port, and TLS identity. Spooky spawns a separate QUIC worker group and bootstrap TLS listener per entry.
+
+Runtime interpretation:
+
+- becomes the authoritative listener set when non-empty
+- each entry is normalized independently
+- duplicate bind combinations are rejected before startup or reload commit
 
 ### Runtime Normalization And Precedence
 
@@ -172,13 +377,31 @@ Startup rejects ambiguous or contradictory combinations, including duplicate eff
 
 Named upstream pool definitions. Each key represents a unique upstream pool with its own routing rules, load balancing strategy, and backend servers.
 
+Runtime interpretation:
+
+- lowered into `RuntimeUpstream`
+- route matching becomes `RuntimeRouteMatchPolicy`
+- backend entries become `RuntimeBackend` plus `RuntimeBackendEndpoint`
+- effective upstream TLS, auth, admission, and load-balancing policy are resolved here
+
 ### load_balancing
 
 Optional global fallback for upstream load balancing. If an upstream omits `upstream.<name>.load_balancing`, the top-level `load_balancing` value is applied to that upstream during config load.
 
+Runtime interpretation:
+
+- global fallback only
+- each effective upstream receives a canonical `RuntimeLoadBalancingPolicy`
+- request key strings are parsed into `RuntimeRequestKeySpec`
+
 ### log
 
 Logging configuration. Controls log level and output formatting.
+
+Runtime interpretation:
+
+- `log.level` participates in live reload
+- log sink shape such as file output and format is treated as startup-owned and may require restart
 
 ## Default Values
 
@@ -191,6 +414,26 @@ Use that page when you need:
 - the difference between `null`, empty collections, empty strings, and structured section defaults
 
 This reference page keeps the schema and semantics, while [Configuration Defaults](defaults.md) owns the exhaustive default matrix.
+
+## Validation Model
+
+Validation happens during runtime interpretation, not lazily in downstream crates.
+
+Important validation categories include:
+
+- invalid listener bind combinations
+- invalid or contradictory TLS identity configuration
+- duplicate normalized route matchers
+- invalid backend endpoint addresses
+- unsupported load-balancing strategies or key specs
+- zero or out-of-range timeout and limit values
+- illegal cross-field timeout ordering
+- unsupported watchdog or auth policy combinations
+
+The expected downstream contract is:
+
+- if `RuntimeConfig::from_config(...)` succeeds, the runtime receives canonical and validated policy objects
+- data-plane and control-plane crates should consume those objects rather than repeat raw-schema validation
 
 ## Listen Configuration
 

--- a/docs/operations/control-plane.md
+++ b/docs/operations/control-plane.md
@@ -1,0 +1,188 @@
+# Control Plane
+
+This document explains the operator-facing control-plane services in Spooky and the boundaries each service is allowed to know about runtime state.
+
+## Services
+
+The control plane consists of three main service surfaces:
+
+- control API
+- metrics endpoint
+- watchdog service
+
+These services are not listener sidecars anymore. They are explicit services built from canonical runtime views and shared services.
+
+## Control API
+
+The control API is the privileged administrative HTTP surface.
+
+Its responsibilities are:
+
+- health and readiness checks
+- runtime snapshot rendering
+- runtime reload
+- listener certificate reload
+- controlled restart requests
+
+### Transport and protocol expectations
+
+- protocol: HTTP/1.1 over TLS
+- audience: operators and automation only
+- security model: bearer-token protected for privileged routes
+
+### Route families
+
+The current route family includes:
+
+- health
+- ready
+- runtime
+- reload-certs
+- reload
+- restart
+
+Refer to [Control API Reference](../reference/control-api-reference.md) for concrete endpoints.
+
+### What the control API is allowed to know
+
+The control API should read from:
+
+- canonical runtime generation view
+- shared runtime services
+- backend lifecycle inventory
+- watchdog state
+
+It should not depend on listener-local internals that only exist because a particular ingress path happens to hold them.
+
+## Metrics Endpoint
+
+The metrics endpoint is the Prometheus scrape surface.
+
+Its responsibilities are:
+
+- expose rendered Prometheus text
+- validate the configured scrape path
+- stay bound to the current runtime metrics surface
+
+### Operator expectations
+
+- only the configured metrics path returns metrics
+- wrong paths return `404`
+- response content type is Prometheus text format
+- metrics are rendered from the canonical shared metrics registry
+
+The metrics endpoint is intentionally simpler than the control API. It is a read-only scrape surface, not an administration interface.
+
+## Watchdog Service
+
+The watchdog is the control-plane coordinator for runtime liveness degradation and controlled restart workflows.
+
+Its responsibilities are:
+
+- monitor poll progress and service health
+- mark the runtime degraded when thresholds are crossed
+- request controlled restarts
+- coordinate drained worker completion across the runtime
+
+### Important watchdog state
+
+Operators should expect the watchdog to surface:
+
+- whether it is enabled
+- whether the system is degraded
+- whether a restart has been requested
+- restart reason
+- restart request timestamp
+- whether all expected workers have drained
+
+This state is surfaced through control-plane runtime views rather than by reading listener internals directly.
+
+## Runtime View Contract
+
+All control-plane services should depend on the same runtime model:
+
+- active runtime generation
+- shared runtime services
+- generation-owned state where relevant
+
+This ensures:
+
+- metrics and control API describe the same active generation
+- restart and reload actions act on the same authoritative runtime handle
+- backend lifecycle state is rendered from one canonical inventory
+
+## Authentication and Access Model
+
+### Control API
+
+Privileged control API routes require bearer-token authorization.
+
+Health and readiness routes are intentionally treated differently from privileged administration routes and may be left unauthenticated depending on configuration and deployment pattern.
+
+### Metrics endpoint
+
+The metrics endpoint is typically protected by deployment topology rather than by the control API auth model.
+
+Expose it only on loopback or an isolated observability network unless you explicitly want broader visibility.
+
+### Watchdog
+
+The watchdog is not a public HTTP surface. It is an internal coordinator surfaced through metrics and control API snapshots.
+
+## Separation from the Data Plane
+
+Control-plane code should be able to answer operator questions without becoming part of the request hot path.
+
+That means:
+
+- no request-path policy logic should live in control-plane services
+- no control-plane-only state should be required to serve requests
+- admin surfaces should observe canonical runtime state, not own it
+
+## Operational Expectations
+
+Operators should expect the control plane to answer questions such as:
+
+- what runtime generation is active
+- is the system ready to serve
+- is the watchdog degraded or requesting restart
+- what do backend health and placement look like
+- can a reload be applied safely
+
+They should not need to infer those answers indirectly from unrelated logs.
+
+## Failure Behavior
+
+When control-plane services fail, the desired behavior is:
+
+- fail clearly
+- leave the active data plane intact
+- preserve the authoritative runtime generation unless an explicit swap succeeded
+
+For example:
+
+- a rejected reload must leave the active generation unchanged
+- a metrics scrape failure should not affect request serving
+- a control API bind or TLS initialization failure should be treated as an explicit service failure, not hidden behind data-plane behavior
+
+## Contributor Rules
+
+When adding operator-facing functionality:
+
+- put administrative request handling in control API modules
+- put scrape-only rendering in metrics modules
+- put restart/degraded coordination in watchdog
+- read runtime state through canonical runtime views
+
+Do not:
+
+- add listener-local state dependencies only to satisfy an admin surface
+- duplicate runtime snapshot assembly in multiple services
+- let control-plane services become alternate owners of runtime state
+
+## Related Pages
+
+- [Observability Contract](../architecture/observability-contract.md)
+- [Reload and Drain](reload-and-drain.md)
+- [Metrics and Alerts](metrics-and-alerts.md)
+- [Control API Reference](../reference/control-api-reference.md)

--- a/docs/operations/metrics-and-alerts.md
+++ b/docs/operations/metrics-and-alerts.md
@@ -1,0 +1,260 @@
+# Metrics and Alerts
+
+This document explains which Spooky metrics matter most in production and how operators should use them for alerting and dashboards.
+
+## Purpose
+
+Spooky exposes many counters, gauges, and labeled request families. Operators should focus on the metrics that answer:
+
+- is traffic succeeding
+- is latency rising
+- is admission or overload policy firing
+- are backends healthy
+- are retries and hedges increasing
+- is the runtime generation and control plane behaving normally
+
+For the full catalog, see [Metrics Reference](../reference/metrics-reference.md).
+
+## Primary Production Domains
+
+The metrics surface is easiest to understand by domain.
+
+### Request outcome metrics
+
+These answer whether traffic is succeeding or failing.
+
+Key families:
+
+- `spooky_requests_total`
+- `spooky_requests_success`
+- `spooky_requests_failure`
+- `spooky_upstream_requests_total{upstream,status_class,outcome}`
+- `spooky_backend_requests_total{upstream,backend,status_class,outcome}`
+
+Use these to answer:
+
+- which upstream is failing
+- which backend is producing the failures
+- whether failures are timeouts, overload, rate-limit, or backend errors
+
+### Latency metrics
+
+These answer how long requests are taking.
+
+Key families:
+
+- `spooky_upstream_request_latency_ms_bucket`
+- `spooky_upstream_request_latency_ms_sum`
+- `spooky_upstream_request_latency_ms_count`
+- `spooky_route_latency_ms_p50`
+- `spooky_route_latency_ms_p95`
+- `spooky_route_latency_ms_p99`
+
+Prefer the histogram family for service-level alerting and the route percentile gauges for quick route-level dashboards.
+
+### Admission and overload metrics
+
+These answer whether the system is refusing work before dispatch.
+
+Key families:
+
+- `spooky_policy_denied`
+- `spooky_request_rate_limited`
+- `spooky_overload_shed`
+- `spooky_overload_shed_by_reason_total{reason=...}`
+- `spooky_inflight_wait_admit_total{scope=...}`
+- `spooky_brownout_active`
+- `spooky_circuit_breaker_rejected_total`
+
+These are especially important during load tests, incident response, and capacity tuning.
+
+### Backend health and lifecycle metrics
+
+These answer whether upstream capacity is healthy.
+
+Key families:
+
+- `spooky_health_checks_total`
+- `spooky_health_checks_success`
+- `spooky_health_checks_failure`
+- `spooky_backend_timeouts`
+- `spooky_backend_errors`
+- `spooky_health_failures_total{reason=...}`
+- `spooky_backend_dns_refresh_success_total`
+- `spooky_backend_dns_refresh_failure_total`
+- `spooky_backend_dns_address_set_changes_total`
+- `spooky_backend_client_rotations_total`
+
+These should be interpreted together with backend lifecycle snapshots from the control API.
+
+### Buffering and body-pressure metrics
+
+These answer whether request or response streaming pressure is building.
+
+Key families:
+
+- `spooky_request_buffered_bytes`
+- `spooky_request_buffered_high_watermark_bytes`
+- `spooky_request_buffer_limit_rejects`
+- `spooky_response_prebuffer_limit_rejects`
+
+These are important leading indicators of backpressure or response-shaping issues before outright traffic failure.
+
+### Retry and hedge metrics
+
+These answer whether resiliency behavior is activating.
+
+Key families:
+
+- `spooky_retries_total`
+- `spooky_retry_denied_total{reason=...}`
+- `spooky_retry_attempts_total{reason=...}`
+- `spooky_hedge_triggered_total`
+- `spooky_hedge_won_total`
+- `spooky_hedge_wasted_total`
+- `spooky_hedge_primary_won_after_trigger_total`
+
+Rising retries or hedges may be correct behavior, but sustained increases usually indicate backend degradation or timeout pressure.
+
+### Connection and ingress metrics
+
+These answer whether the edge ingress path itself is healthy.
+
+Key families:
+
+- `spooky_active_connections`
+- `spooky_connection_cap_rejects`
+- `spooky_ingress_packets_total`
+- `spooky_ingress_queue_drops`
+- `spooky_ingress_queue_drop_bytes`
+- `spooky_ingress_queue_bytes`
+- `spooky_ingress_bad_header_total`
+- `spooky_ingress_rate_limited_total`
+- `spooky_ingress_unroutable_total`
+- `spooky_ingress_draining_drops_total`
+
+These are key signals for edge saturation, malformed traffic, and drain behavior.
+
+### TLS metrics
+
+These answer whether TLS negotiation is healthy on both downstream and upstream paths.
+
+Key families:
+
+- `spooky_downstream_tls_handshake_success_total`
+- `spooky_downstream_tls_handshake_failure_total{listener,reason}`
+- `spooky_downstream_tls_certificate_selection_total{listener,selection}`
+- `spooky_downstream_tls_alpn_total{listener,protocol}`
+- `spooky_upstream_tls_failure_total{backend,phase,reason}`
+
+These are critical for certificate rollouts and protocol transition debugging.
+
+### Control-plane and runtime metrics
+
+These answer whether the administrative surfaces and watchdog are stable.
+
+Key families:
+
+- `spooky_control_api_connection_limit_drops`
+- `spooky_watchdog_restart_requests`
+- `spooky_watchdog_restart_hooks`
+- `spooky_watchdog_degraded_windows`
+- `spooky_runtime_panics`
+
+These are not request SLO metrics, but they are important for platform reliability.
+
+## First Dashboards To Build
+
+Start with dashboards grouped by the domains above.
+
+Recommended first dashboards:
+
+- request success/failure by upstream
+- backend outcome and timeout dashboard
+- upstream latency percentile dashboard
+- admission and overload dashboard
+- retry and hedge activity dashboard
+- backend DNS refresh and health dashboard
+- ingress saturation and buffering dashboard
+- TLS health dashboard
+- runtime/control-plane health dashboard
+
+## First Alerts To Add
+
+### Request failure alerts
+
+Alert on sustained increases in:
+
+- upstream 5xx rate
+- backend error outcome rate
+- timeout outcome rate
+
+### Admission alerts
+
+Alert on sustained growth in:
+
+- overload shed by reason
+- rate-limit denials where unexpected
+- request buffer or response prebuffer rejects
+
+### Backend health alerts
+
+Alert on:
+
+- health-check failure rate increases
+- backend timeout spikes
+- backend DNS refresh failures
+- upstream TLS failure increases
+
+### Ingress saturation alerts
+
+Alert on:
+
+- ingress queue drops
+- ingress queue bytes remaining elevated
+- connection cap rejects
+- request buffered bytes remaining elevated
+
+### Control-plane alerts
+
+Alert on:
+
+- watchdog restart requests
+- watchdog degraded windows
+- runtime panics
+- unexpected control API limiter drops
+
+## Metric Interpretation Rules
+
+### Use labeled families first
+
+The coarse top-level counters are useful, but production dashboards should usually prefer the labeled upstream and backend families so the problem can be localized.
+
+### Use canonical reason labels
+
+Reason labels are part of the stable observability contract. Build alerts and dashboards on canonical values rather than prose parsing.
+
+### Correlate metrics with control-plane snapshots
+
+Metrics tell you trend and rate. Control-plane snapshots tell you current runtime state. Use both:
+
+- metrics to detect an issue
+- control API runtime and backend inventory to inspect current state
+
+## Operator Expectations
+
+Metrics should let operators answer:
+
+- what is failing
+- where it is failing
+- why it is failing in canonical reason terms
+- whether the problem is ingress, policy, backend, transport, TLS, or runtime control
+
+If a dashboard requires reading implementation-specific logs to interpret a core metric, the dashboard likely needs to be redesigned around the canonical labeled families.
+
+## Related Pages
+
+- [Metrics Reference](../reference/metrics-reference.md)
+- [Observability Contract](../architecture/observability-contract.md)
+- [Control Plane](control-plane.md)
+- [Reload and Drain](reload-and-drain.md)

--- a/docs/operations/reload-and-drain.md
+++ b/docs/operations/reload-and-drain.md
@@ -1,0 +1,203 @@
+# Reload and Drain
+
+This document explains what changes live in Spooky, what requires restart, and what operators should expect during reload and drain workflows.
+
+## Purpose
+
+Spooky now has a clearer runtime generation model:
+
+- startup-owned state
+- generation-owned state
+- long-lived shared services
+
+Reload and drain behavior follows that model.
+
+## Runtime Reload Model
+
+Runtime reload works by preparing a complete next runtime bundle and atomically swapping it into place.
+
+Important properties:
+
+- readers observe whole bundles, not partial in-place mutation
+- the previous generation remains valid for in-flight work that still holds it
+- generation-scoped tasks for the previous bundle are retired after replacement
+
+This means reload is a generation swap, not a best-effort patch of live state.
+
+## What Reload Changes Live
+
+Runtime reload is intended for changes such as:
+
+- routing and upstream policy changes
+- backend set changes
+- load-balancing changes
+- admission and resilience policy changes
+- runtime timeout and transport policy changes that are modeled as reloadable generation state
+- `log.level` changes
+
+When the reload succeeds:
+
+- new requests use the new generation immediately
+- in-flight work on the old generation drains naturally
+
+## What Does Not Reload Live
+
+Some changes are restart-required because they belong to startup-owned or separately bound service domains.
+
+Examples include:
+
+- non-live logging sink settings such as log file path and log format
+- tracing enablement and related startup-owned tracing settings
+- some bind and service-surface compatibility changes that require new listeners or rebind validation
+
+The system should reject these as incompatible reloads rather than partially applying them.
+
+## Reload Compatibility Checks
+
+Reload compatibility is validated centrally before swap.
+
+The control-plane reload flow checks:
+
+- listener/runtime compatibility
+- control API compatibility
+- metrics endpoint compatibility
+- startup-owned state compatibility
+
+Operators should expect:
+
+- an explicit rejection when a reload is not safe
+- the currently active generation to remain authoritative when rejection occurs
+
+## Control API Reload Endpoints
+
+Two control-plane actions matter here:
+
+- runtime reload
+- certificate reload
+
+### Runtime reload
+
+This rebuilds and validates a new runtime generation and swaps it if allowed.
+
+### Certificate reload
+
+This reloads listener TLS material for new handshakes only. It is not the same as full runtime config reload.
+
+## Runtime Generation Visibility
+
+Operators should verify reload outcomes using:
+
+- control API runtime generation id
+- reload response payloads
+- logs around reload rejection or generation swap
+
+Do not assume that file edits on disk imply the active runtime changed. The authoritative signal is the committed active generation.
+
+## Drain Semantics
+
+Drain is the controlled path for stopping new useful work while letting existing work finish when possible.
+
+At a high level, drain means:
+
+- listener enters draining mode
+- existing active streams are allowed to finish if possible
+- if no active streams remain, connections are closed and the listener can stop
+- if the drain timeout expires, remaining connections are closed
+
+Drain is part of graceful shutdown and also part of watchdog-driven restart workflows.
+
+## Watchdog-Driven Restart Flow
+
+The watchdog can request a restart when runtime progress degrades beyond policy thresholds.
+
+The expected flow is:
+
+1. watchdog requests restart and records a reason
+2. listener sees the restart request and enters draining mode
+3. workers eventually report drained state
+4. watchdog completes the restart cycle once the workflow is done
+
+Operators should expect readiness and runtime snapshot state to reflect this transition rather than needing to infer it from scattered logs.
+
+## What Happens to In-Flight Requests
+
+### On reload
+
+- existing requests continue on the generation they started with
+- new requests use the new generation after the swap
+
+### On drain
+
+- active requests may complete if they finish before drain timeout and before forced close
+- if graceful completion is not possible, remaining connections are closed
+
+This is why generation ownership and drain lifecycle are distinct concerns.
+
+## Operator Expectations
+
+Operators should expect reload to answer:
+
+- did compatibility validation pass
+- was a new generation committed
+- what generation is active now
+
+Operators should expect drain to answer:
+
+- is draining active
+- did the watchdog request it
+- how long has restart been pending
+- have workers drained yet
+
+## Recommended Workflow
+
+For routine runtime changes:
+
+1. update config on disk
+2. call runtime reload
+3. verify the active generation changed
+4. verify control API snapshot and metrics align with expected state
+
+For restart-required changes:
+
+1. stage the config change
+2. use maintenance orchestration or restart workflow
+3. treat the restart as a controlled drain event, not as a hot reload
+
+For certificate-only changes:
+
+1. update TLS material
+2. use certificate reload
+3. verify new handshakes use the refreshed material
+
+## Failure Expectations
+
+If reload fails:
+
+- active generation remains unchanged
+- rejection should be explicit
+- operators should not assume partial progress
+
+If drain times out:
+
+- remaining connections are closed
+- the process should still complete shutdown/restart progression rather than hanging indefinitely
+
+## Contributor Rules
+
+When adding new reloadable state:
+
+- decide whether it is startup-owned, generation-owned, or process-shared
+- make reload compatibility explicit
+- expose reload result through canonical runtime generation/state surfaces
+
+Do not:
+
+- add silent partial reload behavior
+- let control-plane code invent its own reload compatibility rules outside the canonical path
+- mutate active runtime state in place when the generation model expects replacement
+
+## Related Pages
+
+- [Runtime Generation Model](../architecture/runtime-generation.md)
+- [Control Plane](control-plane.md)
+- [Control API Reference](../reference/control-api-reference.md)

--- a/docs/public-api-surface-inventory.md
+++ b/docs/public-api-surface-inventory.md
@@ -1,20 +1,20 @@
 # Public API Surface Inventory
 
-Phase 1 baseline for `refactor/final-api-lockdown-and-deletion`.
-
 How to use this file:
 
 - use it as the canonical map of intentional crate façades before adding or widening visibility
 - check whether a type or module is meant to be a public entrypoint, a crate-local collaboration seam, or an accidental leak
 - update this file when a refactor deliberately changes a crate boundary, instead of letting visibility drift silently
 - do not use this file as a substitute for module docs; use it to answer "should this be public at all?"
+- prefer adding new logic behind an owning façade or crate-local seam instead of widening visibility for convenience
+- if a type belongs to runtime ownership, transport execution, bridge shaping, or load-balancing substrate, keep it in that owning layer rather than re-exporting it from an unrelated crate root
 
 Purpose:
-- re-state the current crate façades exactly as the branch exposes them
+- re-state the current crate façades exactly as the codebase exposes them
 - classify every non-private boundary item in the primary architecture crates
 - identify which exposed items are canonical API, crate-local collaboration seams, compatibility surfaces, or stale leftovers
 
-Scope for this baseline:
+Scope:
 - `crates/edge`
 - `crates/config`
 - `crates/bridge`
@@ -27,7 +27,7 @@ Classification keys:
 - `temporary compatibility surface`: intentionally exposed, but not the recommended long-term owning surface
 - `stale leftover`: exposed item that no longer has a clear architectural reason to stay visible
 
-This document classifies current visibility. It does not by itself change policy.
+This document classifies current visibility. It is a contributor aid for deciding whether code belongs on a public crate surface, an internal collaboration seam, or nowhere visible at all.
 
 ## `spooky-edge`
 
@@ -40,7 +40,7 @@ This document classifies current visibility. It does not by itself change policy
 | --- | --- | --- | --- |
 | `benchmark` | `pub mod` | canonical public API | Explicit support surface at crate root. |
 | `body` | `pub mod` | canonical public API | Owning module for `ChannelBody`. |
-| `cid_radix` | `pub mod` | canonical public API | Still treated as a direct crate surface on this branch. |
+| `cid_radix` | `pub mod` | canonical public API | Direct crate surface today. |
 | `constants` | private `mod` | n/a | Edge defaults now escape only through deliberate root re-exports. |
 | `hash` | private `mod` | n/a | Hash helpers now escape only through deliberate root re-exports. |
 | `metrics` | `pub mod` | canonical public API | Owns exported metrics-facing runtime types. |
@@ -78,7 +78,7 @@ This document classifies current visibility. It does not by itself change policy
 | `runtime::health` | `pub mod` | canonical public API | Stable health classification/output surface. |
 | `runtime::listener` | `pub mod` | canonical public API | Public listener state type owner. |
 | `runtime::policy` | `pub mod` | canonical public API | Public runtime policy access surface. |
-| `runtime::shared_state` | `pub mod` | canonical public API | Stable shared-state surface on this branch. |
+| `runtime::shared_state` | `pub mod` | canonical public API | Stable shared-state surface. |
 | `runtime::tasks` | `pub(crate) mod` | internal-to-crate collaboration surface | Runtime task lifecycle internals. |
 | `runtime::tls` | `pub(crate) mod` | internal-to-crate collaboration surface | Runtime TLS loading/reload internals. |
 
@@ -92,7 +92,7 @@ This document classifies current visibility. It does not by itself change policy
 | `watchdog::state` | `pub(crate) mod` | internal-to-crate collaboration surface | Internal state carrier. |
 | `watchdog::time` | `pub(crate) mod` | internal-to-crate collaboration surface | Internal timing helpers. |
 
-### Phase 1 baseline calls
+### Edge boundary notes
 
 - `quic_listener` staying private is correct and should remain the baseline.
 - `runtime::{connection,generation,tasks,tls}` and `watchdog::{config,service,state,time}` are legitimate crate-local collaboration seams.
@@ -111,7 +111,7 @@ This document classifies current visibility. It does not by itself change policy
 | --- | --- | --- | --- |
 | `backend_endpoint` | `pub mod` | canonical public API | Shared endpoint parsing/runtime shaping surface. |
 | `config` | `pub mod` | canonical public API | User-facing raw config schema owner. |
-| `default` | `pub mod` | canonical public API | Explicit defaults surface on this branch. |
+| `default` | `pub mod` | canonical public API | Explicit defaults surface. |
 | `loader` | `pub mod` | canonical public API | Canonical config-loading entrypoint. |
 | `runtime` | `pub mod` | canonical public API | Canonical normalized runtime output surface. |
 | `validator` | `pub mod` | canonical public API | Canonical validation surface. |
@@ -140,7 +140,7 @@ This document classifies current visibility. It does not by itself change policy
 | `RuntimeConfig::upstreams_as_config` | `#[cfg(test)] pub(crate) fn` | internal-to-crate collaboration surface | Test-only visibility shim; not public API. |
 | `RuntimeUpstream::backend_tls_policy` field | `pub(crate)` field | internal-to-crate collaboration surface | Internal escape hatch on an otherwise public type. |
 
-### Phase 1 baseline calls
+### Config boundary notes
 
 - `runtime` remains the correct canonical API owner for lowered policy/config state.
 - policy interpreter modules are correctly private already.
@@ -165,7 +165,7 @@ This document classifies current visibility. It does not by itself change policy
 | `response` | `pub mod` | canonical public API | Canonical response normalization surface. |
 | `websocket` | `pub mod` | canonical public API | Canonical websocket and upgrade helper surface. |
 
-### Phase 1 baseline calls
+### Bridge boundary notes
 
 - the bridge crate façade is already narrow and aligned with intended ownership.
 - `BridgeError` no longer escapes through the bridge root; callers use the owning `spooky-errors` path.
@@ -190,7 +190,7 @@ This document classifies current visibility. It does not by itself change policy
 | `upstream_pool` | `pub mod` | canonical public API | Deliberate public subsystem. |
 | `HealthTransition` | `pub use` | canonical public API | Narrow shared lifecycle transition type promoted from private backend internals. |
 
-### Phase 1 baseline calls
+### LB boundary notes
 
 - `algorithms`, `backend`, and `backend_pool` are no longer public module trees.
 - `HealthTransition` remains public as the only deliberate cross-crate lifecycle type from the prior backend substrate.
@@ -226,7 +226,7 @@ This document classifies current visibility. It does not by itself change policy
 | `TransportClientRotation` | `pub struct` | canonical public API | Narrow public wrapper around internal rotation state. |
 | `UpstreamTransportPool` | `pub struct` | canonical public API | Canonical execution façade for downstream callers. |
 
-### Phase 1 baseline calls
+### Transport boundary notes
 
 - the transport crate boundary is already in the intended shape: private protocol modules plus narrow façade re-exports.
 - no hidden compatibility modules remain at the crate root.
@@ -250,23 +250,19 @@ This document classifies current visibility. It does not by itself change policy
 
 ### Temporary compatibility surfaces
 
-- none in the scoped crates after the Phase 3 hidden-surface audit
+- none in the scoped crates
 
-### Stale leftovers requiring Phase 2 review
+### Stale leftovers
 
-- none at the crate-root façade level in the scoped crates after the Phase 2 lockdown pass
+- none at the crate-root façade level in the scoped crates
 
-## Current Exit Check
+## Placement Guidance
 
 - every non-private boundary item in the scoped crates has an explicit classification
-- the current baseline no longer relies on “probably needed” wording
-- the Phase 2 and Phase 3 façade-hardening work is reflected in the classifications above
-
-## Verification Pass
-
-- `cargo fmt --all` applied; the only changes were whitespace reflow caused by earlier renames and field removals
-- `cargo check --workspace --all-targets` is clean, and `spooky-edge` reports no `unreachable_pub` warnings
-- crate-targeted tests pass for `lb`, `bridge`, `transport`, `config`, and `edge`
-- `cargo test --workspace --no-fail-fast` passes: 725 tests, 0 failures, 2 ignored
-- the five scoped crate roots were re-read and match the intended architecture; `runtime` and `watchdog` submodule visibility also matches this document
-- known pre-existing flake: `edge` integration test `concurrent_large_body_pressure_is_bounded` intermittently observes a `502` where it asserts only `200`/`503`. Reproduced on `e089628` (before this branch's cleanup), so it is not a regression from the lockdown work.
+- if a new item does not clearly fit `canonical public API` or `internal-to-crate collaboration surface`, it probably should not be exposed
+- public crate roots should stay narrow and intentional
+- protocol details belong in owning crates such as `bridge` and `transport`, not in unrelated façade exports
+- runtime state and lifecycle ownership belong under `edge::runtime`, not under request-ingress helpers
+- request shaping and response normalization belong under `bridge`
+- balancing substrate belongs under `lb`
+- normalized runtime policy output belongs under `config::runtime`

--- a/docs/public-api-surface-inventory.md
+++ b/docs/public-api-surface-inventory.md
@@ -2,6 +2,13 @@
 
 Phase 1 baseline for `refactor/final-api-lockdown-and-deletion`.
 
+How to use this file:
+
+- use it as the canonical map of intentional crate façades before adding or widening visibility
+- check whether a type or module is meant to be a public entrypoint, a crate-local collaboration seam, or an accidental leak
+- update this file when a refactor deliberately changes a crate boundary, instead of letting visibility drift silently
+- do not use this file as a substitute for module docs; use it to answer "should this be public at all?"
+
 Purpose:
 - re-state the current crate façades exactly as the branch exposes them
 - classify every non-private boundary item in the primary architecture crates
@@ -249,13 +256,13 @@ This document classifies current visibility. It does not by itself change policy
 
 - none at the crate-root façade level in the scoped crates after the Phase 2 lockdown pass
 
-## Phase 1 Exit Check
+## Current Exit Check
 
 - every non-private boundary item in the scoped crates has an explicit classification
 - the current baseline no longer relies on “probably needed” wording
-- the main unresolved Phase 2 targets are now named rather than implicit
+- the Phase 2 and Phase 3 façade-hardening work is reflected in the classifications above
 
-## Phase 8 Verification Pass
+## Verification Pass
 
 - `cargo fmt --all` applied; the only changes were whitespace reflow caused by earlier renames and field removals
 - `cargo check --workspace --all-targets` is clean, and `spooky-edge` reports no `unreachable_pub` warnings

--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -8,6 +8,25 @@ Legend:
 - `Partial`: implemented with important caveats or limited scope
 - `Missing`: not implemented as a first-class feature
 
+## Refactor Foundations
+
+These are architectural foundations rather than user-facing product features, but they now materially define how the codebase behaves and how future work should be added.
+
+| Area | Status | Notes |
+| --- | --- | --- |
+| Request admission and policy evaluation | `Done` | Shared admission flow covers auth checks, scoped rate limits, brownout, overload, and rejection mapping |
+| Route resolution and backend selection pipeline | `Done` | Shared route match, upstream lookup, LB strategy, backend selection, and resolution telemetry flow |
+| Canonical load-balancing key resolution | `Done` | Cookie/query/header/bearer/CID/peer-IP extraction plus shared fallback behavior |
+| Shared upstream error classification | `Done` | Timeout/transport/TLS/protocol normalization with shared health and retry interpretation |
+| Canonical request building | `Done` | Host policy, forwarded-header policy, and shared H1/H2 request construction live behind `bridge` |
+| Canonical response normalization | `Done` | Hop-header stripping, trailer handling, bodyless/no-content shaping, and bootstrap/QUIC parity |
+| External auth decision layer | `Done` | Timeout/failure-mode handling, allowlist filtering, mutation safety, deny/challenge/redirect mapping |
+| Runtime generation model | `Done` | Startup-owned, generation-owned, and shared runtime ownership boundaries are formalized |
+| Unified backend lifecycle model | `Done` | DNS refresh, health observations, request feedback, pool placement, and lifecycle snapshots are coordinated |
+| Canonical transport façade | `Done` | Edge depends on transport execution contract instead of H1/H2 pool details |
+| Listener/runtime façade split | `Done` | `quic_listener` and bootstrap paths are decomposed into orchestration-oriented modules |
+| Public API and visibility hardening | `Done` | Canonical crate façades and reduced accidental exports across edge, config, bridge, lb, transport, and errors |
+
 ## Protocols
 
 | Area | Status | Notes |
@@ -89,7 +108,7 @@ Legend:
 | Runtime status endpoint | `Done` | Implemented |
 | Restart endpoint | `Done` | Implemented |
 | Cert reload endpoint | `Done` | Implemented |
-| Full config hot reload | `Partial` | Startup-owned settings + listner removal, bind still need restart |
+| Full config hot reload | `Partial` | Broad runtime swap exists; startup-owned settings and bind/topology changes still require restart or explicit compatibility handling |
 | Dynamic route updates | `Done via config reload` | routing index rebuilt + swapped |
 | Dynamic upstream membership API | `Missing` | No first-class API |
 | DNS refresh | `Done` | Implemented for hostname-based backends |
@@ -115,6 +134,8 @@ Legend:
 | --- | --- | --- |
 | Prometheus metrics | `Done` | Rich built-in metrics |
 | Structured logging | `Done` | Plain and JSON formats |
+| Canonical observability vocabulary | `Done` | Shared reason slugs align metrics, logs, and control-plane snapshot fields |
+| Control-plane runtime snapshots | `Done` | Backend lifecycle, runtime generation, watchdog, TLS, and coarse metrics summary exposed through shared runtime views |
 | OTLP tracing hooks | `Done` | Optional |
 | Packaging for Docker | `Done` | Present |
 | Packaging for Debian/systemd | `Done` | Present |
@@ -128,6 +149,7 @@ Spooky is strongest today as:
 - an HTTP/3-first edge proxy
 - a deterministic routing and balancing layer with scheme-driven H1/H2 upstream transport
 - a proxy with strong resource-bound and teardown behavior
+- a codebase with shared policy/runtime boundaries in place across request path, runtime ownership, backend lifecycle, transport, and observability
 
 Spooky is not yet strongest as:
 


### PR DESCRIPTION
## Summary
This PR updates the documentation to match the refactored codebase and the final runtime ownership model. It adds missing architecture and operations docs, aligns configuration docs with the runtime interpreter, and cleans up the public API inventory, feature matrix, and changelog so contributors and operators see the current system shape instead of pre-refactor structure.

## What Changed
- added architecture docs for:
  - edge runtime ownership
  - bootstrap vs QUIC ingress roles
  - runtime generation model
  - backend lifecycle
  - request lifecycle
  - transport boundaries
  - observability contract
- added operations docs for:
  - control plane
  - reload and drain behavior
  - metrics and alerts
- updated configuration reference to distinguish:
  - raw YAML schema
  - normalized runtime interpretation
  - runtime policy domain boundaries
- updated public API inventory to:
  - remove branch/phase audit noise
  - keep only durable façade and visibility guidance
  - make crate-boundary intent clearer for future contributors
- updated feature matrix to mark the major refactor foundations as complete
- updated changelog summary to explain the architectural stabilization and façade hardening work

## Why
The codebase has gone through a large refactor across runtime ownership, backend lifecycle, request processing, transport abstraction, control-plane services, and public API boundaries. The docs needed to catch up so:
- operators can understand reload, drain, control-plane, and observability behavior
- contributors can understand subsystem ownership and crate boundaries
- the documented feature surface matches the actual implementation

## Result
The docs now reflect the current architecture more accurately and provide a cleaner foundation for future feature work without carrying forward refactor-branch language or outdated subsystem descriptions.