### PR TITLE
test: strengthen lb and backend lifecycle contract coverage

### DIFF
--- a/crates/edge/src/quic_listener/control_api/tests.rs
+++ b/crates/edge/src/quic_listener/control_api/tests.rs
@@ -309,7 +309,10 @@ fn control_api_backend_inventory_and_summary_share_one_canonical_snapshot_contra
     assert_eq!(backend.resolution.authority_host, "127.0.0.1");
     assert_eq!(backend.resolution.authority_port, 7001);
     assert_eq!(backend.resolution.refresh_generation, 0);
-    assert_eq!(backend.membership, crate::runtime::backend::state::BackendMembershipState::Active);
+    assert_eq!(
+        backend.membership,
+        crate::runtime::backend::state::BackendMembershipState::Active
+    );
     assert!(matches!(
         backend.health,
         crate::runtime::backend::state::BackendHealthState::Healthy

--- a/crates/edge/src/quic_listener/control_api/tests.rs
+++ b/crates/edge/src/quic_listener/control_api/tests.rs
@@ -290,6 +290,38 @@ fn control_api_state_sees_the_active_runtime_generation_after_bundle_replace() {
 }
 
 #[test]
+fn control_api_backend_inventory_and_summary_share_one_canonical_snapshot_contract() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+    let config = test_config(cert, key);
+    let bundle = runtime_bundle_from_config("runtime.yaml", &config);
+    let (state, _) = runtime_bundle_control_api_state(bundle);
+
+    let service_state = state.current_service_state();
+    let inventory = service_state.snapshot_backend_inventory();
+    let summary = service_state.snapshot_backend_health();
+
+    assert_eq!(summary, inventory.summary());
+    assert_eq!(inventory.backends.len(), 1);
+
+    let backend = &inventory.backends[0];
+    assert_eq!(backend.identity.backend_addr, "http://127.0.0.1:7001");
+    assert_eq!(backend.resolution.authority_host, "127.0.0.1");
+    assert_eq!(backend.resolution.authority_port, 7001);
+    assert_eq!(backend.resolution.refresh_generation, 0);
+    assert_eq!(backend.membership, crate::runtime::backend::state::BackendMembershipState::Active);
+    assert!(matches!(
+        backend.health,
+        crate::runtime::backend::state::BackendHealthState::Healthy
+    ));
+    assert_eq!(backend.placements.len(), 1);
+    assert_eq!(backend.placements[0].upstream_name, "api");
+    assert!(backend.placements[0].healthy);
+    assert_eq!(summary.total_backends, 1);
+    assert_eq!(summary.healthy_backends, 1);
+}
+
+#[test]
 fn reload_preserves_process_scoped_watchdog_and_dns_resolver() {
     // Regression: process-shared services must be carried across a reload, not
     // rebuilt. Rebuilding the watchdog silently discards an in-flight

--- a/crates/edge/src/quic_listener/forwarding/lb_key.rs
+++ b/crates/edge/src/quic_listener/forwarding/lb_key.rs
@@ -505,4 +505,122 @@ mod tests {
             LbKeySource::DefaultFallback,
         );
     }
+
+    #[test]
+    fn runtime_key_resolver_extracts_each_canonical_source_type() {
+        let request = request_parts_with_headers(
+            "POST",
+            "/api/items?tenant=acme&region=us",
+            Some("api.example.com"),
+            Some("cid-123"),
+            Some("203.0.113.9:443".parse().expect("client addr")),
+            HashMap::from([
+                ("authorization".to_string(), "Bearer token-3".to_string()),
+                (
+                    "cookie".to_string(),
+                    "session=s123; theme=dark; empty=".to_string(),
+                ),
+                ("x-user-id".to_string(), "alice".to_string()),
+            ]),
+        );
+
+        let assert_runtime_key = |spec: RuntimeRequestKeySpec, expected: &str| {
+            let resolved = QUICListener::resolve_lb_key_for_runtime_input(
+                RuntimeLoadBalancingStrategy::ConsistentHash,
+                Some(&spec),
+                &request,
+            );
+            assert_resolved(resolved, expected, LbKeySource::ConfiguredSpec);
+        };
+
+        assert_runtime_key(
+            RuntimeRequestKeySpec::Header("x-user-id".to_string()),
+            "alice",
+        );
+        assert_runtime_key(RuntimeRequestKeySpec::Cookie("session".to_string()), "s123");
+        assert_runtime_key(RuntimeRequestKeySpec::Query("tenant".to_string()), "acme");
+        assert_runtime_key(RuntimeRequestKeySpec::BearerToken, "token-3");
+        assert_runtime_key(RuntimeRequestKeySpec::Cid, "cid-123");
+        assert_runtime_key(RuntimeRequestKeySpec::StickyCid, "cid-123");
+        assert_runtime_key(RuntimeRequestKeySpec::PeerIp, "203.0.113.9");
+        assert_runtime_key(RuntimeRequestKeySpec::ClientIp, "203.0.113.9");
+        assert_runtime_key(RuntimeRequestKeySpec::Path, "/api/items");
+        assert_runtime_key(RuntimeRequestKeySpec::Authority, "api.example.com");
+        assert_runtime_key(RuntimeRequestKeySpec::Method, "POST");
+    }
+
+    #[test]
+    fn direct_key_resolver_falls_back_for_invalid_or_missing_key_sources() {
+        let request = request_parts_with_headers(
+            "GET",
+            "/resource?tenant=&region=us",
+            Some("api.example.com"),
+            Some("cid-456"),
+            Some("198.51.100.2:443".parse().expect("client addr")),
+            HashMap::from([
+                ("authorization".to_string(), "Basic abc".to_string()),
+                ("cookie".to_string(), "session=; theme=dark".to_string()),
+            ]),
+        );
+
+        let assert_default_fallback = |spec: &str, expected: &str| {
+            let resolved = QUICListener::resolve_lb_key(
+                "",
+                Some(spec),
+                request.method,
+                request.path,
+                request.authority,
+                request.cid_key,
+                request.client_addr,
+                request.header_lookup,
+            );
+            assert_resolved(resolved, expected, LbKeySource::DefaultFallback);
+        };
+
+        assert_default_fallback("header:x-user-id", "api.example.com");
+        assert_default_fallback("header:", "api.example.com");
+        assert_default_fallback("cookie:session", "api.example.com");
+        assert_default_fallback("query:tenant", "api.example.com");
+        assert_default_fallback("bearer_token", "api.example.com");
+        assert_default_fallback("not-a-real-spec", "api.example.com");
+    }
+
+    #[test]
+    fn sticky_cid_runtime_strategy_uses_cid_before_default_fallback() {
+        let sticky_request = request_parts_with_headers(
+            "GET",
+            "/resource",
+            Some("api.example.com"),
+            Some("cid-999"),
+            None,
+            HashMap::new(),
+        );
+        assert_resolved(
+            QUICListener::resolve_lb_key_for_runtime_input(
+                RuntimeLoadBalancingStrategy::StickyCid,
+                Some(&RuntimeRequestKeySpec::Header("x-missing".to_string())),
+                &sticky_request,
+            ),
+            "cid-999",
+            LbKeySource::StickyCidFallback,
+        );
+
+        let no_cid_request = request_parts_with_headers(
+            "GET",
+            "/resource",
+            Some("api.example.com"),
+            None,
+            None,
+            HashMap::new(),
+        );
+        assert_resolved(
+            QUICListener::resolve_lb_key_for_runtime_input(
+                RuntimeLoadBalancingStrategy::StickyCid,
+                Some(&RuntimeRequestKeySpec::Header("x-missing".to_string())),
+                &no_cid_request,
+            ),
+            "api.example.com",
+            LbKeySource::DefaultFallback,
+        );
+    }
 }

--- a/crates/edge/src/runtime/backend/event.rs
+++ b/crates/edge/src/runtime/backend/event.rs
@@ -249,4 +249,69 @@ mod tests {
             }
         ));
     }
+
+    #[test]
+    fn request_feedback_from_status_maps_success_client_error_and_server_error() {
+        let identity = BackendIdentity::new("https://backend.internal:8443");
+
+        let success =
+            BackendRequestFeedback::from_status(identity.clone(), Duration::from_millis(5), StatusCode::OK);
+        assert!(matches!(success.outcome, BackendRequestFeedbackOutcome::Success));
+        assert_eq!(success.status, Some(200));
+
+        let client_error = BackendRequestFeedback::from_status(
+            identity.clone(),
+            Duration::from_millis(5),
+            StatusCode::TOO_MANY_REQUESTS,
+        );
+        assert!(matches!(
+            client_error.outcome,
+            BackendRequestFeedbackOutcome::Neutral
+        ));
+        assert_eq!(client_error.status, Some(429));
+
+        let server_error = BackendRequestFeedback::from_status(
+            identity,
+            Duration::from_millis(5),
+            StatusCode::BAD_GATEWAY,
+        );
+        assert!(matches!(
+            server_error.outcome,
+            BackendRequestFeedbackOutcome::Failure {
+                reason: Some(HealthFailureReason::HttpStatus5xx)
+            }
+        ));
+        assert_eq!(server_error.status, Some(502));
+    }
+
+    #[test]
+    fn explicit_request_feedback_failure_preserves_reason_mapping() {
+        let timeout = BackendRequestFeedback::failure(
+            BackendIdentity::new("https://backend.internal:8443"),
+            Duration::from_millis(50),
+            None,
+            Some(HealthFailureReason::Timeout),
+        );
+        assert!(matches!(
+            timeout.outcome,
+            BackendRequestFeedbackOutcome::Failure {
+                reason: Some(HealthFailureReason::Timeout)
+            }
+        ));
+        assert_eq!(timeout.status, None);
+
+        let transport = BackendRequestFeedback::failure(
+            BackendIdentity::new("https://backend.internal:8443"),
+            Duration::from_millis(50),
+            Some(0),
+            Some(HealthFailureReason::Transport),
+        );
+        assert!(matches!(
+            transport.outcome,
+            BackendRequestFeedbackOutcome::Failure {
+                reason: Some(HealthFailureReason::Transport)
+            }
+        ));
+        assert_eq!(transport.status, Some(0));
+    }
 }

--- a/crates/edge/src/runtime/backend/event.rs
+++ b/crates/edge/src/runtime/backend/event.rs
@@ -254,9 +254,15 @@ mod tests {
     fn request_feedback_from_status_maps_success_client_error_and_server_error() {
         let identity = BackendIdentity::new("https://backend.internal:8443");
 
-        let success =
-            BackendRequestFeedback::from_status(identity.clone(), Duration::from_millis(5), StatusCode::OK);
-        assert!(matches!(success.outcome, BackendRequestFeedbackOutcome::Success));
+        let success = BackendRequestFeedback::from_status(
+            identity.clone(),
+            Duration::from_millis(5),
+            StatusCode::OK,
+        );
+        assert!(matches!(
+            success.outcome,
+            BackendRequestFeedbackOutcome::Success
+        ));
         assert_eq!(success.status, Some(200));
 
         let client_error = BackendRequestFeedback::from_status(

--- a/crates/edge/src/runtime/backend/lifecycle.rs
+++ b/crates/edge/src/runtime/backend/lifecycle.rs
@@ -1177,6 +1177,42 @@ mod tests {
         }
 
         #[test]
+        fn backend_snapshot_exposes_resolved_addresses_and_refresh_generation() {
+            let backend_addr = "https://backend.internal:8443";
+            let resolved_addrs = vec![
+                "10.0.0.10:8443".parse::<SocketAddr>().expect("addr"),
+                "10.0.0.11:8443".parse::<SocketAddr>().expect("addr"),
+            ];
+            let store = Arc::new(RuntimeBackendResolutionStore::new([
+                RuntimeBackendResolution::hostname(
+                    backend_addr.to_string(),
+                    "backend.internal".to_string(),
+                    8443,
+                ),
+            ]));
+            store
+                .apply_resolution_refresh(backend_addr, resolved_addrs.clone(), SystemTime::UNIX_EPOCH)
+                .expect("seed refresh");
+            let coordinator = BackendLifecycleCoordinator::new(store);
+
+            let snapshot = coordinator
+                .snapshot_backend(backend_addr)
+                .expect("backend snapshot");
+
+            assert_eq!(snapshot.identity.backend_addr, backend_addr);
+            assert_eq!(snapshot.resolution.authority_host, "backend.internal");
+            assert_eq!(snapshot.resolution.authority_port, 8443);
+            assert_eq!(snapshot.resolution.resolved_addrs, resolved_addrs);
+            assert_eq!(snapshot.resolution.refresh_generation, 1);
+            assert_eq!(
+                snapshot.resolution.last_refresh_success_at,
+                Some(SystemTime::UNIX_EPOCH)
+            );
+            assert!(matches!(snapshot.health, BackendHealthState::Unknown));
+            assert_eq!(snapshot.membership, BackendMembershipState::Active);
+        }
+
+        #[test]
         fn lifecycle_coordinator_merges_resolution_and_pool_health_into_inventory() {
             let store = Arc::new(RuntimeBackendResolutionStore::new([
                 RuntimeBackendResolution::hostname(
@@ -1238,6 +1274,77 @@ mod tests {
             assert_eq!(removed.membership, BackendMembershipState::Removed);
             assert!(removed.placements.is_empty());
             assert_eq!(inventory.summary().total_backends, 1);
+        }
+
+        #[test]
+        fn inventory_exposes_canonical_health_membership_and_resolution_views() {
+            let placed_backend = "127.0.0.1:8080";
+            let removed_backend = "127.0.0.1:9090";
+            let resolved_addrs = vec!["10.0.0.10:8080".parse::<SocketAddr>().expect("addr")];
+            let store = Arc::new(RuntimeBackendResolutionStore::new([
+                RuntimeBackendResolution::hostname(
+                    placed_backend.to_string(),
+                    "backend-a.internal".to_string(),
+                    8080,
+                ),
+                RuntimeBackendResolution::hostname(
+                    removed_backend.to_string(),
+                    "backend-b.internal".to_string(),
+                    9090,
+                ),
+            ]));
+            store
+                .apply_resolution_refresh(placed_backend, resolved_addrs.clone(), SystemTime::UNIX_EPOCH)
+                .expect("seed refresh");
+            let coordinator = BackendLifecycleCoordinator::new(Arc::clone(&store));
+            let pool = test_active_health_upstream_pool();
+            let failure = evaluate_active_health_check(
+                BackendIdentity::new(placed_backend),
+                BackendHealthObservationOutcome::Failure,
+                Some(spooky_lb::health::HealthFailureReason::Transport),
+                100,
+                0,
+            );
+            let transition =
+                coordinator.apply_health_observation(Some(&pool), Some(0), &failure.observation);
+            assert!(matches!(
+                transition,
+                Some(HealthTransition::BecameUnhealthy)
+            ));
+
+            let mut pools = HashMap::new();
+            pools.insert("api".to_string(), pool);
+            let inventory = coordinator.snapshot_inventory(&pools);
+
+            let active = inventory
+                .backends
+                .iter()
+                .find(|backend| backend.identity.backend_addr == placed_backend)
+                .expect("active backend");
+            assert_eq!(active.identity.backend_addr, placed_backend);
+            assert_eq!(active.membership, BackendMembershipState::Active);
+            assert!(matches!(
+                active.health,
+                BackendHealthState::Unhealthy { reason: None }
+            ));
+            assert_eq!(active.resolution.resolved_addrs, resolved_addrs);
+            assert_eq!(active.resolution.refresh_generation, 1);
+            assert_eq!(active.resolution.last_refresh_success_at, Some(SystemTime::UNIX_EPOCH));
+            assert_eq!(active.placements.len(), 1);
+            assert!(!active.placements[0].healthy);
+
+            let removed = inventory
+                .backends
+                .iter()
+                .find(|backend| backend.identity.backend_addr == removed_backend)
+                .expect("removed backend");
+            assert_eq!(removed.identity.backend_addr, removed_backend);
+            assert_eq!(removed.membership, BackendMembershipState::Removed);
+            assert!(matches!(removed.health, BackendHealthState::Unknown));
+            assert!(removed.placements.is_empty());
+
+            assert_eq!(inventory.summary().total_backends, 1);
+            assert_eq!(inventory.summary().healthy_backends, 0);
         }
     }
 

--- a/crates/edge/src/runtime/backend/lifecycle.rs
+++ b/crates/edge/src/runtime/backend/lifecycle.rs
@@ -710,103 +710,6 @@ mod tests {
     use super::*;
     use crate::runtime::backend::event::{BackendHealthObservationOutcome, BackendRequestFeedback};
 
-    #[test]
-    fn refresh_classification_maps_every_variant_and_preserves_traffic_on_failure() {
-        let updated = BackendDnsRefreshApplication::Updated {
-            backend_addr: "http://backend:8080".to_string(),
-            authority_host: "backend".to_string(),
-            previous_addrs: vec![],
-            current_addrs: vec!["10.0.0.1:8080".parse().expect("addr")],
-            generation: 1,
-            refreshed_at: SystemTime::UNIX_EPOCH,
-            client_rotation: ClientRotationOutcome::Rotated,
-        };
-        assert_eq!(
-            updated.classification(),
-            BackendRefreshClassification::Refreshed
-        );
-        assert!(!updated.traffic_continues_on_existing());
-
-        let unchanged = BackendDnsRefreshApplication::Unchanged {
-            backend_addr: "http://backend:8080".to_string(),
-            authority_host: "backend".to_string(),
-            current_addrs: vec!["10.0.0.1:8080".parse().expect("addr")],
-            generation: 1,
-            refreshed_at: SystemTime::UNIX_EPOCH,
-        };
-        assert_eq!(
-            unchanged.classification(),
-            BackendRefreshClassification::Unchanged
-        );
-        assert!(unchanged.traffic_continues_on_existing());
-
-        let empty = BackendDnsRefreshApplication::EmptyAnswerRetained {
-            backend_addr: "http://backend:8080".to_string(),
-            authority_host: "backend".to_string(),
-            retained_addrs: vec!["10.0.0.1:8080".parse().expect("addr")],
-        };
-        assert_eq!(
-            empty.classification(),
-            BackendRefreshClassification::Rejected
-        );
-        assert!(empty.traffic_continues_on_existing());
-        assert!(empty.classification().is_failure());
-
-        let failed = BackendDnsRefreshApplication::LookupFailed {
-            backend_addr: "http://backend:8080".to_string(),
-            authority_host: "backend".to_string(),
-            retained_addrs: vec!["10.0.0.1:8080".parse().expect("addr")],
-            error: "nxdomain".to_string(),
-        };
-        assert_eq!(
-            failed.classification(),
-            BackendRefreshClassification::FailedActivePreserved
-        );
-        // The core Phase 7 safety invariant: a failure never drops the backend.
-        assert!(failed.traffic_continues_on_existing());
-        assert!(failed.classification().is_failure());
-        assert_eq!(failed.backend_addr(), "http://backend:8080");
-        assert_eq!(failed.authority_host(), "backend");
-    }
-
-    #[test]
-    fn rotation_failure_is_metered_and_does_not_hide_refresh_success() {
-        let metrics = Metrics::default();
-        let updated = BackendDnsRefreshApplication::Updated {
-            backend_addr: "http://backend.internal:8080".to_string(),
-            authority_host: "backend.internal".to_string(),
-            previous_addrs: vec!["10.0.0.1:8080".parse().expect("addr")],
-            current_addrs: vec!["10.0.0.2:8080".parse().expect("addr")],
-            generation: 2,
-            refreshed_at: SystemTime::UNIX_EPOCH,
-            client_rotation: ClientRotationOutcome::Failed {
-                error: "pool busy".to_string(),
-            },
-        };
-
-        observe_backend_dns_refresh(&metrics, &updated);
-
-        // The resolution refresh still counts as a success...
-        assert_eq!(
-            metrics
-                .backend_client_rotation_failures
-                .load(std::sync::atomic::Ordering::Relaxed),
-            1,
-            "rotation failure must be metered, not silently dropped"
-        );
-        // ...and the rotation-success counter is untouched by a failure.
-        assert_eq!(
-            metrics
-                .backend_client_rotations
-                .load(std::sync::atomic::Ordering::Relaxed),
-            0
-        );
-        assert_eq!(
-            updated_client_rotation(&updated).failure(),
-            Some("pool busy")
-        );
-    }
-
     fn updated_client_rotation(app: &BackendDnsRefreshApplication) -> &ClientRotationOutcome {
         match app {
             BackendDnsRefreshApplication::Updated {
@@ -899,512 +802,627 @@ mod tests {
         .expect("transport pool")
     }
 
-    #[test]
-    fn lifecycle_state_seeds_from_resolution_with_unknown_health() {
-        let resolution = RuntimeBackendResolution::hostname(
-            "https://backend.internal:8443".to_string(),
-            "backend.internal".to_string(),
-            8443,
-        );
 
-        let state = RuntimeBackendLifecycleState::from(&resolution);
+    mod refresh_application {
+        use super::*;
 
-        assert_eq!(state.identity.backend_addr, "https://backend.internal:8443");
-        assert_eq!(state.membership, BackendMembershipState::Active);
-        assert_eq!(state.health, BackendHealthState::Unknown);
-        assert!(state.resolution.is_hostname());
+        #[test]
+        fn refresh_classification_maps_every_variant_and_preserves_traffic_on_failure() {
+            let updated = BackendDnsRefreshApplication::Updated {
+                backend_addr: "http://backend:8080".to_string(),
+                authority_host: "backend".to_string(),
+                previous_addrs: vec![],
+                current_addrs: vec!["10.0.0.1:8080".parse().expect("addr")],
+                generation: 1,
+                refreshed_at: SystemTime::UNIX_EPOCH,
+                client_rotation: ClientRotationOutcome::Rotated,
+            };
+            assert_eq!(
+                updated.classification(),
+                BackendRefreshClassification::Refreshed
+            );
+            assert!(!updated.traffic_continues_on_existing());
+
+            let unchanged = BackendDnsRefreshApplication::Unchanged {
+                backend_addr: "http://backend:8080".to_string(),
+                authority_host: "backend".to_string(),
+                current_addrs: vec!["10.0.0.1:8080".parse().expect("addr")],
+                generation: 1,
+                refreshed_at: SystemTime::UNIX_EPOCH,
+            };
+            assert_eq!(
+                unchanged.classification(),
+                BackendRefreshClassification::Unchanged
+            );
+            assert!(unchanged.traffic_continues_on_existing());
+
+            let empty = BackendDnsRefreshApplication::EmptyAnswerRetained {
+                backend_addr: "http://backend:8080".to_string(),
+                authority_host: "backend".to_string(),
+                retained_addrs: vec!["10.0.0.1:8080".parse().expect("addr")],
+            };
+            assert_eq!(
+                empty.classification(),
+                BackendRefreshClassification::Rejected
+            );
+            assert!(empty.traffic_continues_on_existing());
+            assert!(empty.classification().is_failure());
+
+            let failed = BackendDnsRefreshApplication::LookupFailed {
+                backend_addr: "http://backend:8080".to_string(),
+                authority_host: "backend".to_string(),
+                retained_addrs: vec!["10.0.0.1:8080".parse().expect("addr")],
+                error: "nxdomain".to_string(),
+            };
+            assert_eq!(
+                failed.classification(),
+                BackendRefreshClassification::FailedActivePreserved
+            );
+            assert!(failed.traffic_continues_on_existing());
+            assert!(failed.classification().is_failure());
+            assert_eq!(failed.backend_addr(), "http://backend:8080");
+            assert_eq!(failed.authority_host(), "backend");
+        }
+
+        #[test]
+        fn rotation_failure_is_metered_and_does_not_hide_refresh_success() {
+            let metrics = Metrics::default();
+            let updated = BackendDnsRefreshApplication::Updated {
+                backend_addr: "http://backend.internal:8080".to_string(),
+                authority_host: "backend.internal".to_string(),
+                previous_addrs: vec!["10.0.0.1:8080".parse().expect("addr")],
+                current_addrs: vec!["10.0.0.2:8080".parse().expect("addr")],
+                generation: 2,
+                refreshed_at: SystemTime::UNIX_EPOCH,
+                client_rotation: ClientRotationOutcome::Failed {
+                    error: "pool busy".to_string(),
+                },
+            };
+
+            observe_backend_dns_refresh(&metrics, &updated);
+
+            assert_eq!(
+                metrics
+                    .backend_client_rotation_failures
+                    .load(std::sync::atomic::Ordering::Relaxed),
+                1,
+                "rotation failure must be metered, not silently dropped"
+            );
+            assert_eq!(
+                metrics
+                    .backend_client_rotations
+                    .load(std::sync::atomic::Ordering::Relaxed),
+                0
+            );
+            assert_eq!(
+                updated_client_rotation(&updated).failure(),
+                Some("pool busy")
+            );
+        }
+
+        #[test]
+        fn hostname_refresh_updates_resolved_addrs_and_generation() {
+            let backend_addr = "http://backend.internal:8080";
+            let store = Arc::new(RuntimeBackendResolutionStore::new([
+                RuntimeBackendResolution::hostname(
+                    backend_addr.to_string(),
+                    "backend.internal".to_string(),
+                    8080,
+                ),
+            ]));
+            let coordinator = BackendLifecycleCoordinator::new(Arc::clone(&store));
+            let resolver = SharedDnsResolver::new();
+            let transport_pool = test_transport_pool(backend_addr);
+            let backend = coordinator.backend(backend_addr).expect("backend");
+            let new_addrs = vec!["10.0.0.10:8080".parse::<SocketAddr>().expect("addr")];
+
+            let outcome = coordinator.apply_refresh(
+                &backend,
+                Ok(new_addrs.clone()),
+                &resolver,
+                &transport_pool,
+            );
+
+            let BackendDnsRefreshApplication::Updated {
+                current_addrs,
+                generation,
+                client_rotation,
+                ..
+            } = &outcome
+            else {
+                panic!("expected Updated outcome, got: {outcome:?}");
+            };
+            assert_eq!(current_addrs, &new_addrs);
+            assert_eq!(*generation, 1);
+            assert!(client_rotation.rotated());
+
+            let snapshot = coordinator
+                .snapshot_backend(backend_addr)
+                .expect("snapshot");
+            assert_eq!(snapshot.resolution.resolved_addrs, new_addrs);
+            assert_eq!(snapshot.resolution.refresh_generation, 1);
+            assert_eq!(
+                resolver.cached_addrs("backend.internal"),
+                Some(vec!["10.0.0.10:0".parse::<SocketAddr>().expect("addr")])
+            );
+        }
+
+        #[test]
+        fn unchanged_refresh_does_not_rotate_clients_unnecessarily() {
+            let backend_addr = "http://backend.internal:8080";
+            let initial_addrs = vec!["10.0.0.10:8080".parse::<SocketAddr>().expect("addr")];
+            let store = Arc::new(RuntimeBackendResolutionStore::new([
+                RuntimeBackendResolution::hostname(
+                    backend_addr.to_string(),
+                    "backend.internal".to_string(),
+                    8080,
+                ),
+            ]));
+            store
+                .apply_resolution_refresh(
+                    backend_addr,
+                    initial_addrs.clone(),
+                    std::time::SystemTime::UNIX_EPOCH,
+                )
+                .expect("seed refresh");
+            let coordinator = BackendLifecycleCoordinator::new(Arc::clone(&store));
+            let resolver = SharedDnsResolver::new();
+            let transport_pool = test_transport_pool(backend_addr);
+            let backend = coordinator.backend(backend_addr).expect("backend");
+
+            let outcome = coordinator.apply_refresh(
+                &backend,
+                Ok(initial_addrs.clone()),
+                &resolver,
+                &transport_pool,
+            );
+
+            assert!(matches!(
+                outcome,
+                BackendDnsRefreshApplication::Unchanged {
+                    current_addrs,
+                    generation: 2,
+                    ..
+                } if current_addrs == initial_addrs
+            ));
+        }
+
+        #[test]
+        fn empty_dns_answer_retains_prior_addresses() {
+            let backend_addr = "http://backend.internal:8080";
+            let retained_addrs = vec!["10.0.0.10:8080".parse::<SocketAddr>().expect("addr")];
+            let store = Arc::new(RuntimeBackendResolutionStore::new([
+                RuntimeBackendResolution::hostname(
+                    backend_addr.to_string(),
+                    "backend.internal".to_string(),
+                    8080,
+                ),
+            ]));
+            store
+                .apply_resolution_refresh(
+                    backend_addr,
+                    retained_addrs.clone(),
+                    std::time::SystemTime::UNIX_EPOCH,
+                )
+                .expect("seed refresh");
+            let coordinator = BackendLifecycleCoordinator::new(store);
+            let resolver = SharedDnsResolver::new();
+            let transport_pool = test_transport_pool(backend_addr);
+            let backend = coordinator.backend(backend_addr).expect("backend");
+
+            let outcome =
+                coordinator.apply_refresh(&backend, Ok(Vec::new()), &resolver, &transport_pool);
+
+            assert!(matches!(
+                outcome,
+                BackendDnsRefreshApplication::EmptyAnswerRetained {
+                    retained_addrs: actual,
+                    ..
+                } if actual == retained_addrs
+            ));
+        }
+
+        #[test]
+        fn failed_refresh_preserves_existing_resolution_and_generation() {
+            let backend_addr = "http://backend.internal:8080";
+            let retained_addrs = vec!["10.0.0.10:8080".parse::<SocketAddr>().expect("addr")];
+            let store = Arc::new(RuntimeBackendResolutionStore::new([
+                RuntimeBackendResolution::hostname(
+                    backend_addr.to_string(),
+                    "backend.internal".to_string(),
+                    8080,
+                ),
+            ]));
+            store
+                .apply_resolution_refresh(
+                    backend_addr,
+                    retained_addrs.clone(),
+                    std::time::SystemTime::UNIX_EPOCH,
+                )
+                .expect("seed refresh");
+            let coordinator = BackendLifecycleCoordinator::new(Arc::clone(&store));
+            let resolver = SharedDnsResolver::new();
+            let transport_pool = test_transport_pool(backend_addr);
+            let backend = coordinator.backend(backend_addr).expect("backend");
+
+            let outcome = coordinator.apply_refresh(
+                &backend,
+                Err("nxdomain".to_string()),
+                &resolver,
+                &transport_pool,
+            );
+
+            assert!(matches!(
+                outcome,
+                BackendDnsRefreshApplication::LookupFailed {
+                    retained_addrs: ref actual,
+                    ..
+                } if *actual == retained_addrs
+            ));
+            let snapshot = coordinator
+                .snapshot_backend(backend_addr)
+                .expect("snapshot after failed refresh");
+            assert_eq!(snapshot.resolution.resolved_addrs, retained_addrs);
+            assert_eq!(snapshot.resolution.refresh_generation, 1);
+            assert_eq!(
+                outcome.classification(),
+                BackendRefreshClassification::FailedActivePreserved
+            );
+        }
     }
 
-    #[test]
-    fn lifecycle_coordinator_exposes_backend_snapshots() {
-        let store = Arc::new(RuntimeBackendResolutionStore::new([
-            RuntimeBackendResolution::hostname(
+    mod snapshot_inventory {
+        use super::*;
+
+        #[test]
+        fn lifecycle_state_seeds_from_resolution_with_unknown_health() {
+            let resolution = RuntimeBackendResolution::hostname(
                 "https://backend.internal:8443".to_string(),
                 "backend.internal".to_string(),
                 8443,
-            ),
-        ]));
-        let coordinator = BackendLifecycleCoordinator::new(Arc::clone(&store));
+            );
 
-        let snapshot = coordinator
-            .snapshot_backend("https://backend.internal:8443")
-            .expect("backend snapshot");
-        assert_eq!(
-            snapshot.identity.backend_addr,
-            "https://backend.internal:8443"
-        );
+            let state = RuntimeBackendLifecycleState::from(&resolution);
 
-        let all = coordinator.snapshot_all();
-        assert_eq!(all.len(), 1);
-        assert!(all.contains_key("https://backend.internal:8443"));
-    }
-
-    #[test]
-    fn lifecycle_coordinator_merges_resolution_and_pool_health_into_inventory() {
-        let store = Arc::new(RuntimeBackendResolutionStore::new([
-            RuntimeBackendResolution::hostname(
-                "127.0.0.1:8080".to_string(),
-                "backend.internal".to_string(),
-                8080,
-            ),
-        ]));
-        let coordinator = BackendLifecycleCoordinator::new(store);
-        let mut pools = HashMap::new();
-        pools.insert("api".to_string(), test_upstream_pool());
-
-        let inventory = coordinator.snapshot_inventory(&pools);
-        let backend = inventory
-            .backends
-            .iter()
-            .find(|backend| backend.identity.backend_addr == "127.0.0.1:8080")
-            .expect("backend inventory");
-
-        assert_eq!(inventory.summary().healthy_backends, 1);
-        assert_eq!(inventory.summary().total_backends, 1);
-        assert_eq!(backend.placements.len(), 1);
-        assert!(matches!(backend.health, BackendHealthState::Healthy));
-        assert_eq!(backend.placements[0].upstream_name, "api");
-    }
-
-    #[test]
-    fn hostname_refresh_updates_resolved_addrs_and_generation() {
-        let backend_addr = "http://backend.internal:8080";
-        let store = Arc::new(RuntimeBackendResolutionStore::new([
-            RuntimeBackendResolution::hostname(
-                backend_addr.to_string(),
-                "backend.internal".to_string(),
-                8080,
-            ),
-        ]));
-        let coordinator = BackendLifecycleCoordinator::new(Arc::clone(&store));
-        let resolver = SharedDnsResolver::new();
-        let transport_pool = test_transport_pool(backend_addr);
-        let backend = coordinator.backend(backend_addr).expect("backend");
-        let new_addrs = vec!["10.0.0.10:8080".parse::<SocketAddr>().expect("addr")];
-
-        let outcome =
-            coordinator.apply_refresh(&backend, Ok(new_addrs.clone()), &resolver, &transport_pool);
-
-        let BackendDnsRefreshApplication::Updated {
-            current_addrs,
-            generation,
-            client_rotation,
-            ..
-        } = &outcome
-        else {
-            panic!("expected Updated outcome, got: {outcome:?}");
-        };
-        assert_eq!(current_addrs, &new_addrs);
-        assert_eq!(*generation, 1);
-        assert!(client_rotation.rotated());
-
-        let snapshot = coordinator
-            .snapshot_backend(backend_addr)
-            .expect("snapshot");
-        assert_eq!(snapshot.resolution.resolved_addrs, new_addrs);
-        assert_eq!(snapshot.resolution.refresh_generation, 1);
-        assert_eq!(
-            resolver.cached_addrs("backend.internal"),
-            Some(vec!["10.0.0.10:0".parse::<SocketAddr>().expect("addr")])
-        );
-    }
-
-    #[test]
-    fn unchanged_refresh_does_not_rotate_clients_unnecessarily() {
-        let backend_addr = "http://backend.internal:8080";
-        let initial_addrs = vec!["10.0.0.10:8080".parse::<SocketAddr>().expect("addr")];
-        let store = Arc::new(RuntimeBackendResolutionStore::new([
-            RuntimeBackendResolution::hostname(
-                backend_addr.to_string(),
-                "backend.internal".to_string(),
-                8080,
-            ),
-        ]));
-        store
-            .apply_resolution_refresh(
-                backend_addr,
-                initial_addrs.clone(),
-                std::time::SystemTime::UNIX_EPOCH,
-            )
-            .expect("seed refresh");
-        let coordinator = BackendLifecycleCoordinator::new(Arc::clone(&store));
-        let resolver = SharedDnsResolver::new();
-        let transport_pool = test_transport_pool(backend_addr);
-        let backend = coordinator.backend(backend_addr).expect("backend");
-
-        let outcome = coordinator.apply_refresh(
-            &backend,
-            Ok(initial_addrs.clone()),
-            &resolver,
-            &transport_pool,
-        );
-
-        assert!(matches!(
-            outcome,
-            BackendDnsRefreshApplication::Unchanged {
-                current_addrs,
-                generation: 2,
-                ..
-            } if current_addrs == initial_addrs
-        ));
-    }
-
-    #[test]
-    fn empty_dns_answer_retains_prior_addresses() {
-        let backend_addr = "http://backend.internal:8080";
-        let retained_addrs = vec!["10.0.0.10:8080".parse::<SocketAddr>().expect("addr")];
-        let store = Arc::new(RuntimeBackendResolutionStore::new([
-            RuntimeBackendResolution::hostname(
-                backend_addr.to_string(),
-                "backend.internal".to_string(),
-                8080,
-            ),
-        ]));
-        store
-            .apply_resolution_refresh(
-                backend_addr,
-                retained_addrs.clone(),
-                std::time::SystemTime::UNIX_EPOCH,
-            )
-            .expect("seed refresh");
-        let coordinator = BackendLifecycleCoordinator::new(store);
-        let resolver = SharedDnsResolver::new();
-        let transport_pool = test_transport_pool(backend_addr);
-        let backend = coordinator.backend(backend_addr).expect("backend");
-
-        let outcome =
-            coordinator.apply_refresh(&backend, Ok(Vec::new()), &resolver, &transport_pool);
-
-        assert!(matches!(
-            outcome,
-            BackendDnsRefreshApplication::EmptyAnswerRetained {
-                retained_addrs: actual,
-                ..
-            } if actual == retained_addrs
-        ));
-    }
-
-    #[test]
-    fn request_feedback_applier_marks_backend_unhealthy_after_failure_threshold() {
-        let pool = test_upstream_pool();
-        let feedback = BackendRequestFeedback::failure(
-            BackendIdentity::new("127.0.0.1:8080"),
-            Duration::from_millis(10),
-            Some(503),
-            Some(spooky_lb::health::HealthFailureReason::HttpStatus5xx),
-        );
-        assert!(apply_backend_request_feedback(Some(&pool), Some(0), &feedback).is_none());
-        assert!(apply_backend_request_feedback(Some(&pool), Some(0), &feedback).is_none());
-        let unhealthy = apply_backend_request_feedback(Some(&pool), Some(0), &feedback);
-        assert!(matches!(unhealthy, Some(HealthTransition::BecameUnhealthy)));
-    }
-
-    #[test]
-    fn request_accounting_applier_finishes_inflight_request() {
-        let pool = test_upstream_pool();
-        {
-            let guard = pool.read().expect("read");
-            assert!(guard.begin_request_if_healthy(0));
+            assert_eq!(state.identity.backend_addr, "https://backend.internal:8443");
+            assert_eq!(state.membership, BackendMembershipState::Active);
+            assert_eq!(state.health, BackendHealthState::Unknown);
+            assert!(state.resolution.is_hostname());
         }
 
-        apply_backend_request_accounting(
-            Some(&pool),
-            Some(0),
-            Duration::from_millis(15),
-            Some(200),
-        );
+        #[test]
+        fn lifecycle_coordinator_exposes_backend_snapshots() {
+            let store = Arc::new(RuntimeBackendResolutionStore::new([
+                RuntimeBackendResolution::hostname(
+                    "https://backend.internal:8443".to_string(),
+                    "backend.internal".to_string(),
+                    8443,
+                ),
+            ]));
+            let coordinator = BackendLifecycleCoordinator::new(Arc::clone(&store));
 
-        let guard = pool.read().expect("read");
-        let state = guard.backend_runtime_state(0).expect("backend state");
-        assert_eq!(state.active_requests, 0);
-        assert!(state.ewma_latency_ms.is_some());
+            let snapshot = coordinator
+                .snapshot_backend("https://backend.internal:8443")
+                .expect("backend snapshot");
+            assert_eq!(
+                snapshot.identity.backend_addr,
+                "https://backend.internal:8443"
+            );
+
+            let all = coordinator.snapshot_all();
+            assert_eq!(all.len(), 1);
+            assert!(all.contains_key("https://backend.internal:8443"));
+        }
+
+        #[test]
+        fn lifecycle_coordinator_merges_resolution_and_pool_health_into_inventory() {
+            let store = Arc::new(RuntimeBackendResolutionStore::new([
+                RuntimeBackendResolution::hostname(
+                    "127.0.0.1:8080".to_string(),
+                    "backend.internal".to_string(),
+                    8080,
+                ),
+            ]));
+            let coordinator = BackendLifecycleCoordinator::new(store);
+            let mut pools = HashMap::new();
+            pools.insert("api".to_string(), test_upstream_pool());
+
+            let inventory = coordinator.snapshot_inventory(&pools);
+            let backend = inventory
+                .backends
+                .iter()
+                .find(|backend| backend.identity.backend_addr == "127.0.0.1:8080")
+                .expect("backend inventory");
+
+            assert_eq!(inventory.summary().healthy_backends, 1);
+            assert_eq!(inventory.summary().total_backends, 1);
+            assert_eq!(backend.placements.len(), 1);
+            assert!(matches!(backend.health, BackendHealthState::Healthy));
+            assert_eq!(backend.placements[0].upstream_name, "api");
+        }
+
+        #[test]
+        fn inventory_marks_missing_pool_members_as_removed_without_losing_live_placements() {
+            let store = Arc::new(RuntimeBackendResolutionStore::new([
+                RuntimeBackendResolution::hostname(
+                    "127.0.0.1:8080".to_string(),
+                    "backend-a.internal".to_string(),
+                    8080,
+                ),
+                RuntimeBackendResolution::hostname(
+                    "127.0.0.1:9090".to_string(),
+                    "backend-b.internal".to_string(),
+                    9090,
+                ),
+            ]));
+            let coordinator = BackendLifecycleCoordinator::new(store);
+            let mut pools = HashMap::new();
+            pools.insert("api".to_string(), test_upstream_pool());
+
+            let inventory = coordinator.snapshot_inventory(&pools);
+            let active = inventory
+                .backends
+                .iter()
+                .find(|backend| backend.identity.backend_addr == "127.0.0.1:8080")
+                .expect("active backend");
+            let removed = inventory
+                .backends
+                .iter()
+                .find(|backend| backend.identity.backend_addr == "127.0.0.1:9090")
+                .expect("removed backend");
+
+            assert_eq!(active.membership, BackendMembershipState::Active);
+            assert_eq!(active.placements.len(), 1);
+            assert_eq!(removed.membership, BackendMembershipState::Removed);
+            assert!(removed.placements.is_empty());
+            assert_eq!(inventory.summary().total_backends, 1);
+        }
     }
 
-    #[test]
-    fn active_health_check_evaluation_tracks_backoff_and_transition() {
-        let pool = test_active_health_upstream_pool();
+    mod health_observation_application {
+        use super::*;
 
-        let failure = evaluate_active_health_check(
-            BackendIdentity::new("127.0.0.1:8080"),
-            BackendHealthObservationOutcome::Failure,
-            Some(spooky_lb::health::HealthFailureReason::Transport),
-            100,
-            0,
-        );
-        assert_eq!(failure.next_consecutive_failures, 1);
-        assert_eq!(failure.next_delay, Duration::from_millis(200));
-        let transition =
-            apply_backend_health_observation(Some(&pool), Some(0), &failure.observation);
-        assert!(matches!(
-            transition,
-            Some(HealthTransition::BecameUnhealthy)
-        ));
+        #[test]
+        fn active_health_check_evaluation_tracks_backoff_and_transition() {
+            let pool = test_active_health_upstream_pool();
 
-        let success = evaluate_active_health_check(
-            BackendIdentity::new("127.0.0.1:8080"),
-            BackendHealthObservationOutcome::Success,
-            None,
-            100,
-            failure.next_consecutive_failures,
-        );
-        assert_eq!(success.next_consecutive_failures, 0);
-        assert_eq!(success.next_delay, Duration::from_millis(100));
-        let transition =
-            apply_backend_health_observation(Some(&pool), Some(0), &success.observation);
-        assert!(matches!(transition, Some(HealthTransition::BecameHealthy)));
+            let failure = evaluate_active_health_check(
+                BackendIdentity::new("127.0.0.1:8080"),
+                BackendHealthObservationOutcome::Failure,
+                Some(spooky_lb::health::HealthFailureReason::Transport),
+                100,
+                0,
+            );
+            assert_eq!(failure.next_consecutive_failures, 1);
+            assert_eq!(failure.next_delay, Duration::from_millis(200));
+            let transition =
+                apply_backend_health_observation(Some(&pool), Some(0), &failure.observation);
+            assert!(matches!(
+                transition,
+                Some(HealthTransition::BecameUnhealthy)
+            ));
+
+            let success = evaluate_active_health_check(
+                BackendIdentity::new("127.0.0.1:8080"),
+                BackendHealthObservationOutcome::Success,
+                None,
+                100,
+                failure.next_consecutive_failures,
+            );
+            assert_eq!(success.next_consecutive_failures, 0);
+            assert_eq!(success.next_delay, Duration::from_millis(100));
+            let transition =
+                apply_backend_health_observation(Some(&pool), Some(0), &success.observation);
+            assert!(matches!(transition, Some(HealthTransition::BecameHealthy)));
+        }
+
+        #[test]
+        fn coordinator_health_observation_marks_backend_unhealthy_and_recovers() {
+            let pool = test_active_health_upstream_pool();
+            let store = Arc::new(RuntimeBackendResolutionStore::new([
+                RuntimeBackendResolution::hostname(
+                    "127.0.0.1:8080".to_string(),
+                    "backend.internal".to_string(),
+                    8080,
+                ),
+            ]));
+            let coordinator = BackendLifecycleCoordinator::new(store);
+
+            let failure = evaluate_active_health_check(
+                BackendIdentity::new("127.0.0.1:8080"),
+                BackendHealthObservationOutcome::Failure,
+                Some(spooky_lb::health::HealthFailureReason::Transport),
+                100,
+                0,
+            );
+            let transition =
+                coordinator.apply_health_observation(Some(&pool), Some(0), &failure.observation);
+            assert!(matches!(
+                transition,
+                Some(HealthTransition::BecameUnhealthy)
+            ));
+
+            let mut pools = HashMap::new();
+            pools.insert("api".to_string(), Arc::clone(&pool));
+            let summary = coordinator.snapshot_inventory(&pools).summary();
+            assert_eq!(summary.healthy_backends, 0);
+            assert_eq!(summary.total_backends, 1);
+
+            let success = evaluate_active_health_check(
+                BackendIdentity::new("127.0.0.1:8080"),
+                BackendHealthObservationOutcome::Success,
+                None,
+                100,
+                failure.next_consecutive_failures,
+            );
+            let transition =
+                coordinator.apply_health_observation(Some(&pool), Some(0), &success.observation);
+            assert!(matches!(transition, Some(HealthTransition::BecameHealthy)));
+
+            let summary = coordinator.snapshot_inventory(&pools).summary();
+            assert_eq!(summary.healthy_backends, 1);
+        }
     }
 
-    #[test]
-    fn coordinator_health_observation_marks_backend_unhealthy_and_recovers() {
-        let pool = test_active_health_upstream_pool();
-        let store = Arc::new(RuntimeBackendResolutionStore::new([
-            RuntimeBackendResolution::hostname(
-                "127.0.0.1:8080".to_string(),
-                "backend.internal".to_string(),
-                8080,
-            ),
-        ]));
-        let coordinator = BackendLifecycleCoordinator::new(store);
+    mod request_feedback_application {
+        use super::*;
 
-        let failure = evaluate_active_health_check(
-            BackendIdentity::new("127.0.0.1:8080"),
-            BackendHealthObservationOutcome::Failure,
-            Some(spooky_lb::health::HealthFailureReason::Transport),
-            100,
-            0,
-        );
-        let transition =
-            coordinator.apply_health_observation(Some(&pool), Some(0), &failure.observation);
-        assert!(matches!(
-            transition,
-            Some(HealthTransition::BecameUnhealthy)
-        ));
-
-        let mut pools = HashMap::new();
-        pools.insert("api".to_string(), Arc::clone(&pool));
-        let summary = coordinator.snapshot_inventory(&pools).summary();
-        assert_eq!(summary.healthy_backends, 0);
-        assert_eq!(summary.total_backends, 1);
-
-        let success = evaluate_active_health_check(
-            BackendIdentity::new("127.0.0.1:8080"),
-            BackendHealthObservationOutcome::Success,
-            None,
-            100,
-            failure.next_consecutive_failures,
-        );
-        let transition =
-            coordinator.apply_health_observation(Some(&pool), Some(0), &success.observation);
-        assert!(matches!(transition, Some(HealthTransition::BecameHealthy)));
-
-        let summary = coordinator.snapshot_inventory(&pools).summary();
-        assert_eq!(summary.healthy_backends, 1);
-    }
-
-    #[test]
-    fn coordinator_request_feedback_updates_inventory_consistently() {
-        let pool = test_upstream_pool();
-        let store = Arc::new(RuntimeBackendResolutionStore::new([
-            RuntimeBackendResolution::hostname(
-                "127.0.0.1:8080".to_string(),
-                "backend.internal".to_string(),
-                8080,
-            ),
-        ]));
-        let coordinator = BackendLifecycleCoordinator::new(store);
-        let mut pools = HashMap::new();
-        pools.insert("api".to_string(), Arc::clone(&pool));
-
-        let transition = apply_backend_request_feedback(
-            Some(&pool),
-            Some(0),
-            &BackendRequestFeedback::failure(
+        #[test]
+        fn request_feedback_applier_marks_backend_unhealthy_after_failure_threshold() {
+            let pool = test_upstream_pool();
+            let feedback = BackendRequestFeedback::failure(
                 BackendIdentity::new("127.0.0.1:8080"),
                 Duration::from_millis(10),
                 Some(503),
                 Some(spooky_lb::health::HealthFailureReason::HttpStatus5xx),
-            ),
-        );
-        assert!(transition.is_none());
+            );
+            assert!(apply_backend_request_feedback(Some(&pool), Some(0), &feedback).is_none());
+            assert!(apply_backend_request_feedback(Some(&pool), Some(0), &feedback).is_none());
+            let unhealthy = apply_backend_request_feedback(Some(&pool), Some(0), &feedback);
+            assert!(matches!(unhealthy, Some(HealthTransition::BecameUnhealthy)));
+        }
 
-        let transition = apply_backend_request_feedback(
-            Some(&pool),
-            Some(0),
-            &BackendRequestFeedback::failure(
+        #[test]
+        fn request_accounting_applier_finishes_inflight_request() {
+            let pool = test_upstream_pool();
+            {
+                let guard = pool.read().expect("read");
+                assert!(guard.begin_request_if_healthy(0));
+            }
+
+            apply_backend_request_accounting(
+                Some(&pool),
+                Some(0),
+                Duration::from_millis(15),
+                Some(200),
+            );
+
+            let guard = pool.read().expect("read");
+            let state = guard.backend_runtime_state(0).expect("backend state");
+            assert_eq!(state.active_requests, 0);
+            assert!(state.ewma_latency_ms.is_some());
+        }
+
+        #[test]
+        fn coordinator_request_feedback_updates_inventory_consistently() {
+            let pool = test_upstream_pool();
+            let store = Arc::new(RuntimeBackendResolutionStore::new([
+                RuntimeBackendResolution::hostname(
+                    "127.0.0.1:8080".to_string(),
+                    "backend.internal".to_string(),
+                    8080,
+                ),
+            ]));
+            let coordinator = BackendLifecycleCoordinator::new(store);
+            let mut pools = HashMap::new();
+            pools.insert("api".to_string(), Arc::clone(&pool));
+
+            let transition = apply_backend_request_feedback(
+                Some(&pool),
+                Some(0),
+                &BackendRequestFeedback::failure(
+                    BackendIdentity::new("127.0.0.1:8080"),
+                    Duration::from_millis(10),
+                    Some(503),
+                    Some(spooky_lb::health::HealthFailureReason::HttpStatus5xx),
+                ),
+            );
+            assert!(transition.is_none());
+
+            let transition = apply_backend_request_feedback(
+                Some(&pool),
+                Some(0),
+                &BackendRequestFeedback::failure(
+                    BackendIdentity::new("127.0.0.1:8080"),
+                    Duration::from_millis(10),
+                    Some(503),
+                    Some(spooky_lb::health::HealthFailureReason::HttpStatus5xx),
+                ),
+            );
+            assert!(transition.is_none());
+
+            let transition = apply_backend_request_feedback(
+                Some(&pool),
+                Some(0),
+                &BackendRequestFeedback::failure(
+                    BackendIdentity::new("127.0.0.1:8080"),
+                    Duration::from_millis(10),
+                    Some(503),
+                    Some(spooky_lb::health::HealthFailureReason::HttpStatus5xx),
+                ),
+            );
+            assert!(matches!(
+                transition,
+                Some(HealthTransition::BecameUnhealthy)
+            ));
+
+            let inventory = coordinator.snapshot_inventory(&pools);
+            let backend = inventory
+                .backends
+                .iter()
+                .find(|backend| backend.identity.backend_addr == "127.0.0.1:8080")
+                .expect("backend inventory");
+            assert!(matches!(
+                backend.health,
+                BackendHealthState::Unhealthy { .. }
+            ));
+            assert!(!backend.placements[0].healthy);
+            assert_eq!(inventory.summary().healthy_backends, 0);
+        }
+
+        #[test]
+        fn request_feedback_does_not_duplicate_active_health_check_ownership() {
+            let pool = test_active_health_upstream_pool();
+            let store = Arc::new(RuntimeBackendResolutionStore::new([
+                RuntimeBackendResolution::hostname(
+                    "127.0.0.1:8080".to_string(),
+                    "backend.internal".to_string(),
+                    8080,
+                ),
+            ]));
+            let coordinator = BackendLifecycleCoordinator::new(store);
+            let mut pools = HashMap::new();
+            pools.insert("api".to_string(), Arc::clone(&pool));
+
+            let transition = apply_backend_request_feedback(
+                Some(&pool),
+                Some(0),
+                &BackendRequestFeedback::failure(
+                    BackendIdentity::new("127.0.0.1:8080"),
+                    Duration::from_millis(10),
+                    Some(503),
+                    Some(spooky_lb::health::HealthFailureReason::HttpStatus5xx),
+                ),
+            );
+            assert!(transition.is_none());
+            assert_eq!(
+                coordinator
+                    .snapshot_inventory(&pools)
+                    .summary()
+                    .healthy_backends,
+                1
+            );
+
+            let failure = evaluate_active_health_check(
                 BackendIdentity::new("127.0.0.1:8080"),
-                Duration::from_millis(10),
-                Some(503),
-                Some(spooky_lb::health::HealthFailureReason::HttpStatus5xx),
-            ),
-        );
-        assert!(transition.is_none());
-
-        let transition = apply_backend_request_feedback(
-            Some(&pool),
-            Some(0),
-            &BackendRequestFeedback::failure(
-                BackendIdentity::new("127.0.0.1:8080"),
-                Duration::from_millis(10),
-                Some(503),
-                Some(spooky_lb::health::HealthFailureReason::HttpStatus5xx),
-            ),
-        );
-        assert!(matches!(
-            transition,
-            Some(HealthTransition::BecameUnhealthy)
-        ));
-
-        let inventory = coordinator.snapshot_inventory(&pools);
-        let backend = inventory
-            .backends
-            .iter()
-            .find(|backend| backend.identity.backend_addr == "127.0.0.1:8080")
-            .expect("backend inventory");
-        assert!(matches!(
-            backend.health,
-            BackendHealthState::Unhealthy { .. }
-        ));
-        assert!(!backend.placements[0].healthy);
-        assert_eq!(inventory.summary().healthy_backends, 0);
-    }
-
-    #[test]
-    fn failed_refresh_preserves_existing_resolution_and_generation() {
-        let backend_addr = "http://backend.internal:8080";
-        let retained_addrs = vec!["10.0.0.10:8080".parse::<SocketAddr>().expect("addr")];
-        let store = Arc::new(RuntimeBackendResolutionStore::new([
-            RuntimeBackendResolution::hostname(
-                backend_addr.to_string(),
-                "backend.internal".to_string(),
-                8080,
-            ),
-        ]));
-        store
-            .apply_resolution_refresh(
-                backend_addr,
-                retained_addrs.clone(),
-                std::time::SystemTime::UNIX_EPOCH,
-            )
-            .expect("seed refresh");
-        let coordinator = BackendLifecycleCoordinator::new(Arc::clone(&store));
-        let resolver = SharedDnsResolver::new();
-        let transport_pool = test_transport_pool(backend_addr);
-        let backend = coordinator.backend(backend_addr).expect("backend");
-
-        let outcome = coordinator.apply_refresh(
-            &backend,
-            Err("nxdomain".to_string()),
-            &resolver,
-            &transport_pool,
-        );
-
-        assert!(matches!(
-            outcome,
-            BackendDnsRefreshApplication::LookupFailed {
-                retained_addrs: ref actual,
-                ..
-            } if *actual == retained_addrs
-        ));
-        let snapshot = coordinator
-            .snapshot_backend(backend_addr)
-            .expect("snapshot after failed refresh");
-        assert_eq!(snapshot.resolution.resolved_addrs, retained_addrs);
-        assert_eq!(snapshot.resolution.refresh_generation, 1);
-        assert_eq!(
-            outcome.classification(),
-            BackendRefreshClassification::FailedActivePreserved
-        );
-    }
-
-    #[test]
-    fn inventory_marks_missing_pool_members_as_removed_without_losing_live_placements() {
-        let store = Arc::new(RuntimeBackendResolutionStore::new([
-            RuntimeBackendResolution::hostname(
-                "127.0.0.1:8080".to_string(),
-                "backend-a.internal".to_string(),
-                8080,
-            ),
-            RuntimeBackendResolution::hostname(
-                "127.0.0.1:9090".to_string(),
-                "backend-b.internal".to_string(),
-                9090,
-            ),
-        ]));
-        let coordinator = BackendLifecycleCoordinator::new(store);
-        let mut pools = HashMap::new();
-        pools.insert("api".to_string(), test_upstream_pool());
-
-        let inventory = coordinator.snapshot_inventory(&pools);
-        let active = inventory
-            .backends
-            .iter()
-            .find(|backend| backend.identity.backend_addr == "127.0.0.1:8080")
-            .expect("active backend");
-        let removed = inventory
-            .backends
-            .iter()
-            .find(|backend| backend.identity.backend_addr == "127.0.0.1:9090")
-            .expect("removed backend");
-
-        assert_eq!(active.membership, BackendMembershipState::Active);
-        assert_eq!(active.placements.len(), 1);
-        assert_eq!(removed.membership, BackendMembershipState::Removed);
-        assert!(removed.placements.is_empty());
-        assert_eq!(inventory.summary().total_backends, 1);
-    }
-
-    #[test]
-    fn request_feedback_does_not_duplicate_active_health_check_ownership() {
-        let pool = test_active_health_upstream_pool();
-        let store = Arc::new(RuntimeBackendResolutionStore::new([
-            RuntimeBackendResolution::hostname(
-                "127.0.0.1:8080".to_string(),
-                "backend.internal".to_string(),
-                8080,
-            ),
-        ]));
-        let coordinator = BackendLifecycleCoordinator::new(store);
-        let mut pools = HashMap::new();
-        pools.insert("api".to_string(), Arc::clone(&pool));
-
-        let transition = apply_backend_request_feedback(
-            Some(&pool),
-            Some(0),
-            &BackendRequestFeedback::failure(
-                BackendIdentity::new("127.0.0.1:8080"),
-                Duration::from_millis(10),
-                Some(503),
-                Some(spooky_lb::health::HealthFailureReason::HttpStatus5xx),
-            ),
-        );
-        assert!(transition.is_none());
-        assert_eq!(
-            coordinator
-                .snapshot_inventory(&pools)
-                .summary()
-                .healthy_backends,
-            1
-        );
-
-        let failure = evaluate_active_health_check(
-            BackendIdentity::new("127.0.0.1:8080"),
-            BackendHealthObservationOutcome::Failure,
-            Some(spooky_lb::health::HealthFailureReason::Transport),
-            100,
-            0,
-        );
-        let transition =
-            coordinator.apply_health_observation(Some(&pool), Some(0), &failure.observation);
-        assert!(matches!(
-            transition,
-            Some(HealthTransition::BecameUnhealthy)
-        ));
-        assert_eq!(
-            coordinator
-                .snapshot_inventory(&pools)
-                .summary()
-                .healthy_backends,
-            0
-        );
+                BackendHealthObservationOutcome::Failure,
+                Some(spooky_lb::health::HealthFailureReason::Transport),
+                100,
+                0,
+            );
+            let transition =
+                coordinator.apply_health_observation(Some(&pool), Some(0), &failure.observation);
+            assert!(matches!(
+                transition,
+                Some(HealthTransition::BecameUnhealthy)
+            ));
+            assert_eq!(
+                coordinator
+                    .snapshot_inventory(&pools)
+                    .summary()
+                    .healthy_backends,
+                0
+            );
+        }
     }
 }

--- a/crates/edge/src/runtime/backend/lifecycle.rs
+++ b/crates/edge/src/runtime/backend/lifecycle.rs
@@ -1501,6 +1501,105 @@ mod tests {
         }
 
         #[test]
+        fn request_feedback_success_keeps_backend_healthy_without_transition() {
+            let pool = test_upstream_pool();
+            let feedback = BackendRequestFeedback::from_status(
+                BackendIdentity::new("127.0.0.1:8080"),
+                Duration::from_millis(10),
+                http::StatusCode::OK,
+            );
+
+            let transition = apply_backend_request_feedback(Some(&pool), Some(0), &feedback);
+            assert!(
+                transition.is_none(),
+                "healthy request completion should not invent a transition"
+            );
+            assert!(
+                pool.read().expect("read").is_backend_healthy(0),
+                "success feedback must preserve healthy state"
+            );
+        }
+
+        #[test]
+        fn request_feedback_client_error_is_neutral_for_health() {
+            let pool = test_upstream_pool();
+            let feedback = BackendRequestFeedback::from_status(
+                BackendIdentity::new("127.0.0.1:8080"),
+                Duration::from_millis(10),
+                http::StatusCode::NOT_FOUND,
+            );
+
+            let transition = apply_backend_request_feedback(Some(&pool), Some(0), &feedback);
+            assert!(
+                transition.is_none(),
+                "client errors should not mutate backend health"
+            );
+            assert!(
+                pool.read().expect("read").is_backend_healthy(0),
+                "neutral feedback must leave pool health unchanged"
+            );
+        }
+
+        #[test]
+        fn request_feedback_timeout_and_transport_failures_share_health_effect_contract() {
+            let timeout_pool = test_upstream_pool();
+            let timeout_feedback = BackendRequestFeedback::failure(
+                BackendIdentity::new("127.0.0.1:8080"),
+                Duration::from_millis(100),
+                None,
+                Some(spooky_lb::health::HealthFailureReason::Timeout),
+            );
+            assert!(apply_backend_request_feedback(Some(&timeout_pool), Some(0), &timeout_feedback).is_none());
+            assert!(apply_backend_request_feedback(Some(&timeout_pool), Some(0), &timeout_feedback).is_none());
+            let timeout_transition =
+                apply_backend_request_feedback(Some(&timeout_pool), Some(0), &timeout_feedback);
+            assert!(matches!(
+                timeout_transition,
+                Some(HealthTransition::BecameUnhealthy)
+            ));
+
+            let transport_pool = test_upstream_pool();
+            let transport_feedback = BackendRequestFeedback::failure(
+                BackendIdentity::new("127.0.0.1:8080"),
+                Duration::from_millis(100),
+                None,
+                Some(spooky_lb::health::HealthFailureReason::Transport),
+            );
+            assert!(apply_backend_request_feedback(Some(&transport_pool), Some(0), &transport_feedback).is_none());
+            assert!(apply_backend_request_feedback(Some(&transport_pool), Some(0), &transport_feedback).is_none());
+            let transport_transition = apply_backend_request_feedback(
+                Some(&transport_pool),
+                Some(0),
+                &transport_feedback,
+            );
+            assert!(matches!(
+                transport_transition,
+                Some(HealthTransition::BecameUnhealthy)
+            ));
+        }
+
+        #[test]
+        fn request_feedback_without_reason_does_not_change_health() {
+            let pool = test_upstream_pool();
+            let feedback = BackendRequestFeedback::failure(
+                BackendIdentity::new("127.0.0.1:8080"),
+                Duration::from_millis(25),
+                Some(503),
+                None,
+            );
+
+            let transition = apply_backend_request_feedback(Some(&pool), Some(0), &feedback);
+            assert!(
+                transition.is_none(),
+                "failure feedback without a mapped health reason must not mutate health"
+            );
+            assert!(
+                pool.read().expect("read").is_backend_healthy(0),
+                "reasonless failure feedback should stay a no-op for health"
+            );
+        }
+
+        #[test]
         fn request_accounting_applier_finishes_inflight_request() {
             let pool = test_upstream_pool();
             {
@@ -1519,6 +1618,50 @@ mod tests {
             let state = guard.backend_runtime_state(0).expect("backend state");
             assert_eq!(state.active_requests, 0);
             assert!(state.ewma_latency_ms.is_some());
+        }
+
+        #[test]
+        fn request_feedback_coordinator_inventory_tracks_timeout_failures() {
+            let pool = test_upstream_pool();
+            let store = Arc::new(RuntimeBackendResolutionStore::new([
+                RuntimeBackendResolution::hostname(
+                    "127.0.0.1:8080".to_string(),
+                    "backend.internal".to_string(),
+                    8080,
+                ),
+            ]));
+            let coordinator = BackendLifecycleCoordinator::new(store);
+            let mut pools = HashMap::new();
+            pools.insert("api".to_string(), Arc::clone(&pool));
+
+            let feedback = BackendRequestFeedback::failure(
+                BackendIdentity::new("127.0.0.1:8080"),
+                Duration::from_millis(10),
+                None,
+                Some(spooky_lb::health::HealthFailureReason::Timeout),
+            );
+            assert!(apply_backend_request_feedback(Some(&pool), Some(0), &feedback).is_none());
+            assert!(apply_backend_request_feedback(Some(&pool), Some(0), &feedback).is_none());
+            let transition = apply_backend_request_feedback(Some(&pool), Some(0), &feedback);
+            assert!(matches!(
+                transition,
+                Some(HealthTransition::BecameUnhealthy)
+            ));
+
+            let inventory = coordinator.snapshot_inventory(&pools);
+            let backend = inventory
+                .backends
+                .iter()
+                .find(|backend| backend.identity.backend_addr == "127.0.0.1:8080")
+                .expect("backend inventory");
+            assert!(matches!(
+                backend.health,
+                BackendHealthState::Unhealthy { reason: None }
+            ));
+            assert!(
+                !backend.placements[0].healthy,
+                "coordinator inventory must reflect the pool mutation contract instead of caller-local branching"
+            );
         }
 
         #[test]

--- a/crates/edge/src/runtime/backend/lifecycle.rs
+++ b/crates/edge/src/runtime/backend/lifecycle.rs
@@ -802,7 +802,6 @@ mod tests {
         .expect("transport pool")
     }
 
-
     mod refresh_application {
         use super::*;
 
@@ -1191,7 +1190,11 @@ mod tests {
                 ),
             ]));
             store
-                .apply_resolution_refresh(backend_addr, resolved_addrs.clone(), SystemTime::UNIX_EPOCH)
+                .apply_resolution_refresh(
+                    backend_addr,
+                    resolved_addrs.clone(),
+                    SystemTime::UNIX_EPOCH,
+                )
                 .expect("seed refresh");
             let coordinator = BackendLifecycleCoordinator::new(store);
 
@@ -1294,7 +1297,11 @@ mod tests {
                 ),
             ]));
             store
-                .apply_resolution_refresh(placed_backend, resolved_addrs.clone(), SystemTime::UNIX_EPOCH)
+                .apply_resolution_refresh(
+                    placed_backend,
+                    resolved_addrs.clone(),
+                    SystemTime::UNIX_EPOCH,
+                )
                 .expect("seed refresh");
             let coordinator = BackendLifecycleCoordinator::new(Arc::clone(&store));
             let pool = test_active_health_upstream_pool();
@@ -1329,7 +1336,10 @@ mod tests {
             ));
             assert_eq!(active.resolution.resolved_addrs, resolved_addrs);
             assert_eq!(active.resolution.refresh_generation, 1);
-            assert_eq!(active.resolution.last_refresh_success_at, Some(SystemTime::UNIX_EPOCH));
+            assert_eq!(
+                active.resolution.last_refresh_success_at,
+                Some(SystemTime::UNIX_EPOCH)
+            );
             assert_eq!(active.placements.len(), 1);
             assert!(!active.placements[0].healthy);
 
@@ -1395,7 +1405,10 @@ mod tests {
             );
 
             let transition = apply_backend_health_observation(Some(&pool), Some(0), &observation);
-            assert!(transition.is_none(), "healthy backend should not re-transition");
+            assert!(
+                transition.is_none(),
+                "healthy backend should not re-transition"
+            );
 
             let guard = pool.read().expect("read");
             let state = guard.backend_runtime_state(0).expect("backend state");
@@ -1469,7 +1482,10 @@ mod tests {
             };
 
             let transition = apply_backend_health_observation(Some(&pool), Some(0), &no_reason);
-            assert!(transition.is_none(), "missing reason must not mutate health");
+            assert!(
+                transition.is_none(),
+                "missing reason must not mutate health"
+            );
             assert!(
                 pool.read().expect("read").is_backend_healthy(0),
                 "pool should remain healthy without a mapped reason"
@@ -1482,12 +1498,8 @@ mod tests {
                 reason: Some(spooky_lb::health::HealthFailureReason::Timeout),
             };
 
-            assert!(
-                apply_backend_health_observation(Some(&pool), Some(0), &failure).is_none()
-            );
-            assert!(
-                apply_backend_health_observation(Some(&pool), Some(0), &failure).is_none()
-            );
+            assert!(apply_backend_health_observation(Some(&pool), Some(0), &failure).is_none());
+            assert!(apply_backend_health_observation(Some(&pool), Some(0), &failure).is_none());
             let transition = apply_backend_health_observation(Some(&pool), Some(0), &failure);
             assert!(matches!(
                 transition,
@@ -1532,8 +1544,7 @@ mod tests {
                     .apply_health_observation(Some(&pool), Some(0), &failure)
                     .is_none()
             );
-            let transition =
-                coordinator.apply_health_observation(Some(&pool), Some(0), &failure);
+            let transition = coordinator.apply_health_observation(Some(&pool), Some(0), &failure);
             assert!(matches!(
                 transition,
                 Some(HealthTransition::BecameUnhealthy)
@@ -1656,8 +1667,14 @@ mod tests {
                 None,
                 Some(spooky_lb::health::HealthFailureReason::Timeout),
             );
-            assert!(apply_backend_request_feedback(Some(&timeout_pool), Some(0), &timeout_feedback).is_none());
-            assert!(apply_backend_request_feedback(Some(&timeout_pool), Some(0), &timeout_feedback).is_none());
+            assert!(
+                apply_backend_request_feedback(Some(&timeout_pool), Some(0), &timeout_feedback)
+                    .is_none()
+            );
+            assert!(
+                apply_backend_request_feedback(Some(&timeout_pool), Some(0), &timeout_feedback)
+                    .is_none()
+            );
             let timeout_transition =
                 apply_backend_request_feedback(Some(&timeout_pool), Some(0), &timeout_feedback);
             assert!(matches!(
@@ -1672,13 +1689,16 @@ mod tests {
                 None,
                 Some(spooky_lb::health::HealthFailureReason::Transport),
             );
-            assert!(apply_backend_request_feedback(Some(&transport_pool), Some(0), &transport_feedback).is_none());
-            assert!(apply_backend_request_feedback(Some(&transport_pool), Some(0), &transport_feedback).is_none());
-            let transport_transition = apply_backend_request_feedback(
-                Some(&transport_pool),
-                Some(0),
-                &transport_feedback,
+            assert!(
+                apply_backend_request_feedback(Some(&transport_pool), Some(0), &transport_feedback)
+                    .is_none()
             );
+            assert!(
+                apply_backend_request_feedback(Some(&transport_pool), Some(0), &transport_feedback)
+                    .is_none()
+            );
+            let transport_transition =
+                apply_backend_request_feedback(Some(&transport_pool), Some(0), &transport_feedback);
             assert!(matches!(
                 transport_transition,
                 Some(HealthTransition::BecameUnhealthy)

--- a/crates/edge/src/runtime/backend/lifecycle.rs
+++ b/crates/edge/src/runtime/backend/lifecycle.rs
@@ -988,6 +988,68 @@ mod tests {
         }
 
         #[test]
+        fn successive_refreshes_increment_generation_across_outcomes() {
+            let backend_addr = "http://backend.internal:8080";
+            let initial_addrs = vec!["10.0.0.10:8080".parse::<SocketAddr>().expect("addr")];
+            let updated_addrs = vec!["10.0.0.11:8080".parse::<SocketAddr>().expect("addr")];
+            let store = Arc::new(RuntimeBackendResolutionStore::new([
+                RuntimeBackendResolution::hostname(
+                    backend_addr.to_string(),
+                    "backend.internal".to_string(),
+                    8080,
+                ),
+            ]));
+            store
+                .apply_resolution_refresh(
+                    backend_addr,
+                    initial_addrs,
+                    std::time::SystemTime::UNIX_EPOCH,
+                )
+                .expect("seed refresh");
+            let coordinator = BackendLifecycleCoordinator::new(Arc::clone(&store));
+            let resolver = SharedDnsResolver::new();
+            let transport_pool = test_transport_pool(backend_addr);
+            let backend = coordinator.backend(backend_addr).expect("backend");
+
+            let refreshed = coordinator.apply_refresh(
+                &backend,
+                Ok(updated_addrs.clone()),
+                &resolver,
+                &transport_pool,
+            );
+            assert!(matches!(
+                refreshed,
+                BackendDnsRefreshApplication::Updated {
+                    generation: 2,
+                    current_addrs,
+                    ..
+                } if current_addrs == updated_addrs
+            ));
+
+            let backend = coordinator.backend(backend_addr).expect("backend");
+            let unchanged = coordinator.apply_refresh(
+                &backend,
+                Ok(updated_addrs.clone()),
+                &resolver,
+                &transport_pool,
+            );
+            assert!(matches!(
+                unchanged,
+                BackendDnsRefreshApplication::Unchanged {
+                    generation: 3,
+                    current_addrs,
+                    ..
+                } if current_addrs == updated_addrs
+            ));
+
+            let snapshot = coordinator
+                .snapshot_backend(backend_addr)
+                .expect("snapshot");
+            assert_eq!(snapshot.resolution.resolved_addrs, updated_addrs);
+            assert_eq!(snapshot.resolution.refresh_generation, 3);
+        }
+
+        #[test]
         fn empty_dns_answer_retains_prior_addresses() {
             let backend_addr = "http://backend.internal:8080";
             let retained_addrs = vec!["10.0.0.10:8080".parse::<SocketAddr>().expect("addr")];

--- a/crates/edge/src/runtime/backend/lifecycle.rs
+++ b/crates/edge/src/runtime/backend/lifecycle.rs
@@ -1279,6 +1279,23 @@ mod tests {
         }
 
         #[test]
+        fn success_observation_keeps_healthy_backend_aligned_with_pool_state() {
+            let pool = test_active_health_upstream_pool();
+            let observation = BackendHealthObservation::active_check(
+                BackendIdentity::new("127.0.0.1:8080"),
+                BackendHealthObservationOutcome::Success,
+                None,
+            );
+
+            let transition = apply_backend_health_observation(Some(&pool), Some(0), &observation);
+            assert!(transition.is_none(), "healthy backend should not re-transition");
+
+            let guard = pool.read().expect("read");
+            let state = guard.backend_runtime_state(0).expect("backend state");
+            assert!(state.healthy, "pool runtime state must remain healthy");
+        }
+
+        #[test]
         fn coordinator_health_observation_marks_backend_unhealthy_and_recovers() {
             let pool = test_active_health_upstream_pool();
             let store = Arc::new(RuntimeBackendResolutionStore::new([
@@ -1323,6 +1340,145 @@ mod tests {
 
             let summary = coordinator.snapshot_inventory(&pools).summary();
             assert_eq!(summary.healthy_backends, 1);
+
+            let backend = coordinator
+                .snapshot_inventory(&pools)
+                .backends
+                .into_iter()
+                .find(|backend| backend.identity.backend_addr == "127.0.0.1:8080")
+                .expect("backend inventory");
+            assert!(matches!(backend.health, BackendHealthState::Healthy));
+            assert!(backend.placements[0].healthy);
+        }
+
+        #[test]
+        fn passive_failure_observation_requires_reason_and_threshold_before_unhealthy() {
+            let pool = test_upstream_pool();
+            let no_reason = BackendHealthObservation {
+                identity: BackendIdentity::new("127.0.0.1:8080"),
+                source: BackendHealthObservationSource::PassiveRequest,
+                outcome: BackendHealthObservationOutcome::Failure,
+                reason: None,
+            };
+
+            let transition = apply_backend_health_observation(Some(&pool), Some(0), &no_reason);
+            assert!(transition.is_none(), "missing reason must not mutate health");
+            assert!(
+                pool.read().expect("read").is_backend_healthy(0),
+                "pool should remain healthy without a mapped reason"
+            );
+
+            let failure = BackendHealthObservation {
+                identity: BackendIdentity::new("127.0.0.1:8080"),
+                source: BackendHealthObservationSource::PassiveRequest,
+                outcome: BackendHealthObservationOutcome::Failure,
+                reason: Some(spooky_lb::health::HealthFailureReason::Timeout),
+            };
+
+            assert!(
+                apply_backend_health_observation(Some(&pool), Some(0), &failure).is_none()
+            );
+            assert!(
+                apply_backend_health_observation(Some(&pool), Some(0), &failure).is_none()
+            );
+            let transition = apply_backend_health_observation(Some(&pool), Some(0), &failure);
+            assert!(matches!(
+                transition,
+                Some(HealthTransition::BecameUnhealthy)
+            ));
+
+            let guard = pool.read().expect("read");
+            let state = guard.backend_runtime_state(0).expect("backend state");
+            assert!(
+                !state.healthy,
+                "pool runtime state must reflect passive failure threshold crossing"
+            );
+        }
+
+        #[test]
+        fn passive_failure_observation_keeps_inventory_aligned_with_pool_state() {
+            let pool = test_upstream_pool();
+            let store = Arc::new(RuntimeBackendResolutionStore::new([
+                RuntimeBackendResolution::hostname(
+                    "127.0.0.1:8080".to_string(),
+                    "backend.internal".to_string(),
+                    8080,
+                ),
+            ]));
+            let coordinator = BackendLifecycleCoordinator::new(store);
+            let mut pools = HashMap::new();
+            pools.insert("api".to_string(), Arc::clone(&pool));
+
+            let failure = BackendHealthObservation {
+                identity: BackendIdentity::new("127.0.0.1:8080"),
+                source: BackendHealthObservationSource::PassiveRequest,
+                outcome: BackendHealthObservationOutcome::Failure,
+                reason: Some(spooky_lb::health::HealthFailureReason::Transport),
+            };
+            assert!(
+                coordinator
+                    .apply_health_observation(Some(&pool), Some(0), &failure)
+                    .is_none()
+            );
+            assert!(
+                coordinator
+                    .apply_health_observation(Some(&pool), Some(0), &failure)
+                    .is_none()
+            );
+            let transition =
+                coordinator.apply_health_observation(Some(&pool), Some(0), &failure);
+            assert!(matches!(
+                transition,
+                Some(HealthTransition::BecameUnhealthy)
+            ));
+
+            let inventory = coordinator.snapshot_inventory(&pools);
+            let backend = inventory
+                .backends
+                .iter()
+                .find(|backend| backend.identity.backend_addr == "127.0.0.1:8080")
+                .expect("backend inventory after failure");
+            assert!(matches!(
+                backend.health,
+                BackendHealthState::Unhealthy { reason: None }
+            ));
+            assert!(
+                !backend.placements[0].healthy,
+                "placement health must match lifecycle unhealthy state"
+            );
+        }
+
+        #[test]
+        fn passive_success_does_not_override_health_without_transition() {
+            let pool = test_upstream_pool();
+            let failure = BackendHealthObservation {
+                identity: BackendIdentity::new("127.0.0.1:8080"),
+                source: BackendHealthObservationSource::PassiveRequest,
+                outcome: BackendHealthObservationOutcome::Failure,
+                reason: Some(spooky_lb::health::HealthFailureReason::Transport),
+            };
+            assert!(apply_backend_health_observation(Some(&pool), Some(0), &failure).is_none());
+            assert!(apply_backend_health_observation(Some(&pool), Some(0), &failure).is_none());
+            assert!(matches!(
+                apply_backend_health_observation(Some(&pool), Some(0), &failure),
+                Some(HealthTransition::BecameUnhealthy)
+            ));
+
+            let success = BackendHealthObservation {
+                identity: BackendIdentity::new("127.0.0.1:8080"),
+                source: BackendHealthObservationSource::PassiveRequest,
+                outcome: BackendHealthObservationOutcome::Success,
+                reason: None,
+            };
+            let transition = apply_backend_health_observation(Some(&pool), Some(0), &success);
+            assert!(
+                transition.is_none(),
+                "passive success should not invent a recovery transition on its own"
+            );
+            assert!(
+                !pool.read().expect("read").is_backend_healthy(0),
+                "pool should remain unhealthy until the proper recovery path runs"
+            );
         }
     }
 

--- a/crates/edge/src/runtime/backend/store.rs
+++ b/crates/edge/src/runtime/backend/store.rs
@@ -177,4 +177,51 @@ mod tests {
             }
         ));
     }
+
+    #[test]
+    fn lifecycle_store_returns_unchanged_refresh_mutation_and_increments_generation() {
+        let backend_addr = "https://backend.internal:8443";
+        let refreshed_at = SystemTime::UNIX_EPOCH;
+        let resolved_addrs = vec!["10.0.0.10:8443".parse::<SocketAddr>().expect("addr")];
+        let store = RuntimeBackendResolutionStore::new([RuntimeBackendResolution::hostname(
+            backend_addr.to_string(),
+            "backend.internal".to_string(),
+            8443,
+        )]);
+
+        let first_mutation = store
+            .apply_resolution_refresh(backend_addr, resolved_addrs.clone(), refreshed_at)
+            .expect("first refresh mutation");
+        assert!(matches!(
+            first_mutation,
+            BackendLifecycleMutation::ResolutionUpdated {
+                result: BackendRefreshResult {
+                    outcome: BackendRefreshOutcome::Updated {
+                        refresh_generation: 1,
+                        ..
+                    },
+                    ..
+                },
+                ..
+            }
+        ));
+
+        let second_mutation = store
+            .apply_resolution_refresh(backend_addr, resolved_addrs.clone(), refreshed_at)
+            .expect("second refresh mutation");
+        assert!(matches!(
+            second_mutation,
+            BackendLifecycleMutation::ResolutionUpdated {
+                result: BackendRefreshResult {
+                    outcome: BackendRefreshOutcome::Unchanged {
+                        refresh_generation: 2,
+                        ..
+                    },
+                    ..
+                },
+                state,
+                ..
+            } if state.resolved_addrs == resolved_addrs && state.refresh_generation == 2
+        ));
+    }
 }

--- a/crates/lb/src/alternate_backend.rs
+++ b/crates/lb/src/alternate_backend.rs
@@ -189,6 +189,24 @@ mod tests {
     }
 
     #[test]
+    fn excludes_multiple_prior_backends_before_selecting_an_alternate() {
+        let pool = UpstreamPool::from_runtime_upstream(&runtime_upstream(upstream(
+            "round-robin",
+            &["http://a", "http://b", "http://c", "http://d"],
+        )))
+        .expect("pool");
+
+        let decision = choose_alternate_backend(&pool, &[0, 1, 2], None);
+        assert_eq!(
+            decision,
+            AlternateBackendDecision::Select(AlternateBackendChoice {
+                index: 3,
+                mode: AlternateBackendSelectionMode::HealthyFallback,
+            })
+        );
+    }
+
+    #[test]
     fn falls_back_to_healthy_scan_when_readonly_strategy_is_unavailable() {
         let pool = UpstreamPool::from_runtime_upstream(&runtime_upstream(upstream(
             "consistent-hash",
@@ -201,6 +219,26 @@ mod tests {
             decision,
             AlternateBackendDecision::Select(AlternateBackendChoice {
                 index: 1,
+                mode: AlternateBackendSelectionMode::HealthyFallback,
+            })
+        );
+    }
+
+    #[test]
+    fn ignores_unhealthy_backends_when_scanning_for_alternates() {
+        let mut pool = UpstreamPool::from_runtime_upstream(&runtime_upstream(upstream(
+            "round-robin",
+            &["http://a", "http://b", "http://c"],
+        )))
+        .expect("pool");
+
+        let _ = pool.mark_backend_failure_from_active_check(1);
+
+        let decision = choose_alternate_backend(&pool, &[0], None);
+        assert_eq!(
+            decision,
+            AlternateBackendDecision::Select(AlternateBackendChoice {
+                index: 2,
                 mode: AlternateBackendSelectionMode::HealthyFallback,
             })
         );
@@ -224,6 +262,51 @@ mod tests {
     }
 
     #[test]
+    fn readonly_strategy_interaction_uses_load_balancer_mode_for_alternates() {
+        let pool = UpstreamPool::from_runtime_upstream(&runtime_upstream(upstream(
+            "round-robin",
+            &["http://a", "http://b", "http://c"],
+        )))
+        .expect("pool");
+
+        let first = choose_alternate_backend(&pool, &[], Some("tenant-a"));
+        let second = choose_alternate_backend(&pool, &[], Some("tenant-b"));
+
+        assert!(matches!(
+            first,
+            AlternateBackendDecision::Select(AlternateBackendChoice {
+                mode: AlternateBackendSelectionMode::LoadBalancerReadonly,
+                ..
+            })
+        ));
+        assert!(matches!(
+            second,
+            AlternateBackendDecision::Select(AlternateBackendChoice {
+                mode: AlternateBackendSelectionMode::LoadBalancerReadonly,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn non_readonly_strategies_use_healthy_fallback_for_alternates() {
+        let pool = UpstreamPool::from_runtime_upstream(&runtime_upstream(upstream(
+            "consistent-hash",
+            &["http://a", "http://b", "http://c"],
+        )))
+        .expect("pool");
+
+        let decision = choose_alternate_backend(&pool, &[0, 1], Some("tenant-a"));
+        assert_eq!(
+            decision,
+            AlternateBackendDecision::Select(AlternateBackendChoice {
+                index: 2,
+                mode: AlternateBackendSelectionMode::HealthyFallback,
+            })
+        );
+    }
+
+    #[test]
     fn reports_when_no_backends_are_healthy() {
         let mut pool = UpstreamPool::from_runtime_upstream(&runtime_upstream(upstream(
             "round-robin",
@@ -235,6 +318,29 @@ mod tests {
         let _ = pool.mark_backend_failure_from_active_check(1);
 
         let decision = choose_alternate_backend(&pool, &[], None);
+        assert_eq!(
+            decision,
+            AlternateBackendDecision::DoNotSelect {
+                denial: AlternateBackendFailureReason::NoHealthyBackends,
+            }
+        );
+    }
+
+    #[test]
+    fn denial_reason_stays_no_healthy_backends_even_when_failover_modes_are_disabled() {
+        let mut pool = UpstreamPool::from_runtime_upstream(&runtime_upstream(upstream(
+            "round-robin",
+            &["http://a", "http://b"],
+        )))
+        .expect("pool");
+        pool.set_alternate_backend_policy(RuntimeAlternateBackendPolicy {
+            readonly_lb_pick: false,
+            healthy_fallback: false,
+        });
+        let _ = pool.mark_backend_failure_from_active_check(0);
+        let _ = pool.mark_backend_failure_from_active_check(1);
+
+        let decision = choose_alternate_backend(&pool, &[0], None);
         assert_eq!(
             decision,
             AlternateBackendDecision::DoNotSelect {

--- a/crates/lb/src/alternate_backend.rs
+++ b/crates/lb/src/alternate_backend.rs
@@ -82,83 +82,23 @@ pub fn choose_alternate_backend(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
-    use spooky_config::{
-        config::{Backend, Config, HealthCheck, Listen, LoadBalancing, RouteMatch, Tls, Upstream},
-        runtime::{RuntimeAlternateBackendPolicy, RuntimeConfig, RuntimeUpstream},
-    };
+    use spooky_config::runtime::RuntimeAlternateBackendPolicy;
 
     use super::*;
-    fn upstream(lb_type: &str, backends: &[&str]) -> Upstream {
-        Upstream {
-            tls: None,
-            load_balancing: LoadBalancing {
-                lb_type: lb_type.to_string(),
-                key: None,
-            },
-            auth: Default::default(),
-            host_policy: Default::default(),
-            forwarded_headers: Default::default(),
-            route: RouteMatch::default(),
-            backends: backends
-                .iter()
-                .enumerate()
-                .map(|(index, address)| Backend {
-                    id: format!("backend-{index}"),
-                    address: (*address).to_string(),
-                    weight: 1,
-                    health_check: Some(HealthCheck {
-                        path: "/health".to_string(),
-                        interval: 1,
-                        timeout_ms: 1000,
-                        failure_threshold: 1,
-                        success_threshold: 1,
-                        cooldown_ms: 1000,
-                    }),
-                })
-                .collect(),
-        }
-    }
+    use crate::test_support::runtime_upstream_from_addresses;
 
-    fn runtime_upstream(upstream: Upstream) -> RuntimeUpstream {
-        let mut upstreams = HashMap::new();
-        upstreams.insert("api".to_string(), upstream);
-
-        RuntimeConfig::from_config(&Config {
-            version: 1,
-            listen: Listen {
-                protocol: "http1".to_string(),
-                tls: Tls {
-                    cert: "/tmp/test-cert.pem".to_string(),
-                    key: "/tmp/test-key.pem".to_string(),
-                    ..Tls::default()
-                },
-                ..Listen::default()
-            },
-            listeners: Vec::new(),
-            upstream: upstreams,
-            load_balancing: None,
-            upstream_tls: Default::default(),
-            log: Default::default(),
-            performance: Default::default(),
-            observability: Default::default(),
-            resilience: Default::default(),
-            security: Default::default(),
-        })
-        .expect("runtime config")
-        .upstreams
-        .remove("api")
-        .expect("runtime upstream")
+    fn pool_for(lb_type: &str, backends: &[&str]) -> UpstreamPool {
+        UpstreamPool::from_runtime_upstream(&runtime_upstream_from_addresses(
+            lb_type,
+            None,
+            backends,
+        ))
+        .expect("alternate-backend fixture pool should build")
     }
 
     #[test]
-    fn chooses_non_excluded_backend_from_readonly_lb_pick() {
-        let pool = UpstreamPool::from_runtime_upstream(&runtime_upstream(upstream(
-            "round-robin",
-            &["http://a", "http://b", "http://c"],
-        )))
-        .expect("pool");
+    fn readonly_lb_pick_wins_when_candidate_is_not_excluded() {
+        let pool = pool_for("round-robin", &["http://a", "http://b", "http://c"]);
 
         let decision = choose_alternate_backend(&pool, &[2], None);
         assert_eq!(
@@ -171,12 +111,8 @@ mod tests {
     }
 
     #[test]
-    fn falls_back_when_readonly_pick_hits_excluded_backend() {
-        let pool = UpstreamPool::from_runtime_upstream(&runtime_upstream(upstream(
-            "round-robin",
-            &["http://a", "http://b", "http://c"],
-        )))
-        .expect("pool");
+    fn healthy_fallback_runs_when_readonly_pick_hits_excluded_backend() {
+        let pool = pool_for("round-robin", &["http://a", "http://b", "http://c"]);
 
         let decision = choose_alternate_backend(&pool, &[0], None);
         assert_eq!(
@@ -189,12 +125,8 @@ mod tests {
     }
 
     #[test]
-    fn excludes_multiple_prior_backends_before_selecting_an_alternate() {
-        let pool = UpstreamPool::from_runtime_upstream(&runtime_upstream(upstream(
-            "round-robin",
-            &["http://a", "http://b", "http://c", "http://d"],
-        )))
-        .expect("pool");
+    fn alternate_selection_respects_multiple_excluded_backends() {
+        let pool = pool_for("round-robin", &["http://a", "http://b", "http://c", "http://d"]);
 
         let decision = choose_alternate_backend(&pool, &[0, 1, 2], None);
         assert_eq!(
@@ -207,12 +139,8 @@ mod tests {
     }
 
     #[test]
-    fn falls_back_to_healthy_scan_when_readonly_strategy_is_unavailable() {
-        let pool = UpstreamPool::from_runtime_upstream(&runtime_upstream(upstream(
-            "consistent-hash",
-            &["http://a", "http://b"],
-        )))
-        .expect("pool");
+    fn healthy_fallback_runs_when_strategy_has_no_readonly_pick() {
+        let pool = pool_for("consistent-hash", &["http://a", "http://b"]);
 
         let decision = choose_alternate_backend(&pool, &[0], None);
         assert_eq!(
@@ -225,12 +153,8 @@ mod tests {
     }
 
     #[test]
-    fn ignores_unhealthy_backends_when_scanning_for_alternates() {
-        let mut pool = UpstreamPool::from_runtime_upstream(&runtime_upstream(upstream(
-            "round-robin",
-            &["http://a", "http://b", "http://c"],
-        )))
-        .expect("pool");
+    fn healthy_fallback_skips_unhealthy_backends() {
+        let mut pool = pool_for("round-robin", &["http://a", "http://b", "http://c"]);
 
         let _ = pool.mark_backend_failure_from_active_check(1);
 
@@ -245,12 +169,8 @@ mod tests {
     }
 
     #[test]
-    fn reports_when_only_excluded_backends_are_healthy() {
-        let pool = UpstreamPool::from_runtime_upstream(&runtime_upstream(upstream(
-            "round-robin",
-            &["http://a"],
-        )))
-        .expect("pool");
+    fn alternate_selection_reports_only_excluded_backends_when_no_candidate_remains() {
+        let pool = pool_for("round-robin", &["http://a"]);
 
         let decision = choose_alternate_backend(&pool, &[0], None);
         assert_eq!(
@@ -263,11 +183,7 @@ mod tests {
 
     #[test]
     fn readonly_strategy_interaction_uses_load_balancer_mode_for_alternates() {
-        let pool = UpstreamPool::from_runtime_upstream(&runtime_upstream(upstream(
-            "round-robin",
-            &["http://a", "http://b", "http://c"],
-        )))
-        .expect("pool");
+        let pool = pool_for("round-robin", &["http://a", "http://b", "http://c"]);
 
         let first = choose_alternate_backend(&pool, &[], Some("tenant-a"));
         let second = choose_alternate_backend(&pool, &[], Some("tenant-b"));
@@ -290,11 +206,7 @@ mod tests {
 
     #[test]
     fn non_readonly_strategies_use_healthy_fallback_for_alternates() {
-        let pool = UpstreamPool::from_runtime_upstream(&runtime_upstream(upstream(
-            "consistent-hash",
-            &["http://a", "http://b", "http://c"],
-        )))
-        .expect("pool");
+        let pool = pool_for("consistent-hash", &["http://a", "http://b", "http://c"]);
 
         let decision = choose_alternate_backend(&pool, &[0, 1], Some("tenant-a"));
         assert_eq!(
@@ -307,12 +219,8 @@ mod tests {
     }
 
     #[test]
-    fn reports_when_no_backends_are_healthy() {
-        let mut pool = UpstreamPool::from_runtime_upstream(&runtime_upstream(upstream(
-            "round-robin",
-            &["http://a", "http://b"],
-        )))
-        .expect("pool");
+    fn alternate_selection_reports_no_healthy_backends_when_pool_is_drained() {
+        let mut pool = pool_for("round-robin", &["http://a", "http://b"]);
 
         let _ = pool.mark_backend_failure_from_active_check(0);
         let _ = pool.mark_backend_failure_from_active_check(1);
@@ -327,12 +235,8 @@ mod tests {
     }
 
     #[test]
-    fn denial_reason_stays_no_healthy_backends_even_when_failover_modes_are_disabled() {
-        let mut pool = UpstreamPool::from_runtime_upstream(&runtime_upstream(upstream(
-            "round-robin",
-            &["http://a", "http://b"],
-        )))
-        .expect("pool");
+    fn no_healthy_backend_denial_survives_policy_disablement() {
+        let mut pool = pool_for("round-robin", &["http://a", "http://b"]);
         pool.set_alternate_backend_policy(RuntimeAlternateBackendPolicy {
             readonly_lb_pick: false,
             healthy_fallback: false,
@@ -350,12 +254,8 @@ mod tests {
     }
 
     #[test]
-    fn suppresses_readonly_pick_when_policy_disables_it() {
-        let mut pool = UpstreamPool::from_runtime_upstream(&runtime_upstream(upstream(
-            "round-robin",
-            &["http://a", "http://b", "http://c"],
-        )))
-        .expect("pool");
+    fn alternate_selection_respects_disabled_readonly_pick_policy() {
+        let mut pool = pool_for("round-robin", &["http://a", "http://b", "http://c"]);
         pool.set_alternate_backend_policy(RuntimeAlternateBackendPolicy {
             readonly_lb_pick: false,
             healthy_fallback: true,
@@ -372,12 +272,8 @@ mod tests {
     }
 
     #[test]
-    fn reports_excluded_backends_when_all_failover_modes_are_disabled() {
-        let mut pool = UpstreamPool::from_runtime_upstream(&runtime_upstream(upstream(
-            "round-robin",
-            &["http://a", "http://b"],
-        )))
-        .expect("pool");
+    fn only_excluded_backend_denial_survives_when_failover_modes_are_disabled() {
+        let mut pool = pool_for("round-robin", &["http://a", "http://b"]);
         pool.set_alternate_backend_policy(RuntimeAlternateBackendPolicy {
             readonly_lb_pick: false,
             healthy_fallback: false,

--- a/crates/lb/src/alternate_backend.rs
+++ b/crates/lb/src/alternate_backend.rs
@@ -89,9 +89,7 @@ mod tests {
 
     fn pool_for(lb_type: &str, backends: &[&str]) -> UpstreamPool {
         UpstreamPool::from_runtime_upstream(&runtime_upstream_from_addresses(
-            lb_type,
-            None,
-            backends,
+            lb_type, None, backends,
         ))
         .expect("alternate-backend fixture pool should build")
     }
@@ -126,7 +124,10 @@ mod tests {
 
     #[test]
     fn alternate_selection_respects_multiple_excluded_backends() {
-        let pool = pool_for("round-robin", &["http://a", "http://b", "http://c", "http://d"]);
+        let pool = pool_for(
+            "round-robin",
+            &["http://a", "http://b", "http://c", "http://d"],
+        );
 
         let decision = choose_alternate_backend(&pool, &[0, 1, 2], None);
         assert_eq!(

--- a/crates/lb/src/lib.rs
+++ b/crates/lb/src/lib.rs
@@ -12,6 +12,8 @@ mod backend_pool;
 pub(crate) mod hash;
 pub mod health;
 pub mod load_balancing;
+#[cfg(test)]
+pub(crate) mod test_support;
 pub mod upstream_pool;
 
 pub use health::HealthTransition;

--- a/crates/lb/src/load_balancing.rs
+++ b/crates/lb/src/load_balancing.rs
@@ -85,47 +85,15 @@ impl LoadBalancing {
 
 #[cfg(test)]
 mod tests {
-    use spooky_config::config::{Backend, HealthCheck};
-
     use super::LoadBalancing;
-    use crate::{backend::BackendState, backend_pool::BackendPool};
-
-    fn pool() -> BackendPool {
-        BackendPool::new_from_states(vec![
-            BackendState::new(&Backend {
-                id: "a".to_string(),
-                address: "http://127.0.0.1:7001".to_string(),
-                weight: 1,
-                health_check: None,
-            }),
-            BackendState::new(&Backend {
-                id: "b".to_string(),
-                address: "http://127.0.0.1:7002".to_string(),
-                weight: 1,
-                health_check: None,
-            }),
-        ])
-    }
-
-    fn health_checked_backend(address: &str) -> BackendState {
-        BackendState::new(&Backend {
-            id: format!("backend-{address}"),
-            address: address.to_string(),
-            weight: 1,
-            health_check: Some(HealthCheck {
-                path: "/health".to_string(),
-                interval: 1,
-                timeout_ms: 1000,
-                failure_threshold: 1,
-                success_threshold: 1,
-                cooldown_ms: 0,
-            }),
-        })
-    }
+    use crate::{
+        backend_pool::BackendPool,
+        test_support::{backend_pool_from_addresses, health_checked_backend_state},
+    };
 
     #[test]
-    fn pick_readonly_is_available_only_for_readonly_strategies() {
-        let pool = pool();
+    fn readonly_pick_is_exposed_only_for_readonly_strategies() {
+        let pool = backend_pool_from_addresses(&["http://127.0.0.1:7001", "http://127.0.0.1:7002"]);
 
         assert!(
             LoadBalancing::from_config("round-robin")
@@ -166,7 +134,7 @@ mod tests {
     }
 
     #[test]
-    fn every_strategy_returns_none_for_an_empty_pool() {
+    fn every_strategy_returns_none_for_empty_backend_inventory() {
         let empty_pool = BackendPool::new_from_states(Vec::new());
 
         for strategy in [
@@ -188,8 +156,8 @@ mod tests {
     #[test]
     fn every_strategy_returns_none_when_all_backends_are_unhealthy() {
         let mut unhealthy_pool = BackendPool::new_from_states(vec![
-            health_checked_backend("10.0.0.1:443"),
-            health_checked_backend("10.0.0.2:443"),
+            health_checked_backend_state("10.0.0.1:443"),
+            health_checked_backend_state("10.0.0.2:443"),
         ]);
         let _ = unhealthy_pool.mark_failure(0);
         let _ = unhealthy_pool.mark_failure(1);

--- a/crates/lb/src/load_balancing.rs
+++ b/crates/lb/src/load_balancing.rs
@@ -85,26 +85,42 @@ impl LoadBalancing {
 
 #[cfg(test)]
 mod tests {
-    use spooky_config::config::Backend;
+    use spooky_config::config::{Backend, HealthCheck};
 
     use super::LoadBalancing;
-    use crate::backend_pool::BackendPool;
+    use crate::{backend::BackendState, backend_pool::BackendPool};
 
     fn pool() -> BackendPool {
         BackendPool::new_from_states(vec![
-            crate::backend::BackendState::new(&Backend {
+            BackendState::new(&Backend {
                 id: "a".to_string(),
                 address: "http://127.0.0.1:7001".to_string(),
                 weight: 1,
                 health_check: None,
             }),
-            crate::backend::BackendState::new(&Backend {
+            BackendState::new(&Backend {
                 id: "b".to_string(),
                 address: "http://127.0.0.1:7002".to_string(),
                 weight: 1,
                 health_check: None,
             }),
         ])
+    }
+
+    fn health_checked_backend(address: &str) -> BackendState {
+        BackendState::new(&Backend {
+            id: format!("backend-{address}"),
+            address: address.to_string(),
+            weight: 1,
+            health_check: Some(HealthCheck {
+                path: "/health".to_string(),
+                interval: 1,
+                timeout_ms: 1000,
+                failure_threshold: 1,
+                success_threshold: 1,
+                cooldown_ms: 0,
+            }),
+        })
     }
 
     #[test]
@@ -147,5 +163,50 @@ mod tests {
                 .pick_readonly("cid-1", &pool)
                 .is_none()
         );
+    }
+
+    #[test]
+    fn every_strategy_returns_none_for_an_empty_pool() {
+        let empty_pool = BackendPool::new_from_states(Vec::new());
+
+        for strategy in [
+            "round-robin",
+            "consistent-hash",
+            "random",
+            "least-connections",
+            "latency-aware",
+            "sticky-cid",
+        ] {
+            let mut lb = LoadBalancing::from_config(strategy).expect("strategy");
+            assert!(
+                lb.pick("tenant:alpha", &empty_pool).is_none(),
+                "strategy {strategy} should not select from an empty backend pool"
+            );
+        }
+    }
+
+    #[test]
+    fn every_strategy_returns_none_when_all_backends_are_unhealthy() {
+        let mut unhealthy_pool = BackendPool::new_from_states(vec![
+            health_checked_backend("10.0.0.1:443"),
+            health_checked_backend("10.0.0.2:443"),
+        ]);
+        let _ = unhealthy_pool.mark_failure(0);
+        let _ = unhealthy_pool.mark_failure(1);
+
+        for strategy in [
+            "round-robin",
+            "consistent-hash",
+            "random",
+            "least-connections",
+            "latency-aware",
+            "sticky-cid",
+        ] {
+            let mut lb = LoadBalancing::from_config(strategy).expect("strategy");
+            assert!(
+                lb.pick("tenant:alpha", &unhealthy_pool).is_none(),
+                "strategy {strategy} should not select from an all-unhealthy backend pool"
+            );
+        }
     }
 }

--- a/crates/lb/src/test_support.rs
+++ b/crates/lb/src/test_support.rs
@@ -1,0 +1,104 @@
+use std::collections::HashMap;
+
+use spooky_config::{
+    config::{Backend, Config, HealthCheck, Listen, LoadBalancing, RouteMatch, Tls, Upstream},
+    runtime::{RuntimeConfig, RuntimeUpstream},
+};
+
+use crate::{backend::BackendState, backend_pool::BackendPool};
+
+pub(crate) fn runtime_upstream_from_addresses(
+    lb_type: &str,
+    key: Option<&str>,
+    addresses: &[&str],
+) -> RuntimeUpstream {
+    let mut upstreams = HashMap::new();
+    upstreams.insert(
+        "api".to_string(),
+        Upstream {
+            tls: None,
+            load_balancing: LoadBalancing {
+                lb_type: lb_type.to_string(),
+                key: key.map(str::to_string),
+            },
+            auth: Default::default(),
+            host_policy: Default::default(),
+            forwarded_headers: Default::default(),
+            route: RouteMatch::default(),
+            backends: addresses
+                .iter()
+                .enumerate()
+                .map(|(index, address)| Backend {
+                    id: format!("backend-{index}"),
+                    address: (*address).to_string(),
+                    weight: 1,
+                    health_check: Some(default_health_check(1000)),
+                })
+                .collect(),
+        },
+    );
+
+    RuntimeConfig::from_config(&Config {
+        version: 1,
+        listen: Listen {
+            protocol: "http1".to_string(),
+            tls: Tls {
+                cert: "/tmp/test-cert.pem".to_string(),
+                key: "/tmp/test-key.pem".to_string(),
+                ..Tls::default()
+            },
+            ..Listen::default()
+        },
+        listeners: Vec::new(),
+        upstream: upstreams,
+        load_balancing: None,
+        upstream_tls: Default::default(),
+        log: Default::default(),
+        performance: Default::default(),
+        observability: Default::default(),
+        resilience: Default::default(),
+        security: Default::default(),
+    })
+    .expect("runtime config fixture should normalize")
+    .upstreams
+    .remove("api")
+    .expect("runtime upstream fixture should exist")
+}
+
+pub(crate) fn backend_pool_from_addresses(addresses: &[&str]) -> BackendPool {
+    BackendPool::new_from_states(
+        addresses
+            .iter()
+            .enumerate()
+            .map(|(index, address)| backend_state(&format!("backend-{index}"), address, None))
+            .collect(),
+    )
+}
+
+pub(crate) fn health_checked_backend_state(address: &str) -> BackendState {
+    backend_state(
+        &format!("backend-{address}"),
+        address,
+        Some(default_health_check(0)),
+    )
+}
+
+fn backend_state(id: &str, address: &str, health_check: Option<HealthCheck>) -> BackendState {
+    BackendState::new(&Backend {
+        id: id.to_string(),
+        address: address.to_string(),
+        weight: 1,
+        health_check,
+    })
+}
+
+fn default_health_check(cooldown_ms: u64) -> HealthCheck {
+    HealthCheck {
+        path: "/health".to_string(),
+        interval: 1,
+        timeout_ms: 1000,
+        failure_threshold: 1,
+        success_threshold: 1,
+        cooldown_ms,
+    }
+}

--- a/crates/lb/src/upstream_pool.rs
+++ b/crates/lb/src/upstream_pool.rs
@@ -177,9 +177,7 @@ impl UpstreamPool {
 
 #[cfg(test)]
 mod tests {
-    use spooky_config::{
-        runtime::{RuntimeLoadBalancingStrategy, RuntimeRequestKeySpec},
-    };
+    use spooky_config::runtime::{RuntimeLoadBalancingStrategy, RuntimeRequestKeySpec};
 
     use super::UpstreamPool;
     use crate::test_support::runtime_upstream_from_addresses;
@@ -191,8 +189,8 @@ mod tests {
             None,
             &["http://127.0.0.1:7001", "http://127.0.0.1:7002"],
         );
-        let mut pool =
-            UpstreamPool::from_runtime_upstream(&runtime_upstream).expect("runtime pool should build");
+        let mut pool = UpstreamPool::from_runtime_upstream(&runtime_upstream)
+            .expect("runtime pool should build");
 
         let idx = pool.pick_without_begin("key").expect("readonly pick");
         assert_eq!(
@@ -255,8 +253,8 @@ mod tests {
             None,
             &["http://127.0.0.1:7001", "http://127.0.0.1:7002"],
         );
-        let mut pool =
-            UpstreamPool::from_runtime_upstream(&runtime_upstream).expect("runtime pool should build");
+        let mut pool = UpstreamPool::from_runtime_upstream(&runtime_upstream)
+            .expect("runtime pool should build");
 
         let before = pool.membership_summary();
         assert_eq!(before.total_backends, 2);

--- a/crates/lb/src/upstream_pool.rs
+++ b/crates/lb/src/upstream_pool.rs
@@ -177,94 +177,22 @@ impl UpstreamPool {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
     use spooky_config::{
-        config::{Backend, Config, HealthCheck, Listen, LoadBalancing, RouteMatch, Tls, Upstream},
-        runtime::{RuntimeConfig, RuntimeLoadBalancingStrategy, RuntimeRequestKeySpec},
+        runtime::{RuntimeLoadBalancingStrategy, RuntimeRequestKeySpec},
     };
 
     use super::UpstreamPool;
-
-    fn runtime_upstream(
-        lb_type: &str,
-        key: Option<&str>,
-    ) -> spooky_config::runtime::RuntimeUpstream {
-        let mut upstreams = HashMap::new();
-        upstreams.insert(
-            "api".to_string(),
-            Upstream {
-                tls: None,
-                load_balancing: LoadBalancing {
-                    lb_type: lb_type.to_string(),
-                    key: key.map(str::to_string),
-                },
-                auth: Default::default(),
-                host_policy: Default::default(),
-                forwarded_headers: Default::default(),
-                route: RouteMatch::default(),
-                backends: vec![
-                    Backend {
-                        id: "backend-a".to_string(),
-                        address: "http://127.0.0.1:7001".to_string(),
-                        weight: 1,
-                        health_check: Some(HealthCheck {
-                            path: "/health".to_string(),
-                            interval: 1,
-                            timeout_ms: 1000,
-                            failure_threshold: 1,
-                            success_threshold: 1,
-                            cooldown_ms: 1000,
-                        }),
-                    },
-                    Backend {
-                        id: "backend-b".to_string(),
-                        address: "http://127.0.0.1:7002".to_string(),
-                        weight: 1,
-                        health_check: Some(HealthCheck {
-                            path: "/health".to_string(),
-                            interval: 1,
-                            timeout_ms: 1000,
-                            failure_threshold: 1,
-                            success_threshold: 1,
-                            cooldown_ms: 1000,
-                        }),
-                    },
-                ],
-            },
-        );
-
-        RuntimeConfig::from_config(&Config {
-            version: 1,
-            listen: Listen {
-                protocol: "http1".to_string(),
-                tls: Tls {
-                    cert: "/tmp/test-cert.pem".to_string(),
-                    key: "/tmp/test-key.pem".to_string(),
-                    ..Tls::default()
-                },
-                ..Listen::default()
-            },
-            listeners: Vec::new(),
-            upstream: upstreams,
-            load_balancing: None,
-            upstream_tls: Default::default(),
-            log: Default::default(),
-            performance: Default::default(),
-            observability: Default::default(),
-            resilience: Default::default(),
-            security: Default::default(),
-        })
-        .expect("runtime config")
-        .upstreams
-        .remove("api")
-        .expect("runtime upstream")
-    }
+    use crate::test_support::runtime_upstream_from_addresses;
 
     #[test]
-    fn pick_without_begin_preserves_active_request_count_but_pick_increments_it() {
-        let runtime_upstream = runtime_upstream("round-robin", None);
-        let mut pool = UpstreamPool::from_runtime_upstream(&runtime_upstream).expect("pool");
+    fn readonly_pick_preserves_request_count_until_mutating_pick_runs() {
+        let runtime_upstream = runtime_upstream_from_addresses(
+            "round-robin",
+            None,
+            &["http://127.0.0.1:7001", "http://127.0.0.1:7002"],
+        );
+        let mut pool =
+            UpstreamPool::from_runtime_upstream(&runtime_upstream).expect("runtime pool should build");
 
         let idx = pool.pick_without_begin("key").expect("readonly pick");
         assert_eq!(
@@ -284,12 +212,13 @@ mod tests {
     }
 
     #[test]
-    fn pool_exposes_lb_key_spec_and_alternate_policy_from_runtime() {
-        let consistent = UpstreamPool::from_runtime_upstream(&runtime_upstream(
+    fn runtime_pool_contract_preserves_lb_key_spec_and_alternate_policy() {
+        let consistent = UpstreamPool::from_runtime_upstream(&runtime_upstream_from_addresses(
             "consistent-hash",
             Some("header:x-user-id"),
+            &["http://127.0.0.1:7001", "http://127.0.0.1:7002"],
         ))
-        .expect("consistent pool");
+        .expect("consistent-hash runtime pool should build");
         assert_eq!(
             consistent.lb_strategy(),
             RuntimeLoadBalancingStrategy::ConsistentHash
@@ -301,11 +230,12 @@ mod tests {
         assert!(!consistent.alternate_backend_policy().readonly_lb_pick);
         assert!(consistent.alternate_backend_policy().healthy_fallback);
 
-        let round_robin = UpstreamPool::from_runtime_upstream(&runtime_upstream(
+        let round_robin = UpstreamPool::from_runtime_upstream(&runtime_upstream_from_addresses(
             "round-robin",
             Some("authority"),
+            &["http://127.0.0.1:7001", "http://127.0.0.1:7002"],
         ))
-        .expect("round robin pool");
+        .expect("round-robin runtime pool should build");
         assert_eq!(
             round_robin.lb_strategy(),
             RuntimeLoadBalancingStrategy::RoundRobin
@@ -320,8 +250,13 @@ mod tests {
 
     #[test]
     fn membership_summary_and_runtime_state_stay_coherent_after_health_updates() {
-        let runtime_upstream = runtime_upstream("round-robin", None);
-        let mut pool = UpstreamPool::from_runtime_upstream(&runtime_upstream).expect("pool");
+        let runtime_upstream = runtime_upstream_from_addresses(
+            "round-robin",
+            None,
+            &["http://127.0.0.1:7001", "http://127.0.0.1:7002"],
+        );
+        let mut pool =
+            UpstreamPool::from_runtime_upstream(&runtime_upstream).expect("runtime pool should build");
 
         let before = pool.membership_summary();
         assert_eq!(before.total_backends, 2);

--- a/crates/lb/tests/runtime_pool_contract.rs
+++ b/crates/lb/tests/runtime_pool_contract.rs
@@ -1,3 +1,5 @@
+//! Runtime-upstream pool contract tests.
+
 use std::collections::HashMap;
 
 use spooky_config::{
@@ -7,7 +9,7 @@ use spooky_config::{
 use spooky_lb::upstream_pool::UpstreamPool;
 
 #[test]
-fn upstream_pool_from_config() {
+fn runtime_upstream_builds_a_pool_with_canonical_lb_contract() {
     let upstream = spooky_config::config::Upstream {
         load_balancing: spooky_config::config::LoadBalancing {
             lb_type: "round-robin".to_string(),

--- a/crates/lb/tests/strategy_behavior.rs
+++ b/crates/lb/tests/strategy_behavior.rs
@@ -1,7 +1,9 @@
+//! Load-balancing strategy domain tests.
+
 use spooky_lb::load_balancing::LoadBalancing;
 
 #[test]
-fn load_balancing_from_config() {
+fn supported_strategy_names_normalize_through_the_canonical_facade() {
     assert!(LoadBalancing::from_config("round-robin").is_ok());
     assert!(LoadBalancing::from_config("consistent-hash").is_ok());
     assert!(LoadBalancing::from_config("random").is_ok());

--- a/crates/lb/tests/strategy_behavior.rs
+++ b/crates/lb/tests/strategy_behavior.rs
@@ -1,6 +1,12 @@
 //! Load-balancing strategy domain tests.
 
-use spooky_lb::load_balancing::LoadBalancing;
+use std::{collections::HashMap, time::Duration};
+
+use spooky_config::{
+    config::{Backend, Config, HealthCheck, Listen, LoadBalancing as ConfigLoadBalancing, RouteMatch, Tls, Upstream},
+    runtime::RuntimeConfig,
+};
+use spooky_lb::{load_balancing::LoadBalancing, upstream_pool::UpstreamPool};
 
 #[test]
 fn supported_strategy_names_normalize_through_the_canonical_facade() {
@@ -11,4 +17,160 @@ fn supported_strategy_names_normalize_through_the_canonical_facade() {
     assert!(LoadBalancing::from_config("latency-aware").is_ok());
     assert!(LoadBalancing::from_config("sticky-cid").is_ok());
     assert!(LoadBalancing::from_config("unknown").is_err());
+}
+
+fn runtime_upstream(strategy: &str, backend_count: usize) -> spooky_config::runtime::RuntimeUpstream {
+    let mut upstreams = HashMap::new();
+    upstreams.insert(
+        "api".to_string(),
+        Upstream {
+            tls: None,
+            load_balancing: ConfigLoadBalancing {
+                lb_type: strategy.to_string(),
+                key: None,
+            },
+            auth: Default::default(),
+            host_policy: Default::default(),
+            forwarded_headers: Default::default(),
+            route: RouteMatch::default(),
+            backends: (0..backend_count)
+                .map(|index| Backend {
+                    id: format!("backend-{index}"),
+                    address: format!("http://127.0.0.1:{}", 7001 + index),
+                    weight: 1,
+                    health_check: Some(HealthCheck {
+                        path: "/health".to_string(),
+                        interval: 1,
+                        timeout_ms: 1000,
+                        failure_threshold: 1,
+                        success_threshold: 1,
+                        cooldown_ms: 0,
+                    }),
+                })
+                .collect(),
+        },
+    );
+
+    RuntimeConfig::from_config(&Config {
+        version: 1,
+        listen: Listen {
+            protocol: "http1".to_string(),
+            tls: Tls {
+                cert: "/tmp/test-cert.pem".to_string(),
+                key: "/tmp/test-key.pem".to_string(),
+                ..Tls::default()
+            },
+            ..Listen::default()
+        },
+        listeners: Vec::new(),
+        upstream: upstreams,
+        load_balancing: None,
+        upstream_tls: Default::default(),
+        log: Default::default(),
+        performance: Default::default(),
+        observability: Default::default(),
+        resilience: Default::default(),
+        security: Default::default(),
+    })
+    .expect("runtime config")
+    .upstreams
+    .remove("api")
+    .expect("runtime upstream")
+}
+
+fn pool(strategy: &str, backend_count: usize) -> UpstreamPool {
+    UpstreamPool::from_runtime_upstream(&runtime_upstream(strategy, backend_count)).expect("pool")
+}
+
+#[test]
+fn round_robin_sequences_across_healthy_backends() {
+    let mut pool = pool("round-robin", 3);
+
+    let picks: Vec<_> = (0..6)
+        .map(|_| pool.pick_without_begin("ignored").expect("round-robin pick"))
+        .collect();
+
+    assert_eq!(picks, vec![0, 1, 2, 0, 1, 2]);
+}
+
+#[test]
+fn random_selection_stays_within_healthy_membership() {
+    let mut pool = pool("random", 3);
+    let _ = pool.mark_backend_failure_from_active_check(0);
+
+    let picks: Vec<_> = (0..64)
+        .map(|_| pool.pick_without_begin("ignored").expect("random pick"))
+        .collect();
+
+    assert!(
+        picks.iter().all(|pick| matches!(pick, 1 | 2)),
+        "random strategy must only return healthy backend indices"
+    );
+}
+
+#[test]
+fn consistent_hash_is_sticky_while_membership_is_stable() {
+    let mut pool = pool("consistent-hash", 3);
+
+    let first = pool
+        .pick_without_begin("tenant:alpha")
+        .expect("first consistent-hash pick");
+    let repeated: Vec<_> = (0..8)
+        .map(|_| {
+            pool.pick_without_begin("tenant:alpha")
+                .expect("repeated consistent-hash pick")
+        })
+        .collect();
+
+    assert!(
+        repeated.iter().all(|pick| *pick == first),
+        "consistent hash should remain sticky for the same key while membership is unchanged"
+    );
+}
+
+#[test]
+fn least_connections_prefers_the_backend_with_fewer_active_requests() {
+    let mut pool = pool("least-connections", 3);
+    pool.begin_request_for_accounting(0);
+    pool.begin_request_for_accounting(0);
+    pool.begin_request_for_accounting(1);
+
+    let pick = pool
+        .pick_without_begin("ignored")
+        .expect("least-connections pick");
+
+    assert_eq!(pick, 2);
+}
+
+#[test]
+fn latency_aware_prefers_the_backend_with_lower_latency() {
+    let mut pool = pool("latency-aware", 2);
+    pool.finish_request(0, Duration::from_millis(150), Some(200));
+    pool.finish_request(1, Duration::from_millis(20), Some(200));
+
+    let pick = pool
+        .pick_without_begin("ignored")
+        .expect("latency-aware pick");
+
+    assert_eq!(pick, 1);
+}
+
+#[test]
+fn strategies_return_none_when_all_backends_are_unhealthy() {
+    for strategy in [
+        "round-robin",
+        "random",
+        "consistent-hash",
+        "least-connections",
+        "latency-aware",
+    ] {
+        let mut pool = pool(strategy, 2);
+        let _ = pool.mark_backend_failure_from_active_check(0);
+        let _ = pool.mark_backend_failure_from_active_check(1);
+
+        assert!(
+            pool.pick_without_begin("key").is_none(),
+            "strategy {strategy} should not select a backend when every backend is unhealthy"
+        );
+    }
 }

--- a/crates/lb/tests/strategy_behavior.rs
+++ b/crates/lb/tests/strategy_behavior.rs
@@ -3,7 +3,10 @@
 use std::{collections::HashMap, time::Duration};
 
 use spooky_config::{
-    config::{Backend, Config, HealthCheck, Listen, LoadBalancing as ConfigLoadBalancing, RouteMatch, Tls, Upstream},
+    config::{
+        Backend, Config, HealthCheck, Listen, LoadBalancing as ConfigLoadBalancing, RouteMatch,
+        Tls, Upstream,
+    },
     runtime::RuntimeConfig,
 };
 use spooky_lb::{load_balancing::LoadBalancing, upstream_pool::UpstreamPool};
@@ -19,7 +22,10 @@ fn supported_strategy_names_normalize_through_the_canonical_facade() {
     assert!(LoadBalancing::from_config("unknown").is_err());
 }
 
-fn runtime_upstream(strategy: &str, backend_count: usize) -> spooky_config::runtime::RuntimeUpstream {
+fn runtime_upstream(
+    strategy: &str,
+    backend_count: usize,
+) -> spooky_config::runtime::RuntimeUpstream {
     let mut upstreams = HashMap::new();
     upstreams.insert(
         "api".to_string(),
@@ -87,7 +93,10 @@ fn round_robin_sequences_across_healthy_backends() {
     let mut pool = pool("round-robin", 3);
 
     let picks: Vec<_> = (0..6)
-        .map(|_| pool.pick_without_begin("ignored").expect("round-robin pick"))
+        .map(|_| {
+            pool.pick_without_begin("ignored")
+                .expect("round-robin pick")
+        })
         .collect();
 
     assert_eq!(picks, vec![0, 1, 2, 0, 1, 2]);


### PR DESCRIPTION
## Summary
This PR rounds out unit-level contract coverage for load balancing and backend lifecycle behavior, then cleans up the supporting test structure so the tests read as the canonical behavioral spec.

## What Changed
- Added backend DNS refresh lifecycle tests covering:
  - resolved-address updates
  - unchanged refresh behavior
  - empty-answer retention
  - refresh generation progression
  - refresh classification mapping
- Added backend health observation lifecycle tests covering:
  - healthy no-op behavior
  - failure threshold behavior
  - recovery path behavior
  - pool/inventory alignment
- Added request feedback lifecycle tests covering:
  - success, neutral, timeout, transport, and 5xx cases
  - no-op feedback cases
  - coordinator-owned health mutation behavior
- Added backend snapshot and inventory correctness tests covering:
  - stable identity
  - resolved address visibility
  - refresh generation visibility
  - health and membership alignment
  - control-plane summary/inventory parity
- Cleaned up LB unit coverage by:
  - extracting shared test builders into `crates/lb/src/test_support.rs`
  - removing duplicated local fixture construction
  - tightening test names around contract behavior

## Why
These tests lock down the shared substrate that Phase 2 and Phase 3 refactors introduced:
- canonical LB behavior
- alternate backend selection rules
- backend lifecycle mutation ownership
- operator-facing snapshot and inventory contracts

That reduces the chance of regressions while future work shifts from refactoring to feature delivery and bug fixing.

## Validation
- `cargo test -p spooky-lb`
- `cargo test -p spooky-edge runtime::backend::`