### PR TITLE
test: tighten bridge and transport contract coverage

### DIFF
--- a/crates/bridge/src/response.rs
+++ b/crates/bridge/src/response.rs
@@ -523,7 +523,10 @@ mod tests {
 
         assert_eq!(normalized.emission.body, ResponseBodyPolicy::Suppress);
         assert!(normalized.emission.emit_end_stream_on_headers);
-        assert_eq!(header_value(&normalized.head.headers, "retry-after"), Some("3"));
+        assert_eq!(
+            header_value(&normalized.head.headers, "retry-after"),
+            Some("3")
+        );
     }
 
     #[test]
@@ -589,7 +592,10 @@ mod tests {
 
         assert_eq!(normalized.emission.body, ResponseBodyPolicy::Suppress);
         assert!(normalized.emission.emit_end_stream_on_headers);
-        assert_eq!(header_value(&normalized.head.headers, "etag"), Some("\"etag-304\""));
+        assert_eq!(
+            header_value(&normalized.head.headers, "etag"),
+            Some("\"etag-304\"")
+        );
         assert_eq!(
             header_value(&normalized.head.headers, "cache-control"),
             Some("max-age=60")
@@ -618,7 +624,10 @@ mod tests {
     #[test]
     fn switching_protocols_preserves_upgrade_headers_when_requested() {
         let mut headers = HeaderMap::new();
-        headers.insert(http::header::CONNECTION, HeaderValue::from_static("upgrade"));
+        headers.insert(
+            http::header::CONNECTION,
+            HeaderValue::from_static("upgrade"),
+        );
         headers.insert(http::header::UPGRADE, HeaderValue::from_static("websocket"));
 
         let normalized = normalize_upstream_response(ResponseNormalizationInput {
@@ -716,7 +725,10 @@ mod tests {
                 .count(),
             1
         );
-        assert_eq!(header_value(&headers, "content-type"), Some("application/json"));
+        assert_eq!(
+            header_value(&headers, "content-type"),
+            Some("application/json")
+        );
         assert_eq!(header_value(&headers, "content-length"), Some("9"));
     }
 

--- a/crates/bridge/src/response.rs
+++ b/crates/bridge/src/response.rs
@@ -419,6 +419,23 @@ mod tests {
     }
 
     #[test]
+    fn trailer_normalization_drops_all_trailers_when_protocol_disallows_them() {
+        let mut trailers = HeaderMap::new();
+        trailers.insert(
+            http::HeaderName::from_static("grpc-status"),
+            HeaderValue::from_static("0"),
+        );
+        trailers.insert(
+            http::HeaderName::from_static("grpc-message"),
+            HeaderValue::from_static("ok"),
+        );
+
+        let normalized = normalize_response_trailers(&trailers, http1_constraints());
+
+        assert!(normalized.is_empty());
+    }
+
+    #[test]
     fn normalizes_http3_head_response_as_bodyless_and_header_terminal() {
         let mut headers = HeaderMap::new();
         headers.insert(http::header::CONTENT_LENGTH, HeaderValue::from_static("12"));
@@ -487,6 +504,29 @@ mod tests {
     }
 
     #[test]
+    fn normalizes_informational_response_as_bodyless_and_terminal() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            http::HeaderName::from_static("retry-after"),
+            HeaderValue::from_static("3"),
+        );
+
+        let normalized = normalize_upstream_response(ResponseNormalizationInput {
+            upstream: UpstreamResponseView {
+                status: StatusCode::CONTINUE,
+                headers: &headers,
+                trailers: None,
+            },
+            body_mode: ResponseBodyMode::Normal,
+            constraints: http1_constraints(),
+        });
+
+        assert_eq!(normalized.emission.body, ResponseBodyPolicy::Suppress);
+        assert!(normalized.emission.emit_end_stream_on_headers);
+        assert_eq!(header_value(&normalized.head.headers, "retry-after"), Some("3"));
+    }
+
+    #[test]
     fn normalizes_http1_no_content_without_suppressing_surviving_metadata() {
         let mut headers = HeaderMap::new();
         headers.insert(http::header::CONTENT_LENGTH, HeaderValue::from_static("0"));
@@ -528,6 +568,35 @@ mod tests {
     }
 
     #[test]
+    fn normalizes_not_modified_response_as_bodyless_while_preserving_end_to_end_metadata() {
+        let mut headers = HeaderMap::new();
+        headers.insert(http::header::CONTENT_LENGTH, HeaderValue::from_static("0"));
+        headers.insert(http::header::ETAG, HeaderValue::from_static("\"etag-304\""));
+        headers.insert(
+            http::header::CACHE_CONTROL,
+            HeaderValue::from_static("max-age=60"),
+        );
+
+        let normalized = normalize_upstream_response(ResponseNormalizationInput {
+            upstream: UpstreamResponseView {
+                status: StatusCode::NOT_MODIFIED,
+                headers: &headers,
+                trailers: None,
+            },
+            body_mode: ResponseBodyMode::Normal,
+            constraints: http1_constraints(),
+        });
+
+        assert_eq!(normalized.emission.body, ResponseBodyPolicy::Suppress);
+        assert!(normalized.emission.emit_end_stream_on_headers);
+        assert_eq!(header_value(&normalized.head.headers, "etag"), Some("\"etag-304\""));
+        assert_eq!(
+            header_value(&normalized.head.headers, "cache-control"),
+            Some("max-age=60")
+        );
+    }
+
+    #[test]
     fn tunnel_success_does_not_force_body_suppression_or_terminal_headers() {
         let mut headers = HeaderMap::new();
         headers.insert(http::header::CONTENT_LENGTH, HeaderValue::from_static("0"));
@@ -544,6 +613,37 @@ mod tests {
 
         assert_eq!(normalized.emission.body, ResponseBodyPolicy::Forward);
         assert!(!normalized.emission.emit_end_stream_on_headers);
+    }
+
+    #[test]
+    fn switching_protocols_preserves_upgrade_headers_when_requested() {
+        let mut headers = HeaderMap::new();
+        headers.insert(http::header::CONNECTION, HeaderValue::from_static("upgrade"));
+        headers.insert(http::header::UPGRADE, HeaderValue::from_static("websocket"));
+
+        let normalized = normalize_upstream_response(ResponseNormalizationInput {
+            upstream: UpstreamResponseView {
+                status: StatusCode::SWITCHING_PROTOCOLS,
+                headers: &headers,
+                trailers: None,
+            },
+            body_mode: ResponseBodyMode::TunnelSuccess,
+            constraints: ResponseProtocolConstraints {
+                preserve_upgrade: true,
+                ..http1_constraints()
+            },
+        });
+
+        assert_eq!(normalized.emission.body, ResponseBodyPolicy::Forward);
+        assert!(!normalized.emission.emit_end_stream_on_headers);
+        assert_eq!(
+            header_value(&normalized.head.headers, "connection"),
+            Some("upgrade")
+        );
+        assert_eq!(
+            header_value(&normalized.head.headers, "upgrade"),
+            Some("websocket")
+        );
     }
 
     #[test]
@@ -576,6 +676,48 @@ mod tests {
                 .any(|header| header.name == http::header::CONTENT_LENGTH
                     && header.value == HeaderValue::from_static("5"))
         );
+    }
+
+    #[test]
+    fn response_defaults_do_not_duplicate_existing_content_type_or_content_length() {
+        let mut headers = vec![
+            NormalizedHeader {
+                name: http::header::CONTENT_TYPE,
+                value: HeaderValue::from_static("application/json"),
+            },
+            NormalizedHeader {
+                name: http::header::CONTENT_LENGTH,
+                value: HeaderValue::from_static("9"),
+            },
+        ];
+
+        apply_response_header_defaults(
+            &mut headers,
+            &ResponseEmissionPolicy {
+                body: ResponseBodyPolicy::Forward,
+                content_length: ContentLengthPolicy::Preserve,
+                content_type: ContentTypePolicy::SynthesizeTextPlain,
+                emit_end_stream_on_headers: false,
+            },
+            9,
+        );
+
+        assert_eq!(
+            headers
+                .iter()
+                .filter(|header| header.name == http::header::CONTENT_TYPE)
+                .count(),
+            1
+        );
+        assert_eq!(
+            headers
+                .iter()
+                .filter(|header| header.name == http::header::CONTENT_LENGTH)
+                .count(),
+            1
+        );
+        assert_eq!(header_value(&headers, "content-type"), Some("application/json"));
+        assert_eq!(header_value(&headers, "content-length"), Some("9"));
     }
 
     #[test]

--- a/crates/bridge/src/websocket.rs
+++ b/crates/bridge/src/websocket.rs
@@ -55,3 +55,69 @@ pub fn h3_websocket_request_kind(
 pub fn h3_websocket_tunnel_requested(method: &str, headers: &[quiche::h3::Header]) -> bool {
     h3_websocket_request_kind(method, headers) != H3WebsocketRequestKind::None
 }
+
+#[cfg(test)]
+mod tests {
+    use quiche::h3::Header;
+
+    use super::{H3WebsocketRequestKind, h3_websocket_request_kind, h3_websocket_tunnel_requested};
+
+    #[test]
+    fn detects_legacy_upgrade_only_when_upgrade_and_connection_requirements_are_met() {
+        let headers = vec![
+            Header::new(b"connection", b"keep-alive, upgrade"),
+            Header::new(b"upgrade", b"websocket"),
+            Header::new(b"sec-websocket-key", b"dGhlIHNhbXBsZSBub25jZQ=="),
+        ];
+
+        assert_eq!(
+            h3_websocket_request_kind("GET", &headers),
+            H3WebsocketRequestKind::LegacyUpgrade
+        );
+        assert!(h3_websocket_tunnel_requested("GET", &headers));
+    }
+
+    #[test]
+    fn detects_extended_connect_only_when_connect_uses_websocket_protocol() {
+        let headers = vec![
+            Header::new(b":protocol", b"websocket"),
+            Header::new(b"sec-websocket-key", b"dGhlIHNhbXBsZSBub25jZQ=="),
+        ];
+
+        assert_eq!(
+            h3_websocket_request_kind("CONNECT", &headers),
+            H3WebsocketRequestKind::ExtendedConnect
+        );
+        assert!(h3_websocket_tunnel_requested("CONNECT", &headers));
+    }
+
+    #[test]
+    fn ignores_incomplete_or_invalid_upgrade_candidates() {
+        let missing_connection = vec![Header::new(b"upgrade", b"websocket")];
+        assert_eq!(
+            h3_websocket_request_kind("GET", &missing_connection),
+            H3WebsocketRequestKind::None
+        );
+
+        let wrong_upgrade_token = vec![
+            Header::new(b"connection", b"upgrade"),
+            Header::new(b"upgrade", b"h2c"),
+        ];
+        assert_eq!(
+            h3_websocket_request_kind("GET", &wrong_upgrade_token),
+            H3WebsocketRequestKind::None
+        );
+
+        let connect_without_protocol = vec![Header::new(b"sec-websocket-key", b"abc")];
+        assert_eq!(
+            h3_websocket_request_kind("CONNECT", &connect_without_protocol),
+            H3WebsocketRequestKind::None
+        );
+
+        let get_with_protocol_header = vec![Header::new(b":protocol", b"websocket")];
+        assert_eq!(
+            h3_websocket_request_kind("GET", &get_with_protocol_header),
+            H3WebsocketRequestKind::None
+        );
+    }
+}

--- a/crates/bridge/tests/regression/common.rs
+++ b/crates/bridge/tests/regression/common.rs
@@ -16,6 +16,9 @@ use spooky_config::{
 };
 use spooky_errors::BridgeError;
 
+pub type CanonicalBridgeRequest = http::Request<BoxBody<Bytes, Infallible>>;
+pub type CanonicalBridgeRequestPair = (CanonicalBridgeRequest, CanonicalBridgeRequest);
+
 #[derive(Clone, Copy)]
 pub struct RequestInputMeta<'a> {
     pub authority: Option<&'a str>,
@@ -92,13 +95,7 @@ pub fn build_h1_and_h2_requests<'a>(
     path: &'a str,
     headers: &'a [Header],
     meta: RequestInputMeta<'a>,
-) -> Result<
-    (
-        http::Request<BoxBody<Bytes, Infallible>>,
-        http::Request<BoxBody<Bytes, Infallible>>,
-    ),
-    BridgeError,
-> {
+) -> Result<CanonicalBridgeRequestPair, BridgeError> {
     let h1 = build_h1_request(
         request_target(endpoint, host_policy, forwarded_header_policy),
         request_input(method, path, headers, meta),

--- a/crates/bridge/tests/regression/common.rs
+++ b/crates/bridge/tests/regression/common.rs
@@ -3,6 +3,7 @@
 use std::{convert::Infallible, net::SocketAddr};
 
 use bytes::Bytes;
+use http::HeaderMap;
 use http_body_util::{BodyExt, Empty, combinators::BoxBody};
 use quiche::h3::Header;
 use spooky_bridge::request::{
@@ -36,6 +37,13 @@ pub fn request_target<'a>(
             forwarded_header_policy,
         },
     }
+}
+
+pub fn bridge_headers(headers: &HeaderMap) -> Vec<Header> {
+    headers
+        .iter()
+        .map(|(name, value)| Header::new(name.as_str().as_bytes(), value.as_bytes()))
+        .collect()
 }
 
 pub fn request_input<'a>(

--- a/crates/bridge/tests/regression/common.rs
+++ b/crates/bridge/tests/regression/common.rs
@@ -6,13 +6,14 @@ use bytes::Bytes;
 use http_body_util::{BodyExt, Empty, combinators::BoxBody};
 use quiche::h3::Header;
 use spooky_bridge::request::{
-    RequestBuildInput, RequestBuildPolicies, RequestBuildTarget, RequestForwardedContext,
-    RequestTraceContext,
+    RequestBodyMode, RequestBuildInput, RequestBuildPolicies, RequestBuildTarget,
+    RequestForwardedContext, RequestTraceContext, build_h1_request, build_h2_request_for_target,
 };
 use spooky_config::{
     backend_endpoint::BackendEndpoint,
     config::{ForwardedHeaderPolicy, UpstreamHostPolicy},
 };
+use spooky_errors::BridgeError;
 
 #[derive(Clone, Copy)]
 pub struct RequestInputMeta<'a> {
@@ -61,4 +62,42 @@ pub fn request_input<'a>(
             client_addr: meta.client_addr,
         },
     }
+}
+
+pub fn request_input_with_body_mode<'a>(
+    method: &'a str,
+    path: &'a str,
+    headers: &'a [Header],
+    meta: RequestInputMeta<'a>,
+    body_mode: RequestBodyMode,
+) -> RequestBuildInput<'a, BoxBody<Bytes, Infallible>> {
+    let mut input = request_input(method, path, headers, meta);
+    input.body_mode = body_mode;
+    input
+}
+
+pub fn build_h1_and_h2_requests<'a>(
+    endpoint: &'a BackendEndpoint,
+    host_policy: &'a UpstreamHostPolicy,
+    forwarded_header_policy: &'a ForwardedHeaderPolicy,
+    method: &'a str,
+    path: &'a str,
+    headers: &'a [Header],
+    meta: RequestInputMeta<'a>,
+) -> Result<
+    (
+        http::Request<BoxBody<Bytes, Infallible>>,
+        http::Request<BoxBody<Bytes, Infallible>>,
+    ),
+    BridgeError,
+> {
+    let h1 = build_h1_request(
+        request_target(endpoint, host_policy, forwarded_header_policy),
+        request_input(method, path, headers, meta),
+    )?;
+    let h2 = build_h2_request_for_target(
+        request_target(endpoint, host_policy, forwarded_header_policy),
+        request_input(method, path, headers, meta),
+    )?;
+    Ok((h1, h2))
 }

--- a/crates/bridge/tests/regression/h3_to_h1.rs
+++ b/crates/bridge/tests/regression/h3_to_h1.rs
@@ -11,14 +11,7 @@ use spooky_config::{
     config::{ForwardedHeaderPolicy, UpstreamHostPolicy},
 };
 
-use crate::common::{RequestInputMeta, request_input, request_target};
-
-fn bootstrap_headers(headers: &HeaderMap) -> Vec<Header> {
-    headers
-        .iter()
-        .map(|(name, value)| Header::new(name.as_str().as_bytes(), value.as_bytes()))
-        .collect()
-}
+use crate::common::{RequestInputMeta, bridge_headers, request_input, request_target};
 
 #[test]
 fn plain_requests_strip_hop_headers_and_add_te_trailers() {
@@ -172,7 +165,7 @@ fn bootstrap_and_forwarding_header_shapes_match_for_h1() {
     bootstrap_headers_map.insert(HOST, HeaderValue::from_static("api.example.com"));
     bootstrap_headers_map.insert("x-custom", HeaderValue::from_static("ok"));
     bootstrap_headers_map.insert("x-forwarded-for", HeaderValue::from_static("1.2.3.4"));
-    let bootstrap_headers = bootstrap_headers(&bootstrap_headers_map);
+    let bootstrap_headers = bridge_headers(&bootstrap_headers_map);
 
     let build = |headers: &[Header]| {
         build_h1_request(

--- a/crates/bridge/tests/regression/host_forwarded_policy.rs
+++ b/crates/bridge/tests/regression/host_forwarded_policy.rs
@@ -214,7 +214,9 @@ fn forwarded_header_policy_modes_apply_identically_for_h1_and_h2() {
         assert!(h1.headers().get("x-secret").is_none());
         assert!(h2.headers().get("x-secret").is_none());
         assert_eq!(
-            h1.headers().get("x-keep").and_then(|value| value.to_str().ok()),
+            h1.headers()
+                .get("x-keep")
+                .and_then(|value| value.to_str().ok()),
             Some("ok")
         );
     }

--- a/crates/bridge/tests/regression/host_forwarded_policy.rs
+++ b/crates/bridge/tests/regression/host_forwarded_policy.rs
@@ -1,0 +1,221 @@
+//! Canonical host-policy and forwarded-header-policy contracts across h1 and h2.
+
+use std::convert::Infallible;
+
+use bytes::Bytes;
+use http_body_util::combinators::BoxBody;
+use quiche::h3::Header;
+use spooky_config::{
+    backend_endpoint::BackendEndpoint,
+    config::{
+        ForwardedHeaderPolicy, ForwardedHeaderPolicyMode, UpstreamHostPolicy,
+        UpstreamHostPolicyMode,
+    },
+};
+
+use crate::common::{RequestInputMeta, build_h1_and_h2_requests};
+
+fn assert_same_header(
+    h1: &http::Request<BoxBody<Bytes, Infallible>>,
+    h2: &http::Request<BoxBody<Bytes, Infallible>>,
+    name: &str,
+) {
+    assert_eq!(
+        h1.headers().get(name).and_then(|value| value.to_str().ok()),
+        h2.headers().get(name).and_then(|value| value.to_str().ok()),
+        "canonical policy application mismatch for header {name}"
+    );
+}
+
+#[test]
+fn pass_through_host_policy_prefers_request_authority_for_h1_and_h2() {
+    let endpoint = BackendEndpoint::parse("backend.internal:8443").expect("endpoint");
+    let host_policy = UpstreamHostPolicy {
+        mode: UpstreamHostPolicyMode::PassThrough,
+        host: None,
+    };
+    let headers = vec![Header::new(b"host", b"spoofed.example.com")];
+
+    let (h1, h2) = build_h1_and_h2_requests(
+        &endpoint,
+        &host_policy,
+        &ForwardedHeaderPolicy::default(),
+        "GET",
+        "/",
+        &headers,
+        RequestInputMeta {
+            authority: Some("tenant.example.com"),
+            content_length: None,
+            request_id: 501,
+            traceparent: None,
+            client_addr: "203.0.113.11:7000".parse().expect("client"),
+        },
+    )
+    .expect("requests");
+
+    for name in [http::header::HOST.as_str(), "x-forwarded-host", "forwarded"] {
+        assert_same_header(&h1, &h2, name);
+    }
+
+    assert_eq!(
+        h1.headers()
+            .get(http::header::HOST)
+            .and_then(|value| value.to_str().ok()),
+        Some("tenant.example.com")
+    );
+    assert_eq!(
+        h1.headers()
+            .get("x-forwarded-host")
+            .and_then(|value| value.to_str().ok()),
+        Some("tenant.example.com")
+    );
+    assert_eq!(
+        h1.headers()
+            .get("forwarded")
+            .and_then(|value| value.to_str().ok()),
+        Some("for=203.0.113.11;proto=https;host=\"tenant.example.com\"")
+    );
+}
+
+#[test]
+fn pass_through_host_policy_falls_back_to_inbound_host_header_for_h1_and_h2() {
+    let endpoint = BackendEndpoint::parse("backend.internal:8443").expect("endpoint");
+    let host_policy = UpstreamHostPolicy {
+        mode: UpstreamHostPolicyMode::PassThrough,
+        host: None,
+    };
+    let headers = vec![Header::new(b"host", b"header-only.example.com")];
+
+    let (h1, h2) = build_h1_and_h2_requests(
+        &endpoint,
+        &host_policy,
+        &ForwardedHeaderPolicy::default(),
+        "GET",
+        "/fallback",
+        &headers,
+        RequestInputMeta {
+            authority: None,
+            content_length: None,
+            request_id: 502,
+            traceparent: None,
+            client_addr: "203.0.113.12:7001".parse().expect("client"),
+        },
+    )
+    .expect("requests");
+
+    for name in [http::header::HOST.as_str(), "x-forwarded-host", "forwarded"] {
+        assert_same_header(&h1, &h2, name);
+    }
+
+    assert_eq!(
+        h1.headers()
+            .get(http::header::HOST)
+            .and_then(|value| value.to_str().ok()),
+        Some("header-only.example.com")
+    );
+    assert_eq!(
+        h1.headers()
+            .get("x-forwarded-host")
+            .and_then(|value| value.to_str().ok()),
+        Some("header-only.example.com")
+    );
+}
+
+#[test]
+fn rewrite_and_upstream_host_policies_apply_identically_for_h1_and_h2() {
+    let endpoint = BackendEndpoint::parse("backend.internal:8443").expect("endpoint");
+    let headers = vec![Header::new(b"host", b"spoofed.example.com")];
+
+    for policy in [
+        UpstreamHostPolicy {
+            mode: UpstreamHostPolicyMode::Rewrite,
+            host: Some("origin.example.com".to_string()),
+        },
+        UpstreamHostPolicy {
+            mode: UpstreamHostPolicyMode::Upstream,
+            host: None,
+        },
+    ] {
+        let (h1, h2) = build_h1_and_h2_requests(
+            &endpoint,
+            &policy,
+            &ForwardedHeaderPolicy::default(),
+            "GET",
+            "/policy",
+            &headers,
+            RequestInputMeta {
+                authority: Some("tenant.example.com"),
+                content_length: None,
+                request_id: 503,
+                traceparent: None,
+                client_addr: "203.0.113.13:7002".parse().expect("client"),
+            },
+        )
+        .expect("requests");
+
+        for name in [http::header::HOST.as_str(), "x-forwarded-host", "forwarded"] {
+            assert_same_header(&h1, &h2, name);
+        }
+    }
+}
+
+#[test]
+fn forwarded_header_policy_modes_apply_identically_for_h1_and_h2() {
+    let endpoint = BackendEndpoint::parse("backend.internal:443").expect("endpoint");
+    let host_policy = UpstreamHostPolicy::default();
+    let headers = vec![
+        Header::new(b"forwarded", b"for=1.2.3.4;proto=http;host=\"old.example\""),
+        Header::new(b"x-forwarded-for", b"1.2.3.4"),
+        Header::new(b"x-forwarded-proto", b"http"),
+        Header::new(b"x-forwarded-host", b"old.example"),
+        Header::new(b"connection", b"keep-alive, x-secret"),
+        Header::new(b"x-secret", b"drop-me"),
+        Header::new(b"x-keep", b"ok"),
+    ];
+
+    for policy in [
+        ForwardedHeaderPolicy {
+            mode: ForwardedHeaderPolicyMode::Overwrite,
+        },
+        ForwardedHeaderPolicy {
+            mode: ForwardedHeaderPolicyMode::Append,
+        },
+        ForwardedHeaderPolicy {
+            mode: ForwardedHeaderPolicyMode::Preserve,
+        },
+    ] {
+        let (h1, h2) = build_h1_and_h2_requests(
+            &endpoint,
+            &host_policy,
+            &policy,
+            "GET",
+            "/forwarded",
+            &headers,
+            RequestInputMeta {
+                authority: Some("api.example.com"),
+                content_length: None,
+                request_id: 504,
+                traceparent: None,
+                client_addr: "203.0.113.14:7003".parse().expect("client"),
+            },
+        )
+        .expect("requests");
+
+        for name in [
+            "forwarded",
+            "x-forwarded-for",
+            "x-forwarded-proto",
+            "x-forwarded-host",
+            "x-keep",
+        ] {
+            assert_same_header(&h1, &h2, name);
+        }
+
+        assert!(h1.headers().get("x-secret").is_none());
+        assert!(h2.headers().get("x-secret").is_none());
+        assert_eq!(
+            h1.headers().get("x-keep").and_then(|value| value.to_str().ok()),
+            Some("ok")
+        );
+    }
+}

--- a/crates/bridge/tests/regression/main.rs
+++ b/crates/bridge/tests/regression/main.rs
@@ -1,14 +1,18 @@
-//! Regression suite for the `spooky_bridge` request-building pipeline.
+//! Regression suite for the `spooky_bridge` request and protocol-shaping contracts.
 //!
 //! Public-API integration tests for `build_h2_request_for_target` (h3→h2) and
 //! `build_h1_request` (h3→h1): scheme selection, host/forwarded-header policy,
 //! hop-by-hop stripping, spoofed-header removal, WebSocket shaping, and H1/H2
-//! output parity. Shared fixtures live in `common`.
+//! output parity. Shared fixtures live in `common`, while response-normalization
+//! contracts live under the bridge unit tests.
 
 mod common;
 
+// Request-shaping contracts.
+mod request_contract;
+mod host_forwarded_policy;
+mod websocket_contract;
+
+// Protocol-specific request behavior and parity.
 mod h3_to_h1;
 mod h3_to_h2;
-mod host_forwarded_policy;
-mod request_contract;
-mod websocket_contract;

--- a/crates/bridge/tests/regression/main.rs
+++ b/crates/bridge/tests/regression/main.rs
@@ -11,3 +11,4 @@ mod h3_to_h1;
 mod h3_to_h2;
 mod host_forwarded_policy;
 mod request_contract;
+mod websocket_contract;

--- a/crates/bridge/tests/regression/main.rs
+++ b/crates/bridge/tests/regression/main.rs
@@ -9,8 +9,8 @@
 mod common;
 
 // Request-shaping contracts.
-mod request_contract;
 mod host_forwarded_policy;
+mod request_contract;
 mod websocket_contract;
 
 // Protocol-specific request behavior and parity.

--- a/crates/bridge/tests/regression/main.rs
+++ b/crates/bridge/tests/regression/main.rs
@@ -9,3 +9,5 @@ mod common;
 
 mod h3_to_h1;
 mod h3_to_h2;
+mod host_forwarded_policy;
+mod request_contract;

--- a/crates/bridge/tests/regression/request_contract.rs
+++ b/crates/bridge/tests/regression/request_contract.rs
@@ -1,0 +1,197 @@
+//! Canonical request-builder input contracts shared across h1 and h2 outputs.
+
+use http::header::{CONTENT_LENGTH, HOST};
+use quiche::h3::Header;
+use spooky_bridge::request::{RequestBodyMode, RequestBuildInput, build_h1_request, build_h2_request_for_target};
+use spooky_config::{
+    backend_endpoint::BackendEndpoint,
+    config::{ForwardedHeaderPolicy, UpstreamHostPolicy},
+};
+
+use crate::common::{
+    RequestInputMeta, build_h1_and_h2_requests, request_input_with_body_mode, request_target,
+};
+
+#[test]
+fn canonical_known_length_inputs_shape_h1_and_h2_requests_consistently() {
+    let endpoint = BackendEndpoint::parse("payments.internal:443").expect("endpoint");
+    let headers = vec![
+        Header::new(b"host", b"spoofed.example.com"),
+        Header::new(b"x-custom", b"ok"),
+    ];
+
+    let (h1, h2) = build_h1_and_h2_requests(
+        &endpoint,
+        &UpstreamHostPolicy::default(),
+        &ForwardedHeaderPolicy::default(),
+        "POST",
+        "/v1/payments",
+        &headers,
+        RequestInputMeta {
+            authority: Some("api.example.com"),
+            content_length: Some(16),
+            request_id: 77,
+            traceparent: Some("00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01"),
+            client_addr: "198.51.100.44:7000".parse().expect("client"),
+        },
+    )
+    .expect("requests");
+
+    assert_eq!(h1.method(), http::Method::POST);
+    assert_eq!(h2.method(), http::Method::POST);
+    assert_eq!(h1.uri().to_string(), "https://payments.internal:443/v1/payments");
+    assert_eq!(h1.uri(), h2.uri());
+
+    for name in [
+        HOST.as_str(),
+        CONTENT_LENGTH.as_str(),
+        "x-custom",
+        "x-forwarded-for",
+        "x-forwarded-proto",
+        "x-forwarded-host",
+        "forwarded",
+        "x-request-id",
+        "traceparent",
+    ] {
+        assert_eq!(
+            h1.headers().get(name).and_then(|value| value.to_str().ok()),
+            h2.headers().get(name).and_then(|value| value.to_str().ok()),
+            "canonical request contract mismatch for header {name}"
+        );
+    }
+
+    assert_eq!(
+        h1.headers().get(HOST).and_then(|value| value.to_str().ok()),
+        Some("api.example.com")
+    );
+    assert_eq!(
+        h1.headers()
+            .get(CONTENT_LENGTH)
+            .and_then(|value| value.to_str().ok()),
+        Some("16")
+    );
+    assert_eq!(
+        h1.headers()
+            .get("x-forwarded-for")
+            .and_then(|value| value.to_str().ok()),
+        Some("198.51.100.44")
+    );
+    assert_eq!(
+        h1.headers()
+            .get("traceparent")
+            .and_then(|value| value.to_str().ok()),
+        Some("00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01")
+    );
+}
+
+#[test]
+fn canonical_streaming_inputs_preserve_authority_and_forwarded_context_without_content_length() {
+    let endpoint = BackendEndpoint::parse("stream.internal:8443").expect("endpoint");
+
+    let (h1, h2) = build_h1_and_h2_requests(
+        &endpoint,
+        &UpstreamHostPolicy::default(),
+        &ForwardedHeaderPolicy::default(),
+        "PATCH",
+        "/streams/live",
+        &[],
+        RequestInputMeta {
+            authority: Some("stream.example.com"),
+            content_length: None,
+            request_id: 88,
+            traceparent: None,
+            client_addr: "203.0.113.9:9443".parse().expect("client"),
+        },
+    )
+    .expect("requests");
+
+    assert_eq!(
+        h1.headers().get(HOST).and_then(|value| value.to_str().ok()),
+        Some("stream.example.com")
+    );
+    assert_eq!(
+        h2.headers().get(HOST).and_then(|value| value.to_str().ok()),
+        Some("stream.example.com")
+    );
+    assert!(h1.headers().get(CONTENT_LENGTH).is_none());
+    assert!(h2.headers().get(CONTENT_LENGTH).is_none());
+    assert_eq!(
+        h1.headers()
+            .get("x-forwarded-for")
+            .and_then(|value| value.to_str().ok()),
+        Some("203.0.113.9")
+    );
+    assert_eq!(
+        h1.headers().get("forwarded").and_then(|value| value.to_str().ok()),
+        Some("for=203.0.113.9;proto=https;host=\"stream.example.com\"")
+    );
+    assert_eq!(
+        h1.headers().get("x-request-id").and_then(|value| value.to_str().ok()),
+        Some("88")
+    );
+    assert!(h1.headers().get("traceparent").is_none());
+    assert!(h2.headers().get("traceparent").is_none());
+}
+
+#[test]
+fn canonical_empty_body_inputs_do_not_emit_content_length_for_h1_or_h2() {
+    let endpoint = BackendEndpoint::parse("backend.internal:443").expect("endpoint");
+    let host_policy = UpstreamHostPolicy::default();
+    let forwarded_header_policy = ForwardedHeaderPolicy::default();
+    let meta = RequestInputMeta {
+        authority: None,
+        content_length: Some(0),
+        request_id: 91,
+        traceparent: None,
+        client_addr: "203.0.113.20:7001".parse().expect("client"),
+    };
+
+    let h1 = build_h1_request(
+        request_target(&endpoint, &host_policy, &forwarded_header_policy),
+        request_input_with_body_mode("GET", "", &[], meta, RequestBodyMode::Empty),
+    )
+    .expect("h1 request");
+    let h2 = build_h2_request_for_target(
+        request_target(&endpoint, &host_policy, &forwarded_header_policy),
+        request_input_with_body_mode("GET", "", &[], meta, RequestBodyMode::Empty),
+    )
+    .expect("h2 request");
+
+    assert_eq!(h1.uri().to_string(), "https://backend.internal:443/");
+    assert_eq!(h1.uri(), h2.uri());
+    assert_eq!(
+        h1.headers().get(HOST).and_then(|value| value.to_str().ok()),
+        Some("backend.internal:443")
+    );
+    assert_eq!(
+        h2.headers().get(HOST).and_then(|value| value.to_str().ok()),
+        Some("backend.internal:443")
+    );
+    assert!(h1.headers().get(CONTENT_LENGTH).is_none());
+    assert!(h2.headers().get(CONTENT_LENGTH).is_none());
+}
+
+#[test]
+fn request_body_mode_helper_maps_lengths_to_canonical_modes() {
+    assert_eq!(
+        RequestBuildInput::<http_body_util::combinators::BoxBody<
+            bytes::Bytes,
+            std::convert::Infallible,
+        >>::body_mode_for_length(Some(0)),
+        RequestBodyMode::Empty
+    );
+    assert_eq!(
+        RequestBuildInput::<http_body_util::combinators::BoxBody<
+            bytes::Bytes,
+            std::convert::Infallible,
+        >>::body_mode_for_length(Some(12)),
+        RequestBodyMode::KnownLength
+    );
+    assert_eq!(
+        RequestBuildInput::<http_body_util::combinators::BoxBody<
+            bytes::Bytes,
+            std::convert::Infallible,
+        >>::body_mode_for_length(None),
+        RequestBodyMode::Streaming
+    );
+}

--- a/crates/bridge/tests/regression/request_contract.rs
+++ b/crates/bridge/tests/regression/request_contract.rs
@@ -2,7 +2,9 @@
 
 use http::header::{CONTENT_LENGTH, HOST};
 use quiche::h3::Header;
-use spooky_bridge::request::{RequestBodyMode, RequestBuildInput, build_h1_request, build_h2_request_for_target};
+use spooky_bridge::request::{
+    RequestBodyMode, RequestBuildInput, build_h1_request, build_h2_request_for_target,
+};
 use spooky_config::{
     backend_endpoint::BackendEndpoint,
     config::{ForwardedHeaderPolicy, UpstreamHostPolicy},
@@ -39,7 +41,10 @@ fn canonical_known_length_inputs_shape_h1_and_h2_requests_consistently() {
 
     assert_eq!(h1.method(), http::Method::POST);
     assert_eq!(h2.method(), http::Method::POST);
-    assert_eq!(h1.uri().to_string(), "https://payments.internal:443/v1/payments");
+    assert_eq!(
+        h1.uri().to_string(),
+        "https://payments.internal:443/v1/payments"
+    );
     assert_eq!(h1.uri(), h2.uri());
 
     for name in [
@@ -122,11 +127,15 @@ fn canonical_streaming_inputs_preserve_authority_and_forwarded_context_without_c
         Some("203.0.113.9")
     );
     assert_eq!(
-        h1.headers().get("forwarded").and_then(|value| value.to_str().ok()),
+        h1.headers()
+            .get("forwarded")
+            .and_then(|value| value.to_str().ok()),
         Some("for=203.0.113.9;proto=https;host=\"stream.example.com\"")
     );
     assert_eq!(
-        h1.headers().get("x-request-id").and_then(|value| value.to_str().ok()),
+        h1.headers()
+            .get("x-request-id")
+            .and_then(|value| value.to_str().ok()),
         Some("88")
     );
     assert!(h1.headers().get("traceparent").is_none());
@@ -174,24 +183,21 @@ fn canonical_empty_body_inputs_do_not_emit_content_length_for_h1_or_h2() {
 #[test]
 fn request_body_mode_helper_maps_lengths_to_canonical_modes() {
     assert_eq!(
-        RequestBuildInput::<http_body_util::combinators::BoxBody<
-            bytes::Bytes,
-            std::convert::Infallible,
-        >>::body_mode_for_length(Some(0)),
+        RequestBuildInput::<
+            http_body_util::combinators::BoxBody<bytes::Bytes, std::convert::Infallible>,
+        >::body_mode_for_length(Some(0)),
         RequestBodyMode::Empty
     );
     assert_eq!(
-        RequestBuildInput::<http_body_util::combinators::BoxBody<
-            bytes::Bytes,
-            std::convert::Infallible,
-        >>::body_mode_for_length(Some(12)),
+        RequestBuildInput::<
+            http_body_util::combinators::BoxBody<bytes::Bytes, std::convert::Infallible>,
+        >::body_mode_for_length(Some(12)),
         RequestBodyMode::KnownLength
     );
     assert_eq!(
-        RequestBuildInput::<http_body_util::combinators::BoxBody<
-            bytes::Bytes,
-            std::convert::Infallible,
-        >>::body_mode_for_length(None),
+        RequestBuildInput::<
+            http_body_util::combinators::BoxBody<bytes::Bytes, std::convert::Infallible>,
+        >::body_mode_for_length(None),
         RequestBodyMode::Streaming
     );
 }

--- a/crates/bridge/tests/regression/websocket_contract.rs
+++ b/crates/bridge/tests/regression/websocket_contract.rs
@@ -138,7 +138,10 @@ fn incomplete_upgrade_candidates_do_not_trigger_websocket_specific_request_shapi
 #[test]
 fn connect_without_websocket_protocol_stays_on_normal_connect_path() {
     let endpoint = BackendEndpoint::parse("proxy.internal:8443").expect("endpoint");
-    let headers = vec![Header::new(b"sec-websocket-key", b"dGhlIHNhbXBsZSBub25jZQ==")];
+    let headers = vec![Header::new(
+        b"sec-websocket-key",
+        b"dGhlIHNhbXBsZSBub25jZQ==",
+    )];
 
     let request = build_h2_request_for_target(
         request_target(
@@ -165,7 +168,10 @@ fn connect_without_websocket_protocol_stays_on_normal_connect_path() {
     assert_eq!(request.uri().to_string(), "target.example.com:443");
     assert!(request.extensions().get::<hyper::ext::Protocol>().is_none());
     assert_eq!(
-        request.headers().get(HOST).and_then(|value| value.to_str().ok()),
+        request
+            .headers()
+            .get(HOST)
+            .and_then(|value| value.to_str().ok()),
         Some("target.example.com:443")
     );
 }

--- a/crates/bridge/tests/regression/websocket_contract.rs
+++ b/crates/bridge/tests/regression/websocket_contract.rs
@@ -8,14 +8,7 @@ use spooky_config::{
     config::{ForwardedHeaderPolicy, UpstreamHostPolicy},
 };
 
-use crate::common::{RequestInputMeta, request_input, request_target};
-
-fn bootstrap_headers(headers: &HeaderMap) -> Vec<Header> {
-    headers
-        .iter()
-        .map(|(name, value)| Header::new(name.as_str().as_bytes(), value.as_bytes()))
-        .collect()
-}
+use crate::common::{RequestInputMeta, bridge_headers, request_input, request_target};
 
 #[test]
 fn legacy_websocket_headers_from_bootstrap_and_forwarding_shape_identically() {
@@ -35,7 +28,7 @@ fn legacy_websocket_headers_from_bootstrap_and_forwarding_shape_identically() {
         "sec-websocket-key",
         HeaderValue::from_static("dGhlIHNhbXBsZSBub25jZQ=="),
     );
-    let bootstrap_headers = bootstrap_headers(&bootstrap_headers_map);
+    let bootstrap_headers = bridge_headers(&bootstrap_headers_map);
 
     let build = |headers: &[Header]| {
         build_h1_request(

--- a/crates/bridge/tests/regression/websocket_contract.rs
+++ b/crates/bridge/tests/regression/websocket_contract.rs
@@ -1,0 +1,178 @@
+//! Websocket and upgrade request-shaping contracts for canonical bridge builders.
+
+use http::{HeaderMap, HeaderValue, header::HOST};
+use quiche::h3::Header;
+use spooky_bridge::request::{build_h1_request, build_h2_request_for_target};
+use spooky_config::{
+    backend_endpoint::BackendEndpoint,
+    config::{ForwardedHeaderPolicy, UpstreamHostPolicy},
+};
+
+use crate::common::{RequestInputMeta, request_input, request_target};
+
+fn bootstrap_headers(headers: &HeaderMap) -> Vec<Header> {
+    headers
+        .iter()
+        .map(|(name, value)| Header::new(name.as_str().as_bytes(), value.as_bytes()))
+        .collect()
+}
+
+#[test]
+fn legacy_websocket_headers_from_bootstrap_and_forwarding_shape_identically() {
+    let endpoint = BackendEndpoint::parse("http://backend.internal:8080").expect("endpoint");
+    let forwarding_headers = vec![
+        Header::new(b"host", b"socket.example.com"),
+        Header::new(b"connection", b"upgrade"),
+        Header::new(b"upgrade", b"websocket"),
+        Header::new(b"sec-websocket-key", b"dGhlIHNhbXBsZSBub25jZQ=="),
+    ];
+
+    let mut bootstrap_headers_map = HeaderMap::new();
+    bootstrap_headers_map.insert(HOST, HeaderValue::from_static("socket.example.com"));
+    bootstrap_headers_map.insert("connection", HeaderValue::from_static("upgrade"));
+    bootstrap_headers_map.insert("upgrade", HeaderValue::from_static("websocket"));
+    bootstrap_headers_map.insert(
+        "sec-websocket-key",
+        HeaderValue::from_static("dGhlIHNhbXBsZSBub25jZQ=="),
+    );
+    let bootstrap_headers = bootstrap_headers(&bootstrap_headers_map);
+
+    let build = |headers: &[Header]| {
+        build_h1_request(
+            request_target(
+                &endpoint,
+                &UpstreamHostPolicy::default(),
+                &ForwardedHeaderPolicy::default(),
+            ),
+            request_input(
+                "GET",
+                "/ws",
+                headers,
+                RequestInputMeta {
+                    authority: Some("socket.example.com"),
+                    content_length: None,
+                    request_id: 601,
+                    traceparent: None,
+                    client_addr: "198.51.100.12:5555".parse().expect("client"),
+                },
+            ),
+        )
+        .expect("request")
+    };
+
+    let forwarding_req = build(&forwarding_headers);
+    let bootstrap_req = build(&bootstrap_headers);
+
+    for name in [
+        HOST.as_str(),
+        "connection",
+        "upgrade",
+        "sec-websocket-key",
+        "x-forwarded-for",
+        "x-forwarded-proto",
+        "x-forwarded-host",
+        "forwarded",
+        "x-request-id",
+    ] {
+        assert_eq!(
+            forwarding_req
+                .headers()
+                .get(name)
+                .and_then(|value| value.to_str().ok()),
+            bootstrap_req
+                .headers()
+                .get(name)
+                .and_then(|value| value.to_str().ok()),
+            "bootstrap and forwarding websocket shaping diverged for header {name}"
+        );
+    }
+}
+
+#[test]
+fn incomplete_upgrade_candidates_do_not_trigger_websocket_specific_request_shaping() {
+    let endpoint = BackendEndpoint::parse("backend.internal:443").expect("endpoint");
+    let headers = vec![
+        Header::new(b"connection", b"keep-alive"),
+        Header::new(b"upgrade", b"websocket"),
+        Header::new(b"sec-websocket-key", b"dGhlIHNhbXBsZSBub25jZQ=="),
+    ];
+
+    let meta = RequestInputMeta {
+        authority: Some("api.example.com"),
+        content_length: None,
+        request_id: 602,
+        traceparent: None,
+        client_addr: "203.0.113.17:7004".parse().expect("client"),
+    };
+
+    let h1 = build_h1_request(
+        request_target(
+            &endpoint,
+            &UpstreamHostPolicy::default(),
+            &ForwardedHeaderPolicy::default(),
+        ),
+        request_input("GET", "/not-ws", &headers, meta),
+    )
+    .expect("h1 request");
+    let h2 = build_h2_request_for_target(
+        request_target(
+            &endpoint,
+            &UpstreamHostPolicy::default(),
+            &ForwardedHeaderPolicy::default(),
+        ),
+        request_input("GET", "/not-ws", &headers, meta),
+    )
+    .expect("h2 request");
+
+    assert_eq!(h1.method(), http::Method::GET);
+    assert_eq!(h2.method(), http::Method::GET);
+    assert_eq!(h1.uri().to_string(), "https://backend.internal:443/not-ws");
+    assert_eq!(h2.uri().to_string(), "https://backend.internal:443/not-ws");
+    assert!(h1.headers().get("connection").is_none());
+    assert!(h1.headers().get("upgrade").is_none());
+    assert!(h2.headers().get("connection").is_none());
+    assert!(h2.headers().get("upgrade").is_none());
+    assert_eq!(
+        h1.headers().get(HOST).and_then(|value| value.to_str().ok()),
+        Some("api.example.com")
+    );
+    assert_eq!(
+        h2.headers().get(HOST).and_then(|value| value.to_str().ok()),
+        Some("api.example.com")
+    );
+}
+
+#[test]
+fn connect_without_websocket_protocol_stays_on_normal_connect_path() {
+    let endpoint = BackendEndpoint::parse("proxy.internal:8443").expect("endpoint");
+    let headers = vec![Header::new(b"sec-websocket-key", b"dGhlIHNhbXBsZSBub25jZQ==")];
+
+    let request = build_h2_request_for_target(
+        request_target(
+            &endpoint,
+            &UpstreamHostPolicy::default(),
+            &ForwardedHeaderPolicy::default(),
+        ),
+        request_input(
+            "CONNECT",
+            "/ignored",
+            &headers,
+            RequestInputMeta {
+                authority: Some("target.example.com:443"),
+                content_length: None,
+                request_id: 603,
+                traceparent: None,
+                client_addr: "203.0.113.18:7005".parse().expect("client"),
+            },
+        ),
+    )
+    .expect("h2 request");
+
+    assert_eq!(request.method(), http::Method::CONNECT);
+    assert_eq!(request.uri().to_string(), "target.example.com:443");
+    assert!(request.extensions().get::<hyper::ext::Protocol>().is_none());
+    assert_eq!(
+        request.headers().get(HOST).and_then(|value| value.to_str().ok()),
+        Some("target.example.com:443")
+    );
+}

--- a/crates/transport/src/transport_pool.rs
+++ b/crates/transport/src/transport_pool.rs
@@ -254,23 +254,17 @@ impl UpstreamTransportPool {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        collections::HashMap,
-        convert::Infallible,
-        time::Duration,
-    };
+    use std::{collections::HashMap, convert::Infallible, time::Duration};
 
     use http_body_util::{BodyExt, Empty, combinators::BoxBody};
     use hyper::{Request, body::Bytes};
     use spooky_config::{
         config::{
             Backend, ClientAuth, Config, ForwardedHeaderPolicy, ForwardedHeaderPolicyMode, Listen,
-            LoadBalancing, Log, Observability, Performance, Resilience, RouteMatch, Security,
-            Tls, Upstream, UpstreamHostPolicy, UpstreamHostPolicyMode, UpstreamTls,
+            LoadBalancing, Log, Observability, Performance, Resilience, RouteMatch, Security, Tls,
+            Upstream, UpstreamHostPolicy, UpstreamHostPolicyMode, UpstreamTls,
         },
-        runtime::{
-            RuntimeBackendConnectionPolicy, RuntimeBackendTransportKind, RuntimeConfig,
-        },
+        runtime::{RuntimeBackendConnectionPolicy, RuntimeBackendTransportKind, RuntimeConfig},
     };
     use spooky_errors::{PoolError, ProxyError};
 

--- a/crates/transport/src/transport_pool.rs
+++ b/crates/transport/src/transport_pool.rs
@@ -413,6 +413,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn h1_rotation_results_stay_effective_without_generation_movement() {
+        let pool = UpstreamTransportPool::new_from_runtime_backends(
+            [(
+                "http://127.0.0.1:8080".to_string(),
+                RuntimeBackendTransportKind::Http1,
+            )],
+            HashMap::new(),
+            connection_policy(),
+            SharedDnsResolver::new(),
+        )
+        .expect("transport pool");
+
+        let first_rotation = pool
+            .rotate_backend_client("http://127.0.0.1:8080")
+            .expect("first h1 rotation");
+        let second_rotation = pool
+            .rotate_backend_client("http://127.0.0.1:8080")
+            .expect("second h1 rotation");
+
+        assert!(first_rotation.rotated());
+        assert!(second_rotation.rotated());
+        assert_eq!(first_rotation.generations(), None);
+        assert_eq!(second_rotation.generations(), None);
+    }
+
+    #[test]
+    fn h2_rotation_results_report_generation_movement_on_each_rotation() {
+        let pool = UpstreamTransportPool::new_from_runtime_backends(
+            [(
+                "https://api.internal:8443".to_string(),
+                RuntimeBackendTransportKind::H2,
+            )],
+            HashMap::new(),
+            connection_policy(),
+            SharedDnsResolver::new(),
+        )
+        .expect("transport pool");
+
+        let first_rotation = pool
+            .rotate_backend_client("https://api.internal:8443")
+            .expect("first h2 rotation");
+        let second_rotation = pool
+            .rotate_backend_client("https://api.internal:8443")
+            .expect("second h2 rotation");
+
+        assert!(first_rotation.rotated());
+        assert!(second_rotation.rotated());
+        assert_eq!(first_rotation.generations(), Some((0, 1)));
+        assert_eq!(second_rotation.generations(), Some((1, 2)));
+    }
+
+    #[tokio::test]
     async fn unknown_backend_send_fails_at_the_transport_facade_boundary() {
         let pool = UpstreamTransportPool::new_from_runtime_backends(
             [(
@@ -438,7 +490,7 @@ mod tests {
     }
 
     #[test]
-    fn missing_backend_rotation_returns_a_non_rotating_facade_result() {
+    fn backend_not_found_rotation_is_a_no_op_facade_result() {
         let pool = UpstreamTransportPool::new_from_runtime_backends(
             [(
                 "https://api.internal:8443".to_string(),

--- a/crates/transport/src/transport_pool.rs
+++ b/crates/transport/src/transport_pool.rs
@@ -251,3 +251,210 @@ impl UpstreamTransportPool {
             .map_err(ProxyError::Pool)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashMap,
+        convert::Infallible,
+        time::Duration,
+    };
+
+    use http_body_util::{BodyExt, Empty, combinators::BoxBody};
+    use hyper::{Request, body::Bytes};
+    use spooky_config::{
+        config::{
+            Backend, ClientAuth, Config, ForwardedHeaderPolicy, ForwardedHeaderPolicyMode, Listen,
+            LoadBalancing, Log, Observability, Performance, Resilience, RouteMatch, Security,
+            Tls, Upstream, UpstreamHostPolicy, UpstreamHostPolicyMode, UpstreamTls,
+        },
+        runtime::{
+            RuntimeBackendConnectionPolicy, RuntimeBackendTransportKind, RuntimeConfig,
+        },
+    };
+    use spooky_errors::{PoolError, ProxyError};
+
+    use super::{BackendTransportEntry, UpstreamTransportPool};
+    use crate::h2_client::SharedDnsResolver;
+
+    fn connection_policy() -> RuntimeBackendConnectionPolicy {
+        RuntimeBackendConnectionPolicy {
+            max_inflight: 8,
+            max_idle_per_backend: 4,
+            pool_idle_timeout: Duration::from_secs(30),
+            connect_timeout: Duration::from_secs(2),
+            execution_timeout: Duration::from_secs(5),
+        }
+    }
+
+    fn runtime_config_with_backends(backends: &[(&str, &str)]) -> RuntimeConfig {
+        let mut upstreams = HashMap::new();
+        for (idx, (name, address)) in backends.iter().enumerate() {
+            upstreams.insert(
+                (*name).to_string(),
+                Upstream {
+                    load_balancing: LoadBalancing {
+                        lb_type: "round-robin".to_string(),
+                        key: None,
+                    },
+                    auth: Default::default(),
+                    host_policy: UpstreamHostPolicy {
+                        mode: UpstreamHostPolicyMode::Rewrite,
+                        host: Some(format!("{name}.internal")),
+                    },
+                    forwarded_headers: ForwardedHeaderPolicy {
+                        mode: ForwardedHeaderPolicyMode::Append,
+                    },
+                    tls: None,
+                    route: RouteMatch {
+                        host: Some(format!("{name}.example.com")),
+                        path_prefix: Some("/".to_string()),
+                        method: None,
+                    },
+                    backends: vec![Backend {
+                        id: format!("backend-{idx}"),
+                        address: (*address).to_string(),
+                        weight: 100,
+                        health_check: None,
+                    }],
+                },
+            );
+        }
+
+        RuntimeConfig::from_config(&Config {
+            version: 1,
+            listen: Listen {
+                protocol: "http3".to_string(),
+                port: 443,
+                address: "0.0.0.0".to_string(),
+                tls: Tls {
+                    cert: "/tmp/tls/default.pem".to_string(),
+                    key: "/tmp/tls/default.key".to_string(),
+                    certificates: Vec::new(),
+                    client_auth: ClientAuth::default(),
+                },
+            },
+            listeners: Vec::new(),
+            upstream: upstreams,
+            load_balancing: None,
+            upstream_tls: UpstreamTls::default(),
+            log: Log::default(),
+            performance: Performance::default(),
+            observability: Observability::default(),
+            resilience: Resilience::default(),
+            security: Security::default(),
+        })
+        .expect("runtime config")
+    }
+
+    fn request() -> Request<BoxBody<Bytes, Infallible>> {
+        Request::builder()
+            .method("GET")
+            .uri("https://example.com/")
+            .body(Empty::<Bytes>::new().boxed())
+            .expect("request")
+    }
+
+    #[test]
+    fn from_runtime_upstreams_selects_backend_protocols_inside_the_transport_facade() {
+        let runtime = runtime_config_with_backends(&[
+            ("http1-api", "http://127.0.0.1:8080"),
+            ("h2-api", "https://api.internal:8443"),
+        ]);
+
+        let pool = UpstreamTransportPool::from_runtime_upstreams(
+            runtime.upstreams.values(),
+            &runtime.policies.transport.backend_connections,
+            SharedDnsResolver::new(),
+            None,
+        )
+        .expect("transport pool");
+
+        assert_eq!(
+            pool.backend_entry("http://127.0.0.1:8080"),
+            Some(BackendTransportEntry::Http1)
+        );
+        assert_eq!(
+            pool.backend_entry("https://api.internal:8443"),
+            Some(BackendTransportEntry::H2)
+        );
+    }
+
+    #[test]
+    fn callers_can_use_one_rotation_api_without_protocol_specific_branching() {
+        let pool = UpstreamTransportPool::new_from_runtime_backends(
+            [
+                (
+                    "http://127.0.0.1:8080".to_string(),
+                    RuntimeBackendTransportKind::Http1,
+                ),
+                (
+                    "https://api.internal:8443".to_string(),
+                    RuntimeBackendTransportKind::H2,
+                ),
+            ],
+            HashMap::new(),
+            connection_policy(),
+            SharedDnsResolver::new(),
+        )
+        .expect("transport pool");
+
+        let http1_rotation = pool
+            .rotate_backend_client("http://127.0.0.1:8080")
+            .expect("http1 rotation");
+        let h2_rotation = pool
+            .rotate_backend_client("https://api.internal:8443")
+            .expect("h2 rotation");
+
+        assert!(http1_rotation.rotated());
+        assert_eq!(http1_rotation.generations(), None);
+        assert!(h2_rotation.rotated());
+        assert_eq!(h2_rotation.generations(), Some((0, 1)));
+    }
+
+    #[tokio::test]
+    async fn unknown_backend_send_fails_at_the_transport_facade_boundary() {
+        let pool = UpstreamTransportPool::new_from_runtime_backends(
+            [(
+                "https://api.internal:8443".to_string(),
+                RuntimeBackendTransportKind::H2,
+            )],
+            HashMap::new(),
+            connection_policy(),
+            SharedDnsResolver::new(),
+        )
+        .expect("transport pool");
+
+        let err = pool
+            .send_backend_request("missing-backend", request())
+            .await
+            .expect_err("missing backend should fail");
+
+        assert!(matches!(
+            err,
+            ProxyError::Pool(PoolError::UnknownBackend(ref backend))
+                if backend == "missing-backend"
+        ));
+    }
+
+    #[test]
+    fn missing_backend_rotation_returns_a_non_rotating_facade_result() {
+        let pool = UpstreamTransportPool::new_from_runtime_backends(
+            [(
+                "https://api.internal:8443".to_string(),
+                RuntimeBackendTransportKind::H2,
+            )],
+            HashMap::new(),
+            connection_policy(),
+            SharedDnsResolver::new(),
+        )
+        .expect("transport pool");
+
+        let rotation = pool
+            .rotate_backend_client("missing-backend")
+            .expect("missing backend rotation should not error");
+
+        assert!(!rotation.rotated());
+        assert_eq!(rotation.generations(), None);
+    }
+}

--- a/crates/transport/tests/abstraction.rs
+++ b/crates/transport/tests/abstraction.rs
@@ -95,10 +95,22 @@ fn build_pool(
     max_inflight: usize,
     resolver: SharedDnsResolver,
 ) -> UpstreamTransportPool {
+    build_pool_with_policy(
+        backends,
+        test_connection_policy(max_inflight),
+        resolver,
+    )
+}
+
+fn build_pool_with_policy(
+    backends: impl IntoIterator<Item = (String, RuntimeBackendTransportKind)>,
+    connection_policy: spooky_config::runtime::RuntimeBackendConnectionPolicy,
+    resolver: SharedDnsResolver,
+) -> UpstreamTransportPool {
     UpstreamTransportPool::new_from_runtime_backends(
         backends,
         HashMap::new(),
-        test_connection_policy(max_inflight),
+        connection_policy,
         resolver,
     )
     .expect("transport pool")
@@ -462,6 +474,52 @@ async fn canonical_error_mapping_is_consistent() {
     ));
     let _ = h2_task.await.expect("h2 task join");
     assert_eq!(h2_tracker.max.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn execution_timeout_maps_to_proxy_timeout_for_h1_and_h2() {
+    let h1_port = match start_h1_server(b"h1", Duration::from_millis(50)).await {
+        Ok(port) => port,
+        Err(err) if loopback_bind_restricted(&err) => return,
+        Err(err) => panic!("failed to start h1 timeout server: {err}"),
+    };
+    let h2_port = match start_h2_server(b"h2", Duration::from_millis(50), None).await {
+        Ok(port) => port,
+        Err(err) if loopback_bind_restricted(&err) => return,
+        Err(err) => panic!("failed to start h2 timeout server: {err}"),
+    };
+
+    let timeout_policy = spooky_config::runtime::RuntimeBackendConnectionPolicy {
+        execution_timeout: Duration::from_millis(5),
+        ..test_connection_policy(4)
+    };
+
+    let pool = build_pool_with_policy(
+        [
+            ("h1-timeout".to_string(), RuntimeBackendTransportKind::Http1),
+            ("h2-timeout".to_string(), RuntimeBackendTransportKind::H2),
+        ],
+        timeout_policy,
+        SharedDnsResolver::new(),
+    );
+
+    let h1_err = pool
+        .send_backend_request(
+            "h1-timeout",
+            request(&format!("http://127.0.0.1:{h1_port}/")),
+        )
+        .await
+        .expect_err("h1 execution should time out");
+    assert!(matches!(h1_err, ProxyError::Timeout));
+
+    let h2_err = pool
+        .send_backend_request(
+            "h2-timeout",
+            request(&format!("http://127.0.0.1:{h2_port}/")),
+        )
+        .await
+        .expect_err("h2 execution should time out");
+    assert!(matches!(h2_err, ProxyError::Timeout));
 }
 
 #[test]

--- a/crates/transport/tests/abstraction.rs
+++ b/crates/transport/tests/abstraction.rs
@@ -1,17 +1,13 @@
-use std::{
-    collections::HashMap,
-    net::TcpListener as StdTcpListener,
-    sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
-    },
-    time::Duration,
-};
+//! Transport facade contract tests.
+//!
+//! These assertions lock the edge-facing behavior of the transport layer while
+//! keeping H1/H2 implementation details hidden behind the canonical facade.
+
+mod support;
+
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use bytes::Bytes;
-use http_body_util::{BodyExt, Full};
-use hyper::{Request, Response, body::Incoming, service::service_fn};
-use hyper_util::rt::{TokioExecutor, TokioIo};
 use spooky_config::{
     config::{
         ClientAuth, Config, Listen, LoadBalancing, Log, Observability, Performance, Resilience,
@@ -21,179 +17,12 @@ use spooky_config::{
 };
 use spooky_errors::{PoolError, ProxyError};
 use spooky_transport::{SharedDnsResolver, UpstreamTransportPool};
-use tokio::net::TcpListener;
 
-struct ConcurrencyTracker {
-    current: AtomicUsize,
-    max: AtomicUsize,
-}
-
-impl ConcurrencyTracker {
-    fn new() -> Self {
-        Self {
-            current: AtomicUsize::new(0),
-            max: AtomicUsize::new(0),
-        }
-    }
-
-    fn enter(&self) {
-        let now = self.current.fetch_add(1, Ordering::SeqCst) + 1;
-        let mut prev = self.max.load(Ordering::SeqCst);
-        while now > prev {
-            match self
-                .max
-                .compare_exchange(prev, now, Ordering::SeqCst, Ordering::SeqCst)
-            {
-                Ok(_) => break,
-                Err(next) => prev = next,
-            }
-        }
-    }
-
-    fn exit(&self) {
-        self.current.fetch_sub(1, Ordering::SeqCst);
-    }
-}
-
-fn loopback_bind_restricted(err: &std::io::Error) -> bool {
-    err.kind() == std::io::ErrorKind::PermissionDenied
-        || matches!(err.raw_os_error(), Some(1) | Some(13))
-}
-
-fn request(
-    uri: &str,
-) -> Request<http_body_util::combinators::BoxBody<Bytes, std::convert::Infallible>> {
-    Request::builder()
-        .method("GET")
-        .uri(uri)
-        .body(Full::new(Bytes::new()).boxed())
-        .expect("request")
-}
-
-fn reserve_unused_port() -> u16 {
-    StdTcpListener::bind("127.0.0.1:0")
-        .expect("bind ephemeral port")
-        .local_addr()
-        .expect("local addr")
-        .port()
-}
-
-fn test_connection_policy(
-    max_inflight: usize,
-) -> spooky_config::runtime::RuntimeBackendConnectionPolicy {
-    spooky_config::runtime::RuntimeBackendConnectionPolicy {
-        max_inflight,
-        max_idle_per_backend: 64,
-        pool_idle_timeout: Duration::from_secs(30),
-        connect_timeout: Duration::from_secs(2),
-        execution_timeout: Duration::from_secs(5),
-    }
-}
-
-fn build_pool(
-    backends: impl IntoIterator<Item = (String, RuntimeBackendTransportKind)>,
-    max_inflight: usize,
-    resolver: SharedDnsResolver,
-) -> UpstreamTransportPool {
-    build_pool_with_policy(
-        backends,
-        test_connection_policy(max_inflight),
-        resolver,
-    )
-}
-
-fn build_pool_with_policy(
-    backends: impl IntoIterator<Item = (String, RuntimeBackendTransportKind)>,
-    connection_policy: spooky_config::runtime::RuntimeBackendConnectionPolicy,
-    resolver: SharedDnsResolver,
-) -> UpstreamTransportPool {
-    UpstreamTransportPool::new_from_runtime_backends(
-        backends,
-        HashMap::new(),
-        connection_policy,
-        resolver,
-    )
-    .expect("transport pool")
-}
-
-async fn read_body(response: Response<Incoming>) -> Bytes {
-    response
-        .into_body()
-        .collect()
-        .await
-        .expect("collect body")
-        .to_bytes()
-}
-
-async fn start_h1_server(body: &'static [u8], delay: Duration) -> std::io::Result<u16> {
-    let listener = TcpListener::bind("127.0.0.1:0").await?;
-    let port = listener.local_addr()?.port();
-
-    tokio::spawn(async move {
-        loop {
-            let (stream, _) = match listener.accept().await {
-                Ok(v) => v,
-                Err(_) => break,
-            };
-            let service = service_fn(move |_req: Request<Incoming>| async move {
-                tokio::time::sleep(delay).await;
-                Ok::<_, std::convert::Infallible>(Response::new(Full::new(Bytes::from_static(
-                    body,
-                ))))
-            });
-
-            tokio::spawn(async move {
-                let _ = hyper::server::conn::http1::Builder::new()
-                    .serve_connection(TokioIo::new(stream), service)
-                    .await;
-            });
-        }
-    });
-
-    Ok(port)
-}
-
-async fn start_h2_server(
-    body: &'static [u8],
-    delay: Duration,
-    tracker: Option<Arc<ConcurrencyTracker>>,
-) -> std::io::Result<u16> {
-    let listener = TcpListener::bind("127.0.0.1:0").await?;
-    let port = listener.local_addr()?.port();
-
-    tokio::spawn(async move {
-        loop {
-            let (stream, _) = match listener.accept().await {
-                Ok(v) => v,
-                Err(_) => break,
-            };
-            let tracker = tracker.clone();
-            let service = service_fn(move |_req: Request<Incoming>| {
-                let tracker = tracker.clone();
-                async move {
-                    if let Some(tracker) = &tracker {
-                        tracker.enter();
-                    }
-                    tokio::time::sleep(delay).await;
-                    if let Some(tracker) = &tracker {
-                        tracker.exit();
-                    }
-                    Ok::<_, std::convert::Infallible>(Response::new(Full::new(Bytes::from_static(
-                        body,
-                    ))))
-                }
-            });
-
-            tokio::spawn(async move {
-                let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
-                    .serve_connection(TokioIo::new(stream), service)
-                    .await;
-            });
-        }
-    });
-
-    Ok(port)
-}
+use crate::support::{
+    ConcurrencyTracker, build_pool, build_pool_with_policy, connection_policy,
+    loopback_bind_restricted, read_body, request, reserve_unused_port, start_h1_server,
+    start_h2_server,
+};
 
 fn transport_test_config(http_backend: &str, https_backend: &str) -> Config {
     let mut config = Config {
@@ -254,7 +83,7 @@ fn transport_test_config(http_backend: &str, https_backend: &str) -> Config {
 }
 
 #[test]
-fn runtime_upstream_interpretation_selects_protocol_internally() {
+fn runtime_upstream_interpretation_selects_protocol_without_caller_branching() {
     let config = transport_test_config("http://127.0.0.1:8080", "https://127.0.0.1:8443");
     let runtime = RuntimeConfig::from_config(&config).expect("runtime config");
 
@@ -280,8 +109,8 @@ fn runtime_upstream_interpretation_selects_protocol_internally() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn request_execution_routes_without_protocol_branching() {
-    let h1_port = match start_h1_server(b"h1", Duration::ZERO).await {
+async fn transport_facade_executes_requests_without_protocol_specific_callers() {
+    let h1_port = match start_h1_server(b"h1", Duration::ZERO, None).await {
         Ok(port) => port,
         Err(err) if loopback_bind_restricted(&err) => return,
         Err(err) => panic!("failed to start h1 server: {err}"),
@@ -323,7 +152,7 @@ async fn request_execution_routes_without_protocol_branching() {
 }
 
 #[test]
-fn client_rotation_behavior_is_stable_across_h1_and_h2() {
+fn transport_facade_exposes_stable_rotation_contract_across_protocols() {
     let pool = build_pool(
         [
             ("h1-backend".to_string(), RuntimeBackendTransportKind::Http1),
@@ -359,7 +188,7 @@ fn client_rotation_behavior_is_stable_across_h1_and_h2() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn canonical_error_mapping_is_consistent() {
+async fn transport_facade_maps_unknown_backend_send_failure_and_overload_consistently() {
     let unknown_pool = build_pool(
         [("known".to_string(), RuntimeBackendTransportKind::Http1)],
         1,
@@ -399,7 +228,13 @@ async fn canonical_error_mapping_is_consistent() {
     assert!(matches!(h2_err, ProxyError::Pool(PoolError::Send(_))));
 
     let h1_tracker = Arc::new(ConcurrencyTracker::new());
-    let h1_overload_port = match start_h1_server(b"h1", Duration::from_millis(50)).await {
+    let h1_overload_port = match start_h1_server(
+        b"h1",
+        Duration::from_millis(50),
+        Some(Arc::clone(&h1_tracker)),
+    )
+    .await
+    {
         Ok(port) => port,
         Err(err) if loopback_bind_restricted(&err) => return,
         Err(err) => panic!("failed to start h1 overload server: {err}"),
@@ -433,7 +268,11 @@ async fn canonical_error_mapping_is_consistent() {
         Err(ProxyError::Pool(PoolError::BackendOverloaded(_)))
     ));
     let _ = h1_task.await.expect("h1 task join");
-    assert_eq!(h1_tracker.max.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        h1_tracker.max_observed(),
+        1,
+        "tracked h1 overload fixture should observe only one admitted request"
+    );
 
     let h2_tracker = Arc::new(ConcurrencyTracker::new());
     let h2_overload_port = match start_h2_server(
@@ -473,12 +312,16 @@ async fn canonical_error_mapping_is_consistent() {
         Err(ProxyError::Pool(PoolError::BackendOverloaded(_)))
     ));
     let _ = h2_task.await.expect("h2 task join");
-    assert_eq!(h2_tracker.max.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        h2_tracker.max_observed(),
+        1,
+        "tracked h2 overload fixture should observe only one admitted request"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn execution_timeout_maps_to_proxy_timeout_for_h1_and_h2() {
-    let h1_port = match start_h1_server(b"h1", Duration::from_millis(50)).await {
+async fn transport_facade_maps_execution_timeouts_to_proxy_timeout_across_protocols() {
+    let h1_port = match start_h1_server(b"h1", Duration::from_millis(50), None).await {
         Ok(port) => port,
         Err(err) if loopback_bind_restricted(&err) => return,
         Err(err) => panic!("failed to start h1 timeout server: {err}"),
@@ -491,7 +334,7 @@ async fn execution_timeout_maps_to_proxy_timeout_for_h1_and_h2() {
 
     let timeout_policy = spooky_config::runtime::RuntimeBackendConnectionPolicy {
         execution_timeout: Duration::from_millis(5),
-        ..test_connection_policy(4)
+        ..connection_policy(4)
     };
 
     let pool = build_pool_with_policy(
@@ -523,7 +366,7 @@ async fn execution_timeout_maps_to_proxy_timeout_for_h1_and_h2() {
 }
 
 #[test]
-fn dns_refresh_rotation_works_through_unified_surface() {
+fn transport_facade_preserves_dns_refresh_rotation_contract() {
     let resolver = SharedDnsResolver::new();
     let backend = "https://api.example.com:443".to_string();
     let pool = build_pool(

--- a/crates/transport/tests/h1_pool.rs
+++ b/crates/transport/tests/h1_pool.rs
@@ -1,103 +1,27 @@
-use std::{
-    sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
-    },
-    time::Duration,
-};
+//! HTTP/1-backed transport facade contract tests.
 
-use bytes::Bytes;
-use http_body_util::{BodyExt, Full};
-use hyper::{Request, Response, body::Incoming, service::service_fn};
-use hyper_util::rt::TokioIo;
-use spooky_config::runtime::{RuntimeBackendConnectionPolicy, RuntimeBackendTransportKind};
+mod support;
+
+use std::{sync::Arc, time::Duration};
+
+use spooky_config::runtime::RuntimeBackendTransportKind;
 use spooky_errors::{PoolError, ProxyError};
 use spooky_transport::{SharedDnsResolver, UpstreamTransportPool};
-use tokio::net::TcpListener;
 
-struct ConcurrencyTracker {
-    current: AtomicUsize,
-    max: AtomicUsize,
-}
-
-impl ConcurrencyTracker {
-    fn new() -> Self {
-        Self {
-            current: AtomicUsize::new(0),
-            max: AtomicUsize::new(0),
-        }
-    }
-
-    fn enter(&self) {
-        let now = self.current.fetch_add(1, Ordering::SeqCst) + 1;
-        let mut prev = self.max.load(Ordering::SeqCst);
-        while now > prev {
-            match self
-                .max
-                .compare_exchange(prev, now, Ordering::SeqCst, Ordering::SeqCst)
-            {
-                Ok(_) => break,
-                Err(next) => prev = next,
-            }
-        }
-    }
-
-    fn exit(&self) {
-        self.current.fetch_sub(1, Ordering::SeqCst);
-    }
-}
-
-fn loopback_bind_restricted(err: &std::io::Error) -> bool {
-    err.kind() == std::io::ErrorKind::PermissionDenied
-        || matches!(err.raw_os_error(), Some(1) | Some(13))
-}
-
-fn test_connection_policy() -> RuntimeBackendConnectionPolicy {
-    RuntimeBackendConnectionPolicy {
-        max_inflight: 1,
-        max_idle_per_backend: 64,
-        pool_idle_timeout: Duration::from_secs(30),
-        connect_timeout: Duration::from_secs(2),
-        execution_timeout: Duration::from_secs(5),
-    }
-}
-
-async fn start_h1_server(tracker: Arc<ConcurrencyTracker>) -> std::io::Result<u16> {
-    let listener = TcpListener::bind("127.0.0.1:0").await?;
-    let port = listener.local_addr()?.port();
-
-    tokio::spawn(async move {
-        loop {
-            let (stream, _) = match listener.accept().await {
-                Ok(v) => v,
-                Err(_) => break,
-            };
-            let tracker = tracker.clone();
-            let service = service_fn(move |_req: Request<Incoming>| {
-                let tracker = tracker.clone();
-                async move {
-                    tracker.enter();
-                    tokio::time::sleep(Duration::from_millis(50)).await;
-                    tracker.exit();
-                    Ok::<_, std::convert::Infallible>(Response::new(Full::new(Bytes::from("ok"))))
-                }
-            });
-
-            tokio::spawn(async move {
-                let _ = hyper::server::conn::http1::Builder::new()
-                    .serve_connection(TokioIo::new(stream), service)
-                    .await;
-            });
-        }
-    });
-
-    Ok(port)
-}
+use crate::support::{
+    ConcurrencyTracker, connection_policy, loopback_bind_restricted, request, start_h1_server,
+};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn pool_limits_inflight_per_backend() {
+async fn http1_transport_enforces_per_backend_inflight_contract() {
     let tracker = Arc::new(ConcurrencyTracker::new());
-    let port = match start_h1_server(tracker.clone()).await {
+    let port = match start_h1_server(
+        b"ok",
+        Duration::from_millis(50),
+        Some(Arc::clone(&tracker)),
+    )
+    .await
+    {
         Ok(port) => port,
         Err(err) if loopback_bind_restricted(&err) => return,
         Err(err) => panic!("failed to start h1 test server: {err}"),
@@ -108,21 +32,13 @@ async fn pool_limits_inflight_per_backend() {
         UpstreamTransportPool::new_from_runtime_backends(
             [(backend.clone(), RuntimeBackendTransportKind::Http1)],
             std::collections::HashMap::new(),
-            test_connection_policy(),
+            connection_policy(1),
             SharedDnsResolver::new(),
         )
         .expect("pool"),
     );
-    let req1 = Request::builder()
-        .method("GET")
-        .uri(format!("http://{backend}/"))
-        .body(Full::new(Bytes::new()).boxed())
-        .unwrap();
-    let req2 = Request::builder()
-        .method("GET")
-        .uri(format!("http://{backend}/"))
-        .body(Full::new(Bytes::new()).boxed())
-        .unwrap();
+    let req1 = request(&format!("http://{backend}/"));
+    let req2 = request(&format!("http://{backend}/"));
 
     let pool1 = pool.clone();
     let backend1 = backend.clone();
@@ -133,56 +49,54 @@ async fn pool_limits_inflight_per_backend() {
     let r2 = tokio::spawn(async move { pool2.send_backend_request(&backend2, req2).await });
 
     let (r1, r2) = tokio::join!(r1, r2);
-    let r1 = r1.unwrap();
-    let r2 = r2.unwrap();
+    let r1 = r1.expect("first request join");
+    let r2 = r2.expect("second request join");
     assert!(
         r1.is_ok() || r2.is_ok(),
-        "at least one request should be admitted"
+        "at least one HTTP/1 request should be admitted"
     );
     assert!(
         matches!(r1, Err(ProxyError::Pool(PoolError::BackendOverloaded(_))))
             || matches!(r2, Err(ProxyError::Pool(PoolError::BackendOverloaded(_)))),
-        "one request should be rejected by backend inflight admission"
+        "one HTTP/1 request should be rejected by per-backend inflight admission"
     );
-
-    let max = tracker.max.load(Ordering::SeqCst);
-    assert_eq!(max, 1);
+    assert_eq!(
+        tracker.max_observed(),
+        1,
+        "only one HTTP/1 request should reach the backend at a time"
+    );
 }
 
 #[tokio::test]
-async fn pool_rejects_unknown_backend() {
+async fn http1_transport_rejects_unknown_backend_at_facade_boundary() {
     let pool = UpstreamTransportPool::new_from_runtime_backends(
         [(
             "127.0.0.1:12345".to_string(),
             RuntimeBackendTransportKind::Http1,
         )],
         std::collections::HashMap::new(),
-        test_connection_policy(),
+        connection_policy(1),
         SharedDnsResolver::new(),
     )
     .expect("pool");
-    let req = Request::builder()
-        .method("GET")
-        .uri("http://127.0.0.1:12345/")
-        .body(Full::new(Bytes::new()).boxed())
-        .unwrap();
+    let req = request("http://127.0.0.1:12345/");
 
     let err = pool
         .send_backend_request("127.0.0.1:9999", req)
         .await
-        .unwrap_err();
+        .expect_err("unknown backend should fail");
     match err {
         ProxyError::Pool(PoolError::UnknownBackend(name)) => {
             assert_eq!(name, "127.0.0.1:9999")
         }
-        _ => panic!("unexpected error"),
+        _ => panic!("unexpected error contract for missing HTTP/1 backend"),
     }
 }
 
 #[tokio::test]
-async fn pool_reports_overload_when_inflight_is_exhausted() {
+async fn http1_transport_reports_backend_overload_when_inflight_is_exhausted() {
     let tracker = Arc::new(ConcurrencyTracker::new());
-    let port = match start_h1_server(tracker).await {
+    let port = match start_h1_server(b"ok", Duration::from_millis(50), Some(tracker)).await {
         Ok(port) => port,
         Err(err) if loopback_bind_restricted(&err) => return,
         Err(err) => panic!("failed to start h1 test server: {err}"),
@@ -192,22 +106,14 @@ async fn pool_reports_overload_when_inflight_is_exhausted() {
         UpstreamTransportPool::new_from_runtime_backends(
             [(backend.clone(), RuntimeBackendTransportKind::Http1)],
             std::collections::HashMap::new(),
-            test_connection_policy(),
+            connection_policy(1),
             SharedDnsResolver::new(),
         )
         .expect("pool"),
     );
 
-    let req1 = Request::builder()
-        .method("GET")
-        .uri(format!("http://{backend}/"))
-        .body(Full::new(Bytes::new()).boxed())
-        .unwrap();
-    let req2 = Request::builder()
-        .method("GET")
-        .uri(format!("http://{backend}/"))
-        .body(Full::new(Bytes::new()).boxed())
-        .unwrap();
+    let req1 = request(&format!("http://{backend}/"));
+    let req2 = request(&format!("http://{backend}/"));
 
     let pool_task = Arc::clone(&pool);
     let backend_task = backend.clone();
@@ -225,14 +131,14 @@ async fn pool_reports_overload_when_inflight_is_exhausted() {
 }
 
 #[test]
-fn pool_rotates_known_backend_client_and_ignores_unknown_backend() {
+fn http1_transport_rotation_contract_is_effective_for_known_backends_and_noop_for_missing_ones() {
     let pool = UpstreamTransportPool::new_from_runtime_backends(
         [(
             "127.0.0.1:12345".to_string(),
             RuntimeBackendTransportKind::Http1,
         )],
         std::collections::HashMap::new(),
-        test_connection_policy(),
+        connection_policy(1),
         SharedDnsResolver::new(),
     )
     .expect("pool");

--- a/crates/transport/tests/h1_pool.rs
+++ b/crates/transport/tests/h1_pool.rs
@@ -15,17 +15,12 @@ use crate::support::{
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http1_transport_enforces_per_backend_inflight_contract() {
     let tracker = Arc::new(ConcurrencyTracker::new());
-    let port = match start_h1_server(
-        b"ok",
-        Duration::from_millis(50),
-        Some(Arc::clone(&tracker)),
-    )
-    .await
-    {
-        Ok(port) => port,
-        Err(err) if loopback_bind_restricted(&err) => return,
-        Err(err) => panic!("failed to start h1 test server: {err}"),
-    };
+    let port =
+        match start_h1_server(b"ok", Duration::from_millis(50), Some(Arc::clone(&tracker))).await {
+            Ok(port) => port,
+            Err(err) if loopback_bind_restricted(&err) => return,
+            Err(err) => panic!("failed to start h1 test server: {err}"),
+        };
     let backend = format!("127.0.0.1:{port}");
 
     let pool = Arc::new(

--- a/crates/transport/tests/h2_pool.rs
+++ b/crates/transport/tests/h2_pool.rs
@@ -15,17 +15,12 @@ use crate::support::{
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn http2_transport_enforces_per_backend_inflight_contract() {
     let tracker = Arc::new(ConcurrencyTracker::new());
-    let port = match start_h2_server(
-        b"ok",
-        Duration::from_millis(50),
-        Some(Arc::clone(&tracker)),
-    )
-    .await
-    {
-        Ok(port) => port,
-        Err(err) if loopback_bind_restricted(&err) => return,
-        Err(err) => panic!("failed to start h2 test server: {err}"),
-    };
+    let port =
+        match start_h2_server(b"ok", Duration::from_millis(50), Some(Arc::clone(&tracker))).await {
+            Ok(port) => port,
+            Err(err) if loopback_bind_restricted(&err) => return,
+            Err(err) => panic!("failed to start h2 test server: {err}"),
+        };
     let backend = format!("127.0.0.1:{port}");
 
     let pool = Arc::new(

--- a/crates/transport/tests/h2_pool.rs
+++ b/crates/transport/tests/h2_pool.rs
@@ -1,104 +1,27 @@
-use std::{
-    collections::HashMap,
-    sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
-    },
-    time::Duration,
-};
+//! HTTP/2-backed transport facade contract tests.
 
-use bytes::Bytes;
-use http_body_util::{BodyExt, Full};
-use hyper::{Request, Response, body::Incoming, service::service_fn};
-use hyper_util::rt::{TokioExecutor, TokioIo};
-use spooky_config::runtime::{RuntimeBackendConnectionPolicy, RuntimeBackendTransportKind};
+mod support;
+
+use std::{sync::Arc, time::Duration};
+
+use spooky_config::runtime::RuntimeBackendTransportKind;
 use spooky_errors::{PoolError, ProxyError};
 use spooky_transport::{SharedDnsResolver, UpstreamTransportPool};
-use tokio::net::TcpListener;
 
-struct ConcurrencyTracker {
-    current: AtomicUsize,
-    max: AtomicUsize,
-}
-
-impl ConcurrencyTracker {
-    fn new() -> Self {
-        Self {
-            current: AtomicUsize::new(0),
-            max: AtomicUsize::new(0),
-        }
-    }
-
-    fn enter(&self) {
-        let now = self.current.fetch_add(1, Ordering::SeqCst) + 1;
-        let mut prev = self.max.load(Ordering::SeqCst);
-        while now > prev {
-            match self
-                .max
-                .compare_exchange(prev, now, Ordering::SeqCst, Ordering::SeqCst)
-            {
-                Ok(_) => break,
-                Err(next) => prev = next,
-            }
-        }
-    }
-
-    fn exit(&self) {
-        self.current.fetch_sub(1, Ordering::SeqCst);
-    }
-}
-
-fn loopback_bind_restricted(err: &std::io::Error) -> bool {
-    err.kind() == std::io::ErrorKind::PermissionDenied
-        || matches!(err.raw_os_error(), Some(1) | Some(13))
-}
-
-fn test_connection_policy() -> RuntimeBackendConnectionPolicy {
-    RuntimeBackendConnectionPolicy {
-        max_inflight: 1,
-        max_idle_per_backend: 64,
-        pool_idle_timeout: Duration::from_secs(30),
-        connect_timeout: Duration::from_secs(2),
-        execution_timeout: Duration::from_secs(5),
-    }
-}
-
-async fn start_h2_server(tracker: Arc<ConcurrencyTracker>) -> std::io::Result<u16> {
-    let listener = TcpListener::bind("127.0.0.1:0").await?;
-    let port = listener.local_addr()?.port();
-
-    tokio::spawn(async move {
-        loop {
-            let (stream, _) = match listener.accept().await {
-                Ok(v) => v,
-                Err(_) => break,
-            };
-            let tracker = tracker.clone();
-            let service = service_fn(move |_req: Request<Incoming>| {
-                let tracker = tracker.clone();
-                async move {
-                    tracker.enter();
-                    tokio::time::sleep(Duration::from_millis(50)).await;
-                    tracker.exit();
-                    Ok::<_, std::convert::Infallible>(Response::new(Full::new(Bytes::from("ok"))))
-                }
-            });
-
-            tokio::spawn(async move {
-                let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
-                    .serve_connection(TokioIo::new(stream), service)
-                    .await;
-            });
-        }
-    });
-
-    Ok(port)
-}
+use crate::support::{
+    ConcurrencyTracker, connection_policy, loopback_bind_restricted, request, start_h2_server,
+};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn pool_limits_inflight_per_backend() {
+async fn http2_transport_enforces_per_backend_inflight_contract() {
     let tracker = Arc::new(ConcurrencyTracker::new());
-    let port = match start_h2_server(tracker.clone()).await {
+    let port = match start_h2_server(
+        b"ok",
+        Duration::from_millis(50),
+        Some(Arc::clone(&tracker)),
+    )
+    .await
+    {
         Ok(port) => port,
         Err(err) if loopback_bind_restricted(&err) => return,
         Err(err) => panic!("failed to start h2 test server: {err}"),
@@ -108,22 +31,14 @@ async fn pool_limits_inflight_per_backend() {
     let pool = Arc::new(
         UpstreamTransportPool::new_from_runtime_backends(
             [(backend.clone(), RuntimeBackendTransportKind::H2)],
-            HashMap::new(),
-            test_connection_policy(),
+            std::collections::HashMap::new(),
+            connection_policy(1),
             SharedDnsResolver::new(),
         )
         .expect("pool"),
     );
-    let req1 = Request::builder()
-        .method("GET")
-        .uri(format!("http://{backend}/"))
-        .body(Full::new(Bytes::new()).boxed())
-        .unwrap();
-    let req2 = Request::builder()
-        .method("GET")
-        .uri(format!("http://{backend}/"))
-        .body(Full::new(Bytes::new()).boxed())
-        .unwrap();
+    let req1 = request(&format!("http://{backend}/"));
+    let req2 = request(&format!("http://{backend}/"));
 
     let pool1 = pool.clone();
     let backend1 = backend.clone();
@@ -134,56 +49,54 @@ async fn pool_limits_inflight_per_backend() {
     let r2 = tokio::spawn(async move { pool2.send_backend_request(&backend2, req2).await });
 
     let (r1, r2) = tokio::join!(r1, r2);
-    let r1 = r1.unwrap();
-    let r2 = r2.unwrap();
+    let r1 = r1.expect("first request join");
+    let r2 = r2.expect("second request join");
     assert!(
         r1.is_ok() || r2.is_ok(),
-        "at least one request should be admitted"
+        "at least one HTTP/2 request should be admitted"
     );
     assert!(
         matches!(r1, Err(ProxyError::Pool(PoolError::BackendOverloaded(_))))
             || matches!(r2, Err(ProxyError::Pool(PoolError::BackendOverloaded(_)))),
-        "one request should be rejected by backend inflight admission"
+        "one HTTP/2 request should be rejected by per-backend inflight admission"
     );
-
-    let max = tracker.max.load(Ordering::SeqCst);
-    assert_eq!(max, 1);
+    assert_eq!(
+        tracker.max_observed(),
+        1,
+        "only one HTTP/2 request should reach the backend at a time"
+    );
 }
 
 #[tokio::test]
-async fn pool_rejects_unknown_backend() {
+async fn http2_transport_rejects_unknown_backend_at_facade_boundary() {
     let pool = UpstreamTransportPool::new_from_runtime_backends(
         [(
             "127.0.0.1:12345".to_string(),
             RuntimeBackendTransportKind::H2,
         )],
-        HashMap::new(),
-        test_connection_policy(),
+        std::collections::HashMap::new(),
+        connection_policy(1),
         SharedDnsResolver::new(),
     )
     .expect("pool");
-    let req = Request::builder()
-        .method("GET")
-        .uri("http://127.0.0.1:12345/")
-        .body(Full::new(Bytes::new()).boxed())
-        .unwrap();
+    let req = request("http://127.0.0.1:12345/");
 
     let err = pool
         .send_backend_request("127.0.0.1:9999", req)
         .await
-        .unwrap_err();
+        .expect_err("unknown backend should fail");
     match err {
         ProxyError::Pool(PoolError::UnknownBackend(name)) => {
             assert_eq!(name, "127.0.0.1:9999")
         }
-        _ => panic!("unexpected error"),
+        _ => panic!("unexpected error contract for missing HTTP/2 backend"),
     }
 }
 
 #[tokio::test]
-async fn pool_reports_overload_when_inflight_is_exhausted() {
+async fn http2_transport_reports_backend_overload_when_inflight_is_exhausted() {
     let tracker = Arc::new(ConcurrencyTracker::new());
-    let port = match start_h2_server(tracker).await {
+    let port = match start_h2_server(b"ok", Duration::from_millis(50), Some(tracker)).await {
         Ok(port) => port,
         Err(err) if loopback_bind_restricted(&err) => return,
         Err(err) => panic!("failed to start h2 test server: {err}"),
@@ -192,23 +105,15 @@ async fn pool_reports_overload_when_inflight_is_exhausted() {
     let pool = Arc::new(
         UpstreamTransportPool::new_from_runtime_backends(
             [(backend.clone(), RuntimeBackendTransportKind::H2)],
-            HashMap::new(),
-            test_connection_policy(),
+            std::collections::HashMap::new(),
+            connection_policy(1),
             SharedDnsResolver::new(),
         )
         .expect("pool"),
     );
 
-    let req1 = Request::builder()
-        .method("GET")
-        .uri(format!("http://{backend}/"))
-        .body(Full::new(Bytes::new()).boxed())
-        .unwrap();
-    let req2 = Request::builder()
-        .method("GET")
-        .uri(format!("http://{backend}/"))
-        .body(Full::new(Bytes::new()).boxed())
-        .unwrap();
+    let req1 = request(&format!("http://{backend}/"));
+    let req2 = request(&format!("http://{backend}/"));
 
     let pool_task = Arc::clone(&pool);
     let backend_task = backend.clone();

--- a/crates/transport/tests/support/mod.rs
+++ b/crates/transport/tests/support/mod.rs
@@ -14,9 +14,7 @@ use bytes::Bytes;
 use http_body_util::{BodyExt, Full, combinators::BoxBody};
 use hyper::{Request, Response, body::Incoming, service::service_fn};
 use hyper_util::rt::{TokioExecutor, TokioIo};
-use spooky_config::runtime::{
-    RuntimeBackendConnectionPolicy, RuntimeBackendTransportKind,
-};
+use spooky_config::runtime::{RuntimeBackendConnectionPolicy, RuntimeBackendTransportKind};
 use spooky_transport::{SharedDnsResolver, UpstreamTransportPool};
 use tokio::net::TcpListener;
 

--- a/crates/transport/tests/support/mod.rs
+++ b/crates/transport/tests/support/mod.rs
@@ -1,0 +1,203 @@
+#![allow(dead_code)]
+
+use std::{
+    collections::HashMap,
+    net::TcpListener as StdTcpListener,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use bytes::Bytes;
+use http_body_util::{BodyExt, Full, combinators::BoxBody};
+use hyper::{Request, Response, body::Incoming, service::service_fn};
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use spooky_config::runtime::{
+    RuntimeBackendConnectionPolicy, RuntimeBackendTransportKind,
+};
+use spooky_transport::{SharedDnsResolver, UpstreamTransportPool};
+use tokio::net::TcpListener;
+
+pub struct ConcurrencyTracker {
+    current: AtomicUsize,
+    max: AtomicUsize,
+}
+
+impl ConcurrencyTracker {
+    pub fn new() -> Self {
+        Self {
+            current: AtomicUsize::new(0),
+            max: AtomicUsize::new(0),
+        }
+    }
+
+    pub fn enter(&self) {
+        let now = self.current.fetch_add(1, Ordering::SeqCst) + 1;
+        let mut prev = self.max.load(Ordering::SeqCst);
+        while now > prev {
+            match self
+                .max
+                .compare_exchange(prev, now, Ordering::SeqCst, Ordering::SeqCst)
+            {
+                Ok(_) => break,
+                Err(next) => prev = next,
+            }
+        }
+    }
+
+    pub fn exit(&self) {
+        self.current.fetch_sub(1, Ordering::SeqCst);
+    }
+
+    pub fn max_observed(&self) -> usize {
+        self.max.load(Ordering::SeqCst)
+    }
+}
+
+pub fn loopback_bind_restricted(err: &std::io::Error) -> bool {
+    err.kind() == std::io::ErrorKind::PermissionDenied
+        || matches!(err.raw_os_error(), Some(1) | Some(13))
+}
+
+pub fn request(uri: &str) -> Request<BoxBody<Bytes, std::convert::Infallible>> {
+    Request::builder()
+        .method("GET")
+        .uri(uri)
+        .body(Full::new(Bytes::new()).boxed())
+        .expect("request")
+}
+
+pub fn reserve_unused_port() -> u16 {
+    StdTcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("local addr")
+        .port()
+}
+
+pub fn connection_policy(max_inflight: usize) -> RuntimeBackendConnectionPolicy {
+    RuntimeBackendConnectionPolicy {
+        max_inflight,
+        max_idle_per_backend: 64,
+        pool_idle_timeout: Duration::from_secs(30),
+        connect_timeout: Duration::from_secs(2),
+        execution_timeout: Duration::from_secs(5),
+    }
+}
+
+pub fn build_pool(
+    backends: impl IntoIterator<Item = (String, RuntimeBackendTransportKind)>,
+    max_inflight: usize,
+    resolver: SharedDnsResolver,
+) -> UpstreamTransportPool {
+    build_pool_with_policy(backends, connection_policy(max_inflight), resolver)
+}
+
+pub fn build_pool_with_policy(
+    backends: impl IntoIterator<Item = (String, RuntimeBackendTransportKind)>,
+    connection_policy: RuntimeBackendConnectionPolicy,
+    resolver: SharedDnsResolver,
+) -> UpstreamTransportPool {
+    UpstreamTransportPool::new_from_runtime_backends(
+        backends,
+        HashMap::new(),
+        connection_policy,
+        resolver,
+    )
+    .expect("transport pool")
+}
+
+pub async fn read_body(response: Response<Incoming>) -> Bytes {
+    response
+        .into_body()
+        .collect()
+        .await
+        .expect("collect body")
+        .to_bytes()
+}
+
+pub async fn start_h1_server(
+    body: &'static [u8],
+    delay: Duration,
+    tracker: Option<Arc<ConcurrencyTracker>>,
+) -> std::io::Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let port = listener.local_addr()?.port();
+
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = match listener.accept().await {
+                Ok(v) => v,
+                Err(_) => break,
+            };
+            let tracker = tracker.clone();
+            let service = service_fn(move |_req: Request<Incoming>| {
+                let tracker = tracker.clone();
+                async move {
+                    if let Some(tracker) = &tracker {
+                        tracker.enter();
+                    }
+                    tokio::time::sleep(delay).await;
+                    if let Some(tracker) = &tracker {
+                        tracker.exit();
+                    }
+                    Ok::<_, std::convert::Infallible>(Response::new(Full::new(Bytes::from_static(
+                        body,
+                    ))))
+                }
+            });
+
+            tokio::spawn(async move {
+                let _ = hyper::server::conn::http1::Builder::new()
+                    .serve_connection(TokioIo::new(stream), service)
+                    .await;
+            });
+        }
+    });
+
+    Ok(port)
+}
+
+pub async fn start_h2_server(
+    body: &'static [u8],
+    delay: Duration,
+    tracker: Option<Arc<ConcurrencyTracker>>,
+) -> std::io::Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let port = listener.local_addr()?.port();
+
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = match listener.accept().await {
+                Ok(v) => v,
+                Err(_) => break,
+            };
+            let tracker = tracker.clone();
+            let service = service_fn(move |_req: Request<Incoming>| {
+                let tracker = tracker.clone();
+                async move {
+                    if let Some(tracker) = &tracker {
+                        tracker.enter();
+                    }
+                    tokio::time::sleep(delay).await;
+                    if let Some(tracker) = &tracker {
+                        tracker.exit();
+                    }
+                    Ok::<_, std::convert::Infallible>(Response::new(Full::new(Bytes::from_static(
+                        body,
+                    ))))
+                }
+            });
+
+            tokio::spawn(async move {
+                let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
+                    .serve_connection(TokioIo::new(stream), service)
+                    .await;
+            });
+        }
+    });
+
+    Ok(port)
+}


### PR DESCRIPTION
## Summary
This PR cleans up the bridge and transport contract test suites so they read as the canonical behavioral spec instead of a collection of ad hoc cases.

## What changed
- consolidated duplicate transport test helpers into a shared support module
- removed duplicated bridge header-fixture helpers in favor of one shared path
- regrouped tests around request shaping, response shaping, and transport facade behavior
- renamed tests to describe stable contracts instead of implementation details
- tightened suite/module docs so ownership and intent are easier to follow

## Coverage locked in
- canonical H1/H2 request-shaping behavior
- host-policy and forwarded-header policy application
- websocket and upgrade request shaping
- canonical response normalization rules
- transport facade protocol selection
- unified client rotation semantics
- stable timeout, send-failure, unknown-backend, and overload mapping at the transport boundary

## Validation
- `cargo test -p spooky-bridge`
- `cargo test -p spooky-transport`