### PR TITLE
test(config): lock runtime interpreter contract coverage

### DIFF
--- a/crates/config/src/runtime.rs
+++ b/crates/config/src/runtime.rs
@@ -644,7 +644,10 @@ mod tests {
 
         let err = runtime_listeners(&config).expect_err("normalized duplicates must fail");
         assert_eq!(err.category(), "listener_bind_conflict");
-        assert_eq!(err.to_string(), "listener_bind_conflict:  localhost :8443 (listener #1) duplicates LOCALHOST:8443 (listener #0) on  localhost :8443");
+        assert_eq!(
+            err.to_string(),
+            "listener_bind_conflict:  localhost :8443 (listener #1) duplicates LOCALHOST:8443 (listener #0) on  localhost :8443"
+        );
     }
 
     #[test]

--- a/crates/config/src/runtime.rs
+++ b/crates/config/src/runtime.rs
@@ -505,6 +505,10 @@ mod tests {
             listeners[0].source,
             RuntimeListenerSource::ExplicitListeners
         );
+        assert_eq!(
+            listeners[1].source,
+            RuntimeListenerSource::ExplicitListeners
+        );
         assert_eq!(listeners[0].listen.port, 8443);
         assert_eq!(listeners[1].listen.port, 9443);
     }
@@ -531,6 +535,50 @@ mod tests {
             }
         );
         assert!(tls.sni_identities.contains_key("api.example.com"));
+    }
+
+    #[test]
+    fn runtime_listener_tls_uses_first_sni_identity_as_default_when_legacy_pair_is_absent() {
+        let mut config = sample_config();
+        config.listen.tls.cert.clear();
+        config.listen.tls.key.clear();
+        config.listen.tls.certificates = vec![
+            TlsCertificate {
+                server_name: "api.example.com".to_string(),
+                cert: "/tmp/tls/api.pem".to_string(),
+                key: "/tmp/tls/api.key".to_string(),
+            },
+            TlsCertificate {
+                server_name: "WWW.EXAMPLE.COM".to_string(),
+                cert: "/tmp/tls/www.pem".to_string(),
+                key: "/tmp/tls/www.key".to_string(),
+            },
+        ];
+
+        let listeners = runtime_listeners(&config).expect("runtime listeners");
+        let tls = &listeners[0].tls;
+
+        assert_eq!(
+            tls.default_identity,
+            RuntimeTlsIdentity {
+                cert_path: "/tmp/tls/api.pem".to_string(),
+                key_path: "/tmp/tls/api.key".to_string(),
+            }
+        );
+        assert_eq!(
+            tls.sni_identities.get("api.example.com"),
+            Some(&RuntimeTlsIdentity {
+                cert_path: "/tmp/tls/api.pem".to_string(),
+                key_path: "/tmp/tls/api.key".to_string(),
+            })
+        );
+        assert_eq!(
+            tls.sni_identities.get("www.example.com"),
+            Some(&RuntimeTlsIdentity {
+                cert_path: "/tmp/tls/www.pem".to_string(),
+                key_path: "/tmp/tls/www.key".to_string(),
+            })
+        );
     }
 
     #[test]
@@ -564,6 +612,39 @@ mod tests {
         let err = runtime_listeners(&config).expect_err("duplicate listeners must fail");
         assert_eq!(err.category(), "listener_bind_conflict");
         assert!(err.to_string().contains("duplicates"));
+    }
+
+    #[test]
+    fn runtime_listeners_reject_duplicate_bindings_after_address_normalization() {
+        let mut config = sample_config();
+        config.listeners = vec![
+            Listen {
+                protocol: "http3".to_string(),
+                port: 8443,
+                address: "LOCALHOST".to_string(),
+                tls: Tls {
+                    cert: "/tmp/tls/dup-1.pem".to_string(),
+                    key: "/tmp/tls/dup-1.key".to_string(),
+                    certificates: Vec::new(),
+                    client_auth: ClientAuth::default(),
+                },
+            },
+            Listen {
+                protocol: "http3".to_string(),
+                port: 8443,
+                address: " localhost ".to_string(),
+                tls: Tls {
+                    cert: "/tmp/tls/dup-2.pem".to_string(),
+                    key: "/tmp/tls/dup-2.key".to_string(),
+                    certificates: Vec::new(),
+                    client_auth: ClientAuth::default(),
+                },
+            },
+        ];
+
+        let err = runtime_listeners(&config).expect_err("normalized duplicates must fail");
+        assert_eq!(err.category(), "listener_bind_conflict");
+        assert_eq!(err.to_string(), "listener_bind_conflict:  localhost :8443 (listener #1) duplicates LOCALHOST:8443 (listener #0) on  localhost :8443");
     }
 
     #[test]

--- a/crates/config/src/runtime/policies/admission.rs
+++ b/crates/config/src/runtime/policies/admission.rs
@@ -461,10 +461,7 @@ mod tests {
     use super::*;
     use crate::config::{Resilience, ScopedRateLimit, ScopedRateLimitScope};
 
-    fn assert_config_invalid(
-        err: RuntimeConfigError,
-        expected: impl AsRef<str>,
-    ) {
+    fn assert_config_invalid(err: RuntimeConfigError, expected: impl AsRef<str>) {
         let expected = expected.as_ref();
         assert_eq!(err.category(), "config_invalid");
         assert_eq!(err.to_string(), format!("config_invalid: {expected}"));
@@ -561,7 +558,10 @@ mod tests {
         resilience.route_queue.default_cap = 9;
         resilience.route_queue.global_cap = 40;
         resilience.route_queue.shed_retry_after_seconds = 12;
-        resilience.route_queue.caps.insert("payments".to_string(), 3);
+        resilience
+            .route_queue
+            .caps
+            .insert("payments".to_string(), 3);
         resilience.brownout.enabled = true;
         resilience.brownout.trigger_inflight_percent = 85;
         resilience.brownout.recover_inflight_percent = 55;

--- a/crates/config/src/runtime/policies/admission.rs
+++ b/crates/config/src/runtime/policies/admission.rs
@@ -455,3 +455,233 @@ impl RuntimeAdmissionPolicy {
         updated
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{Resilience, ScopedRateLimit, ScopedRateLimitScope};
+
+    fn assert_config_invalid(
+        err: RuntimeConfigError,
+        expected: impl AsRef<str>,
+    ) {
+        let expected = expected.as_ref();
+        assert_eq!(err.category(), "config_invalid");
+        assert_eq!(err.to_string(), format!("config_invalid: {expected}"));
+    }
+
+    fn valid_scoped_rule(scope: ScopedRateLimitScope) -> ScopedRateLimit {
+        ScopedRateLimit {
+            name: "tenant-budget".to_string(),
+            scope,
+            requests_per_sec: 25,
+            burst: 50,
+            key: None,
+            route_allowlist: vec!["payments".to_string()],
+            idle_ttl_secs: 60,
+        }
+    }
+
+    fn valid_resilience() -> Resilience {
+        Resilience::default()
+    }
+
+    #[test]
+    fn scoped_rate_limit_normalization_shapes_route_client_tenant_and_token_scopes() {
+        let route = RuntimeScopedRateLimitPolicy::normalize(&ScopedRateLimit {
+            name: "route-limit".to_string(),
+            scope: ScopedRateLimitScope::Route,
+            ..valid_scoped_rule(ScopedRateLimitScope::Route)
+        })
+        .expect("route rule");
+        assert_eq!(route.scope, ScopedRateLimitScope::Route);
+        assert_eq!(route.key, None);
+
+        let client = RuntimeScopedRateLimitPolicy::normalize(&ScopedRateLimit {
+            name: "client-limit".to_string(),
+            scope: ScopedRateLimitScope::Client,
+            key: Some("  header:x-client-id  ".to_string()),
+            ..valid_scoped_rule(ScopedRateLimitScope::Client)
+        })
+        .expect("client rule");
+        assert_eq!(client.key.as_deref(), Some("header:x-client-id"));
+
+        let tenant = RuntimeScopedRateLimitPolicy::normalize(&ScopedRateLimit {
+            name: "tenant-limit".to_string(),
+            scope: ScopedRateLimitScope::Tenant,
+            key: Some(" query:tenant ".to_string()),
+            ..valid_scoped_rule(ScopedRateLimitScope::Tenant)
+        })
+        .expect("tenant rule");
+        assert_eq!(tenant.key.as_deref(), Some("query:tenant"));
+
+        let token = RuntimeScopedRateLimitPolicy::normalize(&ScopedRateLimit {
+            name: "token-limit".to_string(),
+            scope: ScopedRateLimitScope::Token,
+            key: Some(" bearer_token ".to_string()),
+            ..valid_scoped_rule(ScopedRateLimitScope::Token)
+        })
+        .expect("token rule");
+        assert_eq!(token.key.as_deref(), Some("bearer_token"));
+        assert_eq!(token.idle_ttl, Duration::from_secs(60));
+    }
+
+    #[test]
+    fn rate_limit_normalization_rejects_duplicate_rule_names() {
+        let mut resilience = valid_resilience();
+        resilience.scoped_rate_limits = vec![
+            ScopedRateLimit {
+                name: "client-limit".to_string(),
+                scope: ScopedRateLimitScope::Client,
+                key: Some("header:x-client-id".to_string()),
+                ..valid_scoped_rule(ScopedRateLimitScope::Client)
+            },
+            ScopedRateLimit {
+                name: "client-limit".to_string(),
+                scope: ScopedRateLimitScope::Token,
+                key: Some("bearer_token".to_string()),
+                ..valid_scoped_rule(ScopedRateLimitScope::Token)
+            },
+        ];
+
+        let err = RuntimeRateLimitPolicy::normalize(&resilience).expect_err("duplicate names");
+
+        assert_config_invalid(
+            err,
+            "resilience.scoped_rate_limits contains duplicate rule name 'client-limit'",
+        );
+    }
+
+    #[test]
+    fn admission_policy_normalization_shapes_brownout_and_route_queue() {
+        let mut resilience = valid_resilience();
+        resilience.adaptive_admission.min_limit = 10;
+        resilience.adaptive_admission.max_limit = Some(25);
+        resilience.adaptive_admission.high_latency_ms = 1_500;
+        resilience.route_queue.default_cap = 9;
+        resilience.route_queue.global_cap = 40;
+        resilience.route_queue.shed_retry_after_seconds = 12;
+        resilience.route_queue.caps.insert("payments".to_string(), 3);
+        resilience.brownout.enabled = true;
+        resilience.brownout.trigger_inflight_percent = 85;
+        resilience.brownout.recover_inflight_percent = 55;
+        resilience.brownout.core_routes = vec![" /ledger ".to_string(), " /payments ".to_string()];
+
+        let policy = RuntimeAdmissionPolicy::normalize(&resilience, 100).expect("admission");
+
+        assert!(policy.brownout.enabled);
+        assert_eq!(policy.brownout.trigger_inflight_percent, 85);
+        assert_eq!(policy.brownout.recover_inflight_percent, 55);
+        assert_eq!(
+            policy.brownout.core_routes,
+            vec!["/ledger".to_string(), "/payments".to_string()]
+        );
+        assert_eq!(policy.route_queue.default_cap, 9);
+        assert_eq!(policy.route_queue.global_cap, 40);
+        assert_eq!(policy.route_queue.shed_retry_after_seconds, 12);
+        assert_eq!(policy.route_queue.caps.get("payments"), Some(&3));
+        assert_eq!(policy.adaptive_admission.min_limit, 10);
+        assert_eq!(policy.adaptive_admission.max_limit, 25);
+        assert_eq!(
+            policy.adaptive_admission.high_latency,
+            Duration::from_millis(1_500)
+        );
+    }
+
+    #[test]
+    fn scoped_rate_limit_normalization_rejects_invalid_empty_values_and_scope_mismatches() {
+        let route_with_key = ScopedRateLimit {
+            key: Some("header:x-route-id".to_string()),
+            ..valid_scoped_rule(ScopedRateLimitScope::Route)
+        };
+        let err = RuntimeScopedRateLimitPolicy::normalize(&route_with_key)
+            .expect_err("route scope with key must fail");
+        assert_config_invalid(
+            err,
+            "resilience.scoped_rate_limits['tenant-budget'].key is invalid for scope=route",
+        );
+
+        let tenant_without_key = valid_scoped_rule(ScopedRateLimitScope::Tenant);
+        let err = RuntimeScopedRateLimitPolicy::normalize(&tenant_without_key)
+            .expect_err("tenant scope without key must fail");
+        assert_config_invalid(
+            err,
+            "resilience.scoped_rate_limits['tenant-budget'].key is required for scope=tenant",
+        );
+
+        let invalid_key = ScopedRateLimit {
+            scope: ScopedRateLimitScope::Client,
+            key: Some("header:   ".to_string()),
+            ..valid_scoped_rule(ScopedRateLimitScope::Client)
+        };
+        let err = RuntimeScopedRateLimitPolicy::normalize(&invalid_key)
+            .expect_err("invalid key spec must fail");
+        assert_config_invalid(
+            err,
+            "resilience.scoped_rate_limits['tenant-budget'].key must be a supported request key spec",
+        );
+
+        let empty_route_allowlist = ScopedRateLimit {
+            route_allowlist: vec!["payments".to_string(), "   ".to_string()],
+            ..valid_scoped_rule(ScopedRateLimitScope::Token)
+        };
+        let err = RuntimeScopedRateLimitPolicy::normalize(&empty_route_allowlist)
+            .expect_err("empty route allowlist entry must fail");
+        assert_config_invalid(
+            err,
+            "resilience.scoped_rate_limits['tenant-budget'].route_allowlist must not contain empty values",
+        );
+    }
+
+    #[test]
+    fn admission_policy_normalization_rejects_unsupported_protocol_and_brownout_combinations() {
+        let mut resilience = valid_resilience();
+        resilience.protocol.allow_connect = false;
+        resilience.protocol.connect_allowed_ports = vec![443];
+
+        let err = RuntimeAdmissionPolicy::normalize(&resilience, 100)
+            .expect_err("connect restrictions without allow_connect must fail");
+        assert_config_invalid(
+            err,
+            "resilience.protocol.connect_allowed_ports/connect_allowed_authorities require allow_connect=true",
+        );
+
+        let mut resilience = valid_resilience();
+        resilience.protocol.allowed_methods = vec!["GET".to_string(), "BAD METHOD".to_string()];
+        let err = RuntimeAdmissionPolicy::normalize(&resilience, 100)
+            .expect_err("invalid http token must fail");
+        assert_config_invalid(
+            err,
+            "resilience.protocol.allowed_methods must contain valid HTTP method tokens",
+        );
+
+        let mut resilience = valid_resilience();
+        resilience.protocol.denied_path_prefixes = vec!["payments".to_string()];
+        let err = RuntimeAdmissionPolicy::normalize(&resilience, 100)
+            .expect_err("non slash-prefixed path must fail");
+        assert_config_invalid(
+            err,
+            "resilience.protocol.denied_path_prefixes must contain '/'-prefixed paths",
+        );
+
+        let mut resilience = valid_resilience();
+        resilience.protocol.allow_0rtt = true;
+        resilience.protocol.early_data_safe_methods = Vec::new();
+        let err =
+            RuntimeAdmissionPolicy::normalize(&resilience, 100).expect_err("0-rtt guard must fail");
+        assert_config_invalid(
+            err,
+            "resilience.protocol.early_data_safe_methods must be non-empty when allow_0rtt=true",
+        );
+
+        let mut resilience = valid_resilience();
+        resilience.brownout.trigger_inflight_percent = 70;
+        resilience.brownout.recover_inflight_percent = 70;
+        let err = RuntimeAdmissionPolicy::normalize(&resilience, 100)
+            .expect_err("brownout recover threshold must fail");
+        assert_config_invalid(
+            err,
+            "resilience.brownout.recover_inflight_percent must be < trigger_inflight_percent",
+        );
+    }
+}

--- a/crates/config/src/runtime/policies/auth.rs
+++ b/crates/config/src/runtime/policies/auth.rs
@@ -398,10 +398,7 @@ mod tests {
         RouteAuth,
     };
 
-    fn assert_config_invalid(
-        err: RuntimeConfigError,
-        expected: impl AsRef<str>,
-    ) {
+    fn assert_config_invalid(err: RuntimeConfigError, expected: impl AsRef<str>) {
         let expected = expected.as_ref();
         assert_eq!(err.category(), "config_invalid");
         assert_eq!(err.to_string(), format!("config_invalid: {expected}"));
@@ -552,8 +549,8 @@ mod tests {
             ..JwtAuth::default()
         };
 
-        let err = RuntimeJwtAuth::normalize(&jwt, "payments")
-            .expect_err("empty jwt secret must fail");
+        let err =
+            RuntimeJwtAuth::normalize(&jwt, "payments").expect_err("empty jwt secret must fail");
 
         assert_config_invalid(err, "upstream 'payments' auth.jwt.secret must be non-empty");
     }

--- a/crates/config/src/runtime/policies/auth.rs
+++ b/crates/config/src/runtime/policies/auth.rs
@@ -389,3 +389,218 @@ impl RuntimeAuthPolicy {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{
+        ApiKeyAuth, ExternalAuth, ExternalAuthFailureMode, ExternalAuthRequestHeader, JwtAuth,
+        RouteAuth,
+    };
+
+    fn assert_config_invalid(
+        err: RuntimeConfigError,
+        expected: impl AsRef<str>,
+    ) {
+        let expected = expected.as_ref();
+        assert_eq!(err.category(), "config_invalid");
+        assert_eq!(err.to_string(), format!("config_invalid: {expected}"));
+    }
+
+    #[test]
+    fn api_key_auth_normalization_trims_header_and_keys() {
+        let api_key = ApiKeyAuth {
+            header_name: "  x-api-key  ".to_string(),
+            keys: vec![" primary ".to_string(), "backup".to_string()],
+        };
+
+        let normalized = RuntimeApiKeyAuth::normalize(&api_key, "payments").expect("api key auth");
+
+        assert_eq!(normalized.header_name, "x-api-key");
+        assert_eq!(normalized.keys, vec!["primary", "backup"]);
+    }
+
+    #[test]
+    fn jwt_auth_normalization_trims_optional_fields_and_converts_clock_skew() {
+        let jwt = JwtAuth {
+            secret: "  signing-secret  ".to_string(),
+            issuer: Some("  issuer.example  ".to_string()),
+            audience: Some("  payments-api  ".to_string()),
+            clock_skew_secs: 45,
+        };
+
+        let normalized = RuntimeJwtAuth::normalize(&jwt, "payments").expect("jwt auth");
+
+        assert_eq!(normalized.secret, "signing-secret");
+        assert_eq!(normalized.issuer.as_deref(), Some("issuer.example"));
+        assert_eq!(normalized.audience.as_deref(), Some("payments-api"));
+        assert_eq!(normalized.clock_skew, Duration::from_secs(45));
+    }
+
+    #[test]
+    fn external_http_auth_normalization_preserves_failure_mode_and_request_headers() {
+        let external_auth = ExternalAuth::Http {
+            endpoint: "http://auth.internal/check".to_string(),
+            request_headers: vec![ExternalAuthRequestHeader {
+                name: "  x-tenant-id  ".to_string(),
+                value: "{route.tenant}".to_string(),
+            }],
+            response_header_allowlist: vec![" x-auth-user ".to_string(), "x-auth-role".to_string()],
+            timeout_ms: 2_500,
+            failure_mode: ExternalAuthFailureMode::FailOpen,
+        };
+
+        let normalized =
+            RuntimeExternalAuth::normalize(&external_auth, "payments").expect("external auth");
+
+        assert_eq!(
+            normalized,
+            RuntimeExternalAuth::Http {
+                endpoint: "http://auth.internal/check".to_string(),
+                request_headers: vec![RuntimeExternalAuthRequestHeader {
+                    name: "x-tenant-id".to_string(),
+                    value: "{route.tenant}".to_string(),
+                }],
+                response_header_allowlist: vec![
+                    "x-auth-user".to_string(),
+                    "x-auth-role".to_string()
+                ],
+                timeout: Duration::from_millis(2_500),
+                failure_mode: RuntimeExternalAuthFailureMode::FailOpen,
+            }
+        );
+    }
+
+    #[test]
+    fn external_oidc_auth_normalization_shapes_client_and_scope_fields() {
+        let external_auth = ExternalAuth::Oidc {
+            discovery_url: Some(" https://issuer.example/.well-known/openid-configuration ".into()),
+            issuer_url: Some(" https://issuer.example ".into()),
+            client_id: "  spooky-edge  ".to_string(),
+            client_secret: Some("  secret-value  ".to_string()),
+            audience: Some("  payments-api  ".to_string()),
+            scopes: vec!["openid".to_string(), " profile ".to_string()],
+            request_headers: vec![ExternalAuthRequestHeader {
+                name: " x-request-id ".to_string(),
+                value: "{trace.id}".to_string(),
+            }],
+            response_header_allowlist: vec![" x-user ".to_string()],
+            timeout_ms: 3_000,
+            failure_mode: ExternalAuthFailureMode::FailClosed,
+        };
+
+        let normalized =
+            RuntimeExternalAuth::normalize(&external_auth, "payments").expect("oidc auth");
+
+        assert_eq!(
+            normalized,
+            RuntimeExternalAuth::Oidc {
+                discovery_url: Some(
+                    "https://issuer.example/.well-known/openid-configuration".to_string(),
+                ),
+                issuer_url: Some("https://issuer.example".to_string()),
+                client_id: "spooky-edge".to_string(),
+                client_secret: Some("secret-value".to_string()),
+                audience: Some("payments-api".to_string()),
+                scopes: vec!["openid".to_string(), "profile".to_string()],
+                request_headers: vec![RuntimeExternalAuthRequestHeader {
+                    name: "x-request-id".to_string(),
+                    value: "{trace.id}".to_string(),
+                }],
+                response_header_allowlist: vec!["x-user".to_string()],
+                timeout: Duration::from_millis(3_000),
+                failure_mode: RuntimeExternalAuthFailureMode::FailClosed,
+            }
+        );
+    }
+
+    #[test]
+    fn auth_policy_normalization_rejects_invalid_empty_values() {
+        let auth = RouteAuth {
+            required_scopes: vec!["payments:write".to_string(), "   ".to_string()],
+            ..RouteAuth::default()
+        };
+
+        let err = RuntimeAuthPolicy::normalize(&auth, "payments").expect_err("empty scope");
+
+        assert_config_invalid(
+            err,
+            "upstream 'payments' auth.required_scopes must not contain empty values",
+        );
+    }
+
+    #[test]
+    fn api_key_auth_normalization_rejects_empty_header_name() {
+        let api_key = ApiKeyAuth {
+            header_name: "   ".to_string(),
+            keys: vec!["secret".to_string()],
+        };
+
+        let err = RuntimeApiKeyAuth::normalize(&api_key, "payments")
+            .expect_err("empty api key header must fail");
+
+        assert_config_invalid(
+            err,
+            "upstream 'payments' auth.api_key.header_name must be non-empty",
+        );
+    }
+
+    #[test]
+    fn jwt_auth_normalization_rejects_empty_secret() {
+        let jwt = JwtAuth {
+            secret: "   ".to_string(),
+            ..JwtAuth::default()
+        };
+
+        let err = RuntimeJwtAuth::normalize(&jwt, "payments")
+            .expect_err("empty jwt secret must fail");
+
+        assert_config_invalid(err, "upstream 'payments' auth.jwt.secret must be non-empty");
+    }
+
+    #[test]
+    fn external_auth_normalization_rejects_invalid_header_name() {
+        let external_auth = ExternalAuth::Http {
+            endpoint: "http://auth.internal/check".to_string(),
+            request_headers: vec![ExternalAuthRequestHeader {
+                name: "bad header".to_string(),
+                value: "value".to_string(),
+            }],
+            response_header_allowlist: Vec::new(),
+            timeout_ms: 1_000,
+            failure_mode: ExternalAuthFailureMode::FailClosed,
+        };
+
+        let err = RuntimeExternalAuth::normalize(&external_auth, "payments")
+            .expect_err("invalid external auth header must fail");
+
+        assert_config_invalid(
+            err,
+            "upstream 'payments' auth.external_auth.http.request_headers[0].name must be a valid HTTP header name",
+        );
+    }
+
+    #[test]
+    fn external_oidc_auth_normalization_rejects_empty_client_id() {
+        let external_auth = ExternalAuth::Oidc {
+            discovery_url: None,
+            issuer_url: None,
+            client_id: "   ".to_string(),
+            client_secret: None,
+            audience: None,
+            scopes: vec!["openid".to_string()],
+            request_headers: Vec::new(),
+            response_header_allowlist: Vec::new(),
+            timeout_ms: 1_000,
+            failure_mode: ExternalAuthFailureMode::FailClosed,
+        };
+
+        let err = RuntimeExternalAuth::normalize(&external_auth, "payments")
+            .expect_err("empty oidc client id must fail");
+
+        assert_config_invalid(
+            err,
+            "upstream 'payments' auth.external_auth.oidc.client_id must be non-empty",
+        );
+    }
+}

--- a/crates/config/src/runtime/policies/backend.rs
+++ b/crates/config/src/runtime/policies/backend.rs
@@ -279,9 +279,11 @@ mod tests {
 
     #[test]
     fn runtime_backend_dns_policy_shapes_refresh_settings_from_performance() {
-        let mut performance = Performance::default();
-        performance.backend_dns_refresh_enabled = true;
-        performance.backend_dns_refresh_interval_ms = 45_000;
+        let performance = Performance {
+            backend_dns_refresh_enabled: true,
+            backend_dns_refresh_interval_ms: 45_000,
+            ..Performance::default()
+        };
 
         let policy = RuntimeBackendDnsPolicy::from_performance(&performance);
 

--- a/crates/config/src/runtime/policies/backend.rs
+++ b/crates/config/src/runtime/policies/backend.rs
@@ -169,3 +169,196 @@ impl RuntimeBackendDnsPolicy {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::RuntimeBackendTransportKind;
+
+    fn assert_config_invalid(err: RuntimeConfigError, expected: impl AsRef<str>) {
+        let expected = expected.as_ref();
+        assert_eq!(err.category(), "config_invalid");
+        assert_eq!(err.to_string(), format!("config_invalid: {expected}"));
+    }
+
+    #[test]
+    fn runtime_backend_endpoint_normalizes_hostname_backend_and_canonical_authority() {
+        let endpoint = RuntimeBackendEndpoint::normalize("payments", "primary", "api.example.com")
+            .expect("hostname backend");
+
+        assert_eq!(endpoint.configured_address, "api.example.com");
+        assert_eq!(endpoint.origin, "https://api.example.com:443");
+        assert_eq!(endpoint.authority_host, "api.example.com");
+        assert_eq!(endpoint.authority_port, 443);
+        assert_eq!(endpoint.address_kind, RuntimeBackendAddressKind::Hostname);
+        assert_eq!(endpoint.transport_kind, RuntimeBackendTransportKind::H2);
+        assert_eq!(endpoint.canonical.scheme(), BackendScheme::Https);
+        assert_eq!(endpoint.canonical.authority(), "api.example.com:443");
+    }
+
+    #[test]
+    fn runtime_backend_endpoint_normalizes_ip_literal_backend_and_canonical_authority() {
+        let endpoint = RuntimeBackendEndpoint::normalize(
+            "payments",
+            "edge-ipv6",
+            "https://[2001:db8::10]:9443",
+        )
+        .expect("ip literal backend");
+
+        assert_eq!(endpoint.origin, "https://[2001:db8::10]:9443");
+        assert_eq!(endpoint.authority_host, "2001:db8::10");
+        assert_eq!(endpoint.authority_port, 9443);
+        assert_eq!(endpoint.address_kind, RuntimeBackendAddressKind::IpLiteral);
+        assert_eq!(endpoint.transport_kind, RuntimeBackendTransportKind::H2);
+        assert_eq!(endpoint.canonical.authority(), "[2001:db8::10]:9443");
+    }
+
+    #[test]
+    fn runtime_backend_endpoint_derives_transport_kind_from_scheme() {
+        let http_endpoint =
+            RuntimeBackendEndpoint::normalize("payments", "legacy", "http://127.0.0.1:8080")
+                .expect("http backend");
+        let https_endpoint =
+            RuntimeBackendEndpoint::normalize("payments", "modern", "https://api.example.com:8443")
+                .expect("https backend");
+
+        assert_eq!(
+            http_endpoint.transport_kind,
+            RuntimeBackendTransportKind::Http1
+        );
+        assert_eq!(http_endpoint.authority_host, "127.0.0.1");
+        assert_eq!(http_endpoint.authority_port, 8080);
+        assert_eq!(http_endpoint.address_kind, RuntimeBackendAddressKind::IpLiteral);
+        assert_eq!(http_endpoint.canonical.scheme(), BackendScheme::Http);
+
+        assert_eq!(
+            https_endpoint.transport_kind,
+            RuntimeBackendTransportKind::H2
+        );
+        assert_eq!(https_endpoint.authority_host, "api.example.com");
+        assert_eq!(https_endpoint.authority_port, 8443);
+        assert_eq!(https_endpoint.address_kind, RuntimeBackendAddressKind::Hostname);
+        assert_eq!(https_endpoint.canonical.scheme(), BackendScheme::Https);
+    }
+
+    #[test]
+    fn runtime_backend_tls_policy_shapes_effective_tls_settings() {
+        let effective_tls = UpstreamTls {
+            verify_certificates: false,
+            strict_sni: false,
+            ca_file: Some("/etc/spooky/ca.pem".to_string()),
+            ca_dir: Some("/etc/spooky/ca.d".to_string()),
+        };
+
+        let policy = RuntimeBackendTlsPolicy::from_effective_tls(&effective_tls);
+
+        assert_eq!(
+            policy,
+            RuntimeBackendTlsPolicy {
+                verify_certificates: false,
+                strict_sni: false,
+                ca_file: Some("/etc/spooky/ca.pem".to_string()),
+                ca_dir: Some("/etc/spooky/ca.d".to_string()),
+            }
+        );
+        let roundtrip = policy.as_upstream_tls();
+        assert_eq!(
+            roundtrip.verify_certificates,
+            effective_tls.verify_certificates
+        );
+        assert_eq!(roundtrip.strict_sni, effective_tls.strict_sni);
+        assert_eq!(roundtrip.ca_file, effective_tls.ca_file);
+        assert_eq!(roundtrip.ca_dir, effective_tls.ca_dir);
+    }
+
+    #[test]
+    fn runtime_backend_dns_policy_shapes_refresh_settings_from_performance() {
+        let mut performance = Performance::default();
+        performance.backend_dns_refresh_enabled = true;
+        performance.backend_dns_refresh_interval_ms = 45_000;
+
+        let policy = RuntimeBackendDnsPolicy::from_performance(&performance);
+
+        assert!(policy.refresh_enabled);
+        assert_eq!(policy.refresh_interval, Duration::from_millis(45_000));
+    }
+
+    #[test]
+    fn runtime_backend_health_check_normalizes_values_and_blank_path() {
+        let health_check = HealthCheck {
+            path: "   ".to_string(),
+            interval: 5_000,
+            timeout_ms: 900,
+            failure_threshold: 4,
+            success_threshold: 2,
+            cooldown_ms: 1_500,
+        };
+
+        let normalized =
+            RuntimeBackendHealthCheck::normalize("payments", "primary", &health_check)
+                .expect("health check");
+
+        assert_eq!(
+            normalized,
+            RuntimeBackendHealthCheck {
+                path: "/".to_string(),
+                interval: Duration::from_millis(5_000),
+                timeout: Duration::from_millis(900),
+                failure_threshold: 4,
+                success_threshold: 2,
+                cooldown: Duration::from_millis(1_500),
+            }
+        );
+    }
+
+    #[test]
+    fn runtime_backend_health_check_rejects_zero_value_fields() {
+        let cases = [
+            (
+                "health check interval is invalid (0) for backend 'primary' in upstream 'payments'",
+                HealthCheck {
+                    interval: 0,
+                    ..valid_health_check()
+                },
+            ),
+            (
+                "health check timeout is invalid (0) for backend 'primary' in upstream 'payments'",
+                HealthCheck {
+                    timeout_ms: 0,
+                    ..valid_health_check()
+                },
+            ),
+            (
+                "health check failure threshold is invalid (0) for backend 'primary' in upstream 'payments'",
+                HealthCheck {
+                    failure_threshold: 0,
+                    ..valid_health_check()
+                },
+            ),
+            (
+                "health check success threshold is invalid (0) for backend 'primary' in upstream 'payments'",
+                HealthCheck {
+                    success_threshold: 0,
+                    ..valid_health_check()
+                },
+            ),
+        ];
+
+        for (expected, health_check) in cases {
+            let err = RuntimeBackendHealthCheck::normalize("payments", "primary", &health_check)
+                .expect_err(expected);
+            assert_config_invalid(err, expected);
+        }
+    }
+
+    fn valid_health_check() -> HealthCheck {
+        HealthCheck {
+            path: "/health".to_string(),
+            interval: 1_000,
+            timeout_ms: 500,
+            failure_threshold: 3,
+            success_threshold: 2,
+            cooldown_ms: 250,
+        }
+    }
+}

--- a/crates/config/src/runtime/policies/backend.rs
+++ b/crates/config/src/runtime/policies/backend.rs
@@ -228,7 +228,10 @@ mod tests {
         );
         assert_eq!(http_endpoint.authority_host, "127.0.0.1");
         assert_eq!(http_endpoint.authority_port, 8080);
-        assert_eq!(http_endpoint.address_kind, RuntimeBackendAddressKind::IpLiteral);
+        assert_eq!(
+            http_endpoint.address_kind,
+            RuntimeBackendAddressKind::IpLiteral
+        );
         assert_eq!(http_endpoint.canonical.scheme(), BackendScheme::Http);
 
         assert_eq!(
@@ -237,7 +240,10 @@ mod tests {
         );
         assert_eq!(https_endpoint.authority_host, "api.example.com");
         assert_eq!(https_endpoint.authority_port, 8443);
-        assert_eq!(https_endpoint.address_kind, RuntimeBackendAddressKind::Hostname);
+        assert_eq!(
+            https_endpoint.address_kind,
+            RuntimeBackendAddressKind::Hostname
+        );
         assert_eq!(https_endpoint.canonical.scheme(), BackendScheme::Https);
     }
 
@@ -294,9 +300,8 @@ mod tests {
             cooldown_ms: 1_500,
         };
 
-        let normalized =
-            RuntimeBackendHealthCheck::normalize("payments", "primary", &health_check)
-                .expect("health check");
+        let normalized = RuntimeBackendHealthCheck::normalize("payments", "primary", &health_check)
+            .expect("health check");
 
         assert_eq!(
             normalized,

--- a/crates/config/src/runtime/policies/lb.rs
+++ b/crates/config/src/runtime/policies/lb.rs
@@ -160,12 +160,24 @@ mod tests {
             ("round-robin", RuntimeLoadBalancingStrategy::RoundRobin),
             ("round_robin", RuntimeLoadBalancingStrategy::RoundRobin),
             ("rr", RuntimeLoadBalancingStrategy::RoundRobin),
-            ("consistent-hash", RuntimeLoadBalancingStrategy::ConsistentHash),
-            ("consistent_hash", RuntimeLoadBalancingStrategy::ConsistentHash),
+            (
+                "consistent-hash",
+                RuntimeLoadBalancingStrategy::ConsistentHash,
+            ),
+            (
+                "consistent_hash",
+                RuntimeLoadBalancingStrategy::ConsistentHash,
+            ),
             ("ch", RuntimeLoadBalancingStrategy::ConsistentHash),
             ("random", RuntimeLoadBalancingStrategy::Random),
-            ("least-connections", RuntimeLoadBalancingStrategy::LeastConnections),
-            ("least_connections", RuntimeLoadBalancingStrategy::LeastConnections),
+            (
+                "least-connections",
+                RuntimeLoadBalancingStrategy::LeastConnections,
+            ),
+            (
+                "least_connections",
+                RuntimeLoadBalancingStrategy::LeastConnections,
+            ),
             ("lc", RuntimeLoadBalancingStrategy::LeastConnections),
             ("latency-aware", RuntimeLoadBalancingStrategy::LatencyAware),
             ("latency_aware", RuntimeLoadBalancingStrategy::LatencyAware),
@@ -273,7 +285,10 @@ mod tests {
         })
         .expect("round robin policy");
 
-        assert_eq!(round_robin.strategy, RuntimeLoadBalancingStrategy::RoundRobin);
+        assert_eq!(
+            round_robin.strategy,
+            RuntimeLoadBalancingStrategy::RoundRobin
+        );
         assert_eq!(round_robin.key.as_deref(), Some("header:x-user-id"));
         assert_eq!(
             round_robin.key_spec,

--- a/crates/config/src/runtime/policies/lb.rs
+++ b/crates/config/src/runtime/policies/lb.rs
@@ -143,3 +143,186 @@ impl RuntimeLoadBalancingPolicy {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_config_invalid(err: RuntimeConfigError, expected: impl AsRef<str>) {
+        let expected = expected.as_ref();
+        assert_eq!(err.category(), "config_invalid");
+        assert_eq!(err.to_string(), format!("config_invalid: {expected}"));
+    }
+
+    #[test]
+    fn load_balancing_strategy_normalizes_supported_aliases_and_canonical_names() {
+        let cases = [
+            ("round-robin", RuntimeLoadBalancingStrategy::RoundRobin),
+            ("round_robin", RuntimeLoadBalancingStrategy::RoundRobin),
+            ("rr", RuntimeLoadBalancingStrategy::RoundRobin),
+            ("consistent-hash", RuntimeLoadBalancingStrategy::ConsistentHash),
+            ("consistent_hash", RuntimeLoadBalancingStrategy::ConsistentHash),
+            ("ch", RuntimeLoadBalancingStrategy::ConsistentHash),
+            ("random", RuntimeLoadBalancingStrategy::Random),
+            ("least-connections", RuntimeLoadBalancingStrategy::LeastConnections),
+            ("least_connections", RuntimeLoadBalancingStrategy::LeastConnections),
+            ("lc", RuntimeLoadBalancingStrategy::LeastConnections),
+            ("latency-aware", RuntimeLoadBalancingStrategy::LatencyAware),
+            ("latency_aware", RuntimeLoadBalancingStrategy::LatencyAware),
+            ("la", RuntimeLoadBalancingStrategy::LatencyAware),
+            ("sticky-cid", RuntimeLoadBalancingStrategy::StickyCid),
+            ("sticky_cid", RuntimeLoadBalancingStrategy::StickyCid),
+            ("cid-sticky", RuntimeLoadBalancingStrategy::StickyCid),
+            ("cid_sticky", RuntimeLoadBalancingStrategy::StickyCid),
+        ];
+
+        for (raw, expected) in cases {
+            assert_eq!(RuntimeLoadBalancingStrategy::from_lb_type(raw), expected);
+        }
+
+        assert_eq!(
+            RuntimeLoadBalancingStrategy::RoundRobin.canonical_name(),
+            "round-robin"
+        );
+        assert_eq!(
+            RuntimeLoadBalancingStrategy::ConsistentHash.canonical_name(),
+            "consistent-hash"
+        );
+        assert_eq!(
+            RuntimeLoadBalancingStrategy::LeastConnections.canonical_name(),
+            "least-connections"
+        );
+        assert_eq!(
+            RuntimeLoadBalancingStrategy::LatencyAware.canonical_name(),
+            "latency-aware"
+        );
+        assert_eq!(
+            RuntimeLoadBalancingStrategy::StickyCid.canonical_name(),
+            "sticky-cid"
+        );
+    }
+
+    #[test]
+    fn load_balancing_policy_rejects_unsupported_strategy() {
+        let err = RuntimeLoadBalancingPolicy::normalize(&LoadBalancing {
+            lb_type: "maglev".to_string(),
+            key: None,
+        })
+        .expect_err("unsupported strategy must fail");
+
+        assert_config_invalid(err, "unsupported load balancing type 'maglev'");
+    }
+
+    #[test]
+    fn request_key_spec_normalizes_builtin_key_types() {
+        let cases = [
+            ("path", RuntimeRequestKeySpec::Path),
+            ("authority", RuntimeRequestKeySpec::Authority),
+            ("method", RuntimeRequestKeySpec::Method),
+            ("cid", RuntimeRequestKeySpec::Cid),
+            ("sticky-cid", RuntimeRequestKeySpec::StickyCid),
+            ("peer_ip", RuntimeRequestKeySpec::PeerIp),
+            ("client_ip", RuntimeRequestKeySpec::ClientIp),
+            ("bearer_token", RuntimeRequestKeySpec::BearerToken),
+        ];
+
+        for (raw, expected) in cases {
+            assert_eq!(RuntimeRequestKeySpec::normalize(raw).expect(raw), expected);
+        }
+    }
+
+    #[test]
+    fn request_key_spec_normalizes_header_cookie_and_query_forms() {
+        assert_eq!(
+            RuntimeRequestKeySpec::normalize(" header:X-Tenant-ID ").expect("header key"),
+            RuntimeRequestKeySpec::Header("x-tenant-id".to_string())
+        );
+        assert_eq!(
+            RuntimeRequestKeySpec::normalize("cookie:Session_Id").expect("cookie key"),
+            RuntimeRequestKeySpec::Cookie("session_id".to_string())
+        );
+        assert_eq!(
+            RuntimeRequestKeySpec::normalize("query:user_id").expect("query key"),
+            RuntimeRequestKeySpec::Query("user_id".to_string())
+        );
+    }
+
+    #[test]
+    fn request_key_spec_rejects_invalid_forms() {
+        let cases = [
+            "tenant_id",
+            "header:",
+            "cookie:   ",
+            "query:",
+            "body:user",
+            "header",
+        ];
+
+        for raw in cases {
+            let err =
+                RuntimeRequestKeySpec::normalize(raw).expect_err("invalid key spec must fail");
+            assert_config_invalid(err, format!("unsupported request key spec '{}'", raw));
+        }
+    }
+
+    #[test]
+    fn load_balancing_policy_shapes_key_spec_and_alternate_backend_policy() {
+        let round_robin = RuntimeLoadBalancingPolicy::normalize(&LoadBalancing {
+            lb_type: "rr".to_string(),
+            key: Some(" header:x-user-id ".to_string()),
+        })
+        .expect("round robin policy");
+
+        assert_eq!(round_robin.strategy, RuntimeLoadBalancingStrategy::RoundRobin);
+        assert_eq!(round_robin.key.as_deref(), Some("header:x-user-id"));
+        assert_eq!(
+            round_robin.key_spec,
+            Some(RuntimeRequestKeySpec::Header("x-user-id".to_string()))
+        );
+        assert_eq!(
+            round_robin.alternate_backend,
+            RuntimeAlternateBackendPolicy {
+                readonly_lb_pick: true,
+                healthy_fallback: true,
+            }
+        );
+
+        let consistent_hash = RuntimeLoadBalancingPolicy::normalize(&LoadBalancing {
+            lb_type: "consistent_hash".to_string(),
+            key: Some("sticky-cid".to_string()),
+        })
+        .expect("consistent hash policy");
+
+        assert_eq!(
+            consistent_hash.strategy,
+            RuntimeLoadBalancingStrategy::ConsistentHash
+        );
+        assert_eq!(
+            consistent_hash.key_spec,
+            Some(RuntimeRequestKeySpec::StickyCid)
+        );
+        assert_eq!(
+            consistent_hash.alternate_backend,
+            RuntimeAlternateBackendPolicy {
+                readonly_lb_pick: false,
+                healthy_fallback: true,
+            }
+        );
+
+        let sticky_cid = RuntimeLoadBalancingPolicy::normalize(&LoadBalancing {
+            lb_type: "sticky-cid".to_string(),
+            key: None,
+        })
+        .expect("sticky cid policy");
+
+        assert_eq!(sticky_cid.strategy, RuntimeLoadBalancingStrategy::StickyCid);
+        assert_eq!(sticky_cid.key_spec, None);
+        assert_eq!(
+            sticky_cid.alternate_backend,
+            RuntimeAlternateBackendPolicy {
+                readonly_lb_pick: false,
+                healthy_fallback: true,
+            }
+        );
+    }
+}

--- a/crates/config/src/runtime/policies/timeouts.rs
+++ b/crates/config/src/runtime/policies/timeouts.rs
@@ -297,8 +297,8 @@ mod tests {
     }
 
     #[test]
-    fn runtime_timeout_policy_rejects_body_total_timeout_longer_than_backend_total_request_timeout(
-    ) {
+    fn runtime_timeout_policy_rejects_body_total_timeout_longer_than_backend_total_request_timeout()
+    {
         let mut performance = valid_performance();
         performance.backend_body_total_timeout_ms = 4_001;
         performance.backend_total_request_timeout_ms = 4_000;

--- a/crates/config/src/runtime/policies/timeouts.rs
+++ b/crates/config/src/runtime/policies/timeouts.rs
@@ -109,3 +109,219 @@ impl RuntimeTimeoutPolicy {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_performance() -> Performance {
+        Performance::default()
+    }
+
+    #[test]
+    fn runtime_timeout_policy_normalizes_raw_millisecond_fields_into_durations() {
+        let mut performance = valid_performance();
+        performance.inflight_acquire_wait_ms = 7;
+        performance.backend_timeout_ms = 1_000;
+        performance.backend_connect_timeout_ms = 250;
+        performance.backend_body_idle_timeout_ms = 2_000;
+        performance.backend_body_total_timeout_ms = 3_000;
+        performance.backend_total_request_timeout_ms = 4_000;
+        performance.shutdown_drain_timeout_ms = 5_000;
+        performance.client_body_idle_timeout_ms = 6_000;
+        performance.h2_pool_idle_timeout_ms = 7_000;
+        performance.backend_dns_refresh_interval_ms = 8_000;
+        performance.quic_max_idle_timeout_ms = 9_000;
+
+        let policy = RuntimeTimeoutPolicy::normalize(&performance).expect("timeout policy");
+
+        assert_eq!(policy.inflight_acquire_wait, Duration::from_millis(7));
+        assert_eq!(policy.backend_request, Duration::from_millis(1_000));
+        assert_eq!(policy.backend_connect, Duration::from_millis(250));
+        assert_eq!(policy.backend_body_idle, Duration::from_millis(2_000));
+        assert_eq!(policy.backend_body_total, Duration::from_millis(3_000));
+        assert_eq!(policy.backend_total_request, Duration::from_millis(4_000));
+        assert_eq!(policy.shutdown_drain, Duration::from_millis(5_000));
+        assert_eq!(policy.client_body_idle, Duration::from_millis(6_000));
+        assert_eq!(policy.h2_pool_idle, Duration::from_millis(7_000));
+        assert_eq!(
+            policy.backend_dns_refresh_interval,
+            Duration::from_millis(8_000)
+        );
+        assert_eq!(policy.quic_max_idle, Duration::from_millis(9_000));
+    }
+
+    #[test]
+    fn runtime_timeout_policy_allows_zero_inflight_micro_wait() {
+        let mut performance = valid_performance();
+        performance.inflight_acquire_wait_ms = 0;
+
+        let policy = RuntimeTimeoutPolicy::normalize(&performance).expect("timeout policy");
+
+        assert_eq!(policy.inflight_acquire_wait, Duration::ZERO);
+    }
+
+    #[test]
+    fn runtime_timeout_policy_rejects_zero_for_required_timeout_fields() {
+        fn zero_backend_timeout(performance: &mut Performance) {
+            performance.backend_timeout_ms = 0;
+        }
+        fn zero_backend_connect_timeout(performance: &mut Performance) {
+            performance.backend_connect_timeout_ms = 0;
+        }
+        fn zero_backend_body_idle_timeout(performance: &mut Performance) {
+            performance.backend_body_idle_timeout_ms = 0;
+        }
+        fn zero_backend_body_total_timeout(performance: &mut Performance) {
+            performance.backend_body_total_timeout_ms = 0;
+        }
+        fn zero_backend_total_request_timeout(performance: &mut Performance) {
+            performance.backend_total_request_timeout_ms = 0;
+        }
+        fn zero_shutdown_drain_timeout(performance: &mut Performance) {
+            performance.shutdown_drain_timeout_ms = 0;
+        }
+        fn zero_client_body_idle_timeout(performance: &mut Performance) {
+            performance.client_body_idle_timeout_ms = 0;
+        }
+        fn zero_h2_pool_idle_timeout(performance: &mut Performance) {
+            performance.h2_pool_idle_timeout_ms = 0;
+        }
+        fn zero_backend_dns_refresh_interval(performance: &mut Performance) {
+            performance.backend_dns_refresh_interval_ms = 0;
+        }
+        fn zero_quic_max_idle_timeout(performance: &mut Performance) {
+            performance.quic_max_idle_timeout_ms = 0;
+        }
+
+        let cases = [
+            (
+                "performance.backend_timeout_ms must be greater than 0",
+                zero_backend_timeout as fn(&mut Performance),
+            ),
+            (
+                "performance.backend_connect_timeout_ms must be greater than 0",
+                zero_backend_connect_timeout as fn(&mut Performance),
+            ),
+            (
+                "performance.backend_body_idle_timeout_ms must be greater than 0",
+                zero_backend_body_idle_timeout as fn(&mut Performance),
+            ),
+            (
+                "performance.backend_body_total_timeout_ms must be greater than 0",
+                zero_backend_body_total_timeout as fn(&mut Performance),
+            ),
+            (
+                "performance.backend_total_request_timeout_ms must be greater than 0",
+                zero_backend_total_request_timeout as fn(&mut Performance),
+            ),
+            (
+                "performance.shutdown_drain_timeout_ms must be greater than 0",
+                zero_shutdown_drain_timeout as fn(&mut Performance),
+            ),
+            (
+                "performance.client_body_idle_timeout_ms must be greater than 0",
+                zero_client_body_idle_timeout as fn(&mut Performance),
+            ),
+            (
+                "performance.h2_pool_idle_timeout_ms must be greater than 0",
+                zero_h2_pool_idle_timeout as fn(&mut Performance),
+            ),
+            (
+                "performance.backend_dns_refresh_interval_ms must be greater than 0",
+                zero_backend_dns_refresh_interval as fn(&mut Performance),
+            ),
+            (
+                "performance.quic_max_idle_timeout_ms must be greater than 0",
+                zero_quic_max_idle_timeout as fn(&mut Performance),
+            ),
+        ];
+
+        for (expected, mutate) in cases {
+            let mut performance = valid_performance();
+            mutate(&mut performance);
+
+            let err = RuntimeTimeoutPolicy::normalize(&performance).expect_err(expected);
+
+            assert_eq!(err.category(), "config_invalid");
+            assert_eq!(err.to_string(), format!("config_invalid: {expected}"));
+        }
+    }
+
+    #[test]
+    fn runtime_timeout_policy_rejects_connect_timeout_longer_than_backend_request_timeout() {
+        let mut performance = valid_performance();
+        performance.backend_timeout_ms = 999;
+        performance.backend_connect_timeout_ms = 1_000;
+
+        let err =
+            RuntimeTimeoutPolicy::normalize(&performance).expect_err("connect ordering must fail");
+
+        assert_eq!(err.category(), "config_invalid");
+        assert_eq!(
+            err.to_string(),
+            "config_invalid: performance.backend_connect_timeout_ms must be <= backend_timeout_ms"
+        );
+    }
+
+    #[test]
+    fn runtime_timeout_policy_rejects_backend_request_timeout_longer_than_body_idle_timeout() {
+        let mut performance = valid_performance();
+        performance.backend_timeout_ms = 2_001;
+        performance.backend_body_idle_timeout_ms = 2_000;
+
+        let err = RuntimeTimeoutPolicy::normalize(&performance)
+            .expect_err("backend request/body idle ordering must fail");
+
+        assert_eq!(err.category(), "config_invalid");
+        assert_eq!(
+            err.to_string(),
+            "config_invalid: performance.backend_timeout_ms must be <= backend_body_idle_timeout_ms"
+        );
+    }
+
+    #[test]
+    fn runtime_timeout_policy_rejects_body_idle_timeout_longer_than_body_total_timeout() {
+        let mut performance = valid_performance();
+        performance.backend_body_idle_timeout_ms = 3_001;
+        performance.backend_body_total_timeout_ms = 3_000;
+
+        let err = RuntimeTimeoutPolicy::normalize(&performance)
+            .expect_err("body idle/body total ordering must fail");
+
+        assert_eq!(err.category(), "config_invalid");
+        assert_eq!(
+            err.to_string(),
+            "config_invalid: performance.backend_body_idle_timeout_ms must be <= backend_body_total_timeout_ms"
+        );
+    }
+
+    #[test]
+    fn runtime_timeout_policy_rejects_body_total_timeout_longer_than_backend_total_request_timeout(
+    ) {
+        let mut performance = valid_performance();
+        performance.backend_body_total_timeout_ms = 4_001;
+        performance.backend_total_request_timeout_ms = 4_000;
+
+        let err = RuntimeTimeoutPolicy::normalize(&performance)
+            .expect_err("body total/backend total request ordering must fail");
+
+        assert_eq!(err.category(), "config_invalid");
+        assert_eq!(
+            err.to_string(),
+            "config_invalid: performance.backend_body_total_timeout_ms must be <= backend_total_request_timeout_ms"
+        );
+    }
+
+    #[test]
+    fn runtime_timeout_policy_normalizes_shutdown_drain_and_quic_idle_timeouts() {
+        let mut performance = valid_performance();
+        performance.shutdown_drain_timeout_ms = 12_345;
+        performance.quic_max_idle_timeout_ms = 54_321;
+
+        let policy = RuntimeTimeoutPolicy::normalize(&performance).expect("timeout policy");
+
+        assert_eq!(policy.shutdown_drain, Duration::from_millis(12_345));
+        assert_eq!(policy.quic_max_idle, Duration::from_millis(54_321));
+    }
+}

--- a/crates/config/src/runtime/policies/transport.rs
+++ b/crates/config/src/runtime/policies/transport.rs
@@ -266,6 +266,222 @@ mod tests {
     use super::*;
     use crate::config::Performance;
 
+    fn valid_performance() -> Performance {
+        Performance::default()
+    }
+
+    #[test]
+    fn normalize_preserves_worker_and_control_plane_thread_values() {
+        let mut performance = valid_performance();
+        performance.worker_threads = 8;
+        performance.control_plane_threads = 3;
+        performance.packet_shards_per_worker = 2;
+        performance.reuseport = true;
+
+        let policy =
+            RuntimeTransportPolicy::normalize(&performance).expect("normalization must succeed");
+
+        assert_eq!(policy.worker_threads, 8);
+        assert_eq!(policy.control_plane_threads, 3);
+        assert_eq!(policy.packet_shards_per_worker, 2);
+        assert!(policy.reuseport);
+    }
+
+    #[test]
+    fn normalize_preserves_shard_and_queue_settings() {
+        let mut performance = valid_performance();
+        performance.packet_shards_per_worker = 4;
+        performance.packet_shard_queue_capacity = 512;
+        performance.packet_shard_queue_max_bytes = 2 * 1024 * 1024;
+
+        let policy =
+            RuntimeTransportPolicy::normalize(&performance).expect("normalization must succeed");
+
+        assert_eq!(policy.packet_shards_per_worker, 4);
+        assert_eq!(policy.packet_shard_queue_capacity, 512);
+        assert_eq!(policy.packet_shard_queue_max_bytes, 2 * 1024 * 1024);
+    }
+
+    #[test]
+    fn normalize_shapes_inflight_limits_and_backend_pool_capacity() {
+        let mut performance = valid_performance();
+        performance.worker_threads = 4;
+        performance.reuseport = true;
+        performance.global_inflight_limit = 1000;
+        performance.per_upstream_inflight_limit = 250;
+        performance.per_backend_inflight_limit = 32;
+        performance.max_active_connections = 4096;
+
+        let policy =
+            RuntimeTransportPolicy::normalize(&performance).expect("normalization must succeed");
+
+        assert_eq!(policy.global_inflight_limit, 1000);
+        assert_eq!(policy.per_upstream_inflight_limit, 250);
+        assert_eq!(policy.per_backend_inflight_limit, 32);
+        assert_eq!(policy.connection_limits.global_inflight, 1000);
+        assert_eq!(policy.connection_limits.per_upstream_inflight, 250);
+        assert_eq!(policy.connection_limits.per_backend, 32);
+        assert_eq!(policy.connection_limits.backend_pool_max_inflight, 128);
+        assert_eq!(policy.connection_limits.max_active_connections, 4096);
+    }
+
+    #[test]
+    fn normalize_preserves_udp_buffer_sizes() {
+        let mut performance = valid_performance();
+        performance.udp_recv_buffer_bytes = 4 * 1024 * 1024;
+        performance.udp_send_buffer_bytes = 2 * 1024 * 1024;
+
+        let policy =
+            RuntimeTransportPolicy::normalize(&performance).expect("normalization must succeed");
+
+        assert_eq!(policy.udp_recv_buffer_bytes, 4 * 1024 * 1024);
+        assert_eq!(policy.udp_send_buffer_bytes, 2 * 1024 * 1024);
+    }
+
+    #[test]
+    fn normalize_shapes_backend_connection_policy_from_transport_knobs() {
+        let mut performance = valid_performance();
+        performance.worker_threads = 3;
+        performance.reuseport = true;
+        performance.per_backend_inflight_limit = 20;
+        performance.h2_pool_max_idle_per_backend = 11;
+        performance.h2_pool_idle_timeout_ms = 7_500;
+        performance.backend_connect_timeout_ms = 600;
+        performance.backend_timeout_ms = 2_500;
+
+        let policy =
+            RuntimeTransportPolicy::normalize(&performance).expect("normalization must succeed");
+
+        assert_eq!(policy.backend_connections.max_inflight, 60);
+        assert_eq!(policy.backend_connections.max_idle_per_backend, 11);
+        assert_eq!(
+            policy.backend_connections.pool_idle_timeout,
+            Duration::from_millis(7_500)
+        );
+        assert_eq!(
+            policy.backend_connections.connect_timeout,
+            Duration::from_millis(600)
+        );
+        assert_eq!(
+            policy.backend_connections.execution_timeout,
+            Duration::from_millis(2_500)
+        );
+    }
+
+    #[test]
+    fn normalize_rejects_missing_reuseport_when_multiple_workers_are_configured() {
+        let mut performance = valid_performance();
+        performance.worker_threads = 2;
+        performance.reuseport = false;
+
+        let err =
+            RuntimeTransportPolicy::normalize(&performance).expect_err("normalization must fail");
+
+        assert_eq!(err.category(), "config_invalid");
+        assert_eq!(
+            err.to_string(),
+            "config_invalid: performance.reuseport must be true when performance.worker_threads > 1"
+        );
+    }
+
+    #[test]
+    fn normalize_rejects_zero_for_required_worker_and_queue_knobs() {
+        let cases = [
+            (
+                "performance.worker_threads must be greater than 0",
+                zero_worker_threads as fn(&mut Performance),
+            ),
+            (
+                "performance.control_plane_threads must be greater than 0",
+                zero_control_plane_threads as fn(&mut Performance),
+            ),
+            (
+                "performance.packet_shards_per_worker must be greater than 0",
+                zero_packet_shards_per_worker as fn(&mut Performance),
+            ),
+            (
+                "performance.packet_shard_queue_capacity must be greater than 0",
+                zero_packet_shard_queue_capacity as fn(&mut Performance),
+            ),
+            (
+                "performance.packet_shard_queue_max_bytes must be greater than 0",
+                zero_packet_shard_queue_max_bytes as fn(&mut Performance),
+            ),
+        ];
+
+        for (expected, mutate) in cases {
+            let mut performance = valid_performance();
+            mutate(&mut performance);
+
+            let err = RuntimeTransportPolicy::normalize(&performance).expect_err(expected);
+
+            assert_eq!(err.category(), "config_invalid");
+            assert_eq!(err.to_string(), format!("config_invalid: {expected}"));
+        }
+    }
+
+    #[test]
+    fn normalize_rejects_worker_and_shard_values_above_supported_bounds() {
+        let cases = [
+            (
+                "config_invalid: performance.worker_threads=1025 exceeds the maximum of 1024",
+                excessive_worker_threads as fn(&mut Performance),
+            ),
+            (
+                "config_invalid: performance.control_plane_threads=1025 exceeds the maximum of 1024",
+                excessive_control_plane_threads as fn(&mut Performance),
+            ),
+            (
+                "config_invalid: performance.packet_shards_per_worker=257 exceeds the maximum of 256",
+                excessive_packet_shards_per_worker as fn(&mut Performance),
+            ),
+        ];
+
+        for (expected, mutate) in cases {
+            let mut performance = valid_performance();
+            mutate(&mut performance);
+            if performance.worker_threads > 1 {
+                performance.reuseport = true;
+            }
+
+            let err = RuntimeTransportPolicy::normalize(&performance).expect_err(expected);
+
+            assert_eq!(err.to_string(), expected);
+        }
+    }
+
+    fn zero_worker_threads(performance: &mut Performance) {
+        performance.worker_threads = 0;
+    }
+
+    fn zero_control_plane_threads(performance: &mut Performance) {
+        performance.control_plane_threads = 0;
+    }
+
+    fn zero_packet_shards_per_worker(performance: &mut Performance) {
+        performance.packet_shards_per_worker = 0;
+    }
+
+    fn zero_packet_shard_queue_capacity(performance: &mut Performance) {
+        performance.packet_shard_queue_capacity = 0;
+    }
+
+    fn zero_packet_shard_queue_max_bytes(performance: &mut Performance) {
+        performance.packet_shard_queue_max_bytes = 0;
+    }
+
+    fn excessive_worker_threads(performance: &mut Performance) {
+        performance.worker_threads = 1025;
+    }
+
+    fn excessive_control_plane_threads(performance: &mut Performance) {
+        performance.control_plane_threads = 1025;
+    }
+
+    fn excessive_packet_shards_per_worker(performance: &mut Performance) {
+        performance.packet_shards_per_worker = 257;
+    }
+
     #[test]
     fn normalize_rejects_unknown_length_prebuffer_above_response_cap() {
         let performance = Performance {

--- a/crates/config/tests/regression/auth.rs
+++ b/crates/config/tests/regression/auth.rs
@@ -6,20 +6,15 @@ use spooky_config::{
     config::{
         ExternalAuth, ExternalAuthFailureMode, JwtAuth, ScopedRateLimit, ScopedRateLimitScope,
     },
-    runtime::{RuntimeConfig, RuntimeExternalAuth},
+    runtime::RuntimeExternalAuth,
 };
 
-use crate::common::sample_config;
+use crate::common::{api_runtime_upstream, api_upstream_mut, runtime_config, sample_config};
 
 #[test]
-fn runtime_config_preserves_external_auth_contract() {
+fn runtime_config_lowers_http_external_auth_into_canonical_contract() {
     let mut config = sample_config();
-    config
-        .upstream
-        .get_mut("api")
-        .expect("api")
-        .auth
-        .external_auth = Some(ExternalAuth::Http {
+    api_upstream_mut(&mut config).auth.external_auth = Some(ExternalAuth::Http {
         endpoint: "https://auth.internal/check".to_string(),
         request_headers: Vec::new(),
         response_header_allowlist: Vec::new(),
@@ -27,13 +22,8 @@ fn runtime_config_preserves_external_auth_contract() {
         failure_mode: ExternalAuthFailureMode::FailClosed,
     });
 
-    let runtime = RuntimeConfig::from_config(&config).expect("runtime config");
-    let auth = &runtime
-        .upstreams
-        .get("api")
-        .expect("api")
-        .policy
-        .upstream_auth;
+    let runtime = runtime_config(&config);
+    let auth = &api_runtime_upstream(&runtime).policy.upstream_auth;
     match auth.external_auth.as_ref() {
         Some(RuntimeExternalAuth::Http {
             endpoint,
@@ -52,14 +42,9 @@ fn runtime_config_preserves_external_auth_contract() {
 }
 
 #[test]
-fn runtime_config_preserves_oidc_external_auth_metadata() {
+fn runtime_config_lowers_oidc_external_auth_metadata_into_canonical_contract() {
     let mut config = sample_config();
-    config
-        .upstream
-        .get_mut("api")
-        .expect("api")
-        .auth
-        .external_auth = Some(ExternalAuth::Oidc {
+    api_upstream_mut(&mut config).auth.external_auth = Some(ExternalAuth::Oidc {
         discovery_url: Some(
             "https://issuer.example.com/.well-known/openid-configuration".to_string(),
         ),
@@ -74,11 +59,8 @@ fn runtime_config_preserves_oidc_external_auth_metadata() {
         failure_mode: ExternalAuthFailureMode::FailClosed,
     });
 
-    let runtime = RuntimeConfig::from_config(&config).expect("runtime config");
-    match runtime
-        .upstreams
-        .get("api")
-        .expect("api")
+    let runtime = runtime_config(&config);
+    match api_runtime_upstream(&runtime)
         .policy
         .upstream_auth
         .external_auth
@@ -114,9 +96,9 @@ fn runtime_config_preserves_oidc_external_auth_metadata() {
 }
 
 #[test]
-fn runtime_config_normalizes_jwt_and_scoped_rate_limit_shapes() {
+fn runtime_config_normalizes_jwt_and_scoped_rate_limit_contracts() {
     let mut config = sample_config();
-    let upstream = config.upstream.get_mut("api").expect("api upstream");
+    let upstream = api_upstream_mut(&mut config);
     upstream.auth.jwt = Some(JwtAuth {
         secret: "jwt-secret".to_string(),
         issuer: Some(" issuer-1 ".to_string()),
@@ -135,8 +117,8 @@ fn runtime_config_normalizes_jwt_and_scoped_rate_limit_shapes() {
         idle_ttl_secs: 9,
     }];
 
-    let runtime = RuntimeConfig::from_config(&config).expect("runtime config");
-    let api = runtime.upstreams.get("api").expect("api runtime upstream");
+    let runtime = runtime_config(&config);
+    let api = api_runtime_upstream(&runtime);
     let jwt = api.policy.upstream_auth.jwt.as_ref().expect("jwt policy");
     let scoped_limit = runtime
         .policies

--- a/crates/config/tests/regression/backends.rs
+++ b/crates/config/tests/regression/backends.rs
@@ -2,14 +2,14 @@
 
 use std::time::Duration;
 
-use spooky_config::{config::HealthCheck, runtime::RuntimeConfig};
+use spooky_config::config::HealthCheck;
 
-use crate::common::sample_config;
+use crate::common::{api_runtime_upstream, api_upstream_mut, runtime_config, sample_config};
 
 #[test]
-fn runtime_backend_health_check_and_endpoint_are_canonicalized() {
+fn runtime_config_lowers_backend_endpoint_and_health_check_contract() {
     let mut config = sample_config();
-    config.upstream.get_mut("api").expect("api").backends[0].health_check = Some(HealthCheck {
+    api_upstream_mut(&mut config).backends[0].health_check = Some(HealthCheck {
         path: String::new(),
         interval: 2_000,
         timeout_ms: 250,
@@ -18,8 +18,8 @@ fn runtime_backend_health_check_and_endpoint_are_canonicalized() {
         cooldown_ms: 5_000,
     });
 
-    let runtime = RuntimeConfig::from_config(&config).expect("runtime config");
-    let backend = &runtime.upstreams.get("api").expect("api").backends[0];
+    let runtime = runtime_config(&config);
+    let backend = &api_runtime_upstream(&runtime).backends[0];
     let health = backend.health_check.as_ref().expect("health check");
 
     assert_eq!(backend.endpoint.origin, "https://api.internal:8443");

--- a/crates/config/tests/regression/common.rs
+++ b/crates/config/tests/regression/common.rs
@@ -2,12 +2,14 @@
 
 use std::collections::HashMap;
 
-use spooky_config::config::{
-    Backend, ClientAuth, Config, ForwardedHeaderPolicy, ForwardedHeaderPolicyMode, Listen,
-    LoadBalancing, Log, Observability, Performance, Resilience, RouteMatch, Security, Tls,
-    Upstream, UpstreamHostPolicy, UpstreamHostPolicyMode, UpstreamTls,
+use spooky_config::{
+    config::{
+        Backend, ClientAuth, Config, ForwardedHeaderPolicy, ForwardedHeaderPolicyMode, Listen,
+        LoadBalancing, Log, Observability, Performance, Resilience, RouteMatch, Security, Tls,
+        Upstream, UpstreamHostPolicy, UpstreamHostPolicyMode, UpstreamTls,
+    },
+    runtime::{RuntimeConfig, RuntimeConfigError, RuntimeUpstream},
 };
-use spooky_config::runtime::{RuntimeConfig, RuntimeConfigError, RuntimeUpstream};
 
 const API_UPSTREAM: &str = "api";
 
@@ -78,9 +80,8 @@ pub fn api_upstream_mut(config: &mut Config) -> &mut Upstream {
 }
 
 pub fn runtime_config(config: &Config) -> RuntimeConfig {
-    RuntimeConfig::from_config(config).unwrap_or_else(|err| {
-        panic!("shared regression fixture should lower successfully: {err}")
-    })
+    RuntimeConfig::from_config(config)
+        .unwrap_or_else(|err| panic!("shared regression fixture should lower successfully: {err}"))
 }
 
 pub fn runtime_config_err(config: &Config) -> RuntimeConfigError {
@@ -96,7 +97,11 @@ pub fn api_runtime_upstream<'a>(runtime: &'a RuntimeConfig) -> &'a RuntimeUpstre
 }
 
 pub fn assert_config_error_contains(err: &RuntimeConfigError, category: &str, needle: &str) {
-    assert_eq!(err.category(), category, "unexpected runtime error category");
+    assert_eq!(
+        err.category(),
+        category,
+        "unexpected runtime error category"
+    );
     let message = err.to_string();
     assert!(
         message.contains(needle),

--- a/crates/config/tests/regression/common.rs
+++ b/crates/config/tests/regression/common.rs
@@ -89,7 +89,7 @@ pub fn runtime_config_err(config: &Config) -> RuntimeConfigError {
         .expect_err("regression case must reject the runtime lowering input")
 }
 
-pub fn api_runtime_upstream<'a>(runtime: &'a RuntimeConfig) -> &'a RuntimeUpstream {
+pub fn api_runtime_upstream(runtime: &RuntimeConfig) -> &RuntimeUpstream {
     runtime
         .upstreams
         .get(API_UPSTREAM)

--- a/crates/config/tests/regression/common.rs
+++ b/crates/config/tests/regression/common.rs
@@ -7,6 +7,9 @@ use spooky_config::config::{
     LoadBalancing, Log, Observability, Performance, Resilience, RouteMatch, Security, Tls,
     Upstream, UpstreamHostPolicy, UpstreamHostPolicyMode, UpstreamTls,
 };
+use spooky_config::runtime::{RuntimeConfig, RuntimeConfigError, RuntimeUpstream};
+
+const API_UPSTREAM: &str = "api";
 
 /// A minimal, valid single-upstream config used as the base for regression cases.
 pub fn sample_config() -> Config {
@@ -65,4 +68,38 @@ pub fn sample_config() -> Config {
     );
 
     config
+}
+
+pub fn api_upstream_mut(config: &mut Config) -> &mut Upstream {
+    config
+        .upstream
+        .get_mut(API_UPSTREAM)
+        .expect("shared regression fixture must include the 'api' upstream")
+}
+
+pub fn runtime_config(config: &Config) -> RuntimeConfig {
+    RuntimeConfig::from_config(config).unwrap_or_else(|err| {
+        panic!("shared regression fixture should lower successfully: {err}")
+    })
+}
+
+pub fn runtime_config_err(config: &Config) -> RuntimeConfigError {
+    RuntimeConfig::from_config(config)
+        .expect_err("regression case must reject the runtime lowering input")
+}
+
+pub fn api_runtime_upstream<'a>(runtime: &'a RuntimeConfig) -> &'a RuntimeUpstream {
+    runtime
+        .upstreams
+        .get(API_UPSTREAM)
+        .expect("runtime lowering output must include the 'api' upstream")
+}
+
+pub fn assert_config_error_contains(err: &RuntimeConfigError, category: &str, needle: &str) {
+    assert_eq!(err.category(), category, "unexpected runtime error category");
+    let message = err.to_string();
+    assert!(
+        message.contains(needle),
+        "expected runtime error to contain '{needle}', got '{message}'"
+    );
 }

--- a/crates/config/tests/regression/main.rs
+++ b/crates/config/tests/regression/main.rs
@@ -14,5 +14,6 @@ mod common;
 mod auth;
 mod backends;
 mod policy;
+mod reload_boundaries;
 mod timeouts;
 mod tls;

--- a/crates/config/tests/regression/policy.rs
+++ b/crates/config/tests/regression/policy.rs
@@ -14,7 +14,11 @@ fn runtime_config_rejects_host_override_when_host_policy_is_not_rewrite() {
     upstream.host_policy.host = Some("ignored.example.com".to_string());
 
     let err = runtime_config_err(&config);
-    assert_config_error_contains(&err, "unsupported_policy_combination", "mode is not rewrite");
+    assert_config_error_contains(
+        &err,
+        "unsupported_policy_combination",
+        "mode is not rewrite",
+    );
 }
 
 #[test]
@@ -49,5 +53,9 @@ fn runtime_config_rejects_connect_route_when_protocol_policy_disallows_it() {
     config.resilience.protocol.allow_connect = false;
 
     let err = runtime_config_err(&config);
-    assert_config_error_contains(&err, "unsupported_policy_combination", "allow_connect=false");
+    assert_config_error_contains(
+        &err,
+        "unsupported_policy_combination",
+        "allow_connect=false",
+    );
 }

--- a/crates/config/tests/regression/policy.rs
+++ b/crates/config/tests/regression/policy.rs
@@ -1,70 +1,53 @@
 //! Policy-combination and route-matcher rejection cases.
 
-use spooky_config::{config::UpstreamHostPolicyMode, runtime::RuntimeConfig};
+use spooky_config::config::UpstreamHostPolicyMode;
 
-use crate::common::sample_config;
+use crate::common::{
+    api_upstream_mut, assert_config_error_contains, runtime_config_err, sample_config,
+};
 
 #[test]
-fn runtime_config_rejects_ignored_host_rewrite_value() {
+fn runtime_config_rejects_host_override_when_host_policy_is_not_rewrite() {
     let mut config = sample_config();
-    config
-        .upstream
-        .get_mut("api")
-        .expect("upstream")
-        .host_policy
-        .mode = UpstreamHostPolicyMode::Upstream;
-    config
-        .upstream
-        .get_mut("api")
-        .expect("upstream")
-        .host_policy
-        .host = Some("ignored.example.com".to_string());
+    let upstream = api_upstream_mut(&mut config);
+    upstream.host_policy.mode = UpstreamHostPolicyMode::Upstream;
+    upstream.host_policy.host = Some("ignored.example.com".to_string());
 
-    let err = RuntimeConfig::from_config(&config).expect_err("conflicting host policy");
-    assert_eq!(err.category(), "unsupported_policy_combination");
-    assert!(err.to_string().contains("mode is not rewrite"));
+    let err = runtime_config_err(&config);
+    assert_config_error_contains(&err, "unsupported_policy_combination", "mode is not rewrite");
 }
 
 #[test]
-fn runtime_config_rejects_duplicate_route_matchers() {
+fn runtime_config_rejects_duplicate_route_matchers_across_upstreams() {
     let mut config = sample_config();
     config.upstream.insert(
         "api-copy".to_string(),
-        config.upstream.get("api").expect("api").clone(),
+        config
+            .upstream
+            .get("api")
+            .expect("shared regression fixture must include the 'api' upstream")
+            .clone(),
     );
 
-    let err = RuntimeConfig::from_config(&config).expect_err("duplicate routes");
-    assert_eq!(err.category(), "duplicate_route_ambiguity");
-    assert!(err.to_string().contains("conflicts with upstream"));
+    let err = runtime_config_err(&config);
+    assert_config_error_contains(&err, "duplicate_route_ambiguity", "conflicts with upstream");
 }
 
 #[test]
-fn runtime_config_rejects_invalid_lb_key_spec() {
+fn runtime_config_rejects_invalid_request_key_spec() {
     let mut config = sample_config();
-    config
-        .upstream
-        .get_mut("api")
-        .expect("api")
-        .load_balancing
-        .key = Some("header:   ".to_string());
+    api_upstream_mut(&mut config).load_balancing.key = Some("header:   ".to_string());
 
-    let err = RuntimeConfig::from_config(&config).expect_err("invalid key spec must fail");
-    assert_eq!(err.category(), "config_invalid");
-    assert!(err.to_string().contains("unsupported request key spec"));
+    let err = runtime_config_err(&config);
+    assert_config_error_contains(&err, "config_invalid", "unsupported request key spec");
 }
 
 #[test]
-fn runtime_config_rejects_connect_route_when_protocol_disallows_connect() {
+fn runtime_config_rejects_connect_route_when_protocol_policy_disallows_it() {
     let mut config = sample_config();
-    config
-        .upstream
-        .get_mut("api")
-        .expect("upstream")
-        .route
-        .method = Some("CONNECT".to_string());
+    api_upstream_mut(&mut config).route.method = Some("CONNECT".to_string());
     config.resilience.protocol.allow_connect = false;
 
-    let err = RuntimeConfig::from_config(&config).expect_err("connect route must fail");
-    assert_eq!(err.category(), "unsupported_policy_combination");
-    assert!(err.to_string().contains("allow_connect=false"));
+    let err = runtime_config_err(&config);
+    assert_config_error_contains(&err, "unsupported_policy_combination", "allow_connect=false");
 }

--- a/crates/config/tests/regression/reload_boundaries.rs
+++ b/crates/config/tests/regression/reload_boundaries.rs
@@ -4,13 +4,13 @@ use std::time::Duration;
 
 use spooky_config::{
     config::{Listen, LogFormat, Tls},
-    runtime::{RuntimeConfig, RuntimeListenerSource},
+    runtime::RuntimeListenerSource,
 };
 
-use crate::common::sample_config;
+use crate::common::{runtime_config, sample_config};
 
 #[test]
-fn runtime_policies_are_normalized_while_listener_runtime_inputs_stay_raw() {
+fn runtime_config_keeps_generation_policies_normalized_and_listener_inputs_raw() {
     let mut config = sample_config();
     config.performance.backend_timeout_ms = 2_400;
     config.performance.backend_connect_timeout_ms = 600;
@@ -27,7 +27,7 @@ fn runtime_policies_are_normalized_while_listener_runtime_inputs_stay_raw() {
     config.observability.tracing.otlp_endpoint =
         Some("http://otel-collector.internal:4317".to_string());
 
-    let runtime = RuntimeConfig::from_config(&config).expect("runtime config");
+    let runtime = runtime_config(&config);
     let policies = runtime.policies();
     let listener = runtime
         .primary_listener_runtime_config()
@@ -61,7 +61,7 @@ fn runtime_policies_are_normalized_while_listener_runtime_inputs_stay_raw() {
 }
 
 #[test]
-fn explicit_listener_topology_and_tls_identities_stay_listener_owned() {
+fn runtime_config_keeps_explicit_listener_topology_and_tls_identities_listener_owned() {
     let mut config = sample_config();
     config.performance.backend_timeout_ms = 1_750;
     config.performance.backend_connect_timeout_ms = 500;
@@ -96,7 +96,7 @@ fn explicit_listener_topology_and_tls_identities_stay_listener_owned() {
         },
     ];
 
-    let runtime = RuntimeConfig::from_config(&config).expect("runtime config");
+    let runtime = runtime_config(&config);
     let listeners = runtime.listener_runtime_configs();
 
     assert_eq!(listeners.len(), 2);
@@ -125,7 +125,7 @@ fn explicit_listener_topology_and_tls_identities_stay_listener_owned() {
 }
 
 #[test]
-fn log_sink_shape_stays_outside_runtime_generation_contract() {
+fn runtime_config_excludes_log_sink_shape_from_generation_owned_runtime_state() {
     let mut plain = sample_config();
     plain.log.level = "warn".to_string();
     plain.log.file.enabled = false;
@@ -137,8 +137,8 @@ fn log_sink_shape_stays_outside_runtime_generation_contract() {
     json.log.file.path = "/var/log/spooky/edge.json".to_string();
     json.log.format = LogFormat::Json;
 
-    let plain_runtime = RuntimeConfig::from_config(&plain).expect("plain runtime config");
-    let json_runtime = RuntimeConfig::from_config(&json).expect("json runtime config");
+    let plain_runtime = runtime_config(&plain);
+    let json_runtime = runtime_config(&json);
 
     assert_eq!(plain_runtime.policies().timeouts, json_runtime.policies().timeouts);
     assert_eq!(plain_runtime.policies().transport, json_runtime.policies().transport);

--- a/crates/config/tests/regression/reload_boundaries.rs
+++ b/crates/config/tests/regression/reload_boundaries.rs
@@ -1,0 +1,166 @@
+//! Reload-boundary contracts for runtime lowering.
+
+use std::time::Duration;
+
+use spooky_config::{
+    config::{Listen, LogFormat, Tls},
+    runtime::{RuntimeConfig, RuntimeListenerSource},
+};
+
+use crate::common::sample_config;
+
+#[test]
+fn runtime_policies_are_normalized_while_listener_runtime_inputs_stay_raw() {
+    let mut config = sample_config();
+    config.performance.backend_timeout_ms = 2_400;
+    config.performance.backend_connect_timeout_ms = 600;
+    config.performance.backend_body_idle_timeout_ms = 3_000;
+    config.performance.backend_body_total_timeout_ms = 4_000;
+    config.performance.backend_total_request_timeout_ms = 5_000;
+    config.performance.worker_threads = 7;
+    config.performance.packet_shards_per_worker = 3;
+    config.performance.reuseport = true;
+    config.performance.quic_initial_max_data = 2_000_000;
+    config.observability.tracing.enabled = true;
+    config.observability.tracing.service_name = "spooky-edge-prod".to_string();
+    config.observability.tracing.sample_ratio = 0.42;
+    config.observability.tracing.otlp_endpoint =
+        Some("http://otel-collector.internal:4317".to_string());
+
+    let runtime = RuntimeConfig::from_config(&config).expect("runtime config");
+    let policies = runtime.policies();
+    let listener = runtime
+        .primary_listener_runtime_config()
+        .expect("primary listener");
+
+    assert_eq!(
+        policies.timeouts.backend_request,
+        Duration::from_millis(2_400)
+    );
+    assert_eq!(policies.timeouts.backend_connect, Duration::from_millis(600));
+    assert_eq!(policies.transport.quic_initial_max_data, 2_000_000);
+    assert_eq!(listener.policies.timeouts, policies.timeouts);
+    assert_eq!(listener.policies.transport, policies.transport);
+
+    assert_eq!(listener.performance.backend_timeout_ms, 2_400);
+    assert_eq!(listener.performance.backend_connect_timeout_ms, 600);
+    assert_eq!(listener.performance.worker_threads, 7);
+    assert_eq!(listener.performance.packet_shards_per_worker, 3);
+    assert!(listener.performance.reuseport);
+
+    assert!(listener.observability.tracing.enabled);
+    assert_eq!(
+        listener.observability.tracing.service_name,
+        "spooky-edge-prod"
+    );
+    assert_eq!(listener.observability.tracing.sample_ratio, 0.42);
+    assert_eq!(
+        listener.observability.tracing.otlp_endpoint.as_deref(),
+        Some("http://otel-collector.internal:4317")
+    );
+}
+
+#[test]
+fn explicit_listener_topology_and_tls_identities_stay_listener_owned() {
+    let mut config = sample_config();
+    config.performance.backend_timeout_ms = 1_750;
+    config.performance.backend_connect_timeout_ms = 500;
+    config.observability.control_api.enabled = true;
+    config.observability.control_api.address = "127.0.0.1".to_string();
+    config.observability.control_api.port = 9891;
+    config.observability.metrics.enabled = true;
+    config.observability.metrics.address = "127.0.0.1".to_string();
+    config.observability.metrics.port = 9890;
+    config.listeners = vec![
+        Listen {
+            protocol: "http3".to_string(),
+            port: 8443,
+            address: "127.0.0.1".to_string(),
+            tls: Tls {
+                cert: "/tmp/tls/edge-a.pem".to_string(),
+                key: "/tmp/tls/edge-a.key".to_string(),
+                certificates: Vec::new(),
+                client_auth: Default::default(),
+            },
+        },
+        Listen {
+            protocol: "http3".to_string(),
+            port: 9443,
+            address: "127.0.0.2".to_string(),
+            tls: Tls {
+                cert: "/tmp/tls/edge-b.pem".to_string(),
+                key: "/tmp/tls/edge-b.key".to_string(),
+                certificates: Vec::new(),
+                client_auth: Default::default(),
+            },
+        },
+    ];
+
+    let runtime = RuntimeConfig::from_config(&config).expect("runtime config");
+    let listeners = runtime.listener_runtime_configs();
+
+    assert_eq!(listeners.len(), 2);
+    assert_eq!(listeners[0].listen.source, RuntimeListenerSource::ExplicitListeners);
+    assert_eq!(listeners[1].listen.source, RuntimeListenerSource::ExplicitListeners);
+    assert_eq!(listeners[0].listen.listen.address, "127.0.0.1");
+    assert_eq!(listeners[0].listen.listen.port, 8443);
+    assert_eq!(listeners[1].listen.listen.address, "127.0.0.2");
+    assert_eq!(listeners[1].listen.listen.port, 9443);
+    assert_eq!(
+        listeners[0].listen.tls.default_identity.cert_path,
+        "/tmp/tls/edge-a.pem"
+    );
+    assert_eq!(
+        listeners[1].listen.tls.default_identity.cert_path,
+        "/tmp/tls/edge-b.pem"
+    );
+
+    assert_eq!(listeners[0].policies.timeouts, listeners[1].policies.timeouts);
+    assert_eq!(listeners[0].policies.transport, listeners[1].policies.transport);
+
+    assert!(listeners[0].observability.control_api.enabled);
+    assert_eq!(listeners[0].observability.control_api.port, 9891);
+    assert!(listeners[1].observability.metrics.enabled);
+    assert_eq!(listeners[1].observability.metrics.port, 9890);
+}
+
+#[test]
+fn log_sink_shape_stays_outside_runtime_generation_contract() {
+    let mut plain = sample_config();
+    plain.log.level = "warn".to_string();
+    plain.log.file.enabled = false;
+    plain.log.format = LogFormat::Plain;
+
+    let mut json = plain.clone();
+    json.log.level = "debug".to_string();
+    json.log.file.enabled = true;
+    json.log.file.path = "/var/log/spooky/edge.json".to_string();
+    json.log.format = LogFormat::Json;
+
+    let plain_runtime = RuntimeConfig::from_config(&plain).expect("plain runtime config");
+    let json_runtime = RuntimeConfig::from_config(&json).expect("json runtime config");
+
+    assert_eq!(plain_runtime.policies().timeouts, json_runtime.policies().timeouts);
+    assert_eq!(plain_runtime.policies().transport, json_runtime.policies().transport);
+    assert_eq!(plain_runtime.listeners.len(), json_runtime.listeners.len());
+    assert_eq!(
+        plain_runtime.listeners[0].listen.address,
+        json_runtime.listeners[0].listen.address
+    );
+    assert_eq!(
+        plain_runtime.listeners[0].listen.port,
+        json_runtime.listeners[0].listen.port
+    );
+
+    let plain_listener = plain_runtime
+        .primary_listener_runtime_config()
+        .expect("plain primary listener");
+    let json_listener = json_runtime
+        .primary_listener_runtime_config()
+        .expect("json primary listener");
+    assert_eq!(plain_listener.policies.timeouts, json_listener.policies.timeouts);
+    assert_eq!(
+        plain_listener.policies.transport,
+        json_listener.policies.transport
+    );
+}

--- a/crates/config/tests/regression/reload_boundaries.rs
+++ b/crates/config/tests/regression/reload_boundaries.rs
@@ -37,7 +37,10 @@ fn runtime_config_keeps_generation_policies_normalized_and_listener_inputs_raw()
         policies.timeouts.backend_request,
         Duration::from_millis(2_400)
     );
-    assert_eq!(policies.timeouts.backend_connect, Duration::from_millis(600));
+    assert_eq!(
+        policies.timeouts.backend_connect,
+        Duration::from_millis(600)
+    );
     assert_eq!(policies.transport.quic_initial_max_data, 2_000_000);
     assert_eq!(listener.policies.timeouts, policies.timeouts);
     assert_eq!(listener.policies.transport, policies.transport);
@@ -100,8 +103,14 @@ fn runtime_config_keeps_explicit_listener_topology_and_tls_identities_listener_o
     let listeners = runtime.listener_runtime_configs();
 
     assert_eq!(listeners.len(), 2);
-    assert_eq!(listeners[0].listen.source, RuntimeListenerSource::ExplicitListeners);
-    assert_eq!(listeners[1].listen.source, RuntimeListenerSource::ExplicitListeners);
+    assert_eq!(
+        listeners[0].listen.source,
+        RuntimeListenerSource::ExplicitListeners
+    );
+    assert_eq!(
+        listeners[1].listen.source,
+        RuntimeListenerSource::ExplicitListeners
+    );
     assert_eq!(listeners[0].listen.listen.address, "127.0.0.1");
     assert_eq!(listeners[0].listen.listen.port, 8443);
     assert_eq!(listeners[1].listen.listen.address, "127.0.0.2");
@@ -115,8 +124,14 @@ fn runtime_config_keeps_explicit_listener_topology_and_tls_identities_listener_o
         "/tmp/tls/edge-b.pem"
     );
 
-    assert_eq!(listeners[0].policies.timeouts, listeners[1].policies.timeouts);
-    assert_eq!(listeners[0].policies.transport, listeners[1].policies.transport);
+    assert_eq!(
+        listeners[0].policies.timeouts,
+        listeners[1].policies.timeouts
+    );
+    assert_eq!(
+        listeners[0].policies.transport,
+        listeners[1].policies.transport
+    );
 
     assert!(listeners[0].observability.control_api.enabled);
     assert_eq!(listeners[0].observability.control_api.port, 9891);
@@ -140,8 +155,14 @@ fn runtime_config_excludes_log_sink_shape_from_generation_owned_runtime_state() 
     let plain_runtime = runtime_config(&plain);
     let json_runtime = runtime_config(&json);
 
-    assert_eq!(plain_runtime.policies().timeouts, json_runtime.policies().timeouts);
-    assert_eq!(plain_runtime.policies().transport, json_runtime.policies().transport);
+    assert_eq!(
+        plain_runtime.policies().timeouts,
+        json_runtime.policies().timeouts
+    );
+    assert_eq!(
+        plain_runtime.policies().transport,
+        json_runtime.policies().transport
+    );
     assert_eq!(plain_runtime.listeners.len(), json_runtime.listeners.len());
     assert_eq!(
         plain_runtime.listeners[0].listen.address,
@@ -158,7 +179,10 @@ fn runtime_config_excludes_log_sink_shape_from_generation_owned_runtime_state() 
     let json_listener = json_runtime
         .primary_listener_runtime_config()
         .expect("json primary listener");
-    assert_eq!(plain_listener.policies.timeouts, json_listener.policies.timeouts);
+    assert_eq!(
+        plain_listener.policies.timeouts,
+        json_listener.policies.timeouts
+    );
     assert_eq!(
         plain_listener.policies.transport,
         json_listener.policies.transport

--- a/crates/config/tests/regression/timeouts.rs
+++ b/crates/config/tests/regression/timeouts.rs
@@ -2,7 +2,9 @@
 
 use std::time::Duration;
 
-use crate::common::{assert_config_error_contains, runtime_config, runtime_config_err, sample_config};
+use crate::common::{
+    assert_config_error_contains, runtime_config, runtime_config_err, sample_config,
+};
 
 #[test]
 fn runtime_config_normalizes_timeout_and_transport_knobs_into_runtime_policies() {

--- a/crates/config/tests/regression/timeouts.rs
+++ b/crates/config/tests/regression/timeouts.rs
@@ -2,12 +2,10 @@
 
 use std::time::Duration;
 
-use spooky_config::runtime::RuntimeConfig;
-
-use crate::common::sample_config;
+use crate::common::{assert_config_error_contains, runtime_config, runtime_config_err, sample_config};
 
 #[test]
-fn runtime_policy_set_normalizes_timeout_and_transport_knobs() {
+fn runtime_config_normalizes_timeout_and_transport_knobs_into_runtime_policies() {
     let mut config = sample_config();
     config.performance.backend_timeout_ms = 2_500;
     config.performance.backend_connect_timeout_ms = 400;
@@ -20,7 +18,7 @@ fn runtime_policy_set_normalizes_timeout_and_transport_knobs() {
     config.performance.request_buffer_global_cap_bytes = 9_999;
     config.resilience.route_queue.shed_retry_after_seconds = 17;
 
-    let runtime = RuntimeConfig::from_config(&config).expect("runtime config");
+    let runtime = runtime_config(&config);
     let policies = runtime.policies();
 
     assert_eq!(
@@ -41,9 +39,9 @@ fn runtime_policy_set_normalizes_timeout_and_transport_knobs() {
 }
 
 #[test]
-fn runtime_defaults_produce_listener_and_runtime_policy_parity() {
+fn runtime_config_keeps_listener_and_runtime_policy_views_in_sync_for_defaults() {
     let config = sample_config();
-    let runtime = RuntimeConfig::from_config(&config).expect("runtime config");
+    let runtime = runtime_config(&config);
     let listener = runtime
         .primary_listener_runtime_config()
         .expect("primary listener");
@@ -73,15 +71,15 @@ fn runtime_defaults_produce_listener_and_runtime_policy_parity() {
 }
 
 #[test]
-fn runtime_config_rejects_invalid_timeout_ordering() {
+fn runtime_config_rejects_timeout_ordering_that_breaks_runtime_contract() {
     let mut config = sample_config();
     config.performance.backend_connect_timeout_ms = 2_000;
     config.performance.backend_timeout_ms = 1_000;
 
-    let err = RuntimeConfig::from_config(&config).expect_err("timeout ordering must be validated");
-    assert_eq!(err.category(), "config_invalid");
-    assert!(
-        err.to_string()
-            .contains("backend_connect_timeout_ms must be <= backend_timeout_ms")
+    let err = runtime_config_err(&config);
+    assert_config_error_contains(
+        &err,
+        "config_invalid",
+        "backend_connect_timeout_ms must be <= backend_timeout_ms",
     );
 }

--- a/crates/config/tests/regression/tls.rs
+++ b/crates/config/tests/regression/tls.rs
@@ -2,13 +2,16 @@
 
 use spooky_config::{
     config::{ForwardedHeaderPolicyMode, UpstreamHostPolicyMode, UpstreamTls},
-    runtime::{RuntimeBackendTransportKind, RuntimeConfig},
+    runtime::RuntimeBackendTransportKind,
 };
 
-use crate::common::sample_config;
+use crate::common::{
+    api_runtime_upstream, api_upstream_mut, assert_config_error_contains, runtime_config,
+    runtime_config_err, sample_config,
+};
 
 #[test]
-fn runtime_upstream_applies_effective_tls_and_policy_wrappers() {
+fn runtime_config_lowers_effective_tls_and_upstream_policy_wrappers() {
     let mut config = sample_config();
     config.upstream_tls = UpstreamTls {
         verify_certificates: true,
@@ -16,15 +19,15 @@ fn runtime_upstream_applies_effective_tls_and_policy_wrappers() {
         ca_file: Some("/tmp/roots/global.pem".to_string()),
         ca_dir: None,
     };
-    config.upstream.get_mut("api").expect("upstream").tls = Some(UpstreamTls {
+    api_upstream_mut(&mut config).tls = Some(UpstreamTls {
         verify_certificates: false,
         strict_sni: false,
         ca_file: Some("/tmp/roots/upstream.pem".to_string()),
         ca_dir: Some("/tmp/roots/upstream".to_string()),
     });
 
-    let runtime = RuntimeConfig::from_config(&config).expect("runtime config");
-    let upstream = runtime.upstreams.get("api").expect("runtime upstream");
+    let runtime = runtime_config(&config);
+    let upstream = api_runtime_upstream(&runtime);
 
     assert_eq!(upstream.name, "api");
     assert!(!upstream.effective_tls.verify_certificates);
@@ -56,15 +59,14 @@ fn runtime_upstream_applies_effective_tls_and_policy_wrappers() {
 }
 
 #[test]
-fn runtime_http_only_upstream_skips_unused_global_tls_validation() {
+fn runtime_config_skips_global_tls_validation_for_http_only_upstreams() {
     let mut config = sample_config();
-    config.upstream.get_mut("api").expect("upstream").backends[0].address =
-        "http://127.0.0.1:8080".to_string();
+    api_upstream_mut(&mut config).backends[0].address = "http://127.0.0.1:8080".to_string();
     config.upstream_tls.ca_file = Some("   ".to_string());
     config.upstream_tls.ca_dir = Some("   ".to_string());
 
-    let runtime = RuntimeConfig::from_config(&config).expect("runtime config");
-    let upstream = runtime.upstreams.get("api").expect("runtime upstream");
+    let runtime = runtime_config(&config);
+    let upstream = api_runtime_upstream(&runtime);
 
     assert_eq!(
         upstream.backends[0].backend.address,
@@ -73,19 +75,18 @@ fn runtime_http_only_upstream_skips_unused_global_tls_validation() {
 }
 
 #[test]
-fn runtime_http_only_upstream_skips_unused_per_upstream_tls_validation() {
+fn runtime_config_skips_per_upstream_tls_validation_for_http_only_upstreams() {
     let mut config = sample_config();
-    config.upstream.get_mut("api").expect("upstream").backends[0].address =
-        "http://127.0.0.1:8080".to_string();
-    config.upstream.get_mut("api").expect("upstream").tls = Some(UpstreamTls {
+    api_upstream_mut(&mut config).backends[0].address = "http://127.0.0.1:8080".to_string();
+    api_upstream_mut(&mut config).tls = Some(UpstreamTls {
         verify_certificates: true,
         strict_sni: true,
         ca_file: Some("   ".to_string()),
         ca_dir: Some("   ".to_string()),
     });
 
-    let runtime = RuntimeConfig::from_config(&config).expect("runtime config");
-    let upstream = runtime.upstreams.get("api").expect("runtime upstream");
+    let runtime = runtime_config(&config);
+    let upstream = api_runtime_upstream(&runtime);
 
     assert_eq!(
         upstream.backends[0].backend.address,
@@ -94,14 +95,14 @@ fn runtime_http_only_upstream_skips_unused_per_upstream_tls_validation() {
 }
 
 #[test]
-fn runtime_https_upstream_still_requires_non_empty_effective_tls_fields() {
+fn runtime_config_requires_non_empty_effective_tls_fields_for_https_upstreams() {
     let mut config = sample_config();
     config.upstream_tls.ca_file = Some("   ".to_string());
 
-    let err = RuntimeConfig::from_config(&config).expect_err("https upstream must validate");
-    assert_eq!(err.category(), "tls_material_invalid");
-    assert!(
-        err.to_string()
-            .contains("upstream 'api' has an empty effective upstream_tls.ca_file")
+    let err = runtime_config_err(&config);
+    assert_config_error_contains(
+        &err,
+        "tls_material_invalid",
+        "upstream 'api' has an empty effective upstream_tls.ca_file",
     );
 }

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -908,9 +908,7 @@ fn run_h3_client_two_chunk_post(
                     match h3c.send_body(&mut conn, sid, &chunk1[chunk1_written..], false) {
                         Ok(written) => chunk1_written += written,
                         Err(quiche::h3::Error::Done | quiche::h3::Error::StreamBlocked) => {}
-                        Err(quiche::h3::Error::TransportError(quiche::Error::StreamStopped(
-                            _,
-                        ))) => {
+                        Err(quiche::h3::Error::TransportError(quiche::Error::StreamStopped(_))) => {
                             request_stream_stopped = true;
                             chunk1_written = chunk1.len();
                             chunk2_written = chunk2.len();

--- a/crates/edge/tests/h3_bridge.rs
+++ b/crates/edge/tests/h3_bridge.rs
@@ -636,6 +636,7 @@ fn run_h3_client_chunked_post(
     let mut current_chunk_len = 0usize;
     let mut should_fin_for_chunk = false;
     let mut body_done = total_len == 0;
+    let mut request_stream_stopped = false;
     let mut status = String::new();
     let mut body = Vec::new();
     let payload = vec![0u8; chunk_size.max(1)];
@@ -706,6 +707,8 @@ fn run_h3_client_chunked_post(
 
             if let Some(sid) = req_stream_id
                 && !body_done
+                && !request_stream_stopped
+                && status.is_empty()
             {
                 if current_chunk_len == 0 {
                     current_chunk_len = chunk_size.min(remaining);
@@ -732,6 +735,10 @@ fn run_h3_client_chunked_post(
                         }
                     }
                     Err(quiche::h3::Error::Done | quiche::h3::Error::StreamBlocked) => {}
+                    Err(quiche::h3::Error::TransportError(quiche::Error::StreamStopped(_))) => {
+                        request_stream_stopped = true;
+                        body_done = true;
+                    }
                     Err(e) => return Err(format!("send_body: {e:?}")),
                 }
             }
@@ -825,6 +832,7 @@ fn run_h3_client_two_chunk_post(
     let mut status = String::new();
     let mut response_body = Vec::new();
     let start = Instant::now();
+    let mut request_stream_stopped = false;
 
     let (write, send_info) = conn.send(&mut out).map_err(|e| format!("send: {e:?}"))?;
     socket
@@ -889,10 +897,24 @@ fn run_h3_client_two_chunk_post(
             }
 
             if let Some(sid) = stream_id {
-                if chunk1_written < chunk1.len() {
+                if request_stream_stopped {
+                    // Keep polling for the response after the server has
+                    // stopped the request body stream.
+                } else if !status.is_empty() {
+                    request_stream_stopped = true;
+                    chunk1_written = chunk1.len();
+                    chunk2_written = chunk2.len();
+                } else if chunk1_written < chunk1.len() {
                     match h3c.send_body(&mut conn, sid, &chunk1[chunk1_written..], false) {
                         Ok(written) => chunk1_written += written,
                         Err(quiche::h3::Error::Done | quiche::h3::Error::StreamBlocked) => {}
+                        Err(quiche::h3::Error::TransportError(quiche::Error::StreamStopped(
+                            _,
+                        ))) => {
+                            request_stream_stopped = true;
+                            chunk1_written = chunk1.len();
+                            chunk2_written = chunk2.len();
+                        }
                         Err(e) => return Err(format!("send_body chunk1: {e:?}")),
                     }
                 } else {
@@ -904,6 +926,12 @@ fn run_h3_client_two_chunk_post(
                         match h3c.send_body(&mut conn, sid, &chunk2[chunk2_written..], true) {
                             Ok(written) => chunk2_written += written,
                             Err(quiche::h3::Error::Done | quiche::h3::Error::StreamBlocked) => {}
+                            Err(quiche::h3::Error::TransportError(
+                                quiche::Error::StreamStopped(_),
+                            )) => {
+                                request_stream_stopped = true;
+                                chunk2_written = chunk2.len();
+                            }
                             Err(e) => return Err(format!("send_body chunk2: {e:?}")),
                         }
                     }
@@ -3173,7 +3201,7 @@ fn concurrent_large_body_pressure_is_bounded() {
             let chunk2 = vec![0u8; (MAX_REQUEST_BODY_BYTES - 8 * 1024) - chunk1.len()];
             run_h3_client_two_chunk_post(
                 listen_addr,
-                "/slow",
+                "/",
                 chunk1,
                 chunk2,
                 Duration::from_millis(20),


### PR DESCRIPTION
## Summary
Strengthens the `spooky-config` runtime interpreter contract tests so the raw-config to runtime-config lowering is explicitly covered and easier to maintain.

## What Changed
- added regression coverage for listener precedence and listener runtime normalization
- added timeout normalization and timeout-ordering validation coverage
- added transport policy and connection-limit normalization coverage
- added auth, admission, and scoped rate-limit shaping coverage
- added backend endpoint, transport-kind, TLS, DNS, and health-check interpretation coverage
- added load-balancing strategy and request-key normalization coverage
- added reload-boundary coverage for startup-owned versus generation-owned runtime inputs
- cleaned up the regression suite structure, helper reuse, and test naming

## Why
These tests lock the canonical runtime interpreter behavior after the refactor work, so future config changes cannot silently drift across:
- normalized runtime policy output
- listener/runtime ownership boundaries
- backend and transport interpretation
- auth/admission/load-balancing shaping

## Verification
- `cargo test -p spooky-config`