### PR TITLE
test(edge): strengthen policy and runtime unit contract coverage

### DIFF
--- a/crates/edge/src/quic_listener/admission.rs
+++ b/crates/edge/src/quic_listener/admission.rs
@@ -699,301 +699,310 @@ mod tests {
         HashMap::from([(String::from("api"), Arc::new(Semaphore::new(1)))])
     }
 
-    #[test]
-    fn overload_reasons_map_to_stable_metrics_labels_and_response_bodies() {
-        let cases = [
-            (
-                OverloadDecisionReason::Brownout,
-                "brownout",
-                b"brownout active, non-core route shed\n".as_slice(),
-            ),
-            (
-                OverloadDecisionReason::AdaptiveAdmission,
-                "adaptive_admission",
-                b"adaptive admission overload\n".as_slice(),
-            ),
-            (
-                OverloadDecisionReason::RouteCap,
-                "route_cap",
-                b"route queue cap exceeded\n".as_slice(),
-            ),
-            (
-                OverloadDecisionReason::RouteGlobalCap,
-                "route_global_cap",
-                b"global queue cap exceeded\n".as_slice(),
-            ),
-            (
-                OverloadDecisionReason::GlobalInflight,
-                "global_inflight",
-                b"overloaded, retry later\n".as_slice(),
-            ),
-            (
-                OverloadDecisionReason::UpstreamInflight,
-                "upstream_inflight",
-                b"upstream overloaded, retry later\n".as_slice(),
-            ),
-        ];
+    mod admission_rejection_contracts {
+        use super::*;
 
-        for (reason, label, body) in cases {
-            assert_eq!(reason.metrics_reason().reason_label(), label);
-            assert_eq!(reason.response_body(), body);
+        #[test]
+        fn overload_reasons_map_to_stable_metrics_labels_and_response_bodies() {
+            let cases = [
+                (
+                    OverloadDecisionReason::Brownout,
+                    "brownout",
+                    b"brownout active, non-core route shed\n".as_slice(),
+                ),
+                (
+                    OverloadDecisionReason::AdaptiveAdmission,
+                    "adaptive_admission",
+                    b"adaptive admission overload\n".as_slice(),
+                ),
+                (
+                    OverloadDecisionReason::RouteCap,
+                    "route_cap",
+                    b"route queue cap exceeded\n".as_slice(),
+                ),
+                (
+                    OverloadDecisionReason::RouteGlobalCap,
+                    "route_global_cap",
+                    b"global queue cap exceeded\n".as_slice(),
+                ),
+                (
+                    OverloadDecisionReason::GlobalInflight,
+                    "global_inflight",
+                    b"overloaded, retry later\n".as_slice(),
+                ),
+                (
+                    OverloadDecisionReason::UpstreamInflight,
+                    "upstream_inflight",
+                    b"upstream overloaded, retry later\n".as_slice(),
+                ),
+            ];
+
+            for (reason, label, body) in cases {
+                assert_eq!(reason.metrics_reason().reason_label(), label);
+                assert_eq!(reason.response_body(), body);
+            }
+        }
+
+        #[test]
+        fn unauthorized_and_overload_rejections_have_distinct_outward_mapping() {
+            let policy = test_policy_with_api_key();
+            let unauthorized =
+                admission_rejection_response(&evaluate_forwarding_pre_admission_policy(
+                    &policy,
+                    None,
+                    &BrownoutController::new(false, 100, 50, Vec::new()),
+                    0,
+                    "api",
+                    7,
+                    &ScopedRateLimiters::new(&[]),
+                    |_| None,
+                ))
+                .expect("unauthorized response");
+            assert_eq!(unauthorized.status, StatusCode::UNAUTHORIZED);
+            assert_eq!(unauthorized.body, b"unauthorized\n");
+            assert_eq!(unauthorized.www_authenticate, Some("ApiKey"));
+            assert_eq!(unauthorized.retry_after_seconds, None);
+
+            let overload = admission_rejection_response(&evaluate_brownout_policy(
+                &BrownoutController::new(true, 50, 25, vec![String::from("core")]),
+                90,
+                "api",
+                7,
+            ))
+            .expect("overload response");
+            assert_eq!(overload.status, StatusCode::SERVICE_UNAVAILABLE);
+            assert_eq!(overload.body, b"brownout active, non-core route shed\n");
+            assert_eq!(overload.www_authenticate, None);
+            assert_eq!(overload.retry_after_seconds, Some(7));
         }
     }
 
-    #[test]
-    fn unauthorized_and_overload_rejections_have_distinct_outward_mapping() {
-        let policy = test_policy_with_api_key();
-        let unauthorized = admission_rejection_response(&evaluate_forwarding_pre_admission_policy(
-            &policy,
-            None,
-            &BrownoutController::new(false, 100, 50, Vec::new()),
-            0,
-            "api",
-            7,
-            &ScopedRateLimiters::new(&[]),
-            |_| None,
-        ))
-        .expect("unauthorized response");
-        assert_eq!(unauthorized.status, StatusCode::UNAUTHORIZED);
-        assert_eq!(unauthorized.body, b"unauthorized\n");
-        assert_eq!(unauthorized.www_authenticate, Some("ApiKey"));
-        assert_eq!(unauthorized.retry_after_seconds, None);
+    mod post_auth_admission_execution {
+        use super::*;
 
-        let overload = admission_rejection_response(&evaluate_brownout_policy(
-            &BrownoutController::new(true, 50, 25, vec![String::from("core")]),
-            90,
-            "api",
-            7,
-        ))
-        .expect("overload response");
-        assert_eq!(overload.status, StatusCode::SERVICE_UNAVAILABLE);
-        assert_eq!(overload.body, b"brownout active, non-core route shed\n");
-        assert_eq!(overload.www_authenticate, None);
-        assert_eq!(overload.retry_after_seconds, Some(7));
-    }
+        #[test]
+        fn post_auth_admission_rejects_adaptive_admission_overload() {
+            let resilience = test_runtime_resilience(
+                |config| {
+                    config.adaptive_admission.enabled = true;
+                    config.adaptive_admission.min_limit = 1;
+                    config.adaptive_admission.max_limit = Some(1);
+                },
+                8,
+            );
+            let _held = resilience
+                .adaptive_admission
+                .clone()
+                .try_acquire()
+                .expect("held permit");
 
-    #[test]
-    fn post_auth_admission_rejects_adaptive_admission_overload() {
-        let resilience = test_runtime_resilience(
-            |config| {
-                config.adaptive_admission.enabled = true;
-                config.adaptive_admission.min_limit = 1;
-                config.adaptive_admission.max_limit = Some(1);
-            },
-            8,
-        );
-        let _held = resilience
-            .adaptive_admission
-            .clone()
-            .try_acquire()
-            .expect("held permit");
+            let result = execute_forwarding_post_auth_admission(
+                &resilience,
+                "api",
+                Some(&test_upstream_pool()),
+                Some(0),
+                0,
+                &test_upstream_inflight(),
+                Arc::new(Semaphore::new(1)),
+                Duration::ZERO,
+            );
 
-        let result = execute_forwarding_post_auth_admission(
-            &resilience,
-            "api",
-            Some(&test_upstream_pool()),
-            Some(0),
-            0,
-            &test_upstream_inflight(),
-            Arc::new(Semaphore::new(1)),
-            Duration::ZERO,
-        );
+            assert!(matches!(
+                result,
+                PostAuthAdmissionExecution::Rejected(PostAuthAdmissionRejection::Overloaded(
+                    OverloadDecision {
+                        reason: OverloadDecisionReason::AdaptiveAdmission,
+                        ..
+                    }
+                ))
+            ));
+        }
 
-        assert!(matches!(
-            result,
-            PostAuthAdmissionExecution::Rejected(PostAuthAdmissionRejection::Overloaded(
-                OverloadDecision {
-                    reason: OverloadDecisionReason::AdaptiveAdmission,
-                    ..
+        #[test]
+        fn post_auth_admission_rejects_route_cap_and_global_cap_with_distinct_reasons() {
+            let route_cap = test_runtime_resilience(
+                |config| {
+                    config.route_queue.default_cap = 2;
+                    config.route_queue.global_cap = 4;
+                    config.route_queue.caps.insert(String::from("api"), 1);
+                },
+                8,
+            );
+            let _route_held = route_cap
+                .route_queue
+                .clone()
+                .try_acquire("api")
+                .expect("route permit");
+            let route_result = execute_forwarding_post_auth_admission(
+                &route_cap,
+                "api",
+                Some(&test_upstream_pool()),
+                Some(0),
+                0,
+                &test_upstream_inflight(),
+                Arc::new(Semaphore::new(1)),
+                Duration::ZERO,
+            );
+            assert!(matches!(
+                route_result,
+                PostAuthAdmissionExecution::Rejected(PostAuthAdmissionRejection::Overloaded(
+                    OverloadDecision {
+                        reason: OverloadDecisionReason::RouteCap,
+                        ..
+                    }
+                ))
+            ));
+
+            let global_cap = test_runtime_resilience(
+                |config| {
+                    config.route_queue.default_cap = 4;
+                    config.route_queue.global_cap = 1;
+                },
+                8,
+            );
+            let _global_route_held = global_cap
+                .route_queue
+                .clone()
+                .try_acquire("other")
+                .expect("global route permit");
+            let global_result = execute_forwarding_post_auth_admission(
+                &global_cap,
+                "api",
+                Some(&test_upstream_pool()),
+                Some(0),
+                0,
+                &test_upstream_inflight(),
+                Arc::new(Semaphore::new(1)),
+                Duration::ZERO,
+            );
+            assert!(matches!(
+                global_result,
+                PostAuthAdmissionExecution::Rejected(PostAuthAdmissionRejection::Overloaded(
+                    OverloadDecision {
+                        reason: OverloadDecisionReason::RouteGlobalCap,
+                        ..
+                    }
+                ))
+            ));
+        }
+
+        #[test]
+        fn post_auth_admission_rejects_global_and_upstream_inflight_with_distinct_reasons() {
+            let resilience = test_runtime_resilience(|_| {}, 8);
+            let global_inflight = Arc::new(Semaphore::new(1));
+            let _global_held = global_inflight
+                .clone()
+                .try_acquire_owned()
+                .expect("global permit");
+            let global_result = execute_forwarding_post_auth_admission(
+                &resilience,
+                "api",
+                Some(&test_upstream_pool()),
+                Some(0),
+                0,
+                &test_upstream_inflight(),
+                Arc::clone(&global_inflight),
+                Duration::ZERO,
+            );
+            assert!(matches!(
+                global_result,
+                PostAuthAdmissionExecution::Rejected(PostAuthAdmissionRejection::Overloaded(
+                    OverloadDecision {
+                        reason: OverloadDecisionReason::GlobalInflight,
+                        ..
+                    }
+                ))
+            ));
+
+            let resilience = test_runtime_resilience(|_| {}, 8);
+            let upstream_inflight = test_upstream_inflight();
+            let _upstream_held = upstream_inflight
+                .get("api")
+                .expect("api semaphore")
+                .clone()
+                .try_acquire_owned()
+                .expect("upstream permit");
+            let upstream_result = execute_forwarding_post_auth_admission(
+                &resilience,
+                "api",
+                Some(&test_upstream_pool()),
+                Some(0),
+                0,
+                &upstream_inflight,
+                Arc::new(Semaphore::new(1)),
+                Duration::ZERO,
+            );
+            assert!(matches!(
+                upstream_result,
+                PostAuthAdmissionExecution::Rejected(PostAuthAdmissionRejection::Overloaded(
+                    OverloadDecision {
+                        reason: OverloadDecisionReason::UpstreamInflight,
+                        ..
+                    }
+                ))
+            ));
+        }
+
+        #[test]
+        fn missing_upstream_limiter_preserves_overload_reason_in_failure_mapping() {
+            let resilience = test_runtime_resilience(|_| {}, 8);
+
+            let result = execute_forwarding_post_auth_admission(
+                &resilience,
+                "api",
+                Some(&test_upstream_pool()),
+                Some(0),
+                0,
+                &HashMap::new(),
+                Arc::new(Semaphore::new(1)),
+                Duration::ZERO,
+            );
+
+            assert!(matches!(
+                result,
+                PostAuthAdmissionExecution::Rejected(PostAuthAdmissionRejection::Failed(
+                    PostAuthAdmissionFailure {
+                        status: StatusCode::SERVICE_UNAVAILABLE,
+                        overload_reason: Some(OverloadDecisionReason::UpstreamInflight),
+                        route_outcome: Some(RouteOutcome::OverloadShed),
+                        observe_adaptive_overload: true,
+                        ..
+                    }
+                ))
+            ));
+        }
+
+        #[test]
+        fn post_auth_admission_success_does_not_report_wait_when_no_wait_happened() {
+            let resilience = test_runtime_resilience(|_| {}, 8);
+            let pool = test_upstream_pool();
+
+            let (permit, waited) =
+                try_acquire_owned_with_micro_wait(Arc::new(Semaphore::new(1)), Duration::ZERO)
+                    .expect("permit");
+            assert!(!waited);
+            drop(permit);
+
+            let result = execute_forwarding_post_auth_admission(
+                &resilience,
+                "api",
+                Some(&pool),
+                Some(0),
+                0,
+                &test_upstream_inflight(),
+                Arc::new(Semaphore::new(1)),
+                Duration::ZERO,
+            );
+
+            match result {
+                PostAuthAdmissionExecution::Ready(ready) => {
+                    assert_eq!(ready.backend_index, 0);
+                    assert!(!ready.waited_for_global_permit);
+                    assert!(!ready.waited_for_upstream_permit);
                 }
-            ))
-        ));
-    }
-
-    #[test]
-    fn post_auth_admission_rejects_route_cap_and_global_cap_with_distinct_reasons() {
-        let route_cap = test_runtime_resilience(
-            |config| {
-                config.route_queue.default_cap = 2;
-                config.route_queue.global_cap = 4;
-                config.route_queue.caps.insert(String::from("api"), 1);
-            },
-            8,
-        );
-        let _route_held = route_cap
-            .route_queue
-            .clone()
-            .try_acquire("api")
-            .expect("route permit");
-        let route_result = execute_forwarding_post_auth_admission(
-            &route_cap,
-            "api",
-            Some(&test_upstream_pool()),
-            Some(0),
-            0,
-            &test_upstream_inflight(),
-            Arc::new(Semaphore::new(1)),
-            Duration::ZERO,
-        );
-        assert!(matches!(
-            route_result,
-            PostAuthAdmissionExecution::Rejected(PostAuthAdmissionRejection::Overloaded(
-                OverloadDecision {
-                    reason: OverloadDecisionReason::RouteCap,
-                    ..
+                PostAuthAdmissionExecution::Rejected(_) => {
+                    panic!("expected successful admission without waits")
                 }
-            ))
-        ));
-
-        let global_cap = test_runtime_resilience(
-            |config| {
-                config.route_queue.default_cap = 4;
-                config.route_queue.global_cap = 1;
-            },
-            8,
-        );
-        let _global_route_held = global_cap
-            .route_queue
-            .clone()
-            .try_acquire("other")
-            .expect("global route permit");
-        let global_result = execute_forwarding_post_auth_admission(
-            &global_cap,
-            "api",
-            Some(&test_upstream_pool()),
-            Some(0),
-            0,
-            &test_upstream_inflight(),
-            Arc::new(Semaphore::new(1)),
-            Duration::ZERO,
-        );
-        assert!(matches!(
-            global_result,
-            PostAuthAdmissionExecution::Rejected(PostAuthAdmissionRejection::Overloaded(
-                OverloadDecision {
-                    reason: OverloadDecisionReason::RouteGlobalCap,
-                    ..
-                }
-            ))
-        ));
-    }
-
-    #[test]
-    fn post_auth_admission_rejects_global_and_upstream_inflight_with_distinct_reasons() {
-        let resilience = test_runtime_resilience(|_| {}, 8);
-        let global_inflight = Arc::new(Semaphore::new(1));
-        let _global_held = global_inflight
-            .clone()
-            .try_acquire_owned()
-            .expect("global permit");
-        let global_result = execute_forwarding_post_auth_admission(
-            &resilience,
-            "api",
-            Some(&test_upstream_pool()),
-            Some(0),
-            0,
-            &test_upstream_inflight(),
-            Arc::clone(&global_inflight),
-            Duration::ZERO,
-        );
-        assert!(matches!(
-            global_result,
-            PostAuthAdmissionExecution::Rejected(PostAuthAdmissionRejection::Overloaded(
-                OverloadDecision {
-                    reason: OverloadDecisionReason::GlobalInflight,
-                    ..
-                }
-            ))
-        ));
-
-        let resilience = test_runtime_resilience(|_| {}, 8);
-        let upstream_inflight = test_upstream_inflight();
-        let _upstream_held = upstream_inflight
-            .get("api")
-            .expect("api semaphore")
-            .clone()
-            .try_acquire_owned()
-            .expect("upstream permit");
-        let upstream_result = execute_forwarding_post_auth_admission(
-            &resilience,
-            "api",
-            Some(&test_upstream_pool()),
-            Some(0),
-            0,
-            &upstream_inflight,
-            Arc::new(Semaphore::new(1)),
-            Duration::ZERO,
-        );
-        assert!(matches!(
-            upstream_result,
-            PostAuthAdmissionExecution::Rejected(PostAuthAdmissionRejection::Overloaded(
-                OverloadDecision {
-                    reason: OverloadDecisionReason::UpstreamInflight,
-                    ..
-                }
-            ))
-        ));
-    }
-
-    #[test]
-    fn missing_upstream_limiter_preserves_overload_reason_in_failure_mapping() {
-        let resilience = test_runtime_resilience(|_| {}, 8);
-
-        let result = execute_forwarding_post_auth_admission(
-            &resilience,
-            "api",
-            Some(&test_upstream_pool()),
-            Some(0),
-            0,
-            &HashMap::new(),
-            Arc::new(Semaphore::new(1)),
-            Duration::ZERO,
-        );
-
-        assert!(matches!(
-            result,
-            PostAuthAdmissionExecution::Rejected(PostAuthAdmissionRejection::Failed(
-                PostAuthAdmissionFailure {
-                    status: StatusCode::SERVICE_UNAVAILABLE,
-                    overload_reason: Some(OverloadDecisionReason::UpstreamInflight),
-                    route_outcome: Some(RouteOutcome::OverloadShed),
-                    observe_adaptive_overload: true,
-                    ..
-                }
-            ))
-        ));
-    }
-
-    #[test]
-    fn post_auth_admission_success_does_not_report_wait_when_no_wait_happened() {
-        let resilience = test_runtime_resilience(|_| {}, 8);
-        let pool = test_upstream_pool();
-
-        let (permit, waited) =
-            try_acquire_owned_with_micro_wait(Arc::new(Semaphore::new(1)), Duration::ZERO)
-                .expect("permit");
-        assert!(!waited);
-        drop(permit);
-
-        let result = execute_forwarding_post_auth_admission(
-            &resilience,
-            "api",
-            Some(&pool),
-            Some(0),
-            0,
-            &test_upstream_inflight(),
-            Arc::new(Semaphore::new(1)),
-            Duration::ZERO,
-        );
-
-        match result {
-            PostAuthAdmissionExecution::Ready(ready) => {
-                assert_eq!(ready.backend_index, 0);
-                assert!(!ready.waited_for_global_permit);
-                assert!(!ready.waited_for_upstream_permit);
-            }
-            PostAuthAdmissionExecution::Rejected(_) => {
-                panic!("expected successful admission without waits")
             }
         }
     }

--- a/crates/edge/src/quic_listener/admission.rs
+++ b/crates/edge/src/quic_listener/admission.rs
@@ -1016,6 +1016,25 @@ mod tests {
     mod post_auth_admission_execution {
         use super::*;
 
+        fn execute_post_auth_for_api(
+            resilience: &RuntimeResilience,
+            upstream_pool: Option<&Arc<RwLock<UpstreamPool>>>,
+            backend_index: Option<usize>,
+            upstream_inflight: &HashMap<String, Arc<Semaphore>>,
+            global_inflight: Arc<Semaphore>,
+        ) -> PostAuthAdmissionExecution {
+            execute_forwarding_post_auth_admission(
+                resilience,
+                "api",
+                upstream_pool,
+                backend_index,
+                0,
+                upstream_inflight,
+                global_inflight,
+                Duration::ZERO,
+            )
+        }
+
         #[test]
         fn post_auth_admission_rejects_adaptive_admission_overload() {
             let resilience = test_runtime_resilience(
@@ -1032,15 +1051,12 @@ mod tests {
                 .try_acquire()
                 .expect("held permit");
 
-            let result = execute_forwarding_post_auth_admission(
+            let result = execute_post_auth_for_api(
                 &resilience,
-                "api",
                 Some(&test_upstream_pool()),
                 Some(0),
-                0,
                 &test_upstream_inflight(),
                 Arc::new(Semaphore::new(1)),
-                Duration::ZERO,
             );
 
             assert!(matches!(
@@ -1069,15 +1085,12 @@ mod tests {
                 .clone()
                 .try_acquire("api")
                 .expect("route permit");
-            let route_result = execute_forwarding_post_auth_admission(
+            let route_result = execute_post_auth_for_api(
                 &route_cap,
-                "api",
                 Some(&test_upstream_pool()),
                 Some(0),
-                0,
                 &test_upstream_inflight(),
                 Arc::new(Semaphore::new(1)),
-                Duration::ZERO,
             );
             assert!(matches!(
                 route_result,
@@ -1101,15 +1114,12 @@ mod tests {
                 .clone()
                 .try_acquire("other")
                 .expect("global route permit");
-            let global_result = execute_forwarding_post_auth_admission(
+            let global_result = execute_post_auth_for_api(
                 &global_cap,
-                "api",
                 Some(&test_upstream_pool()),
                 Some(0),
-                0,
                 &test_upstream_inflight(),
                 Arc::new(Semaphore::new(1)),
-                Duration::ZERO,
             );
             assert!(matches!(
                 global_result,
@@ -1130,15 +1140,12 @@ mod tests {
                 .clone()
                 .try_acquire_owned()
                 .expect("global permit");
-            let global_result = execute_forwarding_post_auth_admission(
+            let global_result = execute_post_auth_for_api(
                 &resilience,
-                "api",
                 Some(&test_upstream_pool()),
                 Some(0),
-                0,
                 &test_upstream_inflight(),
                 Arc::clone(&global_inflight),
-                Duration::ZERO,
             );
             assert!(matches!(
                 global_result,
@@ -1158,15 +1165,12 @@ mod tests {
                 .clone()
                 .try_acquire_owned()
                 .expect("upstream permit");
-            let upstream_result = execute_forwarding_post_auth_admission(
+            let upstream_result = execute_post_auth_for_api(
                 &resilience,
-                "api",
                 Some(&test_upstream_pool()),
                 Some(0),
-                0,
                 &upstream_inflight,
                 Arc::new(Semaphore::new(1)),
-                Duration::ZERO,
             );
             assert!(matches!(
                 upstream_result,
@@ -1183,15 +1187,12 @@ mod tests {
         fn missing_upstream_limiter_preserves_overload_reason_in_failure_mapping() {
             let resilience = test_runtime_resilience(|_| {}, 8);
 
-            let result = execute_forwarding_post_auth_admission(
+            let result = execute_post_auth_for_api(
                 &resilience,
-                "api",
                 Some(&test_upstream_pool()),
                 Some(0),
-                0,
                 &HashMap::new(),
                 Arc::new(Semaphore::new(1)),
-                Duration::ZERO,
             );
 
             assert!(matches!(
@@ -1209,7 +1210,7 @@ mod tests {
         }
 
         #[test]
-        fn post_auth_admission_success_does_not_report_wait_when_no_wait_happened() {
+        fn post_auth_admission_ready_result_reports_no_wait_when_permits_are_immediate() {
             let resilience = test_runtime_resilience(|_| {}, 8);
             let pool = test_upstream_pool();
 
@@ -1219,15 +1220,12 @@ mod tests {
             assert!(!waited);
             drop(permit);
 
-            let result = execute_forwarding_post_auth_admission(
+            let result = execute_post_auth_for_api(
                 &resilience,
-                "api",
                 Some(&pool),
                 Some(0),
-                0,
                 &test_upstream_inflight(),
                 Arc::new(Semaphore::new(1)),
-                Duration::ZERO,
             );
 
             match result {

--- a/crates/edge/src/quic_listener/admission.rs
+++ b/crates/edge/src/quic_listener/admission.rs
@@ -596,9 +596,10 @@ mod tests {
     use spooky_config::{
         config::{
             Backend, Config, ForwardedHeaderPolicy, HealthCheck, Listen, LoadBalancing, Resilience,
-            RouteAuth, RouteMatch, Tls, Upstream, UpstreamHostPolicy,
+            RouteAuth, RouteMatch, ScopedRateLimit, ScopedRateLimitScope, Tls, Upstream,
+            UpstreamHostPolicy,
         },
-        runtime::{RuntimeApiKeyAuth, RuntimeAuthPolicy, RuntimeConfig},
+        runtime::{RuntimeApiKeyAuth, RuntimeAuthPolicy, RuntimeConfig, RuntimeJwtAuth},
     };
     use tokio::sync::Semaphore;
 
@@ -621,6 +622,44 @@ mod tests {
             forwarded_headers: Default::default(),
             protocol: Default::default(),
         }
+    }
+
+    fn test_policy_with_jwt(
+        secret: &str,
+        required_scopes: Vec<&str>,
+        required_roles: Vec<&str>,
+    ) -> RuntimeUpstreamPolicy {
+        RuntimeUpstreamPolicy {
+            upstream_auth: RuntimeAuthPolicy {
+                api_key: None,
+                jwt: Some(RuntimeJwtAuth {
+                    secret: secret.to_string(),
+                    issuer: Some("issuer-1".to_string()),
+                    audience: Some("aud-1".to_string()),
+                    clock_skew: Duration::from_secs(30),
+                }),
+                external_auth: None,
+                required_scopes: required_scopes.into_iter().map(str::to_string).collect(),
+                required_roles: required_roles.into_iter().map(str::to_string).collect(),
+            },
+            host: Default::default(),
+            forwarded_headers: Default::default(),
+            protocol: Default::default(),
+        }
+    }
+
+    fn test_hs256_jwt(secret: &str, claims: serde_json::Value, alg: &str) -> String {
+        let header = URL_SAFE_NO_PAD.encode(
+            serde_json::to_vec(&serde_json::json!({ "alg": alg, "typ": "JWT" }))
+                .expect("serialize header"),
+        );
+        let payload =
+            URL_SAFE_NO_PAD.encode(serde_json::to_vec(&claims).expect("serialize claims"));
+        let signing_input = format!("{header}.{payload}");
+        let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).expect("mac");
+        mac.update(signing_input.as_bytes());
+        let signature = URL_SAFE_NO_PAD.encode(mac.finalize().into_bytes());
+        format!("{signing_input}.{signature}")
     }
 
     fn test_runtime_resilience(
@@ -774,6 +813,203 @@ mod tests {
             assert_eq!(overload.body, b"brownout active, non-core route shed\n");
             assert_eq!(overload.www_authenticate, None);
             assert_eq!(overload.retry_after_seconds, Some(7));
+        }
+    }
+
+    mod local_auth_policy_contracts {
+        use super::*;
+
+        #[test]
+        fn local_auth_policy_returns_api_key_challenge_when_key_is_missing() {
+            let decision = evaluate_local_auth_policy(&test_policy_with_api_key(), None);
+
+            assert_eq!(
+                decision,
+                AdmissionPolicyDecision::Unauthorized(UnauthorizedDecision {
+                    challenge: AuthChallengeKind::ApiKey,
+                    status: StatusCode::UNAUTHORIZED,
+                    body: b"unauthorized\n",
+                })
+            );
+        }
+
+        #[test]
+        fn local_auth_policy_admits_when_api_key_matches() {
+            let headers = HashMap::from([("x-api-key".to_string(), "secret".to_string())]);
+            let lookup = |name: &str| headers.get(&name.to_ascii_lowercase()).cloned();
+
+            let decision = evaluate_local_auth_policy(&test_policy_with_api_key(), Some(&lookup));
+
+            assert_eq!(decision, AdmissionPolicyDecision::AdmitReady);
+        }
+
+        #[test]
+        fn local_auth_policy_returns_bearer_challenge_for_missing_or_invalid_jwt() {
+            let policy = test_policy_with_jwt("jwt-secret", vec!["payments:read"], vec!["admin"]);
+
+            let missing = evaluate_local_auth_policy(&policy, None);
+            assert_eq!(
+                missing,
+                AdmissionPolicyDecision::Unauthorized(UnauthorizedDecision {
+                    challenge: AuthChallengeKind::Bearer,
+                    status: StatusCode::UNAUTHORIZED,
+                    body: b"unauthorized\n",
+                })
+            );
+
+            let invalid_headers = HashMap::from([(
+                "authorization".to_string(),
+                "Bearer invalid.jwt.token".to_string(),
+            )]);
+            let invalid_lookup =
+                |name: &str| invalid_headers.get(&name.to_ascii_lowercase()).cloned();
+
+            let invalid = evaluate_local_auth_policy(&policy, Some(&invalid_lookup));
+            assert_eq!(
+                invalid,
+                AdmissionPolicyDecision::Unauthorized(UnauthorizedDecision {
+                    challenge: AuthChallengeKind::Bearer,
+                    status: StatusCode::UNAUTHORIZED,
+                    body: b"unauthorized\n",
+                })
+            );
+        }
+
+        #[test]
+        fn local_auth_policy_admits_valid_jwt_when_claims_satisfy_rbac() {
+            let token = test_hs256_jwt(
+                "jwt-secret",
+                serde_json::json!({
+                    "iss": "issuer-1",
+                    "aud": "aud-1",
+                    "exp": 4_000_000_000u64,
+                    "scope": "payments:read transfers:write",
+                    "roles": ["admin", "ops"],
+                }),
+                "HS256",
+            );
+            let headers = HashMap::from([("authorization".to_string(), format!("Bearer {token}"))]);
+            let lookup = |name: &str| headers.get(&name.to_ascii_lowercase()).cloned();
+
+            let decision = evaluate_local_auth_policy(
+                &test_policy_with_jwt("jwt-secret", vec!["payments:read"], vec!["admin"]),
+                Some(&lookup),
+            );
+
+            assert_eq!(decision, AdmissionPolicyDecision::AdmitReady);
+        }
+    }
+
+    mod scoped_rate_limit_policy_contracts {
+        use super::*;
+
+        fn test_scoped_rate_limits() -> ScopedRateLimiters {
+            ScopedRateLimiters::new(&[ScopedRateLimit {
+                name: "tenant-cap".to_string(),
+                scope: ScopedRateLimitScope::Tenant,
+                requests_per_sec: 1,
+                burst: 1,
+                key: Some("header:x-tenant-id".to_string()),
+                route_allowlist: vec!["payments".to_string()],
+                idle_ttl_secs: 60,
+            }])
+        }
+
+        #[test]
+        fn scoped_rate_limit_policy_admits_when_rule_does_not_reject() {
+            let rate_limits = test_scoped_rate_limits();
+
+            let allowed = evaluate_scoped_rate_limit_policy(&rate_limits, "payments", |_| {
+                Some("tenant-a".to_string())
+            });
+            let no_key = evaluate_scoped_rate_limit_policy(&rate_limits, "payments", |_| None);
+            let wrong_route = evaluate_scoped_rate_limit_policy(&rate_limits, "admin", |_| {
+                Some("tenant-a".to_string())
+            });
+
+            assert_eq!(allowed, AdmissionPolicyDecision::AdmitReady);
+            assert_eq!(no_key, AdmissionPolicyDecision::AdmitReady);
+            assert_eq!(wrong_route, AdmissionPolicyDecision::AdmitReady);
+        }
+
+        #[test]
+        fn scoped_rate_limit_policy_returns_typed_rejection_for_exhausted_bucket() {
+            let rate_limits = test_scoped_rate_limits();
+
+            let first = evaluate_scoped_rate_limit_policy(&rate_limits, "payments", |_| {
+                Some("tenant-a".to_string())
+            });
+            let second = evaluate_scoped_rate_limit_policy(&rate_limits, "payments", |_| {
+                Some("tenant-a".to_string())
+            });
+
+            assert_eq!(first, AdmissionPolicyDecision::AdmitReady);
+            assert_eq!(
+                second,
+                AdmissionPolicyDecision::RateLimited(RateLimitedDecision {
+                    rule_name: "tenant-cap".to_string(),
+                    route: "payments".to_string(),
+                    status: StatusCode::TOO_MANY_REQUESTS,
+                    body: b"request rate limited\n",
+                    retry_after_seconds: 1,
+                })
+            );
+        }
+    }
+
+    mod brownout_and_overload_policy_contracts {
+        use super::*;
+
+        #[test]
+        fn brownout_policy_sheds_non_core_routes_and_preserves_core_routes() {
+            let brownout = BrownoutController::new(true, 50, 25, vec![String::from("core")]);
+
+            let core = evaluate_brownout_policy(&brownout, 90, "core", 9);
+            let non_core = evaluate_brownout_policy(&brownout, 90, "payments", 9);
+
+            assert_eq!(core, AdmissionPolicyDecision::AdmitReady);
+            assert_eq!(
+                non_core,
+                AdmissionPolicyDecision::Overloaded(OverloadDecision {
+                    reason: OverloadDecisionReason::Brownout,
+                    status: StatusCode::SERVICE_UNAVAILABLE,
+                    body: b"brownout active, non-core route shed\n",
+                    retry_after_seconds: 9,
+                })
+            );
+        }
+
+        #[test]
+        fn overload_mapping_preserves_route_queue_reasons_and_shared_response_shape() {
+            let route_cap =
+                overload_decision_for_route_queue_rejection(RouteQueueRejection::RouteCap, 0);
+            let global_cap =
+                overload_decision_for_route_queue_rejection(RouteQueueRejection::GlobalCap, 3);
+
+            assert_eq!(
+                route_cap,
+                AdmissionPolicyDecision::Overloaded(OverloadDecision {
+                    reason: OverloadDecisionReason::RouteCap,
+                    status: StatusCode::SERVICE_UNAVAILABLE,
+                    body: b"route queue cap exceeded\n",
+                    retry_after_seconds: 1,
+                })
+            );
+            assert_eq!(
+                global_cap,
+                AdmissionPolicyDecision::Overloaded(OverloadDecision {
+                    reason: OverloadDecisionReason::RouteGlobalCap,
+                    status: StatusCode::SERVICE_UNAVAILABLE,
+                    body: b"global queue cap exceeded\n",
+                    retry_after_seconds: 3,
+                })
+            );
+
+            let mapped = admission_rejection_response(&global_cap).expect("rejection mapping");
+            assert_eq!(mapped.status, StatusCode::SERVICE_UNAVAILABLE);
+            assert_eq!(mapped.body, b"global queue cap exceeded\n");
+            assert_eq!(mapped.www_authenticate, None);
+            assert_eq!(mapped.retry_after_seconds, Some(3));
         }
     }
 

--- a/crates/edge/src/runtime/bundle.rs
+++ b/crates/edge/src/runtime/bundle.rs
@@ -259,7 +259,16 @@ impl RuntimeBundleHandle {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, path::Path};
+    use std::{
+        collections::HashMap,
+        future,
+        path::Path,
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        time::Duration,
+    };
 
     use rcgen::{Certificate, CertificateParams, SanType};
     use spooky_config::{
@@ -271,9 +280,10 @@ mod tests {
         runtime::RuntimeConfig,
     };
     use tempfile::tempdir;
+    use tokio::sync::oneshot;
 
     use super::*;
-    use crate::runtime::listener::QUICListener;
+    use crate::runtime::{listener::QUICListener, tasks::RuntimeTaskRegistration};
 
     fn write_test_cert_for_name(dir: &Path, cert_name: &str, dns_name: &str) -> (String, String) {
         let mut params = CertificateParams::new(vec![dns_name.to_string()]);
@@ -370,8 +380,123 @@ mod tests {
         bundle
     }
 
+    struct CompletionSignal(Option<oneshot::Sender<()>>);
+
+    impl Drop for CompletionSignal {
+        fn drop(&mut self) {
+            if let Some(sender) = self.0.take() {
+                let _ = sender.send(());
+            }
+        }
+    }
+
+    fn spawn_generation_task(
+        bundle: &RuntimeBundle,
+        completed: Arc<AtomicBool>,
+    ) -> tokio::task::AbortHandle {
+        let (completion_tx, completion_rx) = oneshot::channel();
+        let task = tokio::spawn(async move {
+            let _completion = CompletionSignal(Some(completion_tx));
+            future::pending::<()>().await;
+        });
+        let abort = task.abort_handle();
+        let join = task;
+        tokio::spawn(async move {
+            let _ = join.await;
+            completed.store(true, Ordering::Release);
+        });
+        bundle
+            .shared_state
+            .generation_state()
+            .generation_tasks
+            .register(RuntimeTaskRegistration::new(abort.clone(), completion_rx));
+        abort
+    }
+
     mod runtime_generation_view_ownership {
         use super::*;
+
+        #[test]
+        fn current_generation_helpers_share_one_canonical_active_view() {
+            let dir = tempdir().expect("tempdir");
+            let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+            let startup = test_config(cert, key, "http://127.0.0.1:7001");
+
+            let bundle = runtime_bundle_from_config(7, "runtime.yaml", &startup);
+            let handle = RuntimeBundleHandle::new(bundle);
+
+            let current = handle.current_view();
+            let via_generation = handle.with_current_generation(|active| {
+                (
+                    active.generation(),
+                    active.startup().config_path.clone(),
+                    active
+                        .runtime_config()
+                        .upstreams
+                        .get("api")
+                        .expect("upstream")
+                        .backends[0]
+                        .backend
+                        .address
+                        .clone(),
+                )
+            });
+            let via_view = handle.with_current_view(|view| {
+                (
+                    view.generation,
+                    view.startup.config_path.clone(),
+                    view.runtime_config
+                        .upstreams
+                        .get("api")
+                        .expect("upstream")
+                        .backends[0]
+                        .backend
+                        .address
+                        .clone(),
+                )
+            });
+
+            assert_eq!(handle.current_generation(), 7);
+            assert_eq!(current.generation(), 7);
+            assert_eq!(
+                via_generation,
+                (
+                    7,
+                    "runtime.yaml".to_string(),
+                    "http://127.0.0.1:7001".to_string()
+                )
+            );
+            assert_eq!(via_generation, via_view);
+        }
+
+        #[test]
+        fn startup_owned_state_stays_stable_while_generation_owned_runtime_changes() {
+            let dir = tempdir().expect("tempdir");
+            let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+            let startup = test_config(cert.clone(), key.clone(), "http://127.0.0.1:7001");
+            let reloaded = test_config(cert, key, "http://127.0.0.1:7002");
+
+            let current_bundle = runtime_bundle_from_config(1, "spooky.yaml", &startup);
+            let next_bundle = runtime_bundle_from_config(2, "spooky.yaml", &reloaded);
+            let handle = RuntimeBundleHandle::new(current_bundle);
+
+            handle.replace(next_bundle).expect("replace");
+
+            let active = handle.current_view();
+            assert_eq!(active.generation(), 2);
+            assert_eq!(active.startup().config_path, "spooky.yaml");
+            assert_eq!(
+                active
+                    .runtime_config()
+                    .upstreams
+                    .get("api")
+                    .expect("active upstream")
+                    .backends[0]
+                    .backend
+                    .address,
+                "http://127.0.0.1:7002"
+            );
+        }
 
         #[test]
         fn stale_generation_views_do_not_change_after_runtime_bundle_replacement() {
@@ -414,6 +539,40 @@ mod tests {
                     .address,
                 "http://127.0.0.1:7002"
             );
+        }
+
+        #[tokio::test]
+        async fn bundle_replacement_retires_only_previous_generation_tasks() {
+            let dir = tempdir().expect("tempdir");
+            let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+            let startup = test_config(cert.clone(), key.clone(), "http://127.0.0.1:7001");
+            let reloaded = test_config(cert, key, "http://127.0.0.1:7002");
+
+            let current_bundle = runtime_bundle_from_config(1, "spooky.yaml", &startup);
+            let next_bundle = runtime_bundle_from_config(2, "spooky.yaml", &reloaded);
+
+            let retired_completed = Arc::new(AtomicBool::new(false));
+            let active_completed = Arc::new(AtomicBool::new(false));
+            let _retired_task =
+                spawn_generation_task(&current_bundle, Arc::clone(&retired_completed));
+            let active_task = spawn_generation_task(&next_bundle, Arc::clone(&active_completed));
+
+            let handle = RuntimeBundleHandle::new(current_bundle);
+            handle.replace(next_bundle).expect("replace");
+            tokio::time::sleep(Duration::from_millis(20)).await;
+
+            assert!(
+                retired_completed.load(Ordering::Acquire),
+                "previous generation tasks should retire when the bundle is replaced"
+            );
+            assert!(
+                !active_completed.load(Ordering::Acquire),
+                "new generation tasks should remain active after replacement"
+            );
+
+            active_task.abort();
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            assert!(active_completed.load(Ordering::Acquire));
         }
     }
 }

--- a/crates/edge/src/runtime/bundle.rs
+++ b/crates/edge/src/runtime/bundle.rs
@@ -380,6 +380,23 @@ mod tests {
         bundle
     }
 
+    fn runtime_bundle_pair(
+        dir: &Path,
+        startup_path: &str,
+        startup_backend_addr: &str,
+        next_generation: u64,
+        next_path: &str,
+        next_backend_addr: &str,
+    ) -> (RuntimeBundle, RuntimeBundle) {
+        let (cert, key) = write_test_cert_for_name(dir, "server", "api.example.com");
+        let startup = test_config(cert.clone(), key.clone(), startup_backend_addr);
+        let reloaded = test_config(cert, key, next_backend_addr);
+        (
+            runtime_bundle_from_config(1, startup_path, &startup),
+            runtime_bundle_from_config(next_generation, next_path, &reloaded),
+        )
+    }
+
     struct CompletionSignal(Option<oneshot::Sender<()>>);
 
     impl Drop for CompletionSignal {
@@ -419,10 +436,16 @@ mod tests {
         #[test]
         fn current_generation_helpers_share_one_canonical_active_view() {
             let dir = tempdir().expect("tempdir");
-            let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
-            let startup = test_config(cert, key, "http://127.0.0.1:7001");
-
-            let bundle = runtime_bundle_from_config(7, "runtime.yaml", &startup);
+            let (startup_bundle, _) = runtime_bundle_pair(
+                dir.path(),
+                "runtime.yaml",
+                "http://127.0.0.1:7001",
+                8,
+                "unused.yaml",
+                "http://127.0.0.1:7002",
+            );
+            let mut bundle = startup_bundle;
+            bundle.generation = 7;
             let handle = RuntimeBundleHandle::new(bundle);
 
             let current = handle.current_view();
@@ -472,12 +495,14 @@ mod tests {
         #[test]
         fn startup_owned_state_stays_stable_while_generation_owned_runtime_changes() {
             let dir = tempdir().expect("tempdir");
-            let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
-            let startup = test_config(cert.clone(), key.clone(), "http://127.0.0.1:7001");
-            let reloaded = test_config(cert, key, "http://127.0.0.1:7002");
-
-            let current_bundle = runtime_bundle_from_config(1, "spooky.yaml", &startup);
-            let next_bundle = runtime_bundle_from_config(2, "spooky.yaml", &reloaded);
+            let (current_bundle, next_bundle) = runtime_bundle_pair(
+                dir.path(),
+                "spooky.yaml",
+                "http://127.0.0.1:7001",
+                2,
+                "spooky.yaml",
+                "http://127.0.0.1:7002",
+            );
             let handle = RuntimeBundleHandle::new(current_bundle);
 
             handle.replace(next_bundle).expect("replace");
@@ -499,14 +524,16 @@ mod tests {
         }
 
         #[test]
-        fn stale_generation_views_do_not_change_after_runtime_bundle_replacement() {
+        fn stale_generation_views_keep_the_original_runtime_snapshot_after_replacement() {
             let dir = tempdir().expect("tempdir");
-            let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
-            let startup = test_config(cert.clone(), key.clone(), "http://127.0.0.1:7001");
-            let reloaded = test_config(cert, key, "http://127.0.0.1:7002");
-
-            let current_bundle = runtime_bundle_from_config(1, "startup.yaml", &startup);
-            let next_bundle = runtime_bundle_from_config(2, "reloaded.yaml", &reloaded);
+            let (current_bundle, next_bundle) = runtime_bundle_pair(
+                dir.path(),
+                "startup.yaml",
+                "http://127.0.0.1:7001",
+                2,
+                "reloaded.yaml",
+                "http://127.0.0.1:7002",
+            );
             let handle = RuntimeBundleHandle::new(current_bundle.clone());
 
             let stale = handle.current_view();
@@ -544,12 +571,14 @@ mod tests {
         #[tokio::test]
         async fn bundle_replacement_retires_only_previous_generation_tasks() {
             let dir = tempdir().expect("tempdir");
-            let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
-            let startup = test_config(cert.clone(), key.clone(), "http://127.0.0.1:7001");
-            let reloaded = test_config(cert, key, "http://127.0.0.1:7002");
-
-            let current_bundle = runtime_bundle_from_config(1, "spooky.yaml", &startup);
-            let next_bundle = runtime_bundle_from_config(2, "spooky.yaml", &reloaded);
+            let (current_bundle, next_bundle) = runtime_bundle_pair(
+                dir.path(),
+                "spooky.yaml",
+                "http://127.0.0.1:7001",
+                2,
+                "spooky.yaml",
+                "http://127.0.0.1:7002",
+            );
 
             let retired_completed = Arc::new(AtomicBool::new(false));
             let active_completed = Arc::new(AtomicBool::new(false));

--- a/crates/edge/src/runtime/bundle.rs
+++ b/crates/edge/src/runtime/bundle.rs
@@ -370,46 +370,50 @@ mod tests {
         bundle
     }
 
-    #[test]
-    fn stale_generation_views_do_not_change_after_runtime_bundle_replacement() {
-        let dir = tempdir().expect("tempdir");
-        let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
-        let startup = test_config(cert.clone(), key.clone(), "http://127.0.0.1:7001");
-        let reloaded = test_config(cert, key, "http://127.0.0.1:7002");
+    mod runtime_generation_view_ownership {
+        use super::*;
 
-        let current_bundle = runtime_bundle_from_config(1, "startup.yaml", &startup);
-        let next_bundle = runtime_bundle_from_config(2, "reloaded.yaml", &reloaded);
-        let handle = RuntimeBundleHandle::new(current_bundle.clone());
+        #[test]
+        fn stale_generation_views_do_not_change_after_runtime_bundle_replacement() {
+            let dir = tempdir().expect("tempdir");
+            let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+            let startup = test_config(cert.clone(), key.clone(), "http://127.0.0.1:7001");
+            let reloaded = test_config(cert, key, "http://127.0.0.1:7002");
 
-        let stale = handle.current_view();
-        let installed = handle.replace(next_bundle).expect("replace");
+            let current_bundle = runtime_bundle_from_config(1, "startup.yaml", &startup);
+            let next_bundle = runtime_bundle_from_config(2, "reloaded.yaml", &reloaded);
+            let handle = RuntimeBundleHandle::new(current_bundle.clone());
 
-        assert_eq!(installed, 2);
-        assert_eq!(handle.current_generation(), 2);
-        assert_eq!(stale.generation(), 1);
-        assert_eq!(stale.startup().config_path, "startup.yaml");
-        assert_eq!(
-            stale
-                .runtime_config()
-                .upstreams
-                .get("api")
-                .expect("stale upstream")
-                .backends[0]
-                .backend
-                .address,
-            "http://127.0.0.1:7001"
-        );
-        assert_eq!(
-            handle
-                .current()
-                .runtime_config
-                .upstreams
-                .get("api")
-                .expect("current upstream")
-                .backends[0]
-                .backend
-                .address,
-            "http://127.0.0.1:7002"
-        );
+            let stale = handle.current_view();
+            let installed = handle.replace(next_bundle).expect("replace");
+
+            assert_eq!(installed, 2);
+            assert_eq!(handle.current_generation(), 2);
+            assert_eq!(stale.generation(), 1);
+            assert_eq!(stale.startup().config_path, "startup.yaml");
+            assert_eq!(
+                stale
+                    .runtime_config()
+                    .upstreams
+                    .get("api")
+                    .expect("stale upstream")
+                    .backends[0]
+                    .backend
+                    .address,
+                "http://127.0.0.1:7001"
+            );
+            assert_eq!(
+                handle
+                    .current()
+                    .runtime_config
+                    .upstreams
+                    .get("api")
+                    .expect("current upstream")
+                    .backends[0]
+                    .backend
+                    .address,
+                "http://127.0.0.1:7002"
+            );
+        }
     }
 }

--- a/crates/edge/src/runtime/connection/auth.rs
+++ b/crates/edge/src/runtime/connection/auth.rs
@@ -819,6 +819,50 @@ mod tests {
             );
             assert!(!headers.iter().any(|header| header.name() == b"x-team"));
         }
+
+        #[test]
+        fn merge_auth_request_mutations_canonicalizes_existing_and_incoming_values() {
+            let mut existing = vec![
+                PendingHeaderMutation::Upsert {
+                    name: b"x-user".to_vec(),
+                    value: b"stale".to_vec(),
+                },
+                PendingHeaderMutation::Upsert {
+                    name: b"authorization".to_vec(),
+                    value: b"Bearer blocked".to_vec(),
+                },
+            ];
+
+            merge_auth_request_mutations(
+                &mut existing,
+                vec![
+                    PendingHeaderMutation::Upsert {
+                        name: b"X-User".to_vec(),
+                        value: b"fresh".to_vec(),
+                    },
+                    PendingHeaderMutation::Remove {
+                        name: b"x-team".to_vec(),
+                    },
+                    PendingHeaderMutation::Upsert {
+                        name: b"connection".to_vec(),
+                        value: b"close".to_vec(),
+                    },
+                ],
+            );
+
+            assert_eq!(
+                existing,
+                vec![
+                    PendingHeaderMutation::Upsert {
+                        name: b"x-user".to_vec(),
+                        value: b"fresh".to_vec(),
+                    },
+                    PendingHeaderMutation::Remove {
+                        name: b"x-team".to_vec(),
+                    },
+                ]
+            );
+        }
     }
 
     mod external_auth_response_mapping {
@@ -963,6 +1007,20 @@ mod tests {
                     ..
                 })
             ));
+        }
+
+        #[test]
+        fn map_http_external_auth_response_rejects_redirect_without_location_header() {
+            let redirect = map_http_external_auth_response(
+                ExternalAuthResponseMetadata {
+                    status: http::StatusCode::FOUND,
+                    headers: &http::HeaderMap::new(),
+                    body: &[],
+                },
+                &["location".to_string()],
+            );
+
+            assert!(matches!(redirect, Err(ProxyError::Transport(_))));
         }
 
         #[test]
@@ -1128,6 +1186,15 @@ mod tests {
             }))
             .expect_err("non-loopback http introspection endpoint must fail");
             assert!(matches!(invalid, ProxyError::Transport(_)));
+
+            let loopback = validate_oidc_provider_metadata(&json!({
+                "introspection_endpoint": "http://localhost:9000/oauth2/introspect"
+            }))
+            .expect("loopback http introspection endpoint should be allowed");
+            assert_eq!(
+                loopback.introspection_endpoint,
+                "http://localhost:9000/oauth2/introspect"
+            );
         }
 
         #[test]
@@ -1199,6 +1266,33 @@ mod tests {
                     status: http::StatusCode::GATEWAY_TIMEOUT,
                     timed_out: true,
                     ..
+                }
+            ));
+        }
+
+        #[test]
+        fn evaluate_external_auth_completion_distinguishes_fail_open_timeout_from_error() {
+            let timeout = evaluate_external_auth_completion(
+                Err(ProxyError::Timeout),
+                ExternalAuthFailureDisposition::FailOpen,
+            );
+            assert!(matches!(
+                timeout,
+                ExternalAuthCompletion::FailOpen {
+                    timed_out: true,
+                    error: None,
+                }
+            ));
+
+            let error = evaluate_external_auth_completion(
+                Err(ProxyError::Transport("dial failed".into())),
+                ExternalAuthFailureDisposition::FailOpen,
+            );
+            assert!(matches!(
+                error,
+                ExternalAuthCompletion::FailOpen {
+                    timed_out: false,
+                    error: Some(ProxyError::Transport(_)),
                 }
             ));
         }
@@ -1433,6 +1527,31 @@ mod tests {
                     body: b"external auth unavailable\n",
                     error: Some(ProxyError::Transport(_)),
                 }
+            ));
+        }
+
+        #[test]
+        fn resolve_external_auth_state_transition_fail_open_never_emits_auth_rejection() {
+            let timeout = resolve_external_auth_state_transition(
+                Err(ProxyError::Timeout),
+                ExternalAuthFailureDisposition::FailOpen,
+            );
+            let error = resolve_external_auth_state_transition(
+                Err(ProxyError::Transport("dial failed".into())),
+                ExternalAuthFailureDisposition::FailOpen,
+            );
+
+            assert!(matches!(
+                timeout,
+                ExternalAuthStateTransition::Admitted {
+                    request_header_mutations,
+                } if request_header_mutations.is_empty()
+            ));
+            assert!(matches!(
+                error,
+                ExternalAuthStateTransition::Admitted {
+                    request_header_mutations,
+                } if request_header_mutations.is_empty()
             ));
         }
     }

--- a/crates/edge/src/runtime/connection/auth.rs
+++ b/crates/edge/src/runtime/connection/auth.rs
@@ -721,697 +721,719 @@ mod tests {
 
     use super::*;
 
-    #[test]
-    fn canonicalize_auth_request_mutations_drops_protected_and_invalid_names() {
-        let mutations = canonicalize_auth_request_mutations(vec![
-            PendingHeaderMutation::Upsert {
-                name: b"x-auth-user".to_vec(),
-                value: b"alice".to_vec(),
-            },
-            PendingHeaderMutation::Upsert {
-                name: b"authorization".to_vec(),
-                value: b"Bearer blocked".to_vec(),
-            },
-            PendingHeaderMutation::Remove {
-                name: b"bad name".to_vec(),
-            },
-        ]);
+    mod mutation_contracts {
+        use super::*;
 
-        assert_eq!(
-            mutations,
-            vec![PendingHeaderMutation::Upsert {
-                name: b"x-auth-user".to_vec(),
-                value: b"alice".to_vec(),
-            }]
-        );
-    }
+        #[test]
+        fn canonicalize_auth_request_mutations_drops_protected_and_invalid_names() {
+            let mutations = canonicalize_auth_request_mutations(vec![
+                PendingHeaderMutation::Upsert {
+                    name: b"x-auth-user".to_vec(),
+                    value: b"alice".to_vec(),
+                },
+                PendingHeaderMutation::Upsert {
+                    name: b"authorization".to_vec(),
+                    value: b"Bearer blocked".to_vec(),
+                },
+                PendingHeaderMutation::Remove {
+                    name: b"bad name".to_vec(),
+                },
+            ]);
 
-    #[test]
-    fn canonicalize_auth_request_mutations_keeps_last_mutation_per_header() {
-        let mutations = canonicalize_auth_request_mutations(vec![
-            PendingHeaderMutation::Upsert {
-                name: b"X-User".to_vec(),
-                value: b"one".to_vec(),
-            },
-            PendingHeaderMutation::Upsert {
-                name: b"x-team".to_vec(),
-                value: b"red".to_vec(),
-            },
-            PendingHeaderMutation::Remove {
-                name: b"x-user".to_vec(),
-            },
-            PendingHeaderMutation::Upsert {
-                name: b"X-Team".to_vec(),
-                value: b"blue".to_vec(),
-            },
-        ]);
+            assert_eq!(
+                mutations,
+                vec![PendingHeaderMutation::Upsert {
+                    name: b"x-auth-user".to_vec(),
+                    value: b"alice".to_vec(),
+                }]
+            );
+        }
 
-        assert_eq!(
-            mutations,
-            vec![
+        #[test]
+        fn canonicalize_auth_request_mutations_keeps_last_mutation_per_header() {
+            let mutations = canonicalize_auth_request_mutations(vec![
+                PendingHeaderMutation::Upsert {
+                    name: b"X-User".to_vec(),
+                    value: b"one".to_vec(),
+                },
+                PendingHeaderMutation::Upsert {
+                    name: b"x-team".to_vec(),
+                    value: b"red".to_vec(),
+                },
                 PendingHeaderMutation::Remove {
                     name: b"x-user".to_vec(),
                 },
                 PendingHeaderMutation::Upsert {
-                    name: b"x-team".to_vec(),
+                    name: b"X-Team".to_vec(),
                     value: b"blue".to_vec(),
                 },
-            ]
-        );
-    }
+            ]);
 
-    #[test]
-    fn apply_auth_request_mutations_resolves_conflicts_before_header_rewrite() {
-        let mut headers = vec![
-            quiche::h3::Header::new(b":method", b"GET"),
-            quiche::h3::Header::new(b"x-user", b"stale"),
-            quiche::h3::Header::new(b"x-team", b"green"),
-        ];
-        let mutations = vec![
-            PendingHeaderMutation::Upsert {
-                name: b"X-User".to_vec(),
-                value: b"alice".to_vec(),
-            },
-            PendingHeaderMutation::Remove {
-                name: b"x-team".to_vec(),
-            },
-            PendingHeaderMutation::Upsert {
-                name: b"x-user".to_vec(),
-                value: b"fresh".to_vec(),
-            },
-        ];
-
-        apply_auth_request_mutations(&mut headers, &mutations);
-
-        assert!(headers.iter().any(|header| header.name() == b":method"));
-        assert!(
-            headers
-                .iter()
-                .any(|header| header.name() == b"x-user" && header.value() == b"fresh")
-        );
-        assert!(
-            !headers
-                .iter()
-                .any(|header| header.name() == b"x-user" && header.value() == b"alice")
-        );
-        assert!(!headers.iter().any(|header| header.name() == b"x-team"));
-    }
-
-    #[test]
-    fn allowed_auth_headers_is_case_insensitive_and_auth_allow_mutations_keep_safe_values() {
-        let mut headers = http::HeaderMap::new();
-        headers.insert("x-auth-user", http::HeaderValue::from_static("alice"));
-        headers.insert("x-auth-group", http::HeaderValue::from_static("admin"));
-        headers.insert(
-            http::header::AUTHORIZATION,
-            http::HeaderValue::from_static("Bearer blocked"),
-        );
-
-        assert_eq!(
-            allowed_auth_headers(
-                &headers,
-                &[
-                    "X-Auth-User".to_string(),
-                    "x-auth-group".to_string(),
-                    "authorization".to_string(),
-                ],
-            ),
-            vec![
-                ("x-auth-user".to_string(), "alice".to_string()),
-                ("x-auth-group".to_string(), "admin".to_string()),
-                ("authorization".to_string(), "Bearer blocked".to_string()),
-            ]
-        );
-
-        assert_eq!(
-            auth_allow_mutations(
-                &headers,
-                &[
-                    "X-Auth-User".to_string(),
-                    "x-auth-group".to_string(),
-                    "authorization".to_string(),
-                ],
-            ),
-            vec![
-                PendingHeaderMutation::Upsert {
-                    name: b"x-auth-user".to_vec(),
-                    value: b"alice".to_vec(),
-                },
-                PendingHeaderMutation::Upsert {
-                    name: b"x-auth-group".to_vec(),
-                    value: b"admin".to_vec(),
-                },
-            ]
-        );
-    }
-
-    #[test]
-    fn map_http_external_auth_response_covers_allow_deny_redirect_and_challenge() {
-        let mut allow_headers = http::HeaderMap::new();
-        allow_headers.insert("x-auth-user", http::HeaderValue::from_static("alice"));
-        allow_headers.insert(
-            http::header::AUTHORIZATION,
-            http::HeaderValue::from_static("Bearer blocked"),
-        );
-        let allow = map_http_external_auth_response(
-            ExternalAuthResponseMetadata {
-                status: http::StatusCode::OK,
-                headers: &allow_headers,
-                body: &[],
-            },
-            &["x-auth-user".to_string(), "authorization".to_string()],
-        )
-        .expect("allow decision");
-        assert_eq!(
-            allow,
-            ExternalAuthDecision::Allow {
-                request_header_mutations: vec![PendingHeaderMutation::Upsert {
-                    name: b"x-auth-user".to_vec(),
-                    value: b"alice".to_vec(),
-                }],
-            }
-        );
-
-        let mut deny_headers = http::HeaderMap::new();
-        deny_headers.insert("x-auth-reason", http::HeaderValue::from_static("policy"));
-        let deny = map_http_external_auth_response(
-            ExternalAuthResponseMetadata {
-                status: http::StatusCode::FORBIDDEN,
-                headers: &deny_headers,
-                body: b"denied\n",
-            },
-            &["x-auth-reason".to_string()],
-        )
-        .expect("deny decision");
-        assert!(matches!(
-            deny,
-            ExternalAuthDecision::Deny(ExternalAuthDenyResponse {
-                status: http::StatusCode::FORBIDDEN,
-                ..
-            })
-        ));
-
-        let mut redirect_headers = http::HeaderMap::new();
-        redirect_headers.insert(
-            http::header::LOCATION,
-            http::HeaderValue::from_static("https://login.example.com/"),
-        );
-        redirect_headers.insert("x-auth-reason", http::HeaderValue::from_static("login"));
-        let redirect = map_http_external_auth_response(
-            ExternalAuthResponseMetadata {
-                status: http::StatusCode::FOUND,
-                headers: &redirect_headers,
-                body: &[],
-            },
-            &["location".to_string(), "x-auth-reason".to_string()],
-        )
-        .expect("redirect decision");
-        assert!(matches!(
-            redirect,
-            ExternalAuthDecision::Redirect(ExternalAuthRedirectResponse {
-                status: http::StatusCode::FOUND,
-                ..
-            })
-        ));
-
-        let mut challenge_headers = http::HeaderMap::new();
-        challenge_headers.insert(
-            http::header::WWW_AUTHENTICATE,
-            http::HeaderValue::from_static("Bearer realm=\"spooky\""),
-        );
-        challenge_headers.insert("x-auth-reason", http::HeaderValue::from_static("expired"));
-        let challenge = map_http_external_auth_response(
-            ExternalAuthResponseMetadata {
-                status: http::StatusCode::UNAUTHORIZED,
-                headers: &challenge_headers,
-                body: b"challenge\n",
-            },
-            &["www-authenticate".to_string(), "x-auth-reason".to_string()],
-        )
-        .expect("challenge decision");
-        assert!(matches!(
-            challenge,
-            ExternalAuthDecision::Challenge(ExternalAuthChallengeResponse {
-                status: http::StatusCode::UNAUTHORIZED,
-                ..
-            })
-        ));
-    }
-
-    #[test]
-    fn response_header_allowlists_are_enforced_exactly_for_each_external_auth_outcome() {
-        let mut headers = http::HeaderMap::new();
-        headers.insert("x-auth-user", http::HeaderValue::from_static("alice"));
-        headers.insert("x-auth-group", http::HeaderValue::from_static("admin"));
-        headers.insert(
-            http::header::LOCATION,
-            http::HeaderValue::from_static("https://login.example.com/"),
-        );
-        headers.insert(
-            http::header::WWW_AUTHENTICATE,
-            http::HeaderValue::from_static("Bearer realm=\"spooky\""),
-        );
-
-        let allow = map_http_external_auth_response(
-            ExternalAuthResponseMetadata {
-                status: http::StatusCode::OK,
-                headers: &headers,
-                body: &[],
-            },
-            &[
-                "x-auth-user".to_string(),
-                "www-authenticate".to_string(),
-                "location".to_string(),
-            ],
-        )
-        .expect("allow");
-        assert_eq!(
-            allow,
-            ExternalAuthDecision::Allow {
-                request_header_mutations: vec![PendingHeaderMutation::Upsert {
-                    name: b"x-auth-user".to_vec(),
-                    value: b"alice".to_vec(),
-                }],
-            }
-        );
-
-        let redirect = map_http_external_auth_response(
-            ExternalAuthResponseMetadata {
-                status: http::StatusCode::FOUND,
-                headers: &headers,
-                body: &[],
-            },
-            &[
-                "x-auth-user".to_string(),
-                "x-auth-group".to_string(),
-                "location".to_string(),
-            ],
-        )
-        .expect("redirect");
-        assert_eq!(
-            redirect,
-            ExternalAuthDecision::Redirect(ExternalAuthRedirectResponse {
-                status: http::StatusCode::FOUND,
-                headers: vec![
-                    ("x-auth-user".to_string(), "alice".to_string()),
-                    ("x-auth-group".to_string(), "admin".to_string()),
-                ],
-                location: "https://login.example.com/".to_string(),
-            })
-        );
-
-        let challenge = map_http_external_auth_response(
-            ExternalAuthResponseMetadata {
-                status: http::StatusCode::UNAUTHORIZED,
-                headers: &headers,
-                body: b"challenge\n",
-            },
-            &[
-                "x-auth-group".to_string(),
-                "www-authenticate".to_string(),
-                "location".to_string(),
-            ],
-        )
-        .expect("challenge");
-        assert_eq!(
-            challenge,
-            ExternalAuthDecision::Challenge(ExternalAuthChallengeResponse {
-                status: http::StatusCode::UNAUTHORIZED,
-                headers: vec![
-                    ("x-auth-group".to_string(), "admin".to_string()),
-                    (
-                        "location".to_string(),
-                        "https://login.example.com/".to_string(),
-                    ),
-                ],
-                www_authenticate: "Bearer realm=\"spooky\"".to_string(),
-                body: b"challenge\n".to_vec(),
-            })
-        );
-    }
-
-    #[test]
-    fn oidc_authorization_check_maps_missing_and_invalid_bearer_tokens_to_challenges() {
-        assert!(matches!(
-            oidc_authorization_check(None),
-            OidcAuthorizationCheck::Challenge(ExternalAuthChallengeResponse {
-                status: http::StatusCode::UNAUTHORIZED,
-                ..
-            })
-        ));
-
-        let invalid = oidc_authorization_check(Some("Basic abc123"));
-        match invalid {
-            OidcAuthorizationCheck::Challenge(response) => {
-                assert_eq!(response.www_authenticate, "Bearer");
-                assert_eq!(response.body, b"invalid bearer token\n".to_vec());
-            }
-            other => panic!("unexpected authorization result: {other:?}"),
+            assert_eq!(
+                mutations,
+                vec![
+                    PendingHeaderMutation::Remove {
+                        name: b"x-user".to_vec(),
+                    },
+                    PendingHeaderMutation::Upsert {
+                        name: b"x-team".to_vec(),
+                        value: b"blue".to_vec(),
+                    },
+                ]
+            );
         }
 
-        assert_eq!(
-            oidc_authorization_check(Some("Bearer token-1")),
-            OidcAuthorizationCheck::Token("token-1".to_string())
-        );
-        assert_eq!(
-            oidc_authorization_check(Some("bearer token-2")),
-            OidcAuthorizationCheck::Token("token-2".to_string())
-        );
-    }
-
-    #[test]
-    fn oidc_discovery_target_derives_and_validates_provider_metadata_url() {
-        let derived = oidc_discovery_target(None, Some("https://issuer.example.com/base/"))
-            .expect("derived discovery target");
-        assert_eq!(
-            derived.url,
-            "https://issuer.example.com/base/.well-known/openid-configuration"
-        );
-
-        let http_loopback = oidc_discovery_target(Some("http://127.0.0.1:9000/oidc"), None)
-            .expect("loopback discovery should be allowed");
-        assert!(http_loopback.url.starts_with("http://"));
-
-        let err = oidc_discovery_target(Some("http://example.com/oidc"), None)
-            .expect_err("non-loopback http discovery must be rejected");
-        assert!(matches!(err, ProxyError::Transport(_)));
-    }
-
-    #[test]
-    fn validate_oidc_provider_metadata_requires_safe_introspection_endpoint() {
-        let valid = validate_oidc_provider_metadata(&json!({
-            "introspection_endpoint": "https://issuer.example.com/oauth2/introspect"
-        }))
-        .expect("valid metadata");
-        assert_eq!(
-            valid.introspection_endpoint,
-            "https://issuer.example.com/oauth2/introspect"
-        );
-
-        let missing = validate_oidc_provider_metadata(&json!({}))
-            .expect_err("metadata without introspection endpoint must fail");
-        assert!(matches!(missing, ProxyError::Transport(_)));
-
-        let invalid = validate_oidc_provider_metadata(&json!({
-            "introspection_endpoint": "http://example.com/oauth2/introspect"
-        }))
-        .expect_err("non-loopback http introspection endpoint must fail");
-        assert!(matches!(invalid, ProxyError::Transport(_)));
-    }
-
-    #[test]
-    fn oidc_helper_predicates_match_expected_scope_and_audience_shapes() {
-        assert!(oidc_scope_satisfied(
-            &["read".to_string(), "write".to_string()],
-            "read write admin"
-        ));
-        assert!(!oidc_scope_satisfied(
-            &["read".to_string(), "write".to_string()],
-            "read"
-        ));
-
-        assert!(oidc_audience_matches(
-            Some("api://edge"),
-            Some(&json!("api://edge"))
-        ));
-        assert!(oidc_audience_matches(
-            Some("api://edge"),
-            Some(&json!(["other", "api://edge"]))
-        ));
-        assert!(!oidc_audience_matches(
-            Some("api://edge"),
-            Some(&json!("api://other"))
-        ));
-        assert!(oidc_audience_matches(None, None));
-    }
-
-    #[test]
-    fn external_auth_task_config_tracks_timeout_and_disposition() {
-        let auth = RuntimeExternalAuth::Http {
-            endpoint: "http://127.0.0.1:9000/auth".to_string(),
-            request_headers: Vec::new(),
-            response_header_allowlist: Vec::new(),
-            timeout: Duration::from_millis(250),
-            failure_mode: RuntimeExternalAuthFailureMode::FailOpen,
-        };
-
-        let config = ExternalAuthTaskConfig::from_external_auth(&auth);
-        assert_eq!(config.timeout, Duration::from_millis(250));
-        assert_eq!(config.disposition, ExternalAuthFailureDisposition::FailOpen);
-    }
-
-    #[test]
-    fn evaluate_external_auth_completion_maps_fail_open_and_fail_closed_outcomes() {
-        let fail_open = evaluate_external_auth_completion(
-            Err(ProxyError::Transport("unavailable".into())),
-            ExternalAuthFailureDisposition::FailOpen,
-        );
-        assert!(matches!(
-            fail_open,
-            ExternalAuthCompletion::FailOpen {
-                timed_out: false,
-                error: Some(ProxyError::Transport(_)),
-            }
-        ));
-
-        let fail_closed = evaluate_external_auth_completion(
-            Err(ProxyError::Timeout),
-            ExternalAuthFailureDisposition::FailClosed,
-        );
-        assert!(matches!(
-            fail_closed,
-            ExternalAuthCompletion::Reject {
-                status: http::StatusCode::GATEWAY_TIMEOUT,
-                timed_out: true,
-                ..
-            }
-        ));
-    }
-
-    #[test]
-    fn evaluate_external_auth_completion_maps_allow_and_response_decisions() {
-        let allow = evaluate_external_auth_completion(
-            Ok(ExternalAuthDecision::Allow {
-                request_header_mutations: vec![PendingHeaderMutation::Upsert {
-                    name: b"x-auth-user".to_vec(),
+        #[test]
+        fn apply_auth_request_mutations_resolves_conflicts_before_header_rewrite() {
+            let mut headers = vec![
+                quiche::h3::Header::new(b":method", b"GET"),
+                quiche::h3::Header::new(b"x-user", b"stale"),
+                quiche::h3::Header::new(b"x-team", b"green"),
+            ];
+            let mutations = vec![
+                PendingHeaderMutation::Upsert {
+                    name: b"X-User".to_vec(),
                     value: b"alice".to_vec(),
-                }],
-            }),
-            ExternalAuthFailureDisposition::FailClosed,
-        );
-        assert!(matches!(
-            allow,
-            ExternalAuthCompletion::Allow {
-                request_header_mutations,
-            } if request_header_mutations == vec![PendingHeaderMutation::Upsert {
-                name: b"x-auth-user".to_vec(),
-                value: b"alice".to_vec(),
-            }]
-        ));
-
-        let deny = evaluate_external_auth_completion(
-            Ok(ExternalAuthDecision::Deny(ExternalAuthDenyResponse {
-                status: http::StatusCode::FORBIDDEN,
-                headers: vec![("x-auth-reason".to_string(), "policy".to_string())],
-                body: b"denied\n".to_vec(),
-            })),
-            ExternalAuthFailureDisposition::FailClosed,
-        );
-        assert!(matches!(
-            deny,
-            ExternalAuthCompletion::Respond(ExternalAuthDecision::Deny(ExternalAuthDenyResponse {
-                status: http::StatusCode::FORBIDDEN,
-                ..
-            }))
-        ));
-
-        let redirect = evaluate_external_auth_completion(
-            Ok(ExternalAuthDecision::Redirect(
-                ExternalAuthRedirectResponse {
-                    status: http::StatusCode::FOUND,
-                    headers: vec![("x-auth-reason".to_string(), "login".to_string())],
-                    location: "https://login.example.com/".to_string(),
                 },
-            )),
-            ExternalAuthFailureDisposition::FailClosed,
-        );
-        assert!(matches!(
-            redirect,
-            ExternalAuthCompletion::Respond(ExternalAuthDecision::Redirect(
-                ExternalAuthRedirectResponse {
-                    status: http::StatusCode::FOUND,
-                    ..
-                }
-            ))
-        ));
-
-        let challenge = evaluate_external_auth_completion(
-            Ok(ExternalAuthDecision::Challenge(
-                ExternalAuthChallengeResponse {
-                    status: http::StatusCode::UNAUTHORIZED,
-                    headers: vec![("x-auth-reason".to_string(), "expired".to_string())],
-                    www_authenticate: "Bearer realm=\"spooky\"".to_string(),
-                    body: b"challenge\n".to_vec(),
+                PendingHeaderMutation::Remove {
+                    name: b"x-team".to_vec(),
                 },
-            )),
-            ExternalAuthFailureDisposition::FailClosed,
-        );
-        assert!(matches!(
-            challenge,
-            ExternalAuthCompletion::Respond(ExternalAuthDecision::Challenge(
-                ExternalAuthChallengeResponse {
-                    status: http::StatusCode::UNAUTHORIZED,
-                    ..
-                }
-            ))
-        ));
+                PendingHeaderMutation::Upsert {
+                    name: b"x-user".to_vec(),
+                    value: b"fresh".to_vec(),
+                },
+            ];
+
+            apply_auth_request_mutations(&mut headers, &mutations);
+
+            assert!(headers.iter().any(|header| header.name() == b":method"));
+            assert!(
+                headers
+                    .iter()
+                    .any(|header| header.name() == b"x-user" && header.value() == b"fresh")
+            );
+            assert!(
+                !headers
+                    .iter()
+                    .any(|header| header.name() == b"x-user" && header.value() == b"alice")
+            );
+            assert!(!headers.iter().any(|header| header.name() == b"x-team"));
+        }
     }
 
-    #[test]
-    fn evaluate_external_auth_completion_fail_closed_transport_error_maps_to_unavailable() {
-        let rejected = evaluate_external_auth_completion(
-            Err(ProxyError::Transport("connect failed".into())),
-            ExternalAuthFailureDisposition::FailClosed,
-        );
-        assert!(matches!(
-            rejected,
-            ExternalAuthCompletion::Reject {
-                status: http::StatusCode::SERVICE_UNAVAILABLE,
-                body,
-                timed_out: false,
-                error: Some(ProxyError::Transport(_)),
-            } if body == b"external auth unavailable\n"
-        ));
-    }
+    mod external_auth_response_mapping {
+        use super::*;
 
-    #[test]
-    fn resolve_external_auth_state_transition_maps_all_decision_variants_stably() {
-        let allow = resolve_external_auth_state_transition(
-            Ok(ExternalAuthDecision::Allow {
-                request_header_mutations: vec![PendingHeaderMutation::Upsert {
-                    name: b"x-auth-user".to_vec(),
-                    value: b"alice".to_vec(),
-                }],
-            }),
-            ExternalAuthFailureDisposition::FailClosed,
-        );
-        assert!(matches!(
-            allow,
-            ExternalAuthStateTransition::Admitted {
-                request_header_mutations,
-            } if request_header_mutations == vec![PendingHeaderMutation::Upsert {
-                name: b"x-auth-user".to_vec(),
-                value: b"alice".to_vec(),
-            }]
-        ));
+        #[test]
+        fn allowed_auth_headers_is_case_insensitive_and_auth_allow_mutations_keep_safe_values() {
+            let mut headers = http::HeaderMap::new();
+            headers.insert("x-auth-user", http::HeaderValue::from_static("alice"));
+            headers.insert("x-auth-group", http::HeaderValue::from_static("admin"));
+            headers.insert(
+                http::header::AUTHORIZATION,
+                http::HeaderValue::from_static("Bearer blocked"),
+            );
 
-        let deny = resolve_external_auth_state_transition(
-            Ok(ExternalAuthDecision::Deny(ExternalAuthDenyResponse {
-                status: http::StatusCode::FORBIDDEN,
-                headers: vec![("x-auth-reason".to_string(), "policy".to_string())],
-                body: b"denied\n".to_vec(),
-            })),
-            ExternalAuthFailureDisposition::FailClosed,
-        );
-        assert!(matches!(
-            deny,
-            ExternalAuthStateTransition::RejectedAuthDenied {
-                decision: ExternalAuthDecision::Deny(ExternalAuthDenyResponse {
+            assert_eq!(
+                allowed_auth_headers(
+                    &headers,
+                    &[
+                        "X-Auth-User".to_string(),
+                        "x-auth-group".to_string(),
+                        "authorization".to_string(),
+                    ],
+                ),
+                vec![
+                    ("x-auth-user".to_string(), "alice".to_string()),
+                    ("x-auth-group".to_string(), "admin".to_string()),
+                    ("authorization".to_string(), "Bearer blocked".to_string()),
+                ]
+            );
+
+            assert_eq!(
+                auth_allow_mutations(
+                    &headers,
+                    &[
+                        "X-Auth-User".to_string(),
+                        "x-auth-group".to_string(),
+                        "authorization".to_string(),
+                    ],
+                ),
+                vec![
+                    PendingHeaderMutation::Upsert {
+                        name: b"x-auth-user".to_vec(),
+                        value: b"alice".to_vec(),
+                    },
+                    PendingHeaderMutation::Upsert {
+                        name: b"x-auth-group".to_vec(),
+                        value: b"admin".to_vec(),
+                    },
+                ]
+            );
+        }
+
+        #[test]
+        fn map_http_external_auth_response_covers_allow_deny_redirect_and_challenge() {
+            let mut allow_headers = http::HeaderMap::new();
+            allow_headers.insert("x-auth-user", http::HeaderValue::from_static("alice"));
+            allow_headers.insert(
+                http::header::AUTHORIZATION,
+                http::HeaderValue::from_static("Bearer blocked"),
+            );
+            let allow = map_http_external_auth_response(
+                ExternalAuthResponseMetadata {
+                    status: http::StatusCode::OK,
+                    headers: &allow_headers,
+                    body: &[],
+                },
+                &["x-auth-user".to_string(), "authorization".to_string()],
+            )
+            .expect("allow decision");
+            assert_eq!(
+                allow,
+                ExternalAuthDecision::Allow {
+                    request_header_mutations: vec![PendingHeaderMutation::Upsert {
+                        name: b"x-auth-user".to_vec(),
+                        value: b"alice".to_vec(),
+                    }],
+                }
+            );
+
+            let mut deny_headers = http::HeaderMap::new();
+            deny_headers.insert("x-auth-reason", http::HeaderValue::from_static("policy"));
+            let deny = map_http_external_auth_response(
+                ExternalAuthResponseMetadata {
+                    status: http::StatusCode::FORBIDDEN,
+                    headers: &deny_headers,
+                    body: b"denied\n",
+                },
+                &["x-auth-reason".to_string()],
+            )
+            .expect("deny decision");
+            assert!(matches!(
+                deny,
+                ExternalAuthDecision::Deny(ExternalAuthDenyResponse {
                     status: http::StatusCode::FORBIDDEN,
                     ..
                 })
-            }
-        ));
+            ));
 
-        let redirect = resolve_external_auth_state_transition(
-            Ok(ExternalAuthDecision::Redirect(
-                ExternalAuthRedirectResponse {
+            let mut redirect_headers = http::HeaderMap::new();
+            redirect_headers.insert(
+                http::header::LOCATION,
+                http::HeaderValue::from_static("https://login.example.com/"),
+            );
+            redirect_headers.insert("x-auth-reason", http::HeaderValue::from_static("login"));
+            let redirect = map_http_external_auth_response(
+                ExternalAuthResponseMetadata {
                     status: http::StatusCode::FOUND,
-                    headers: vec![("x-auth-reason".to_string(), "login".to_string())],
-                    location: "https://login.example.com/".to_string(),
+                    headers: &redirect_headers,
+                    body: &[],
                 },
-            )),
-            ExternalAuthFailureDisposition::FailClosed,
-        );
-        assert!(matches!(
-            redirect,
-            ExternalAuthStateTransition::RejectedAuthDenied {
-                decision: ExternalAuthDecision::Redirect(ExternalAuthRedirectResponse {
+                &["location".to_string(), "x-auth-reason".to_string()],
+            )
+            .expect("redirect decision");
+            assert!(matches!(
+                redirect,
+                ExternalAuthDecision::Redirect(ExternalAuthRedirectResponse {
                     status: http::StatusCode::FOUND,
                     ..
                 })
-            }
-        ));
+            ));
 
-        let challenge = resolve_external_auth_state_transition(
-            Ok(ExternalAuthDecision::Challenge(
-                ExternalAuthChallengeResponse {
+            let mut challenge_headers = http::HeaderMap::new();
+            challenge_headers.insert(
+                http::header::WWW_AUTHENTICATE,
+                http::HeaderValue::from_static("Bearer realm=\"spooky\""),
+            );
+            challenge_headers.insert("x-auth-reason", http::HeaderValue::from_static("expired"));
+            let challenge = map_http_external_auth_response(
+                ExternalAuthResponseMetadata {
                     status: http::StatusCode::UNAUTHORIZED,
-                    headers: vec![("x-auth-reason".to_string(), "expired".to_string())],
+                    headers: &challenge_headers,
+                    body: b"challenge\n",
+                },
+                &["www-authenticate".to_string(), "x-auth-reason".to_string()],
+            )
+            .expect("challenge decision");
+            assert!(matches!(
+                challenge,
+                ExternalAuthDecision::Challenge(ExternalAuthChallengeResponse {
+                    status: http::StatusCode::UNAUTHORIZED,
+                    ..
+                })
+            ));
+        }
+
+        #[test]
+        fn response_header_allowlists_are_enforced_exactly_for_each_external_auth_outcome() {
+            let mut headers = http::HeaderMap::new();
+            headers.insert("x-auth-user", http::HeaderValue::from_static("alice"));
+            headers.insert("x-auth-group", http::HeaderValue::from_static("admin"));
+            headers.insert(
+                http::header::LOCATION,
+                http::HeaderValue::from_static("https://login.example.com/"),
+            );
+            headers.insert(
+                http::header::WWW_AUTHENTICATE,
+                http::HeaderValue::from_static("Bearer realm=\"spooky\""),
+            );
+
+            let allow = map_http_external_auth_response(
+                ExternalAuthResponseMetadata {
+                    status: http::StatusCode::OK,
+                    headers: &headers,
+                    body: &[],
+                },
+                &[
+                    "x-auth-user".to_string(),
+                    "www-authenticate".to_string(),
+                    "location".to_string(),
+                ],
+            )
+            .expect("allow");
+            assert_eq!(
+                allow,
+                ExternalAuthDecision::Allow {
+                    request_header_mutations: vec![PendingHeaderMutation::Upsert {
+                        name: b"x-auth-user".to_vec(),
+                        value: b"alice".to_vec(),
+                    }],
+                }
+            );
+
+            let redirect = map_http_external_auth_response(
+                ExternalAuthResponseMetadata {
+                    status: http::StatusCode::FOUND,
+                    headers: &headers,
+                    body: &[],
+                },
+                &[
+                    "x-auth-user".to_string(),
+                    "x-auth-group".to_string(),
+                    "location".to_string(),
+                ],
+            )
+            .expect("redirect");
+            assert_eq!(
+                redirect,
+                ExternalAuthDecision::Redirect(ExternalAuthRedirectResponse {
+                    status: http::StatusCode::FOUND,
+                    headers: vec![
+                        ("x-auth-user".to_string(), "alice".to_string()),
+                        ("x-auth-group".to_string(), "admin".to_string()),
+                    ],
+                    location: "https://login.example.com/".to_string(),
+                })
+            );
+
+            let challenge = map_http_external_auth_response(
+                ExternalAuthResponseMetadata {
+                    status: http::StatusCode::UNAUTHORIZED,
+                    headers: &headers,
+                    body: b"challenge\n",
+                },
+                &[
+                    "x-auth-group".to_string(),
+                    "www-authenticate".to_string(),
+                    "location".to_string(),
+                ],
+            )
+            .expect("challenge");
+            assert_eq!(
+                challenge,
+                ExternalAuthDecision::Challenge(ExternalAuthChallengeResponse {
+                    status: http::StatusCode::UNAUTHORIZED,
+                    headers: vec![
+                        ("x-auth-group".to_string(), "admin".to_string()),
+                        (
+                            "location".to_string(),
+                            "https://login.example.com/".to_string(),
+                        ),
+                    ],
                     www_authenticate: "Bearer realm=\"spooky\"".to_string(),
                     body: b"challenge\n".to_vec(),
-                },
-            )),
-            ExternalAuthFailureDisposition::FailClosed,
-        );
-        assert!(matches!(
-            challenge,
-            ExternalAuthStateTransition::RejectedAuthDenied {
-                decision: ExternalAuthDecision::Challenge(ExternalAuthChallengeResponse {
+                })
+            );
+        }
+    }
+
+    mod oidc_helpers {
+        use super::*;
+
+        #[test]
+        fn oidc_authorization_check_maps_missing_and_invalid_bearer_tokens_to_challenges() {
+            assert!(matches!(
+                oidc_authorization_check(None),
+                OidcAuthorizationCheck::Challenge(ExternalAuthChallengeResponse {
                     status: http::StatusCode::UNAUTHORIZED,
                     ..
                 })
+            ));
+
+            let invalid = oidc_authorization_check(Some("Basic abc123"));
+            match invalid {
+                OidcAuthorizationCheck::Challenge(response) => {
+                    assert_eq!(response.www_authenticate, "Bearer");
+                    assert_eq!(response.body, b"invalid bearer token\n".to_vec());
+                }
+                other => panic!("unexpected authorization result: {other:?}"),
             }
-        ));
+
+            assert_eq!(
+                oidc_authorization_check(Some("Bearer token-1")),
+                OidcAuthorizationCheck::Token("token-1".to_string())
+            );
+            assert_eq!(
+                oidc_authorization_check(Some("bearer token-2")),
+                OidcAuthorizationCheck::Token("token-2".to_string())
+            );
+        }
+
+        #[test]
+        fn oidc_discovery_target_derives_and_validates_provider_metadata_url() {
+            let derived = oidc_discovery_target(None, Some("https://issuer.example.com/base/"))
+                .expect("derived discovery target");
+            assert_eq!(
+                derived.url,
+                "https://issuer.example.com/base/.well-known/openid-configuration"
+            );
+
+            let http_loopback = oidc_discovery_target(Some("http://127.0.0.1:9000/oidc"), None)
+                .expect("loopback discovery should be allowed");
+            assert!(http_loopback.url.starts_with("http://"));
+
+            let err = oidc_discovery_target(Some("http://example.com/oidc"), None)
+                .expect_err("non-loopback http discovery must be rejected");
+            assert!(matches!(err, ProxyError::Transport(_)));
+        }
+
+        #[test]
+        fn validate_oidc_provider_metadata_requires_safe_introspection_endpoint() {
+            let valid = validate_oidc_provider_metadata(&json!({
+                "introspection_endpoint": "https://issuer.example.com/oauth2/introspect"
+            }))
+            .expect("valid metadata");
+            assert_eq!(
+                valid.introspection_endpoint,
+                "https://issuer.example.com/oauth2/introspect"
+            );
+
+            let missing = validate_oidc_provider_metadata(&json!({}))
+                .expect_err("metadata without introspection endpoint must fail");
+            assert!(matches!(missing, ProxyError::Transport(_)));
+
+            let invalid = validate_oidc_provider_metadata(&json!({
+                "introspection_endpoint": "http://example.com/oauth2/introspect"
+            }))
+            .expect_err("non-loopback http introspection endpoint must fail");
+            assert!(matches!(invalid, ProxyError::Transport(_)));
+        }
+
+        #[test]
+        fn oidc_helper_predicates_match_expected_scope_and_audience_shapes() {
+            assert!(oidc_scope_satisfied(
+                &["read".to_string(), "write".to_string()],
+                "read write admin"
+            ));
+            assert!(!oidc_scope_satisfied(
+                &["read".to_string(), "write".to_string()],
+                "read"
+            ));
+
+            assert!(oidc_audience_matches(
+                Some("api://edge"),
+                Some(&json!("api://edge"))
+            ));
+            assert!(oidc_audience_matches(
+                Some("api://edge"),
+                Some(&json!(["other", "api://edge"]))
+            ));
+            assert!(!oidc_audience_matches(
+                Some("api://edge"),
+                Some(&json!("api://other"))
+            ));
+            assert!(oidc_audience_matches(None, None));
+        }
     }
 
-    #[test]
-    fn resolve_external_auth_state_transition_maps_timeout_and_execution_errors_stably() {
-        let fail_open_timeout = resolve_external_auth_state_transition(
-            Err(ProxyError::Timeout),
-            ExternalAuthFailureDisposition::FailOpen,
-        );
-        assert!(matches!(
-            fail_open_timeout,
-            ExternalAuthStateTransition::Admitted {
-                request_header_mutations,
-            } if request_header_mutations.is_empty()
-        ));
+    mod external_auth_completion {
+        use super::*;
 
-        let fail_closed_timeout = resolve_external_auth_state_transition(
-            Err(ProxyError::Timeout),
-            ExternalAuthFailureDisposition::FailClosed,
-        );
-        assert!(matches!(
-            fail_closed_timeout,
-            ExternalAuthStateTransition::TimedOutAuth {
-                status: http::StatusCode::GATEWAY_TIMEOUT,
-                body: b"external auth timeout\n",
-            }
-        ));
+        #[test]
+        fn external_auth_task_config_tracks_timeout_and_disposition() {
+            let auth = RuntimeExternalAuth::Http {
+                endpoint: "http://127.0.0.1:9000/auth".to_string(),
+                request_headers: Vec::new(),
+                response_header_allowlist: Vec::new(),
+                timeout: Duration::from_millis(250),
+                failure_mode: RuntimeExternalAuthFailureMode::FailOpen,
+            };
 
-        let fail_open_error = resolve_external_auth_state_transition(
-            Err(ProxyError::Transport("dial failed".into())),
-            ExternalAuthFailureDisposition::FailOpen,
-        );
-        assert!(matches!(
-            fail_open_error,
-            ExternalAuthStateTransition::Admitted {
-                request_header_mutations,
-            } if request_header_mutations.is_empty()
-        ));
+            let config = ExternalAuthTaskConfig::from_external_auth(&auth);
+            assert_eq!(config.timeout, Duration::from_millis(250));
+            assert_eq!(config.disposition, ExternalAuthFailureDisposition::FailOpen);
+        }
 
-        let fail_closed_error = resolve_external_auth_state_transition(
-            Err(ProxyError::Transport("dial failed".into())),
-            ExternalAuthFailureDisposition::FailClosed,
-        );
-        assert!(matches!(
-            fail_closed_error,
-            ExternalAuthStateTransition::RejectedAuthUnavailable {
-                status: http::StatusCode::SERVICE_UNAVAILABLE,
-                body: b"external auth unavailable\n",
-                error: Some(ProxyError::Transport(_)),
-            }
-        ));
+        #[test]
+        fn evaluate_external_auth_completion_maps_fail_open_and_fail_closed_outcomes() {
+            let fail_open = evaluate_external_auth_completion(
+                Err(ProxyError::Transport("unavailable".into())),
+                ExternalAuthFailureDisposition::FailOpen,
+            );
+            assert!(matches!(
+                fail_open,
+                ExternalAuthCompletion::FailOpen {
+                    timed_out: false,
+                    error: Some(ProxyError::Transport(_)),
+                }
+            ));
+
+            let fail_closed = evaluate_external_auth_completion(
+                Err(ProxyError::Timeout),
+                ExternalAuthFailureDisposition::FailClosed,
+            );
+            assert!(matches!(
+                fail_closed,
+                ExternalAuthCompletion::Reject {
+                    status: http::StatusCode::GATEWAY_TIMEOUT,
+                    timed_out: true,
+                    ..
+                }
+            ));
+        }
+
+        #[test]
+        fn evaluate_external_auth_completion_maps_allow_and_response_decisions() {
+            let allow = evaluate_external_auth_completion(
+                Ok(ExternalAuthDecision::Allow {
+                    request_header_mutations: vec![PendingHeaderMutation::Upsert {
+                        name: b"x-auth-user".to_vec(),
+                        value: b"alice".to_vec(),
+                    }],
+                }),
+                ExternalAuthFailureDisposition::FailClosed,
+            );
+            assert!(matches!(
+                allow,
+                ExternalAuthCompletion::Allow {
+                    request_header_mutations,
+                } if request_header_mutations == vec![PendingHeaderMutation::Upsert {
+                    name: b"x-auth-user".to_vec(),
+                    value: b"alice".to_vec(),
+                }]
+            ));
+
+            let deny = evaluate_external_auth_completion(
+                Ok(ExternalAuthDecision::Deny(ExternalAuthDenyResponse {
+                    status: http::StatusCode::FORBIDDEN,
+                    headers: vec![("x-auth-reason".to_string(), "policy".to_string())],
+                    body: b"denied\n".to_vec(),
+                })),
+                ExternalAuthFailureDisposition::FailClosed,
+            );
+            assert!(matches!(
+                deny,
+                ExternalAuthCompletion::Respond(ExternalAuthDecision::Deny(
+                    ExternalAuthDenyResponse {
+                        status: http::StatusCode::FORBIDDEN,
+                        ..
+                    }
+                ))
+            ));
+
+            let redirect = evaluate_external_auth_completion(
+                Ok(ExternalAuthDecision::Redirect(
+                    ExternalAuthRedirectResponse {
+                        status: http::StatusCode::FOUND,
+                        headers: vec![("x-auth-reason".to_string(), "login".to_string())],
+                        location: "https://login.example.com/".to_string(),
+                    },
+                )),
+                ExternalAuthFailureDisposition::FailClosed,
+            );
+            assert!(matches!(
+                redirect,
+                ExternalAuthCompletion::Respond(ExternalAuthDecision::Redirect(
+                    ExternalAuthRedirectResponse {
+                        status: http::StatusCode::FOUND,
+                        ..
+                    }
+                ))
+            ));
+
+            let challenge = evaluate_external_auth_completion(
+                Ok(ExternalAuthDecision::Challenge(
+                    ExternalAuthChallengeResponse {
+                        status: http::StatusCode::UNAUTHORIZED,
+                        headers: vec![("x-auth-reason".to_string(), "expired".to_string())],
+                        www_authenticate: "Bearer realm=\"spooky\"".to_string(),
+                        body: b"challenge\n".to_vec(),
+                    },
+                )),
+                ExternalAuthFailureDisposition::FailClosed,
+            );
+            assert!(matches!(
+                challenge,
+                ExternalAuthCompletion::Respond(ExternalAuthDecision::Challenge(
+                    ExternalAuthChallengeResponse {
+                        status: http::StatusCode::UNAUTHORIZED,
+                        ..
+                    }
+                ))
+            ));
+        }
+
+        #[test]
+        fn evaluate_external_auth_completion_fail_closed_transport_error_maps_to_unavailable() {
+            let rejected = evaluate_external_auth_completion(
+                Err(ProxyError::Transport("connect failed".into())),
+                ExternalAuthFailureDisposition::FailClosed,
+            );
+            assert!(matches!(
+                rejected,
+                ExternalAuthCompletion::Reject {
+                    status: http::StatusCode::SERVICE_UNAVAILABLE,
+                    body,
+                    timed_out: false,
+                    error: Some(ProxyError::Transport(_)),
+                } if body == b"external auth unavailable\n"
+            ));
+        }
+    }
+
+    mod external_auth_state_transitions {
+        use super::*;
+
+        #[test]
+        fn resolve_external_auth_state_transition_maps_all_decision_variants_stably() {
+            let allow = resolve_external_auth_state_transition(
+                Ok(ExternalAuthDecision::Allow {
+                    request_header_mutations: vec![PendingHeaderMutation::Upsert {
+                        name: b"x-auth-user".to_vec(),
+                        value: b"alice".to_vec(),
+                    }],
+                }),
+                ExternalAuthFailureDisposition::FailClosed,
+            );
+            assert!(matches!(
+                allow,
+                ExternalAuthStateTransition::Admitted {
+                    request_header_mutations,
+                } if request_header_mutations == vec![PendingHeaderMutation::Upsert {
+                    name: b"x-auth-user".to_vec(),
+                    value: b"alice".to_vec(),
+                }]
+            ));
+
+            let deny = resolve_external_auth_state_transition(
+                Ok(ExternalAuthDecision::Deny(ExternalAuthDenyResponse {
+                    status: http::StatusCode::FORBIDDEN,
+                    headers: vec![("x-auth-reason".to_string(), "policy".to_string())],
+                    body: b"denied\n".to_vec(),
+                })),
+                ExternalAuthFailureDisposition::FailClosed,
+            );
+            assert!(matches!(
+                deny,
+                ExternalAuthStateTransition::RejectedAuthDenied {
+                    decision: ExternalAuthDecision::Deny(ExternalAuthDenyResponse {
+                        status: http::StatusCode::FORBIDDEN,
+                        ..
+                    })
+                }
+            ));
+
+            let redirect = resolve_external_auth_state_transition(
+                Ok(ExternalAuthDecision::Redirect(
+                    ExternalAuthRedirectResponse {
+                        status: http::StatusCode::FOUND,
+                        headers: vec![("x-auth-reason".to_string(), "login".to_string())],
+                        location: "https://login.example.com/".to_string(),
+                    },
+                )),
+                ExternalAuthFailureDisposition::FailClosed,
+            );
+            assert!(matches!(
+                redirect,
+                ExternalAuthStateTransition::RejectedAuthDenied {
+                    decision: ExternalAuthDecision::Redirect(ExternalAuthRedirectResponse {
+                        status: http::StatusCode::FOUND,
+                        ..
+                    })
+                }
+            ));
+
+            let challenge = resolve_external_auth_state_transition(
+                Ok(ExternalAuthDecision::Challenge(
+                    ExternalAuthChallengeResponse {
+                        status: http::StatusCode::UNAUTHORIZED,
+                        headers: vec![("x-auth-reason".to_string(), "expired".to_string())],
+                        www_authenticate: "Bearer realm=\"spooky\"".to_string(),
+                        body: b"challenge\n".to_vec(),
+                    },
+                )),
+                ExternalAuthFailureDisposition::FailClosed,
+            );
+            assert!(matches!(
+                challenge,
+                ExternalAuthStateTransition::RejectedAuthDenied {
+                    decision: ExternalAuthDecision::Challenge(ExternalAuthChallengeResponse {
+                        status: http::StatusCode::UNAUTHORIZED,
+                        ..
+                    })
+                }
+            ));
+        }
+
+        #[test]
+        fn resolve_external_auth_state_transition_maps_timeout_and_execution_errors_stably() {
+            let fail_open_timeout = resolve_external_auth_state_transition(
+                Err(ProxyError::Timeout),
+                ExternalAuthFailureDisposition::FailOpen,
+            );
+            assert!(matches!(
+                fail_open_timeout,
+                ExternalAuthStateTransition::Admitted {
+                    request_header_mutations,
+                } if request_header_mutations.is_empty()
+            ));
+
+            let fail_closed_timeout = resolve_external_auth_state_transition(
+                Err(ProxyError::Timeout),
+                ExternalAuthFailureDisposition::FailClosed,
+            );
+            assert!(matches!(
+                fail_closed_timeout,
+                ExternalAuthStateTransition::TimedOutAuth {
+                    status: http::StatusCode::GATEWAY_TIMEOUT,
+                    body: b"external auth timeout\n",
+                }
+            ));
+
+            let fail_open_error = resolve_external_auth_state_transition(
+                Err(ProxyError::Transport("dial failed".into())),
+                ExternalAuthFailureDisposition::FailOpen,
+            );
+            assert!(matches!(
+                fail_open_error,
+                ExternalAuthStateTransition::Admitted {
+                    request_header_mutations,
+                } if request_header_mutations.is_empty()
+            ));
+
+            let fail_closed_error = resolve_external_auth_state_transition(
+                Err(ProxyError::Transport("dial failed".into())),
+                ExternalAuthFailureDisposition::FailClosed,
+            );
+            assert!(matches!(
+                fail_closed_error,
+                ExternalAuthStateTransition::RejectedAuthUnavailable {
+                    status: http::StatusCode::SERVICE_UNAVAILABLE,
+                    body: b"external auth unavailable\n",
+                    error: Some(ProxyError::Transport(_)),
+                }
+            ));
+        }
     }
 }

--- a/crates/edge/src/runtime/connection/guardrails.rs
+++ b/crates/edge/src/runtime/connection/guardrails.rs
@@ -335,10 +335,13 @@ pub(crate) fn response_chunk_ranges(
 ) -> Vec<(usize, usize)> {
     match policy {
         ResponseChunkEmissionPolicy::Passthrough => vec![(0, data_len)],
-        ResponseChunkEmissionPolicy::FixedSize { max_chunk_bytes } => (0..data_len)
-            .step_by(max_chunk_bytes.max(1))
-            .map(|start| (start, (start + max_chunk_bytes).min(data_len)))
-            .collect(),
+        ResponseChunkEmissionPolicy::FixedSize { max_chunk_bytes } => {
+            let chunk_bytes = max_chunk_bytes.max(1);
+            (0..data_len)
+                .step_by(chunk_bytes)
+                .map(|start| (start, (start + chunk_bytes).min(data_len)))
+                .collect()
+        }
     }
 }
 
@@ -348,6 +351,29 @@ mod tests {
 
     mod request_body_ingress {
         use super::*;
+
+        #[test]
+        fn request_body_timeout_checks_continue_before_idle_or_total_limits() {
+            let decision = evaluate_request_body_timeouts(
+                RequestBodyGuardrailConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    total_timeout: Duration::from_secs(30),
+                    max_body_bytes: usize::MAX,
+                    max_buffered_bytes: usize::MAX,
+                },
+                RequestBodyGuardrailInput {
+                    elapsed: Duration::from_secs(4),
+                    idle_for: Duration::from_secs(2),
+                    bytes_received: 0,
+                    buffered_bytes: 0,
+                    next_chunk_bytes: 0,
+                    declared_content_length: None,
+                    exempt_from_body_size_cap: false,
+                },
+            );
+
+            assert_eq!(decision, RequestBodyGuardrailDecision::Continue);
+        }
 
         #[test]
         fn request_body_idle_timeout_rejects() {
@@ -514,6 +540,34 @@ mod tests {
         }
 
         #[test]
+        fn request_body_declared_length_over_buffer_cap_rejects_as_buffered_body() {
+            let decision = evaluate_request_body_ingress(
+                RequestBodyGuardrailConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    total_timeout: Duration::from_secs(30),
+                    max_body_bytes: 64,
+                    max_buffered_bytes: 8,
+                },
+                RequestBodyGuardrailInput {
+                    elapsed: Duration::ZERO,
+                    idle_for: Duration::ZERO,
+                    bytes_received: 0,
+                    buffered_bytes: 6,
+                    next_chunk_bytes: 3,
+                    declared_content_length: Some(32),
+                    exempt_from_body_size_cap: false,
+                },
+            );
+
+            assert_eq!(
+                decision,
+                RequestBodyGuardrailDecision::Reject {
+                    kind: BodyLimitKind::BufferedBody,
+                }
+            );
+        }
+
+        #[test]
         fn checked_request_body_ingress_returns_next_accounting_state() {
             let next_state = checked_request_body_ingress(
                 RequestBodyGuardrailConfig {
@@ -542,10 +596,77 @@ mod tests {
                 }
             );
         }
+
+        #[test]
+        fn checked_request_body_ingress_returns_stable_reject_without_next_state() {
+            let rejection = checked_request_body_ingress(
+                RequestBodyGuardrailConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    total_timeout: Duration::from_secs(30),
+                    max_body_bytes: 16,
+                    max_buffered_bytes: 32,
+                },
+                RequestBodyGuardrailInput {
+                    elapsed: Duration::ZERO,
+                    idle_for: Duration::ZERO,
+                    bytes_received: 12,
+                    buffered_bytes: 0,
+                    next_chunk_bytes: 5,
+                    declared_content_length: None,
+                    exempt_from_body_size_cap: false,
+                },
+            )
+            .expect_err("oversized request body should reject");
+
+            assert_eq!(
+                rejection,
+                RequestBodyGuardrailDecision::Reject {
+                    kind: BodyLimitKind::BodySize,
+                }
+            );
+        }
     }
 
     mod response_body_egress {
         use super::*;
+
+        #[test]
+        fn response_body_guardrails_continue_without_reject_when_under_limits() {
+            let decision = evaluate_response_body_guardrails(
+                ResponseBodyGuardrailConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    total_timeout: Duration::from_secs(30),
+                    max_body_bytes: 64,
+                    unknown_length_prebuffer_bytes: 16,
+                    chunk_bytes: 8,
+                },
+                ResponseBodyGuardrailInput {
+                    elapsed: Duration::from_secs(1),
+                    idle_for: Duration::from_secs(1),
+                    bytes_received: 2,
+                    prebuffered_bytes: 0,
+                    next_chunk_bytes: 2,
+                    declared_content_length: Some(12),
+                    headers_emitted: false,
+                    progressive_emission_allowed: true,
+                    body_forwarding_enabled: true,
+                    exempt_from_body_size_cap: false,
+                },
+            );
+
+            assert_eq!(
+                decision,
+                ResponseBodyGuardrailDecision::Continue {
+                    streaming: ResponseStreamingPolicy {
+                        emission: ProgressiveEmissionPolicy::StreamProgressively,
+                        chunk_emission: ResponseChunkEmissionPolicy::FixedSize {
+                            max_chunk_bytes: 8
+                        },
+                        wait_timeout: Duration::from_secs(4),
+                    },
+                }
+            );
+        }
 
         #[test]
         fn response_body_prefers_prebuffer_for_unknown_length_before_headers() {
@@ -790,6 +911,44 @@ mod tests {
         }
 
         #[test]
+        fn response_body_streams_progressively_when_progressive_emission_is_disabled() {
+            let decision = evaluate_response_body_guardrails(
+                ResponseBodyGuardrailConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    total_timeout: Duration::from_secs(30),
+                    max_body_bytes: 64,
+                    unknown_length_prebuffer_bytes: 16,
+                    chunk_bytes: 8,
+                },
+                ResponseBodyGuardrailInput {
+                    elapsed: Duration::from_secs(1),
+                    idle_for: Duration::from_secs(1),
+                    bytes_received: 0,
+                    prebuffered_bytes: 0,
+                    next_chunk_bytes: 0,
+                    declared_content_length: None,
+                    headers_emitted: false,
+                    progressive_emission_allowed: false,
+                    body_forwarding_enabled: true,
+                    exempt_from_body_size_cap: false,
+                },
+            );
+
+            assert_eq!(
+                decision,
+                ResponseBodyGuardrailDecision::Continue {
+                    streaming: ResponseStreamingPolicy {
+                        emission: ProgressiveEmissionPolicy::StreamProgressively,
+                        chunk_emission: ResponseChunkEmissionPolicy::FixedSize {
+                            max_chunk_bytes: 8
+                        },
+                        wait_timeout: Duration::from_secs(4),
+                    },
+                }
+            );
+        }
+
+        #[test]
         fn response_body_suppresses_emission_when_body_is_disabled() {
             let decision = evaluate_response_body_guardrails(
                 ResponseBodyGuardrailConfig {
@@ -867,6 +1026,39 @@ mod tests {
                 }
             );
         }
+
+        #[test]
+        fn checked_response_body_guardrails_returns_stable_reject_without_next_state() {
+            let rejection = checked_response_body_guardrails(
+                ResponseBodyGuardrailConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    total_timeout: Duration::from_secs(30),
+                    max_body_bytes: 16,
+                    unknown_length_prebuffer_bytes: 8,
+                    chunk_bytes: 4,
+                },
+                ResponseBodyGuardrailInput {
+                    elapsed: Duration::ZERO,
+                    idle_for: Duration::ZERO,
+                    bytes_received: 12,
+                    prebuffered_bytes: 0,
+                    next_chunk_bytes: 5,
+                    declared_content_length: None,
+                    headers_emitted: true,
+                    progressive_emission_allowed: true,
+                    body_forwarding_enabled: true,
+                    exempt_from_body_size_cap: false,
+                },
+            )
+            .expect_err("oversized response body should reject");
+
+            assert_eq!(
+                rejection,
+                ResponseBodyGuardrailDecision::Reject {
+                    kind: BodyLimitKind::BodySize,
+                }
+            );
+        }
     }
 
     mod response_chunking {
@@ -888,6 +1080,17 @@ mod tests {
             assert_eq!(
                 response_chunk_ranges(10, ResponseChunkEmissionPolicy::Passthrough),
                 vec![(0, 10)]
+            );
+        }
+
+        #[test]
+        fn response_chunk_ranges_use_minimum_chunk_size_of_one() {
+            assert_eq!(
+                response_chunk_ranges(
+                    3,
+                    ResponseChunkEmissionPolicy::FixedSize { max_chunk_bytes: 0 }
+                ),
+                vec![(0, 1), (1, 2), (2, 3)]
             );
         }
     }

--- a/crates/edge/src/runtime/connection/guardrails.rs
+++ b/crates/edge/src/runtime/connection/guardrails.rs
@@ -346,529 +346,549 @@ pub(crate) fn response_chunk_ranges(
 mod tests {
     use super::*;
 
-    #[test]
-    fn request_body_idle_timeout_rejects() {
-        let decision = evaluate_request_body_timeouts(
-            RequestBodyGuardrailConfig {
-                idle_timeout: Duration::from_secs(5),
-                total_timeout: Duration::from_secs(30),
-                max_body_bytes: usize::MAX,
-                max_buffered_bytes: usize::MAX,
-            },
-            RequestBodyGuardrailInput {
-                elapsed: Duration::from_secs(4),
-                idle_for: Duration::from_secs(5),
-                bytes_received: 0,
-                buffered_bytes: 0,
-                next_chunk_bytes: 0,
-                declared_content_length: None,
-                exempt_from_body_size_cap: false,
-            },
-        );
+    mod request_body_ingress {
+        use super::*;
 
-        assert_eq!(
-            decision,
-            RequestBodyGuardrailDecision::Timeout {
-                kind: BodyTimeoutKind::Idle,
-            }
-        );
-    }
+        #[test]
+        fn request_body_idle_timeout_rejects() {
+            let decision = evaluate_request_body_timeouts(
+                RequestBodyGuardrailConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    total_timeout: Duration::from_secs(30),
+                    max_body_bytes: usize::MAX,
+                    max_buffered_bytes: usize::MAX,
+                },
+                RequestBodyGuardrailInput {
+                    elapsed: Duration::from_secs(4),
+                    idle_for: Duration::from_secs(5),
+                    bytes_received: 0,
+                    buffered_bytes: 0,
+                    next_chunk_bytes: 0,
+                    declared_content_length: None,
+                    exempt_from_body_size_cap: false,
+                },
+            );
 
-    #[test]
-    fn request_body_total_timeout_rejects() {
-        let decision = evaluate_request_body_timeouts(
-            RequestBodyGuardrailConfig {
-                idle_timeout: Duration::from_secs(5),
-                total_timeout: Duration::from_secs(30),
-                max_body_bytes: usize::MAX,
-                max_buffered_bytes: usize::MAX,
-            },
-            RequestBodyGuardrailInput {
-                elapsed: Duration::from_secs(30),
-                idle_for: Duration::from_secs(1),
-                bytes_received: 0,
-                buffered_bytes: 0,
-                next_chunk_bytes: 0,
-                declared_content_length: None,
-                exempt_from_body_size_cap: false,
-            },
-        );
+            assert_eq!(
+                decision,
+                RequestBodyGuardrailDecision::Timeout {
+                    kind: BodyTimeoutKind::Idle,
+                }
+            );
+        }
 
-        assert_eq!(
-            decision,
-            RequestBodyGuardrailDecision::Timeout {
-                kind: BodyTimeoutKind::Total,
-            }
-        );
-    }
+        #[test]
+        fn request_body_total_timeout_rejects() {
+            let decision = evaluate_request_body_timeouts(
+                RequestBodyGuardrailConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    total_timeout: Duration::from_secs(30),
+                    max_body_bytes: usize::MAX,
+                    max_buffered_bytes: usize::MAX,
+                },
+                RequestBodyGuardrailInput {
+                    elapsed: Duration::from_secs(30),
+                    idle_for: Duration::from_secs(1),
+                    bytes_received: 0,
+                    buffered_bytes: 0,
+                    next_chunk_bytes: 0,
+                    declared_content_length: None,
+                    exempt_from_body_size_cap: false,
+                },
+            );
 
-    #[test]
-    fn request_body_size_cap_respects_connect_exemption() {
-        let config = RequestBodyGuardrailConfig {
-            idle_timeout: Duration::from_secs(5),
-            total_timeout: Duration::from_secs(30),
-            max_body_bytes: 16,
-            max_buffered_bytes: usize::MAX,
-        };
-        let input = RequestBodyGuardrailInput {
-            elapsed: Duration::ZERO,
-            idle_for: Duration::ZERO,
-            bytes_received: 12,
-            buffered_bytes: 0,
-            next_chunk_bytes: 8,
-            declared_content_length: None,
-            exempt_from_body_size_cap: true,
-        };
+            assert_eq!(
+                decision,
+                RequestBodyGuardrailDecision::Timeout {
+                    kind: BodyTimeoutKind::Total,
+                }
+            );
+        }
 
-        assert_eq!(
-            evaluate_request_body_ingress(config, input),
-            RequestBodyGuardrailDecision::Continue
-        );
-    }
-
-    #[test]
-    fn request_body_unknown_length_prebuffer_cap_rejects() {
-        let decision = evaluate_request_body_ingress(
-            RequestBodyGuardrailConfig {
-                idle_timeout: Duration::from_secs(5),
-                total_timeout: Duration::from_secs(30),
-                max_body_bytes: usize::MAX,
-                max_buffered_bytes: 10,
-            },
-            RequestBodyGuardrailInput {
-                elapsed: Duration::ZERO,
-                idle_for: Duration::ZERO,
-                bytes_received: 0,
-                buffered_bytes: 6,
-                next_chunk_bytes: 5,
-                declared_content_length: None,
-                exempt_from_body_size_cap: false,
-            },
-        );
-
-        assert_eq!(
-            decision,
-            RequestBodyGuardrailDecision::Reject {
-                kind: BodyLimitKind::UnknownLengthPrebuffer,
-            }
-        );
-    }
-
-    #[test]
-    fn request_body_declared_length_cap_rejects() {
-        let decision = evaluate_request_body_ingress(
-            RequestBodyGuardrailConfig {
+        #[test]
+        fn request_body_size_cap_respects_connect_exemption() {
+            let config = RequestBodyGuardrailConfig {
                 idle_timeout: Duration::from_secs(5),
                 total_timeout: Duration::from_secs(30),
                 max_body_bytes: 16,
                 max_buffered_bytes: usize::MAX,
-            },
-            RequestBodyGuardrailInput {
-                elapsed: Duration::ZERO,
-                idle_for: Duration::ZERO,
-                bytes_received: 0,
-                buffered_bytes: 0,
-                next_chunk_bytes: 0,
-                declared_content_length: Some(17),
-                exempt_from_body_size_cap: false,
-            },
-        );
-
-        assert_eq!(
-            decision,
-            RequestBodyGuardrailDecision::Reject {
-                kind: BodyLimitKind::BodySize,
-            }
-        );
-    }
-
-    #[test]
-    fn request_body_running_total_cap_rejects() {
-        let decision = evaluate_request_body_ingress(
-            RequestBodyGuardrailConfig {
-                idle_timeout: Duration::from_secs(5),
-                total_timeout: Duration::from_secs(30),
-                max_body_bytes: 16,
-                max_buffered_bytes: usize::MAX,
-            },
-            RequestBodyGuardrailInput {
+            };
+            let input = RequestBodyGuardrailInput {
                 elapsed: Duration::ZERO,
                 idle_for: Duration::ZERO,
                 bytes_received: 12,
                 buffered_bytes: 0,
-                next_chunk_bytes: 5,
+                next_chunk_bytes: 8,
                 declared_content_length: None,
-                exempt_from_body_size_cap: false,
-            },
-        );
+                exempt_from_body_size_cap: true,
+            };
 
-        assert_eq!(
-            decision,
-            RequestBodyGuardrailDecision::Reject {
-                kind: BodyLimitKind::BodySize,
-            }
-        );
-    }
+            assert_eq!(
+                evaluate_request_body_ingress(config, input),
+                RequestBodyGuardrailDecision::Continue
+            );
+        }
 
-    #[test]
-    fn checked_request_body_ingress_returns_next_accounting_state() {
-        let next_state = checked_request_body_ingress(
-            RequestBodyGuardrailConfig {
-                idle_timeout: Duration::from_secs(5),
-                total_timeout: Duration::from_secs(30),
-                max_body_bytes: 64,
-                max_buffered_bytes: 32,
-            },
-            RequestBodyGuardrailInput {
-                elapsed: Duration::ZERO,
-                idle_for: Duration::ZERO,
-                bytes_received: 7,
-                buffered_bytes: 3,
-                next_chunk_bytes: 5,
-                declared_content_length: None,
-                exempt_from_body_size_cap: false,
-            },
-        )
-        .expect("request ingress should pass");
-
-        assert_eq!(
-            next_state,
-            RequestBodyIngressState {
-                bytes_received: 12,
-                buffered_bytes: 8,
-            }
-        );
-    }
-
-    #[test]
-    fn response_body_prefers_prebuffer_for_unknown_length_before_headers() {
-        let decision = evaluate_response_body_guardrails(
-            ResponseBodyGuardrailConfig {
-                idle_timeout: Duration::from_secs(5),
-                total_timeout: Duration::from_secs(30),
-                max_body_bytes: 64,
-                unknown_length_prebuffer_bytes: 16,
-                chunk_bytes: 8,
-            },
-            ResponseBodyGuardrailInput {
-                elapsed: Duration::from_secs(1),
-                idle_for: Duration::from_secs(1),
-                bytes_received: 0,
-                prebuffered_bytes: 0,
-                next_chunk_bytes: 0,
-                declared_content_length: None,
-                headers_emitted: false,
-                progressive_emission_allowed: true,
-                body_forwarding_enabled: true,
-                exempt_from_body_size_cap: false,
-            },
-        );
-
-        assert_eq!(
-            decision,
-            ResponseBodyGuardrailDecision::Continue {
-                streaming: ResponseStreamingPolicy {
-                    emission: ProgressiveEmissionPolicy::PrebufferUntilValidated,
-                    chunk_emission: ResponseChunkEmissionPolicy::FixedSize { max_chunk_bytes: 8 },
-                    wait_timeout: Duration::from_secs(4),
+        #[test]
+        fn request_body_unknown_length_prebuffer_cap_rejects() {
+            let decision = evaluate_request_body_ingress(
+                RequestBodyGuardrailConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    total_timeout: Duration::from_secs(30),
+                    max_body_bytes: usize::MAX,
+                    max_buffered_bytes: 10,
                 },
-            }
-        );
-    }
-
-    #[test]
-    fn response_body_declared_length_cap_rejects() {
-        let decision = evaluate_response_body_guardrails(
-            ResponseBodyGuardrailConfig {
-                idle_timeout: Duration::from_secs(5),
-                total_timeout: Duration::from_secs(30),
-                max_body_bytes: 16,
-                unknown_length_prebuffer_bytes: 8,
-                chunk_bytes: 8,
-            },
-            ResponseBodyGuardrailInput {
-                elapsed: Duration::ZERO,
-                idle_for: Duration::ZERO,
-                bytes_received: 0,
-                prebuffered_bytes: 0,
-                next_chunk_bytes: 0,
-                declared_content_length: Some(17),
-                headers_emitted: false,
-                progressive_emission_allowed: true,
-                body_forwarding_enabled: true,
-                exempt_from_body_size_cap: false,
-            },
-        );
-
-        assert_eq!(
-            decision,
-            ResponseBodyGuardrailDecision::Reject {
-                kind: BodyLimitKind::BodySize,
-            }
-        );
-    }
-
-    #[test]
-    fn response_body_unknown_length_prebuffer_cap_rejects() {
-        let decision = evaluate_response_body_guardrails(
-            ResponseBodyGuardrailConfig {
-                idle_timeout: Duration::from_secs(5),
-                total_timeout: Duration::from_secs(30),
-                max_body_bytes: 64,
-                unknown_length_prebuffer_bytes: 10,
-                chunk_bytes: 4,
-            },
-            ResponseBodyGuardrailInput {
-                elapsed: Duration::from_secs(1),
-                idle_for: Duration::from_secs(1),
-                bytes_received: 6,
-                prebuffered_bytes: 6,
-                next_chunk_bytes: 5,
-                declared_content_length: None,
-                headers_emitted: false,
-                progressive_emission_allowed: true,
-                body_forwarding_enabled: true,
-                exempt_from_body_size_cap: false,
-            },
-        );
-
-        assert_eq!(
-            decision,
-            ResponseBodyGuardrailDecision::Reject {
-                kind: BodyLimitKind::UnknownLengthPrebuffer,
-            }
-        );
-    }
-
-    #[test]
-    fn response_body_total_timeout_rejects() {
-        let decision = evaluate_response_body_guardrails(
-            ResponseBodyGuardrailConfig {
-                idle_timeout: Duration::from_secs(5),
-                total_timeout: Duration::from_secs(30),
-                max_body_bytes: 64,
-                unknown_length_prebuffer_bytes: 16,
-                chunk_bytes: 8,
-            },
-            ResponseBodyGuardrailInput {
-                elapsed: Duration::from_secs(30),
-                idle_for: Duration::from_secs(1),
-                bytes_received: 0,
-                prebuffered_bytes: 0,
-                next_chunk_bytes: 0,
-                declared_content_length: None,
-                headers_emitted: false,
-                progressive_emission_allowed: true,
-                body_forwarding_enabled: true,
-                exempt_from_body_size_cap: false,
-            },
-        );
-
-        assert_eq!(
-            decision,
-            ResponseBodyGuardrailDecision::Timeout {
-                kind: BodyTimeoutKind::Total,
-            }
-        );
-    }
-
-    #[test]
-    fn response_body_total_timeout_is_ignored_after_progress() {
-        let decision = evaluate_response_body_guardrails(
-            ResponseBodyGuardrailConfig {
-                idle_timeout: Duration::from_secs(5),
-                total_timeout: Duration::from_secs(30),
-                max_body_bytes: 64,
-                unknown_length_prebuffer_bytes: 16,
-                chunk_bytes: 8,
-            },
-            ResponseBodyGuardrailInput {
-                elapsed: Duration::from_secs(30),
-                idle_for: Duration::from_secs(1),
-                bytes_received: 1,
-                prebuffered_bytes: 0,
-                next_chunk_bytes: 0,
-                declared_content_length: None,
-                headers_emitted: false,
-                progressive_emission_allowed: true,
-                body_forwarding_enabled: true,
-                exempt_from_body_size_cap: false,
-            },
-        );
-
-        assert_eq!(
-            decision,
-            ResponseBodyGuardrailDecision::Continue {
-                streaming: ResponseStreamingPolicy {
-                    emission: ProgressiveEmissionPolicy::PrebufferUntilValidated,
-                    chunk_emission: ResponseChunkEmissionPolicy::FixedSize { max_chunk_bytes: 8 },
-                    wait_timeout: Duration::from_secs(4),
+                RequestBodyGuardrailInput {
+                    elapsed: Duration::ZERO,
+                    idle_for: Duration::ZERO,
+                    bytes_received: 0,
+                    buffered_bytes: 6,
+                    next_chunk_bytes: 5,
+                    declared_content_length: None,
+                    exempt_from_body_size_cap: false,
                 },
-            }
-        );
-    }
+            );
 
-    #[test]
-    fn response_body_idle_timeout_rejects() {
-        let decision = evaluate_response_body_guardrails(
-            ResponseBodyGuardrailConfig {
-                idle_timeout: Duration::from_secs(5),
-                total_timeout: Duration::from_secs(30),
-                max_body_bytes: 64,
-                unknown_length_prebuffer_bytes: 16,
-                chunk_bytes: 8,
-            },
-            ResponseBodyGuardrailInput {
-                elapsed: Duration::from_secs(4),
-                idle_for: Duration::from_secs(5),
-                bytes_received: 0,
-                prebuffered_bytes: 0,
-                next_chunk_bytes: 0,
-                declared_content_length: None,
-                headers_emitted: false,
-                progressive_emission_allowed: true,
-                body_forwarding_enabled: true,
-                exempt_from_body_size_cap: false,
-            },
-        );
+            assert_eq!(
+                decision,
+                RequestBodyGuardrailDecision::Reject {
+                    kind: BodyLimitKind::UnknownLengthPrebuffer,
+                }
+            );
+        }
 
-        assert_eq!(
-            decision,
-            ResponseBodyGuardrailDecision::Timeout {
-                kind: BodyTimeoutKind::Idle,
-            }
-        );
-    }
-
-    #[test]
-    fn response_body_known_length_streams_progressively() {
-        let decision = evaluate_response_body_guardrails(
-            ResponseBodyGuardrailConfig {
-                idle_timeout: Duration::from_secs(5),
-                total_timeout: Duration::from_secs(30),
-                max_body_bytes: 64,
-                unknown_length_prebuffer_bytes: 16,
-                chunk_bytes: 8,
-            },
-            ResponseBodyGuardrailInput {
-                elapsed: Duration::from_secs(1),
-                idle_for: Duration::from_secs(1),
-                bytes_received: 0,
-                prebuffered_bytes: 0,
-                next_chunk_bytes: 0,
-                declared_content_length: Some(12),
-                headers_emitted: false,
-                progressive_emission_allowed: true,
-                body_forwarding_enabled: true,
-                exempt_from_body_size_cap: false,
-            },
-        );
-
-        assert_eq!(
-            decision,
-            ResponseBodyGuardrailDecision::Continue {
-                streaming: ResponseStreamingPolicy {
-                    emission: ProgressiveEmissionPolicy::StreamProgressively,
-                    chunk_emission: ResponseChunkEmissionPolicy::FixedSize { max_chunk_bytes: 8 },
-                    wait_timeout: Duration::from_secs(4),
+        #[test]
+        fn request_body_declared_length_cap_rejects() {
+            let decision = evaluate_request_body_ingress(
+                RequestBodyGuardrailConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    total_timeout: Duration::from_secs(30),
+                    max_body_bytes: 16,
+                    max_buffered_bytes: usize::MAX,
                 },
-            }
-        );
-    }
-
-    #[test]
-    fn response_body_suppresses_emission_when_body_is_disabled() {
-        let decision = evaluate_response_body_guardrails(
-            ResponseBodyGuardrailConfig {
-                idle_timeout: Duration::from_secs(5),
-                total_timeout: Duration::from_secs(30),
-                max_body_bytes: 64,
-                unknown_length_prebuffer_bytes: 16,
-                chunk_bytes: 8,
-            },
-            ResponseBodyGuardrailInput {
-                elapsed: Duration::from_secs(1),
-                idle_for: Duration::from_secs(1),
-                bytes_received: 0,
-                prebuffered_bytes: 0,
-                next_chunk_bytes: 0,
-                declared_content_length: None,
-                headers_emitted: false,
-                progressive_emission_allowed: true,
-                body_forwarding_enabled: false,
-                exempt_from_body_size_cap: false,
-            },
-        );
-
-        assert_eq!(
-            decision,
-            ResponseBodyGuardrailDecision::Continue {
-                streaming: ResponseStreamingPolicy {
-                    emission: ProgressiveEmissionPolicy::SuppressBody,
-                    chunk_emission: ResponseChunkEmissionPolicy::Passthrough,
-                    wait_timeout: Duration::from_secs(4),
+                RequestBodyGuardrailInput {
+                    elapsed: Duration::ZERO,
+                    idle_for: Duration::ZERO,
+                    bytes_received: 0,
+                    buffered_bytes: 0,
+                    next_chunk_bytes: 0,
+                    declared_content_length: Some(17),
+                    exempt_from_body_size_cap: false,
                 },
-            }
-        );
-    }
+            );
 
-    #[test]
-    fn checked_response_body_guardrails_returns_next_streaming_state() {
-        let evaluated = checked_response_body_guardrails(
-            ResponseBodyGuardrailConfig {
-                idle_timeout: Duration::from_secs(5),
-                total_timeout: Duration::from_secs(30),
-                max_body_bytes: 64,
-                unknown_length_prebuffer_bytes: 16,
-                chunk_bytes: 4,
-            },
-            ResponseBodyGuardrailInput {
-                elapsed: Duration::from_secs(1),
-                idle_for: Duration::from_secs(1),
-                bytes_received: 5,
-                prebuffered_bytes: 5,
-                next_chunk_bytes: 3,
-                declared_content_length: None,
-                headers_emitted: false,
-                progressive_emission_allowed: true,
-                body_forwarding_enabled: true,
-                exempt_from_body_size_cap: false,
-            },
-        )
-        .expect("response egress should pass");
+            assert_eq!(
+                decision,
+                RequestBodyGuardrailDecision::Reject {
+                    kind: BodyLimitKind::BodySize,
+                }
+            );
+        }
 
-        assert_eq!(
-            evaluated,
-            EvaluatedResponseBodyGuardrail {
-                streaming: ResponseStreamingPolicy {
-                    emission: ProgressiveEmissionPolicy::PrebufferUntilValidated,
-                    chunk_emission: ResponseChunkEmissionPolicy::FixedSize { max_chunk_bytes: 4 },
-                    wait_timeout: Duration::from_secs(4),
+        #[test]
+        fn request_body_running_total_cap_rejects() {
+            let decision = evaluate_request_body_ingress(
+                RequestBodyGuardrailConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    total_timeout: Duration::from_secs(30),
+                    max_body_bytes: 16,
+                    max_buffered_bytes: usize::MAX,
                 },
-                next_state: ResponseBodyEgressState {
-                    bytes_received: 8,
-                    prebuffered_bytes: 8,
+                RequestBodyGuardrailInput {
+                    elapsed: Duration::ZERO,
+                    idle_for: Duration::ZERO,
+                    bytes_received: 12,
+                    buffered_bytes: 0,
+                    next_chunk_bytes: 5,
+                    declared_content_length: None,
+                    exempt_from_body_size_cap: false,
                 },
-            }
-        );
+            );
+
+            assert_eq!(
+                decision,
+                RequestBodyGuardrailDecision::Reject {
+                    kind: BodyLimitKind::BodySize,
+                }
+            );
+        }
+
+        #[test]
+        fn checked_request_body_ingress_returns_next_accounting_state() {
+            let next_state = checked_request_body_ingress(
+                RequestBodyGuardrailConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    total_timeout: Duration::from_secs(30),
+                    max_body_bytes: 64,
+                    max_buffered_bytes: 32,
+                },
+                RequestBodyGuardrailInput {
+                    elapsed: Duration::ZERO,
+                    idle_for: Duration::ZERO,
+                    bytes_received: 7,
+                    buffered_bytes: 3,
+                    next_chunk_bytes: 5,
+                    declared_content_length: None,
+                    exempt_from_body_size_cap: false,
+                },
+            )
+            .expect("request ingress should pass");
+
+            assert_eq!(
+                next_state,
+                RequestBodyIngressState {
+                    bytes_received: 12,
+                    buffered_bytes: 8,
+                }
+            );
+        }
     }
 
-    #[test]
-    fn response_chunk_ranges_follow_fixed_size_policy() {
-        assert_eq!(
-            response_chunk_ranges(
-                10,
-                ResponseChunkEmissionPolicy::FixedSize { max_chunk_bytes: 4 }
-            ),
-            vec![(0, 4), (4, 8), (8, 10)]
-        );
+    mod response_body_egress {
+        use super::*;
+
+        #[test]
+        fn response_body_prefers_prebuffer_for_unknown_length_before_headers() {
+            let decision = evaluate_response_body_guardrails(
+                ResponseBodyGuardrailConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    total_timeout: Duration::from_secs(30),
+                    max_body_bytes: 64,
+                    unknown_length_prebuffer_bytes: 16,
+                    chunk_bytes: 8,
+                },
+                ResponseBodyGuardrailInput {
+                    elapsed: Duration::from_secs(1),
+                    idle_for: Duration::from_secs(1),
+                    bytes_received: 0,
+                    prebuffered_bytes: 0,
+                    next_chunk_bytes: 0,
+                    declared_content_length: None,
+                    headers_emitted: false,
+                    progressive_emission_allowed: true,
+                    body_forwarding_enabled: true,
+                    exempt_from_body_size_cap: false,
+                },
+            );
+
+            assert_eq!(
+                decision,
+                ResponseBodyGuardrailDecision::Continue {
+                    streaming: ResponseStreamingPolicy {
+                        emission: ProgressiveEmissionPolicy::PrebufferUntilValidated,
+                        chunk_emission: ResponseChunkEmissionPolicy::FixedSize {
+                            max_chunk_bytes: 8
+                        },
+                        wait_timeout: Duration::from_secs(4),
+                    },
+                }
+            );
+        }
+
+        #[test]
+        fn response_body_declared_length_cap_rejects() {
+            let decision = evaluate_response_body_guardrails(
+                ResponseBodyGuardrailConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    total_timeout: Duration::from_secs(30),
+                    max_body_bytes: 16,
+                    unknown_length_prebuffer_bytes: 8,
+                    chunk_bytes: 8,
+                },
+                ResponseBodyGuardrailInput {
+                    elapsed: Duration::ZERO,
+                    idle_for: Duration::ZERO,
+                    bytes_received: 0,
+                    prebuffered_bytes: 0,
+                    next_chunk_bytes: 0,
+                    declared_content_length: Some(17),
+                    headers_emitted: false,
+                    progressive_emission_allowed: true,
+                    body_forwarding_enabled: true,
+                    exempt_from_body_size_cap: false,
+                },
+            );
+
+            assert_eq!(
+                decision,
+                ResponseBodyGuardrailDecision::Reject {
+                    kind: BodyLimitKind::BodySize,
+                }
+            );
+        }
+
+        #[test]
+        fn response_body_unknown_length_prebuffer_cap_rejects() {
+            let decision = evaluate_response_body_guardrails(
+                ResponseBodyGuardrailConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    total_timeout: Duration::from_secs(30),
+                    max_body_bytes: 64,
+                    unknown_length_prebuffer_bytes: 10,
+                    chunk_bytes: 4,
+                },
+                ResponseBodyGuardrailInput {
+                    elapsed: Duration::from_secs(1),
+                    idle_for: Duration::from_secs(1),
+                    bytes_received: 6,
+                    prebuffered_bytes: 6,
+                    next_chunk_bytes: 5,
+                    declared_content_length: None,
+                    headers_emitted: false,
+                    progressive_emission_allowed: true,
+                    body_forwarding_enabled: true,
+                    exempt_from_body_size_cap: false,
+                },
+            );
+
+            assert_eq!(
+                decision,
+                ResponseBodyGuardrailDecision::Reject {
+                    kind: BodyLimitKind::UnknownLengthPrebuffer,
+                }
+            );
+        }
+
+        #[test]
+        fn response_body_total_timeout_rejects() {
+            let decision = evaluate_response_body_guardrails(
+                ResponseBodyGuardrailConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    total_timeout: Duration::from_secs(30),
+                    max_body_bytes: 64,
+                    unknown_length_prebuffer_bytes: 16,
+                    chunk_bytes: 8,
+                },
+                ResponseBodyGuardrailInput {
+                    elapsed: Duration::from_secs(30),
+                    idle_for: Duration::from_secs(1),
+                    bytes_received: 0,
+                    prebuffered_bytes: 0,
+                    next_chunk_bytes: 0,
+                    declared_content_length: None,
+                    headers_emitted: false,
+                    progressive_emission_allowed: true,
+                    body_forwarding_enabled: true,
+                    exempt_from_body_size_cap: false,
+                },
+            );
+
+            assert_eq!(
+                decision,
+                ResponseBodyGuardrailDecision::Timeout {
+                    kind: BodyTimeoutKind::Total,
+                }
+            );
+        }
+
+        #[test]
+        fn response_body_total_timeout_is_ignored_after_progress() {
+            let decision = evaluate_response_body_guardrails(
+                ResponseBodyGuardrailConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    total_timeout: Duration::from_secs(30),
+                    max_body_bytes: 64,
+                    unknown_length_prebuffer_bytes: 16,
+                    chunk_bytes: 8,
+                },
+                ResponseBodyGuardrailInput {
+                    elapsed: Duration::from_secs(30),
+                    idle_for: Duration::from_secs(1),
+                    bytes_received: 1,
+                    prebuffered_bytes: 0,
+                    next_chunk_bytes: 0,
+                    declared_content_length: None,
+                    headers_emitted: false,
+                    progressive_emission_allowed: true,
+                    body_forwarding_enabled: true,
+                    exempt_from_body_size_cap: false,
+                },
+            );
+
+            assert_eq!(
+                decision,
+                ResponseBodyGuardrailDecision::Continue {
+                    streaming: ResponseStreamingPolicy {
+                        emission: ProgressiveEmissionPolicy::PrebufferUntilValidated,
+                        chunk_emission: ResponseChunkEmissionPolicy::FixedSize {
+                            max_chunk_bytes: 8
+                        },
+                        wait_timeout: Duration::from_secs(4),
+                    },
+                }
+            );
+        }
+
+        #[test]
+        fn response_body_idle_timeout_rejects() {
+            let decision = evaluate_response_body_guardrails(
+                ResponseBodyGuardrailConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    total_timeout: Duration::from_secs(30),
+                    max_body_bytes: 64,
+                    unknown_length_prebuffer_bytes: 16,
+                    chunk_bytes: 8,
+                },
+                ResponseBodyGuardrailInput {
+                    elapsed: Duration::from_secs(4),
+                    idle_for: Duration::from_secs(5),
+                    bytes_received: 0,
+                    prebuffered_bytes: 0,
+                    next_chunk_bytes: 0,
+                    declared_content_length: None,
+                    headers_emitted: false,
+                    progressive_emission_allowed: true,
+                    body_forwarding_enabled: true,
+                    exempt_from_body_size_cap: false,
+                },
+            );
+
+            assert_eq!(
+                decision,
+                ResponseBodyGuardrailDecision::Timeout {
+                    kind: BodyTimeoutKind::Idle,
+                }
+            );
+        }
+
+        #[test]
+        fn response_body_known_length_streams_progressively() {
+            let decision = evaluate_response_body_guardrails(
+                ResponseBodyGuardrailConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    total_timeout: Duration::from_secs(30),
+                    max_body_bytes: 64,
+                    unknown_length_prebuffer_bytes: 16,
+                    chunk_bytes: 8,
+                },
+                ResponseBodyGuardrailInput {
+                    elapsed: Duration::from_secs(1),
+                    idle_for: Duration::from_secs(1),
+                    bytes_received: 0,
+                    prebuffered_bytes: 0,
+                    next_chunk_bytes: 0,
+                    declared_content_length: Some(12),
+                    headers_emitted: false,
+                    progressive_emission_allowed: true,
+                    body_forwarding_enabled: true,
+                    exempt_from_body_size_cap: false,
+                },
+            );
+
+            assert_eq!(
+                decision,
+                ResponseBodyGuardrailDecision::Continue {
+                    streaming: ResponseStreamingPolicy {
+                        emission: ProgressiveEmissionPolicy::StreamProgressively,
+                        chunk_emission: ResponseChunkEmissionPolicy::FixedSize {
+                            max_chunk_bytes: 8
+                        },
+                        wait_timeout: Duration::from_secs(4),
+                    },
+                }
+            );
+        }
+
+        #[test]
+        fn response_body_suppresses_emission_when_body_is_disabled() {
+            let decision = evaluate_response_body_guardrails(
+                ResponseBodyGuardrailConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    total_timeout: Duration::from_secs(30),
+                    max_body_bytes: 64,
+                    unknown_length_prebuffer_bytes: 16,
+                    chunk_bytes: 8,
+                },
+                ResponseBodyGuardrailInput {
+                    elapsed: Duration::from_secs(1),
+                    idle_for: Duration::from_secs(1),
+                    bytes_received: 0,
+                    prebuffered_bytes: 0,
+                    next_chunk_bytes: 0,
+                    declared_content_length: None,
+                    headers_emitted: false,
+                    progressive_emission_allowed: true,
+                    body_forwarding_enabled: false,
+                    exempt_from_body_size_cap: false,
+                },
+            );
+
+            assert_eq!(
+                decision,
+                ResponseBodyGuardrailDecision::Continue {
+                    streaming: ResponseStreamingPolicy {
+                        emission: ProgressiveEmissionPolicy::SuppressBody,
+                        chunk_emission: ResponseChunkEmissionPolicy::Passthrough,
+                        wait_timeout: Duration::from_secs(4),
+                    },
+                }
+            );
+        }
+
+        #[test]
+        fn checked_response_body_guardrails_returns_next_streaming_state() {
+            let evaluated = checked_response_body_guardrails(
+                ResponseBodyGuardrailConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    total_timeout: Duration::from_secs(30),
+                    max_body_bytes: 64,
+                    unknown_length_prebuffer_bytes: 16,
+                    chunk_bytes: 4,
+                },
+                ResponseBodyGuardrailInput {
+                    elapsed: Duration::from_secs(1),
+                    idle_for: Duration::from_secs(1),
+                    bytes_received: 5,
+                    prebuffered_bytes: 5,
+                    next_chunk_bytes: 3,
+                    declared_content_length: None,
+                    headers_emitted: false,
+                    progressive_emission_allowed: true,
+                    body_forwarding_enabled: true,
+                    exempt_from_body_size_cap: false,
+                },
+            )
+            .expect("response egress should pass");
+
+            assert_eq!(
+                evaluated,
+                EvaluatedResponseBodyGuardrail {
+                    streaming: ResponseStreamingPolicy {
+                        emission: ProgressiveEmissionPolicy::PrebufferUntilValidated,
+                        chunk_emission: ResponseChunkEmissionPolicy::FixedSize {
+                            max_chunk_bytes: 4
+                        },
+                        wait_timeout: Duration::from_secs(4),
+                    },
+                    next_state: ResponseBodyEgressState {
+                        bytes_received: 8,
+                        prebuffered_bytes: 8,
+                    },
+                }
+            );
+        }
     }
 
-    #[test]
-    fn response_chunk_ranges_passthrough_policy_keeps_single_chunk() {
-        assert_eq!(
-            response_chunk_ranges(10, ResponseChunkEmissionPolicy::Passthrough),
-            vec![(0, 10)]
-        );
+    mod response_chunking {
+        use super::*;
+
+        #[test]
+        fn response_chunk_ranges_follow_fixed_size_policy() {
+            assert_eq!(
+                response_chunk_ranges(
+                    10,
+                    ResponseChunkEmissionPolicy::FixedSize { max_chunk_bytes: 4 }
+                ),
+                vec![(0, 4), (4, 8), (8, 10)]
+            );
+        }
+
+        #[test]
+        fn response_chunk_ranges_passthrough_policy_keeps_single_chunk() {
+            assert_eq!(
+                response_chunk_ranges(10, ResponseChunkEmissionPolicy::Passthrough),
+                vec![(0, 10)]
+            );
+        }
     }
 }

--- a/crates/edge/src/runtime/connection/outcome.rs
+++ b/crates/edge/src/runtime/connection/outcome.rs
@@ -975,465 +975,477 @@ mod tests {
         }
     }
 
-    #[test]
-    fn backend_failure_kinds_are_traceable_from_terminal_state() {
-        use crate::runtime::connection::stream::{BackendFailedState, TerminalState};
+    mod outcome_classification {
+        use super::*;
 
-        let cases = [
-            (
-                BackendFailureReason::UpstreamTimeout,
-                BackendFailureClass::Timeout,
-            ),
-            (BackendFailureReason::UpstreamTls, BackendFailureClass::Tls),
-            (
-                BackendFailureReason::UpstreamBridge,
-                BackendFailureClass::Bridge,
-            ),
-            (
-                BackendFailureReason::UpstreamProtocol,
-                BackendFailureClass::Protocol,
-            ),
-            (
-                BackendFailureReason::UpstreamTransport,
-                BackendFailureClass::Transport,
-            ),
-            (
-                BackendFailureReason::DispatchSpawnFailed,
-                BackendFailureClass::Transport,
-            ),
-        ];
-        for (reason, expected_kind) in cases {
-            let state = TerminalState::BackendFailed(BackendFailedState {
-                reason,
-                snapshot: terminal_snapshot_for_test(),
-            });
-            let decision = classify_terminal_outcome(&state);
-            assert_eq!(
-                decision.backend_failure_kind,
-                Some(expected_kind),
-                "reason {reason:?} should map to {expected_kind:?}"
-            );
-            // Timeout maps to the timeout route outcome; every other kind to a
-            // generic upstream failure — but the fine-grained kind is preserved.
-            if matches!(reason, BackendFailureReason::UpstreamTimeout) {
-                assert_eq!(decision.route_outcome, CanonicalRouteOutcome::Timeout);
-            } else {
+        #[test]
+        fn backend_failure_kinds_are_traceable_from_terminal_state() {
+            use crate::runtime::connection::stream::{BackendFailedState, TerminalState};
+
+            let cases = [
+                (
+                    BackendFailureReason::UpstreamTimeout,
+                    BackendFailureClass::Timeout,
+                ),
+                (BackendFailureReason::UpstreamTls, BackendFailureClass::Tls),
+                (
+                    BackendFailureReason::UpstreamBridge,
+                    BackendFailureClass::Bridge,
+                ),
+                (
+                    BackendFailureReason::UpstreamProtocol,
+                    BackendFailureClass::Protocol,
+                ),
+                (
+                    BackendFailureReason::UpstreamTransport,
+                    BackendFailureClass::Transport,
+                ),
+                (
+                    BackendFailureReason::DispatchSpawnFailed,
+                    BackendFailureClass::Transport,
+                ),
+            ];
+            for (reason, expected_kind) in cases {
+                let state = TerminalState::BackendFailed(BackendFailedState {
+                    reason,
+                    snapshot: terminal_snapshot_for_test(),
+                });
+                let decision = classify_terminal_outcome(&state);
                 assert_eq!(
-                    decision.route_outcome,
-                    CanonicalRouteOutcome::UpstreamFailure
+                    decision.backend_failure_kind,
+                    Some(expected_kind),
+                    "reason {reason:?} should map to {expected_kind:?}"
                 );
+                // Timeout maps to the timeout route outcome; every other kind to a
+                // generic upstream failure — but the fine-grained kind is preserved.
+                if matches!(reason, BackendFailureReason::UpstreamTimeout) {
+                    assert_eq!(decision.route_outcome, CanonicalRouteOutcome::Timeout);
+                } else {
+                    assert_eq!(
+                        decision.route_outcome,
+                        CanonicalRouteOutcome::UpstreamFailure
+                    );
+                }
             }
         }
-    }
 
-    #[test]
-    fn rejection_kinds_distinguish_validation_from_auth_and_overload() {
-        use crate::runtime::connection::stream::{RejectedState, TerminalState};
+        #[test]
+        fn rejection_kinds_distinguish_validation_from_auth_and_overload() {
+            use crate::runtime::connection::stream::{RejectedState, TerminalState};
 
-        let validation = classify_terminal_outcome(&TerminalState::Rejected(RejectedState {
-            reason: RejectionReason::ValidationFailed,
-            snapshot: terminal_snapshot_for_test(),
-        }));
-        assert_eq!(
-            validation.rejection_kind,
-            Some(RejectionClass::ValidationPolicy)
-        );
+            let validation = classify_terminal_outcome(&TerminalState::Rejected(RejectedState {
+                reason: RejectionReason::ValidationFailed,
+                snapshot: terminal_snapshot_for_test(),
+            }));
+            assert_eq!(
+                validation.rejection_kind,
+                Some(RejectionClass::ValidationPolicy)
+            );
 
-        let auth = classify_terminal_outcome(&TerminalState::Rejected(RejectedState {
-            reason: RejectionReason::AuthDenied,
-            snapshot: terminal_snapshot_for_test(),
-        }));
-        assert_eq!(auth.rejection_kind, Some(RejectionClass::AuthDenied));
-
-        let overload = classify_terminal_outcome(&TerminalState::Rejected(RejectedState {
-            reason: RejectionReason::Overloaded,
-            snapshot: terminal_snapshot_for_test(),
-        }));
-        assert_eq!(overload.rejection_kind, Some(RejectionClass::OverloadShed));
-    }
-
-    #[test]
-    fn classifies_success_status_as_success() {
-        let decision = classify_status_outcome(StatusCode::OK);
-        assert_eq!(decision.route_outcome, CanonicalRouteOutcome::Success);
-        assert_eq!(decision.backend_outcome, CanonicalBackendOutcome::Success);
-        assert_eq!(decision.health_effect, HealthEffectHint::Success);
-    }
-
-    #[test]
-    fn classifies_timeout_proxy_error_as_timeout() {
-        let decision = classify_proxy_error_outcome(&ProxyError::Timeout, None);
-        assert_eq!(decision.route_outcome, CanonicalRouteOutcome::Timeout);
-        assert_eq!(decision.backend_outcome, CanonicalBackendOutcome::Timeout);
-        assert_eq!(
-            decision.health_effect,
-            HealthEffectHint::Failure {
-                reason: HealthFailureReason::Timeout,
-            }
-        );
-    }
-
-    #[test]
-    fn classifies_overload_admission_outcome() {
-        let decision = classify_admission_outcome(AdmissionOutcomeClass::OverloadShed {
-            reason: Some(OverloadShedReason::GlobalInflight),
-        });
-        assert_eq!(decision.route_outcome, CanonicalRouteOutcome::OverloadShed);
-        assert_eq!(
-            decision.backend_outcome,
-            CanonicalBackendOutcome::OverloadShed
-        );
-        assert_eq!(
-            decision.overload_reason,
-            Some(OverloadShedReason::GlobalInflight)
-        );
-    }
-
-    #[test]
-    fn observe_status_outcome_records_success_metrics() {
-        let metrics = test_metrics();
-
-        let decision = observe_status_outcome(
-            &metrics,
-            RouteOutcomeTarget { route: "api" },
-            Some(BackendOutcomeTarget {
-                upstream: "api",
-                backend_addr: Some("backend-a"),
-                backend_index: Some(0),
-            }),
-            Duration::from_millis(12),
-            StatusCode::OK,
-        );
-
-        assert_eq!(decision.route_outcome, CanonicalRouteOutcome::Success);
-        assert_eq!(
-            metrics
-                .requests_success
-                .load(std::sync::atomic::Ordering::Relaxed),
-            1
-        );
-        assert_eq!(
-            metrics
-                .requests_failure
-                .load(std::sync::atomic::Ordering::Relaxed),
-            0
-        );
-        assert_eq!(upstream_request_count(&metrics, "api", "2xx", "success"), 1);
-        assert_eq!(
-            backend_request_count(&metrics, "api", "backend-a", "2xx", "success"),
-            1
-        );
-    }
-
-    #[test]
-    fn timeout_outcome_records_5xx_labels_and_matching_latency_bucket() {
-        let metrics = test_metrics();
-
-        let timeout = observe_proxy_error_outcome(
-            &metrics,
-            RouteOutcomeTarget { route: "api" },
-            Some(BackendOutcomeTarget {
-                upstream: "api",
-                backend_addr: Some("backend-a"),
-                backend_index: Some(0),
-            }),
-            Duration::from_millis(320),
-            Some(StatusCode::GATEWAY_TIMEOUT),
-            &ProxyError::Timeout,
-            None,
-        );
-
-        assert_eq!(timeout.route_outcome, CanonicalRouteOutcome::Timeout);
-        assert_eq!(upstream_request_count(&metrics, "api", "5xx", "timeout"), 1);
-        assert_eq!(
-            backend_request_count(&metrics, "api", "backend-a", "5xx", "timeout"),
-            1
-        );
-
-        let latency = upstream_latency_stats(&metrics, "api", "timeout");
-        assert_eq!(latency.count, 1);
-        assert_eq!(latency.latency_ms_sum, 320);
-        assert_eq!(latency.latency_buckets[7], 1);
-    }
-
-    #[test]
-    fn success_outcome_records_2xx_labels_and_matching_latency_bucket() {
-        let metrics = test_metrics();
-
-        let success = observe_status_outcome(
-            &metrics,
-            RouteOutcomeTarget { route: "api" },
-            Some(BackendOutcomeTarget {
-                upstream: "api",
-                backend_addr: Some("backend-a"),
-                backend_index: Some(0),
-            }),
-            Duration::from_millis(12),
-            StatusCode::OK,
-        );
-
-        assert_eq!(success.route_outcome, CanonicalRouteOutcome::Success);
-        assert_eq!(upstream_request_count(&metrics, "api", "2xx", "success"), 1);
-        assert_eq!(
-            backend_request_count(&metrics, "api", "backend-a", "2xx", "success"),
-            1
-        );
-
-        let latency = upstream_latency_stats(&metrics, "api", "success");
-        assert_eq!(latency.count, 1);
-        assert_eq!(latency.latency_ms_sum, 12);
-        assert_eq!(latency.latency_buckets[3], 1);
-    }
-
-    #[test]
-    fn observe_proxy_error_outcome_records_timeout_and_unrouted_failure() {
-        let metrics = test_metrics();
-
-        let timeout = observe_proxy_error_outcome(
-            &metrics,
-            RouteOutcomeTarget { route: "api" },
-            Some(BackendOutcomeTarget {
-                upstream: "api",
-                backend_addr: Some("backend-a"),
-                backend_index: Some(0),
-            }),
-            Duration::from_millis(50),
-            Some(StatusCode::REQUEST_TIMEOUT),
-            &ProxyError::Timeout,
-            None,
-        );
-        let unrouted = observe_proxy_error_outcome(
-            &metrics,
-            RouteOutcomeTarget::UNROUTED,
-            None,
-            Duration::from_millis(5),
-            Some(StatusCode::BAD_GATEWAY),
-            &ProxyError::Transport("no route".into()),
-            None,
-        );
-
-        assert_eq!(timeout.route_outcome, CanonicalRouteOutcome::Timeout);
-        assert_eq!(
-            unrouted.route_outcome,
-            CanonicalRouteOutcome::UpstreamFailure
-        );
-        assert_eq!(
-            metrics
-                .requests_failure
-                .load(std::sync::atomic::Ordering::Relaxed),
-            2
-        );
-        assert_eq!(upstream_request_count(&metrics, "api", "4xx", "timeout"), 1);
-        assert_eq!(
-            upstream_request_count(&metrics, "unrouted", "5xx", "failure"),
-            1
-        );
-    }
-
-    #[test]
-    fn observe_admission_outcome_records_overload_auth_and_rate_limit() {
-        let metrics = test_metrics();
-
-        let overload = observe_admission_outcome(
-            &metrics,
-            RouteOutcomeTarget { route: "api" },
-            Some(BackendOutcomeTarget {
-                upstream: "api",
-                backend_addr: Some("backend-a"),
-                backend_index: Some(0),
-            }),
-            Duration::from_millis(1),
-            StatusCode::SERVICE_UNAVAILABLE,
-            AdmissionOutcomeClass::OverloadShed {
-                reason: Some(OverloadShedReason::GlobalInflight),
-            },
-        );
-        let auth = observe_admission_outcome(
-            &metrics,
-            RouteOutcomeTarget { route: "api" },
-            Some(BackendOutcomeTarget {
-                upstream: "api",
-                backend_addr: Some("backend-a"),
-                backend_index: Some(0),
-            }),
-            Duration::from_millis(2),
-            StatusCode::UNAUTHORIZED,
-            AdmissionOutcomeClass::AuthDenied,
-        );
-        let rate_limited = observe_admission_outcome(
-            &metrics,
-            RouteOutcomeTarget { route: "api" },
-            Some(BackendOutcomeTarget {
-                upstream: "api",
-                backend_addr: Some("backend-a"),
-                backend_index: Some(0),
-            }),
-            Duration::from_millis(3),
-            StatusCode::TOO_MANY_REQUESTS,
-            AdmissionOutcomeClass::RateLimited,
-        );
-
-        assert_eq!(overload.route_outcome, CanonicalRouteOutcome::OverloadShed);
-        assert_eq!(auth.route_outcome, CanonicalRouteOutcome::AuthDenied);
-        assert_eq!(
-            rate_limited.route_outcome,
-            CanonicalRouteOutcome::RateLimited
-        );
-        assert_eq!(
-            metrics
-                .overload_shed
-                .load(std::sync::atomic::Ordering::Relaxed),
-            1
-        );
-        assert_eq!(
-            metrics
-                .overload_shed_global_inflight
-                .load(std::sync::atomic::Ordering::Relaxed),
-            1
-        );
-        assert_eq!(
-            upstream_request_count(&metrics, "api", "5xx", "overload_shed"),
-            1
-        );
-        assert_eq!(upstream_request_count(&metrics, "api", "4xx", "failure"), 1);
-        assert_eq!(
-            upstream_request_count(&metrics, "api", "4xx", "rate_limited"),
-            1
-        );
-    }
-
-    #[test]
-    fn outcome_reason_mapping_stays_canonical_for_admission_and_backend_failures() {
-        let auth = classify_terminal_outcome(&TerminalState::Rejected(
-            crate::runtime::connection::stream::RejectedState {
+            let auth = classify_terminal_outcome(&TerminalState::Rejected(RejectedState {
                 reason: RejectionReason::AuthDenied,
                 snapshot: terminal_snapshot_for_test(),
-            },
-        ));
-        let overload = classify_terminal_outcome(&TerminalState::Rejected(
-            crate::runtime::connection::stream::RejectedState {
+            }));
+            assert_eq!(auth.rejection_kind, Some(RejectionClass::AuthDenied));
+
+            let overload = classify_terminal_outcome(&TerminalState::Rejected(RejectedState {
                 reason: RejectionReason::Overloaded,
                 snapshot: terminal_snapshot_for_test(),
-            },
-        ));
-        let backend = classify_terminal_outcome(&TerminalState::BackendFailed(
-            crate::runtime::connection::stream::BackendFailedState {
-                reason: BackendFailureReason::UpstreamProtocol,
-                snapshot: terminal_snapshot_for_test(),
-            },
-        ));
-
-        assert_eq!(auth.rejection_kind, Some(RejectionClass::AuthDenied));
-        assert_eq!(overload.rejection_kind, Some(RejectionClass::OverloadShed));
-        assert_eq!(
-            backend.backend_failure_kind,
-            Some(BackendFailureClass::Protocol)
-        );
-        assert_eq!(auth.route_outcome, CanonicalRouteOutcome::AuthDenied);
-        assert_eq!(overload.route_outcome, CanonicalRouteOutcome::OverloadShed);
-        assert_eq!(
-            backend.route_outcome,
-            CanonicalRouteOutcome::UpstreamFailure
-        );
-    }
-
-    #[test]
-    fn backend_accounting_and_health_hooks_remain_stable() {
-        let metrics = test_metrics();
-        let pool = test_upstream_pool();
-
-        {
-            let guard = pool.read().expect("read");
-            assert!(guard.begin_request_if_healthy(0));
-        }
-        finish_backend_request_accounting(BackendRequestFinishInput {
-            upstream_pool: Some(&pool),
-            backend_index: Some(0),
-            elapsed: Duration::from_millis(20),
-            status: Some(StatusCode::OK.as_u16()),
-        });
-        {
-            let guard = pool.read().expect("read");
-            let state = guard.backend_runtime_state(0).expect("backend state");
-            assert_eq!(state.active_requests, 0);
-            assert!(state.ewma_latency_ms.is_some());
+            }));
+            assert_eq!(overload.rejection_kind, Some(RejectionClass::OverloadShed));
         }
 
-        let unhealthy = observe_backend_response_status(BackendHealthObservationInput {
-            backend_addr: "backend-a",
-            backend_index: 0,
-            upstream_pool: Some(&pool),
-            status: StatusCode::INTERNAL_SERVER_ERROR,
-        });
-        assert!(matches!(unhealthy, Some(HealthTransition::BecameUnhealthy)));
+        #[test]
+        fn classifies_success_status_as_success() {
+            let decision = classify_status_outcome(StatusCode::OK);
+            assert_eq!(decision.route_outcome, CanonicalRouteOutcome::Success);
+            assert_eq!(decision.backend_outcome, CanonicalBackendOutcome::Success);
+            assert_eq!(decision.health_effect, HealthEffectHint::Success);
+        }
 
-        let healthy = observe_backend_response_status(BackendHealthObservationInput {
-            backend_addr: "backend-a",
-            backend_index: 0,
-            upstream_pool: Some(&pool),
-            status: StatusCode::OK,
-        });
-        assert!(matches!(healthy, Some(HealthTransition::BecameHealthy)));
+        #[test]
+        fn classifies_timeout_proxy_error_as_timeout() {
+            let decision = classify_proxy_error_outcome(&ProxyError::Timeout, None);
+            assert_eq!(decision.route_outcome, CanonicalRouteOutcome::Timeout);
+            assert_eq!(decision.backend_outcome, CanonicalBackendOutcome::Timeout);
+            assert_eq!(
+                decision.health_effect,
+                HealthEffectHint::Failure {
+                    reason: HealthFailureReason::Timeout,
+                }
+            );
+        }
 
-        let classified = spooky_errors::classify_upstream_proxy_error(&ProxyError::Timeout)
-            .expect("classified timeout");
-        let transition = observe_classified_backend_failure(ClassifiedBackendFailureInput {
-            metrics_phase: "bootstrap",
-            backend_addr: "backend-a",
-            backend_index: 0,
-            upstream_pool: Some(&pool),
-            metrics: &metrics,
-            classified: &classified,
-        });
-        assert!(matches!(
-            transition,
-            Some(HealthTransition::BecameUnhealthy)
-        ));
-        assert_eq!(
-            metrics
-                .health_failure_timeout
-                .load(std::sync::atomic::Ordering::Relaxed),
-            1
-        );
+        #[test]
+        fn classifies_overload_admission_outcome() {
+            let decision = classify_admission_outcome(AdmissionOutcomeClass::OverloadShed {
+                reason: Some(OverloadShedReason::GlobalInflight),
+            });
+            assert_eq!(decision.route_outcome, CanonicalRouteOutcome::OverloadShed);
+            assert_eq!(
+                decision.backend_outcome,
+                CanonicalBackendOutcome::OverloadShed
+            );
+            assert_eq!(
+                decision.overload_reason,
+                Some(OverloadShedReason::GlobalInflight)
+            );
+        }
+
+        #[test]
+        fn outcome_reason_mapping_stays_canonical_for_admission_and_backend_failures() {
+            let auth = classify_terminal_outcome(&TerminalState::Rejected(
+                crate::runtime::connection::stream::RejectedState {
+                    reason: RejectionReason::AuthDenied,
+                    snapshot: terminal_snapshot_for_test(),
+                },
+            ));
+            let overload = classify_terminal_outcome(&TerminalState::Rejected(
+                crate::runtime::connection::stream::RejectedState {
+                    reason: RejectionReason::Overloaded,
+                    snapshot: terminal_snapshot_for_test(),
+                },
+            ));
+            let backend = classify_terminal_outcome(&TerminalState::BackendFailed(
+                crate::runtime::connection::stream::BackendFailedState {
+                    reason: BackendFailureReason::UpstreamProtocol,
+                    snapshot: terminal_snapshot_for_test(),
+                },
+            ));
+
+            assert_eq!(auth.rejection_kind, Some(RejectionClass::AuthDenied));
+            assert_eq!(overload.rejection_kind, Some(RejectionClass::OverloadShed));
+            assert_eq!(
+                backend.backend_failure_kind,
+                Some(BackendFailureClass::Protocol)
+            );
+            assert_eq!(auth.route_outcome, CanonicalRouteOutcome::AuthDenied);
+            assert_eq!(overload.route_outcome, CanonicalRouteOutcome::OverloadShed);
+            assert_eq!(
+                backend.route_outcome,
+                CanonicalRouteOutcome::UpstreamFailure
+            );
+        }
     }
 
-    #[test]
-    fn forwarding_and_bootstrap_shared_recorders_emit_same_metrics_shape() {
-        let metrics = test_metrics();
+    mod metrics_recording {
+        use super::*;
 
-        let forwarding = observe_proxy_error_outcome(
-            &metrics,
-            RouteOutcomeTarget { route: "api" },
-            Some(BackendOutcomeTarget {
-                upstream: "api",
-                backend_addr: Some("backend-a"),
-                backend_index: Some(0),
-            }),
-            Duration::from_millis(10),
-            Some(StatusCode::BAD_GATEWAY),
-            &ProxyError::Transport("forwarding upstream error".into()),
-            None,
-        );
-        let bootstrap = observe_proxy_error_outcome(
-            &metrics,
-            RouteOutcomeTarget { route: "api" },
-            Some(BackendOutcomeTarget {
-                upstream: "api",
-                backend_addr: Some("backend-a"),
-                backend_index: Some(0),
-            }),
-            Duration::from_millis(12),
-            Some(StatusCode::BAD_GATEWAY),
-            &ProxyError::Transport("bootstrap upstream error".into()),
-            None,
-        );
+        #[test]
+        fn observe_status_outcome_records_success_metrics() {
+            let metrics = test_metrics();
 
-        assert_eq!(forwarding.route_outcome, bootstrap.route_outcome);
-        assert_eq!(forwarding.backend_outcome, bootstrap.backend_outcome);
-        assert_eq!(upstream_request_count(&metrics, "api", "5xx", "failure"), 2);
-        assert_eq!(
-            backend_request_count(&metrics, "api", "backend-a", "5xx", "failure"),
-            2
-        );
+            let decision = observe_status_outcome(
+                &metrics,
+                RouteOutcomeTarget { route: "api" },
+                Some(BackendOutcomeTarget {
+                    upstream: "api",
+                    backend_addr: Some("backend-a"),
+                    backend_index: Some(0),
+                }),
+                Duration::from_millis(12),
+                StatusCode::OK,
+            );
+
+            assert_eq!(decision.route_outcome, CanonicalRouteOutcome::Success);
+            assert_eq!(
+                metrics
+                    .requests_success
+                    .load(std::sync::atomic::Ordering::Relaxed),
+                1
+            );
+            assert_eq!(
+                metrics
+                    .requests_failure
+                    .load(std::sync::atomic::Ordering::Relaxed),
+                0
+            );
+            assert_eq!(upstream_request_count(&metrics, "api", "2xx", "success"), 1);
+            assert_eq!(
+                backend_request_count(&metrics, "api", "backend-a", "2xx", "success"),
+                1
+            );
+        }
+
+        #[test]
+        fn timeout_outcome_records_5xx_labels_and_matching_latency_bucket() {
+            let metrics = test_metrics();
+
+            let timeout = observe_proxy_error_outcome(
+                &metrics,
+                RouteOutcomeTarget { route: "api" },
+                Some(BackendOutcomeTarget {
+                    upstream: "api",
+                    backend_addr: Some("backend-a"),
+                    backend_index: Some(0),
+                }),
+                Duration::from_millis(320),
+                Some(StatusCode::GATEWAY_TIMEOUT),
+                &ProxyError::Timeout,
+                None,
+            );
+
+            assert_eq!(timeout.route_outcome, CanonicalRouteOutcome::Timeout);
+            assert_eq!(upstream_request_count(&metrics, "api", "5xx", "timeout"), 1);
+            assert_eq!(
+                backend_request_count(&metrics, "api", "backend-a", "5xx", "timeout"),
+                1
+            );
+
+            let latency = upstream_latency_stats(&metrics, "api", "timeout");
+            assert_eq!(latency.count, 1);
+            assert_eq!(latency.latency_ms_sum, 320);
+            assert_eq!(latency.latency_buckets[7], 1);
+        }
+
+        #[test]
+        fn success_outcome_records_2xx_labels_and_matching_latency_bucket() {
+            let metrics = test_metrics();
+
+            let success = observe_status_outcome(
+                &metrics,
+                RouteOutcomeTarget { route: "api" },
+                Some(BackendOutcomeTarget {
+                    upstream: "api",
+                    backend_addr: Some("backend-a"),
+                    backend_index: Some(0),
+                }),
+                Duration::from_millis(12),
+                StatusCode::OK,
+            );
+
+            assert_eq!(success.route_outcome, CanonicalRouteOutcome::Success);
+            assert_eq!(upstream_request_count(&metrics, "api", "2xx", "success"), 1);
+            assert_eq!(
+                backend_request_count(&metrics, "api", "backend-a", "2xx", "success"),
+                1
+            );
+
+            let latency = upstream_latency_stats(&metrics, "api", "success");
+            assert_eq!(latency.count, 1);
+            assert_eq!(latency.latency_ms_sum, 12);
+            assert_eq!(latency.latency_buckets[3], 1);
+        }
+
+        #[test]
+        fn observe_proxy_error_outcome_records_timeout_and_unrouted_failure() {
+            let metrics = test_metrics();
+
+            let timeout = observe_proxy_error_outcome(
+                &metrics,
+                RouteOutcomeTarget { route: "api" },
+                Some(BackendOutcomeTarget {
+                    upstream: "api",
+                    backend_addr: Some("backend-a"),
+                    backend_index: Some(0),
+                }),
+                Duration::from_millis(50),
+                Some(StatusCode::REQUEST_TIMEOUT),
+                &ProxyError::Timeout,
+                None,
+            );
+            let unrouted = observe_proxy_error_outcome(
+                &metrics,
+                RouteOutcomeTarget::UNROUTED,
+                None,
+                Duration::from_millis(5),
+                Some(StatusCode::BAD_GATEWAY),
+                &ProxyError::Transport("no route".into()),
+                None,
+            );
+
+            assert_eq!(timeout.route_outcome, CanonicalRouteOutcome::Timeout);
+            assert_eq!(
+                unrouted.route_outcome,
+                CanonicalRouteOutcome::UpstreamFailure
+            );
+            assert_eq!(
+                metrics
+                    .requests_failure
+                    .load(std::sync::atomic::Ordering::Relaxed),
+                2
+            );
+            assert_eq!(upstream_request_count(&metrics, "api", "4xx", "timeout"), 1);
+            assert_eq!(
+                upstream_request_count(&metrics, "unrouted", "5xx", "failure"),
+                1
+            );
+        }
+
+        #[test]
+        fn observe_admission_outcome_records_overload_auth_and_rate_limit() {
+            let metrics = test_metrics();
+
+            let overload = observe_admission_outcome(
+                &metrics,
+                RouteOutcomeTarget { route: "api" },
+                Some(BackendOutcomeTarget {
+                    upstream: "api",
+                    backend_addr: Some("backend-a"),
+                    backend_index: Some(0),
+                }),
+                Duration::from_millis(1),
+                StatusCode::SERVICE_UNAVAILABLE,
+                AdmissionOutcomeClass::OverloadShed {
+                    reason: Some(OverloadShedReason::GlobalInflight),
+                },
+            );
+            let auth = observe_admission_outcome(
+                &metrics,
+                RouteOutcomeTarget { route: "api" },
+                Some(BackendOutcomeTarget {
+                    upstream: "api",
+                    backend_addr: Some("backend-a"),
+                    backend_index: Some(0),
+                }),
+                Duration::from_millis(2),
+                StatusCode::UNAUTHORIZED,
+                AdmissionOutcomeClass::AuthDenied,
+            );
+            let rate_limited = observe_admission_outcome(
+                &metrics,
+                RouteOutcomeTarget { route: "api" },
+                Some(BackendOutcomeTarget {
+                    upstream: "api",
+                    backend_addr: Some("backend-a"),
+                    backend_index: Some(0),
+                }),
+                Duration::from_millis(3),
+                StatusCode::TOO_MANY_REQUESTS,
+                AdmissionOutcomeClass::RateLimited,
+            );
+
+            assert_eq!(overload.route_outcome, CanonicalRouteOutcome::OverloadShed);
+            assert_eq!(auth.route_outcome, CanonicalRouteOutcome::AuthDenied);
+            assert_eq!(
+                rate_limited.route_outcome,
+                CanonicalRouteOutcome::RateLimited
+            );
+            assert_eq!(
+                metrics
+                    .overload_shed
+                    .load(std::sync::atomic::Ordering::Relaxed),
+                1
+            );
+            assert_eq!(
+                metrics
+                    .overload_shed_global_inflight
+                    .load(std::sync::atomic::Ordering::Relaxed),
+                1
+            );
+            assert_eq!(
+                upstream_request_count(&metrics, "api", "5xx", "overload_shed"),
+                1
+            );
+            assert_eq!(upstream_request_count(&metrics, "api", "4xx", "failure"), 1);
+            assert_eq!(
+                upstream_request_count(&metrics, "api", "4xx", "rate_limited"),
+                1
+            );
+        }
+    }
+
+    mod backend_accounting_hooks {
+        use super::*;
+
+        #[test]
+        fn backend_accounting_and_health_hooks_remain_stable() {
+            let metrics = test_metrics();
+            let pool = test_upstream_pool();
+
+            {
+                let guard = pool.read().expect("read");
+                assert!(guard.begin_request_if_healthy(0));
+            }
+            finish_backend_request_accounting(BackendRequestFinishInput {
+                upstream_pool: Some(&pool),
+                backend_index: Some(0),
+                elapsed: Duration::from_millis(20),
+                status: Some(StatusCode::OK.as_u16()),
+            });
+            {
+                let guard = pool.read().expect("read");
+                let state = guard.backend_runtime_state(0).expect("backend state");
+                assert_eq!(state.active_requests, 0);
+                assert!(state.ewma_latency_ms.is_some());
+            }
+
+            let unhealthy = observe_backend_response_status(BackendHealthObservationInput {
+                backend_addr: "backend-a",
+                backend_index: 0,
+                upstream_pool: Some(&pool),
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+            });
+            assert!(matches!(unhealthy, Some(HealthTransition::BecameUnhealthy)));
+
+            let healthy = observe_backend_response_status(BackendHealthObservationInput {
+                backend_addr: "backend-a",
+                backend_index: 0,
+                upstream_pool: Some(&pool),
+                status: StatusCode::OK,
+            });
+            assert!(matches!(healthy, Some(HealthTransition::BecameHealthy)));
+
+            let classified = spooky_errors::classify_upstream_proxy_error(&ProxyError::Timeout)
+                .expect("classified timeout");
+            let transition = observe_classified_backend_failure(ClassifiedBackendFailureInput {
+                metrics_phase: "bootstrap",
+                backend_addr: "backend-a",
+                backend_index: 0,
+                upstream_pool: Some(&pool),
+                metrics: &metrics,
+                classified: &classified,
+            });
+            assert!(matches!(
+                transition,
+                Some(HealthTransition::BecameUnhealthy)
+            ));
+            assert_eq!(
+                metrics
+                    .health_failure_timeout
+                    .load(std::sync::atomic::Ordering::Relaxed),
+                1
+            );
+        }
+
+        #[test]
+        fn forwarding_and_bootstrap_shared_recorders_emit_same_metrics_shape() {
+            let metrics = test_metrics();
+
+            let forwarding = observe_proxy_error_outcome(
+                &metrics,
+                RouteOutcomeTarget { route: "api" },
+                Some(BackendOutcomeTarget {
+                    upstream: "api",
+                    backend_addr: Some("backend-a"),
+                    backend_index: Some(0),
+                }),
+                Duration::from_millis(10),
+                Some(StatusCode::BAD_GATEWAY),
+                &ProxyError::Transport("forwarding upstream error".into()),
+                None,
+            );
+            let bootstrap = observe_proxy_error_outcome(
+                &metrics,
+                RouteOutcomeTarget { route: "api" },
+                Some(BackendOutcomeTarget {
+                    upstream: "api",
+                    backend_addr: Some("backend-a"),
+                    backend_index: Some(0),
+                }),
+                Duration::from_millis(12),
+                Some(StatusCode::BAD_GATEWAY),
+                &ProxyError::Transport("bootstrap upstream error".into()),
+                None,
+            );
+
+            assert_eq!(forwarding.route_outcome, bootstrap.route_outcome);
+            assert_eq!(forwarding.backend_outcome, bootstrap.backend_outcome);
+            assert_eq!(upstream_request_count(&metrics, "api", "5xx", "failure"), 2);
+            assert_eq!(
+                backend_request_count(&metrics, "api", "backend-a", "5xx", "failure"),
+                2
+            );
+        }
     }
 }

--- a/crates/edge/src/runtime/connection/outcome.rs
+++ b/crates/edge/src/runtime/connection/outcome.rs
@@ -1093,6 +1093,83 @@ mod tests {
         }
 
         #[test]
+        fn admission_outcome_classification_covers_auth_rate_limit_and_failed_paths() {
+            let auth = classify_admission_outcome(AdmissionOutcomeClass::AuthDenied);
+            assert_eq!(auth.route_outcome, CanonicalRouteOutcome::AuthDenied);
+            assert_eq!(auth.backend_outcome, CanonicalBackendOutcome::AuthDenied);
+            assert_eq!(auth.rejection_kind, Some(RejectionClass::AuthDenied));
+
+            let rate_limited = classify_admission_outcome(AdmissionOutcomeClass::RateLimited);
+            assert_eq!(
+                rate_limited.route_outcome,
+                CanonicalRouteOutcome::RateLimited
+            );
+            assert_eq!(
+                rate_limited.backend_outcome,
+                CanonicalBackendOutcome::RateLimited
+            );
+            assert_eq!(
+                rate_limited.rejection_kind,
+                Some(RejectionClass::RateLimited)
+            );
+
+            let failed_timeout =
+                classify_admission_outcome(AdmissionOutcomeClass::Failed { timed_out: true });
+            assert_eq!(failed_timeout.route_outcome, CanonicalRouteOutcome::Timeout);
+            assert_eq!(
+                failed_timeout.backend_outcome,
+                CanonicalBackendOutcome::Timeout
+            );
+            assert_eq!(failed_timeout.rejection_kind, None);
+
+            let failed_upstream =
+                classify_admission_outcome(AdmissionOutcomeClass::Failed { timed_out: false });
+            assert_eq!(
+                failed_upstream.route_outcome,
+                CanonicalRouteOutcome::UpstreamFailure
+            );
+            assert_eq!(
+                failed_upstream.backend_outcome,
+                CanonicalBackendOutcome::UpstreamFailure
+            );
+            assert_eq!(failed_upstream.rejection_kind, None);
+        }
+
+        #[test]
+        fn proxy_error_classification_distinguishes_timeout_overload_and_upstream_failures() {
+            let timeout = classify_proxy_error_outcome(&ProxyError::Timeout, None);
+            assert_eq!(timeout.route_outcome, CanonicalRouteOutcome::Timeout);
+            assert_eq!(timeout.backend_outcome, CanonicalBackendOutcome::Timeout);
+
+            let overload = classify_proxy_error_outcome(
+                &ProxyError::Pool(PoolError::BackendOverloaded("busy".to_string())),
+                Some(OverloadShedReason::BackendInflight),
+            );
+            assert_eq!(overload.route_outcome, CanonicalRouteOutcome::OverloadShed);
+            assert_eq!(
+                overload.backend_outcome,
+                CanonicalBackendOutcome::OverloadShed
+            );
+            assert_eq!(
+                overload.overload_reason,
+                Some(OverloadShedReason::BackendInflight)
+            );
+
+            let unrouted = classify_proxy_error_outcome(
+                &ProxyError::Pool(PoolError::UnknownBackend("missing".to_string())),
+                None,
+            );
+            assert_eq!(
+                unrouted.route_outcome,
+                CanonicalRouteOutcome::UpstreamFailure
+            );
+            assert_eq!(
+                unrouted.backend_outcome,
+                CanonicalBackendOutcome::UpstreamFailure
+            );
+        }
+
+        #[test]
         fn outcome_reason_mapping_stays_canonical_for_admission_and_backend_failures() {
             let auth = classify_terminal_outcome(&TerminalState::Rejected(
                 crate::runtime::connection::stream::RejectedState {
@@ -1343,6 +1420,43 @@ mod tests {
                 1
             );
         }
+
+        #[test]
+        fn typed_request_outcome_observation_records_unrouted_upstream_failure_without_local_branching()
+         {
+            let metrics = test_metrics();
+            let decision = RequestOutcomeClassification {
+                route_outcome: CanonicalRouteOutcome::UpstreamFailure,
+                backend_outcome: CanonicalBackendOutcome::UpstreamFailure,
+                overload_reason: None,
+                rejection_kind: None,
+                backend_failure_kind: Some(BackendFailureClass::Transport),
+                health_effect: HealthEffectHint::Failure {
+                    reason: HealthFailureReason::Transport,
+                },
+            };
+
+            let observed = observe_request_outcome(
+                &metrics,
+                RouteOutcomeTarget::UNROUTED,
+                None,
+                Duration::from_millis(7),
+                Some(StatusCode::BAD_GATEWAY),
+                decision,
+            );
+
+            assert_eq!(observed, decision);
+            assert_eq!(
+                metrics
+                    .requests_failure
+                    .load(std::sync::atomic::Ordering::Relaxed),
+                1
+            );
+            assert_eq!(
+                upstream_request_count(&metrics, "unrouted", "5xx", "failure"),
+                1
+            );
+        }
     }
 
     mod backend_accounting_hooks {
@@ -1445,6 +1559,88 @@ mod tests {
             assert_eq!(
                 backend_request_count(&metrics, "api", "backend-a", "5xx", "failure"),
                 2
+            );
+        }
+
+        #[test]
+        fn finalize_backend_request_cleanup_is_gated_by_typed_cleanup_flag() {
+            let pool = test_upstream_pool();
+            {
+                let guard = pool.read().expect("read");
+                assert!(guard.begin_request_if_healthy(0));
+            }
+
+            let finalized = finalize_backend_request_cleanup(
+                BackendRequestFinishInput {
+                    upstream_pool: Some(&pool),
+                    backend_index: Some(0),
+                    elapsed: Duration::from_millis(15),
+                    status: Some(StatusCode::OK.as_u16()),
+                },
+                false,
+            );
+            assert!(!finalized);
+            {
+                let guard = pool.read().expect("read");
+                let state = guard.backend_runtime_state(0).expect("backend state");
+                assert_eq!(state.active_requests, 1);
+            }
+
+            let finalized = finalize_backend_request_cleanup(
+                BackendRequestFinishInput {
+                    upstream_pool: Some(&pool),
+                    backend_index: Some(0),
+                    elapsed: Duration::from_millis(15),
+                    status: Some(StatusCode::OK.as_u16()),
+                },
+                true,
+            );
+            assert!(finalized);
+            {
+                let guard = pool.read().expect("read");
+                let state = guard.backend_runtime_state(0).expect("backend state");
+                assert_eq!(state.active_requests, 0);
+            }
+        }
+
+        #[test]
+        fn classified_backend_failure_metrics_preserve_reason_mapping_for_tls_and_transport() {
+            let metrics = test_metrics();
+
+            let tls = spooky_errors::classify_upstream_proxy_error(&ProxyError::Tls(
+                "unknown issuer".to_string(),
+            ))
+            .expect("classified tls");
+            let tls_reason = record_classified_backend_failure_metrics(
+                "forwarding",
+                "backend-a",
+                &metrics,
+                &tls,
+            );
+            assert_eq!(tls_reason, None);
+            assert_eq!(
+                metrics
+                    .health_failure_tls
+                    .load(std::sync::atomic::Ordering::Relaxed),
+                0
+            );
+
+            let transport = spooky_errors::classify_upstream_proxy_error(&ProxyError::Transport(
+                "connection reset by peer".to_string(),
+            ))
+            .expect("classified transport");
+            let transport_reason = record_classified_backend_failure_metrics(
+                "forwarding",
+                "backend-a",
+                &metrics,
+                &transport,
+            );
+            assert_eq!(transport_reason, Some(HealthFailureReason::Transport));
+            assert_eq!(
+                metrics
+                    .health_failure_transport
+                    .load(std::sync::atomic::Ordering::Relaxed),
+                1
             );
         }
     }

--- a/crates/edge/src/runtime/connection/outcome.rs
+++ b/crates/edge/src/runtime/connection/outcome.rs
@@ -829,6 +829,18 @@ mod tests {
         Metrics::new(1, [String::from("api"), String::from("unrouted")])
     }
 
+    fn api_route_target() -> RouteOutcomeTarget<'static> {
+        RouteOutcomeTarget { route: "api" }
+    }
+
+    fn api_backend_target() -> Option<BackendOutcomeTarget<'static>> {
+        Some(BackendOutcomeTarget {
+            upstream: "api",
+            backend_addr: Some("backend-a"),
+            backend_index: Some(0),
+        })
+    }
+
     fn test_upstream_pool() -> Arc<RwLock<UpstreamPool>> {
         let mut upstreams = HashMap::new();
         upstreams.insert(
@@ -1214,12 +1226,8 @@ mod tests {
 
             let decision = observe_status_outcome(
                 &metrics,
-                RouteOutcomeTarget { route: "api" },
-                Some(BackendOutcomeTarget {
-                    upstream: "api",
-                    backend_addr: Some("backend-a"),
-                    backend_index: Some(0),
-                }),
+                api_route_target(),
+                api_backend_target(),
                 Duration::from_millis(12),
                 StatusCode::OK,
             );
@@ -1250,12 +1258,8 @@ mod tests {
 
             let timeout = observe_proxy_error_outcome(
                 &metrics,
-                RouteOutcomeTarget { route: "api" },
-                Some(BackendOutcomeTarget {
-                    upstream: "api",
-                    backend_addr: Some("backend-a"),
-                    backend_index: Some(0),
-                }),
+                api_route_target(),
+                api_backend_target(),
                 Duration::from_millis(320),
                 Some(StatusCode::GATEWAY_TIMEOUT),
                 &ProxyError::Timeout,
@@ -1281,12 +1285,8 @@ mod tests {
 
             let success = observe_status_outcome(
                 &metrics,
-                RouteOutcomeTarget { route: "api" },
-                Some(BackendOutcomeTarget {
-                    upstream: "api",
-                    backend_addr: Some("backend-a"),
-                    backend_index: Some(0),
-                }),
+                api_route_target(),
+                api_backend_target(),
                 Duration::from_millis(12),
                 StatusCode::OK,
             );
@@ -1310,12 +1310,8 @@ mod tests {
 
             let timeout = observe_proxy_error_outcome(
                 &metrics,
-                RouteOutcomeTarget { route: "api" },
-                Some(BackendOutcomeTarget {
-                    upstream: "api",
-                    backend_addr: Some("backend-a"),
-                    backend_index: Some(0),
-                }),
+                api_route_target(),
+                api_backend_target(),
                 Duration::from_millis(50),
                 Some(StatusCode::REQUEST_TIMEOUT),
                 &ProxyError::Timeout,
@@ -1355,12 +1351,8 @@ mod tests {
 
             let overload = observe_admission_outcome(
                 &metrics,
-                RouteOutcomeTarget { route: "api" },
-                Some(BackendOutcomeTarget {
-                    upstream: "api",
-                    backend_addr: Some("backend-a"),
-                    backend_index: Some(0),
-                }),
+                api_route_target(),
+                api_backend_target(),
                 Duration::from_millis(1),
                 StatusCode::SERVICE_UNAVAILABLE,
                 AdmissionOutcomeClass::OverloadShed {
@@ -1369,24 +1361,16 @@ mod tests {
             );
             let auth = observe_admission_outcome(
                 &metrics,
-                RouteOutcomeTarget { route: "api" },
-                Some(BackendOutcomeTarget {
-                    upstream: "api",
-                    backend_addr: Some("backend-a"),
-                    backend_index: Some(0),
-                }),
+                api_route_target(),
+                api_backend_target(),
                 Duration::from_millis(2),
                 StatusCode::UNAUTHORIZED,
                 AdmissionOutcomeClass::AuthDenied,
             );
             let rate_limited = observe_admission_outcome(
                 &metrics,
-                RouteOutcomeTarget { route: "api" },
-                Some(BackendOutcomeTarget {
-                    upstream: "api",
-                    backend_addr: Some("backend-a"),
-                    backend_index: Some(0),
-                }),
+                api_route_target(),
+                api_backend_target(),
                 Duration::from_millis(3),
                 StatusCode::TOO_MANY_REQUESTS,
                 AdmissionOutcomeClass::RateLimited,
@@ -1422,8 +1406,7 @@ mod tests {
         }
 
         #[test]
-        fn typed_request_outcome_observation_records_unrouted_upstream_failure_without_local_branching()
-         {
+        fn request_outcome_observation_accepts_canonical_unrouted_failure_decision() {
             let metrics = test_metrics();
             let decision = RequestOutcomeClassification {
                 route_outcome: CanonicalRouteOutcome::UpstreamFailure,
@@ -1463,7 +1446,7 @@ mod tests {
         use super::*;
 
         #[test]
-        fn backend_accounting_and_health_hooks_remain_stable() {
+        fn backend_accounting_hooks_apply_canonical_success_and_failure_feedback() {
             let metrics = test_metrics();
             let pool = test_upstream_pool();
 
@@ -1523,17 +1506,13 @@ mod tests {
         }
 
         #[test]
-        fn forwarding_and_bootstrap_shared_recorders_emit_same_metrics_shape() {
+        fn forwarding_and_bootstrap_recorders_share_the_same_metrics_contract() {
             let metrics = test_metrics();
 
             let forwarding = observe_proxy_error_outcome(
                 &metrics,
-                RouteOutcomeTarget { route: "api" },
-                Some(BackendOutcomeTarget {
-                    upstream: "api",
-                    backend_addr: Some("backend-a"),
-                    backend_index: Some(0),
-                }),
+                api_route_target(),
+                api_backend_target(),
                 Duration::from_millis(10),
                 Some(StatusCode::BAD_GATEWAY),
                 &ProxyError::Transport("forwarding upstream error".into()),
@@ -1541,12 +1520,8 @@ mod tests {
             );
             let bootstrap = observe_proxy_error_outcome(
                 &metrics,
-                RouteOutcomeTarget { route: "api" },
-                Some(BackendOutcomeTarget {
-                    upstream: "api",
-                    backend_addr: Some("backend-a"),
-                    backend_index: Some(0),
-                }),
+                api_route_target(),
+                api_backend_target(),
                 Duration::from_millis(12),
                 Some(StatusCode::BAD_GATEWAY),
                 &ProxyError::Transport("bootstrap upstream error".into()),
@@ -1563,7 +1538,7 @@ mod tests {
         }
 
         #[test]
-        fn finalize_backend_request_cleanup_is_gated_by_typed_cleanup_flag() {
+        fn backend_request_cleanup_runs_only_when_the_caller_marks_it_required() {
             let pool = test_upstream_pool();
             {
                 let guard = pool.read().expect("read");
@@ -1604,7 +1579,7 @@ mod tests {
         }
 
         #[test]
-        fn classified_backend_failure_metrics_preserve_reason_mapping_for_tls_and_transport() {
+        fn classified_backend_failure_metrics_follow_the_shared_health_mapping_contract() {
             let metrics = test_metrics();
 
             let tls = spooky_errors::classify_upstream_proxy_error(&ProxyError::Tls(

--- a/crates/edge/src/runtime/connection/response.rs
+++ b/crates/edge/src/runtime/connection/response.rs
@@ -157,90 +157,95 @@ impl HedgeTelemetry {
 
 #[cfg(test)]
 mod tests {
-    use spooky_errors::{
-        HedgeOutcomeTelemetryReason, HedgeTriggerTelemetryReason, RetryAttemptTelemetryReason,
-        RetryPolicyDenialReason,
-    };
+    mod retry_policy_telemetry {
+        use spooky_errors::{RetryAttemptTelemetryReason, RetryPolicyDenialReason};
 
-    use super::{HedgeTelemetry, RetryTelemetry};
+        use super::super::RetryTelemetry;
 
-    #[test]
-    fn retry_telemetry_tracks_attempt_count_and_reason() {
-        let mut telemetry = RetryTelemetry::default();
+        #[test]
+        fn retry_telemetry_tracks_attempt_count_and_reason() {
+            let mut telemetry = RetryTelemetry::default();
 
-        telemetry.record_attempt(RetryAttemptTelemetryReason::Timeout);
-        telemetry.record_attempt(RetryAttemptTelemetryReason::Transport);
+            telemetry.record_attempt(RetryAttemptTelemetryReason::Timeout);
+            telemetry.record_attempt(RetryAttemptTelemetryReason::Transport);
 
-        assert_eq!(telemetry.count, 2);
-        assert_eq!(
-            telemetry.attempt_reason,
-            Some(RetryAttemptTelemetryReason::Transport)
-        );
+            assert_eq!(telemetry.count, 2);
+            assert_eq!(
+                telemetry.attempt_reason,
+                Some(RetryAttemptTelemetryReason::Transport)
+            );
+        }
+
+        #[test]
+        fn retry_telemetry_preserves_first_denial_reason() {
+            let mut telemetry = RetryTelemetry::default();
+
+            telemetry.record_denial(Some(RetryPolicyDenialReason::BudgetDenied));
+            telemetry.record_denial(Some(RetryPolicyDenialReason::AttemptLimitReached));
+
+            assert_eq!(
+                telemetry.denial_reason,
+                Some(RetryPolicyDenialReason::BudgetDenied)
+            );
+        }
+
+        #[test]
+        fn retry_denial_does_not_count_as_executed_retry_attempt() {
+            let mut telemetry = RetryTelemetry::default();
+
+            telemetry.record_denial(Some(RetryPolicyDenialReason::BudgetDenied));
+
+            assert_eq!(telemetry.count, 0);
+            assert_eq!(telemetry.attempt_reason, None);
+            assert_eq!(
+                telemetry.denial_reason,
+                Some(RetryPolicyDenialReason::BudgetDenied)
+            );
+        }
     }
 
-    #[test]
-    fn retry_telemetry_preserves_first_denial_reason() {
-        let mut telemetry = RetryTelemetry::default();
+    mod hedge_policy_telemetry {
+        use spooky_errors::{HedgeOutcomeTelemetryReason, HedgeTriggerTelemetryReason};
 
-        telemetry.record_denial(Some(RetryPolicyDenialReason::BudgetDenied));
-        telemetry.record_denial(Some(RetryPolicyDenialReason::AttemptLimitReached));
+        use super::super::HedgeTelemetry;
 
-        assert_eq!(
-            telemetry.denial_reason,
-            Some(RetryPolicyDenialReason::BudgetDenied)
-        );
-    }
+        #[test]
+        fn hedge_telemetry_records_typed_trigger_and_outcome() {
+            let mut telemetry = HedgeTelemetry::default();
 
-    #[test]
-    fn retry_denial_does_not_count_as_executed_retry_attempt() {
-        let mut telemetry = RetryTelemetry::default();
+            telemetry.record_trigger(HedgeTriggerTelemetryReason::DelayElapsed);
+            telemetry.record_outcome(HedgeOutcomeTelemetryReason::HedgeWon);
+            telemetry.observe_primary_late_ms(42);
 
-        telemetry.record_denial(Some(RetryPolicyDenialReason::BudgetDenied));
+            assert_eq!(
+                telemetry.trigger_reason,
+                Some(HedgeTriggerTelemetryReason::DelayElapsed)
+            );
+            assert_eq!(
+                telemetry.outcome_reason,
+                Some(HedgeOutcomeTelemetryReason::HedgeWon)
+            );
+            assert_eq!(telemetry.primary_late_ms, 42);
+        }
 
-        assert_eq!(telemetry.count, 0);
-        assert_eq!(telemetry.attempt_reason, None);
-        assert_eq!(
-            telemetry.denial_reason,
-            Some(RetryPolicyDenialReason::BudgetDenied)
-        );
-    }
+        #[test]
+        fn hedge_telemetry_keeps_primary_win_and_hedge_win_outcomes_distinct() {
+            let mut primary_won = HedgeTelemetry::default();
+            primary_won.record_trigger(HedgeTriggerTelemetryReason::DelayElapsed);
+            primary_won.record_outcome(HedgeOutcomeTelemetryReason::PrimaryWonAfterTrigger);
 
-    #[test]
-    fn hedge_telemetry_records_typed_trigger_and_outcome() {
-        let mut telemetry = HedgeTelemetry::default();
+            let mut hedge_won = HedgeTelemetry::default();
+            hedge_won.record_trigger(HedgeTriggerTelemetryReason::DelayElapsed);
+            hedge_won.record_outcome(HedgeOutcomeTelemetryReason::HedgeWon);
 
-        telemetry.record_trigger(HedgeTriggerTelemetryReason::DelayElapsed);
-        telemetry.record_outcome(HedgeOutcomeTelemetryReason::HedgeWon);
-        telemetry.observe_primary_late_ms(42);
-
-        assert_eq!(
-            telemetry.trigger_reason,
-            Some(HedgeTriggerTelemetryReason::DelayElapsed)
-        );
-        assert_eq!(
-            telemetry.outcome_reason,
-            Some(HedgeOutcomeTelemetryReason::HedgeWon)
-        );
-        assert_eq!(telemetry.primary_late_ms, 42);
-    }
-
-    #[test]
-    fn hedge_telemetry_keeps_primary_win_and_hedge_win_outcomes_distinct() {
-        let mut primary_won = HedgeTelemetry::default();
-        primary_won.record_trigger(HedgeTriggerTelemetryReason::DelayElapsed);
-        primary_won.record_outcome(HedgeOutcomeTelemetryReason::PrimaryWonAfterTrigger);
-
-        let mut hedge_won = HedgeTelemetry::default();
-        hedge_won.record_trigger(HedgeTriggerTelemetryReason::DelayElapsed);
-        hedge_won.record_outcome(HedgeOutcomeTelemetryReason::HedgeWon);
-
-        assert_eq!(
-            primary_won.outcome_reason,
-            Some(HedgeOutcomeTelemetryReason::PrimaryWonAfterTrigger)
-        );
-        assert_eq!(
-            hedge_won.outcome_reason,
-            Some(HedgeOutcomeTelemetryReason::HedgeWon)
-        );
+            assert_eq!(
+                primary_won.outcome_reason,
+                Some(HedgeOutcomeTelemetryReason::PrimaryWonAfterTrigger)
+            );
+            assert_eq!(
+                hedge_won.outcome_reason,
+                Some(HedgeOutcomeTelemetryReason::HedgeWon)
+            );
+        }
     }
 }

--- a/crates/edge/src/runtime/tasks.rs
+++ b/crates/edge/src/runtime/tasks.rs
@@ -165,32 +165,37 @@ mod tests {
         task_handle
     }
 
-    #[tokio::test]
-    async fn task_retirement_is_generation_scoped() {
-        let retired_generation = RuntimeTaskRegistry::new();
-        let active_generation = RuntimeTaskRegistry::new();
+    mod runtime_generation_task_ownership {
+        use super::*;
 
-        let retired_completed = Arc::new(AtomicBool::new(false));
-        let active_completed = Arc::new(AtomicBool::new(false));
+        #[tokio::test]
+        async fn task_retirement_is_generation_scoped() {
+            let retired_generation = RuntimeTaskRegistry::new();
+            let active_generation = RuntimeTaskRegistry::new();
 
-        let _retired_task =
-            spawn_registered_task(&retired_generation, Arc::clone(&retired_completed));
-        let active_task = spawn_registered_task(&active_generation, Arc::clone(&active_completed));
+            let retired_completed = Arc::new(AtomicBool::new(false));
+            let active_completed = Arc::new(AtomicBool::new(false));
 
-        retired_generation.retire_generation(Duration::from_millis(50));
-        tokio::time::sleep(Duration::from_millis(20)).await;
+            let _retired_task =
+                spawn_registered_task(&retired_generation, Arc::clone(&retired_completed));
+            let active_task =
+                spawn_registered_task(&active_generation, Arc::clone(&active_completed));
 
-        assert!(
-            retired_completed.load(Ordering::Acquire),
-            "retired generation tasks should be aborted during retirement"
-        );
-        assert!(
-            !active_completed.load(Ordering::Acquire),
-            "active generation tasks should remain alive"
-        );
+            retired_generation.retire_generation(Duration::from_millis(50));
+            tokio::time::sleep(Duration::from_millis(20)).await;
 
-        active_task.abort();
-        tokio::time::sleep(Duration::from_millis(20)).await;
-        assert!(active_completed.load(Ordering::Acquire));
+            assert!(
+                retired_completed.load(Ordering::Acquire),
+                "retired generation tasks should be aborted during retirement"
+            );
+            assert!(
+                !active_completed.load(Ordering::Acquire),
+                "active generation tasks should remain alive"
+            );
+
+            active_task.abort();
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            assert!(active_completed.load(Ordering::Acquire));
+        }
     }
 }

--- a/crates/errors/src/retry.rs
+++ b/crates/errors/src/retry.rs
@@ -414,6 +414,40 @@ mod tests {
     }
 
     #[test]
+    fn retry_denial_reasons_remain_distinct_across_attempt_budget_and_alternate_gates() {
+        let mut attempt_limited = retry_facts();
+        attempt_limited.attempt_count = attempt_limited.max_attempts;
+        assert_eq!(
+            evaluate_retry_policy(attempt_limited),
+            RetryPolicyDecision::DoNotRetry {
+                denial: Some(RetryPolicyDenialReason::AttemptLimitReached),
+            }
+        );
+
+        let mut budget_denied = retry_facts();
+        budget_denied.budget_available = false;
+        assert_eq!(
+            evaluate_retry_policy(budget_denied),
+            RetryPolicyDecision::DoNotRetry {
+                denial: Some(RetryPolicyDenialReason::BudgetDenied),
+            }
+        );
+
+        let mut no_alternate = retry_facts();
+        no_alternate.alternate_backend_available = false;
+        no_alternate.alternate_backend_failure =
+            Some(AlternateBackendFailureReason::NoHealthyBackends);
+        assert_eq!(
+            evaluate_retry_policy(no_alternate),
+            RetryPolicyDecision::DoNotRetry {
+                denial: Some(RetryPolicyDenialReason::AlternateBackendUnavailable(
+                    AlternateBackendFailureReason::NoHealthyBackends,
+                )),
+            }
+        );
+    }
+
+    #[test]
     fn retryable_transport_allows_retry() {
         let mut facts = retry_facts();
         facts.retryability = UpstreamRetryability::Retryable(UpstreamRetryReason::Transport);
@@ -453,6 +487,40 @@ mod tests {
             RetryAttemptTelemetryReason::from(UpstreamRetryReason::Pool),
             RetryAttemptTelemetryReason::Pool
         );
+    }
+
+    #[test]
+    fn retry_attempt_telemetry_reasons_remain_stable_for_all_retryable_classes() {
+        let cases = [
+            (
+                classify_retryability(&ProxyError::Timeout),
+                Some(RetryAttemptTelemetryReason::Timeout),
+            ),
+            (
+                classify_retryability(&ProxyError::Transport("connection reset".into())),
+                Some(RetryAttemptTelemetryReason::Transport),
+            ),
+            (
+                classify_retryability(&ProxyError::Pool(PoolError::UnknownBackend(
+                    "missing".to_string(),
+                ))),
+                Some(RetryAttemptTelemetryReason::Pool),
+            ),
+            (
+                classify_retryability(&ProxyError::Protocol("bad frame".into())),
+                None,
+            ),
+        ];
+
+        for (retryability, expected) in cases {
+            let mapped = match retryability {
+                UpstreamRetryability::Retryable(reason) => {
+                    Some(RetryAttemptTelemetryReason::from(reason))
+                }
+                UpstreamRetryability::Terminal(_) => None,
+            };
+            assert_eq!(mapped, expected);
+        }
     }
 
     #[test]
@@ -713,6 +781,41 @@ mod tests {
             HedgePolicyDecision::DoNotHedge {
                 denial: HedgePolicyDenialReason::BudgetDenied,
             }
+        );
+    }
+
+    #[test]
+    fn hedge_policy_suppression_precedence_prefers_primary_completion_over_budget_denial() {
+        let facts = HedgePolicyFacts {
+            budget_available: false,
+            primary_state: HedgePrimaryState::Completed,
+            ..hedge_facts()
+        };
+
+        assert_eq!(
+            evaluate_hedge_policy(facts),
+            HedgePolicyDecision::DoNotHedge {
+                denial: HedgePolicyDenialReason::PrimaryRequestCompleted,
+            }
+        );
+    }
+
+    #[test]
+    fn hedge_policy_trigger_and_outcome_telemetry_reasons_remain_stable() {
+        let trigger = evaluate_hedge_policy(hedge_facts());
+        assert_eq!(
+            trigger,
+            HedgePolicyDecision::Hedge {
+                reason: HedgeTriggerTelemetryReason::DelayElapsed,
+            }
+        );
+        assert_eq!(
+            HedgeOutcomeTelemetryReason::PrimaryWonAfterTrigger,
+            HedgeOutcomeTelemetryReason::PrimaryWonAfterTrigger
+        );
+        assert_eq!(
+            HedgeOutcomeTelemetryReason::HedgeWon,
+            HedgeOutcomeTelemetryReason::HedgeWon
         );
     }
 

--- a/crates/errors/src/retry.rs
+++ b/crates/errors/src/retry.rs
@@ -243,8 +243,24 @@ pub fn is_retryable(err: &ProxyError) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use bytes::Bytes;
+    use http_body_util::Empty;
+    use hyper::Uri;
+    use hyper_util::{client::legacy::Client, rt::TokioExecutor};
+
     use super::*;
     use crate::{BridgeError, PoolError, ProxyError};
+
+    async fn connect_send_error() -> hyper_util::client::legacy::Error {
+        let client: Client<hyper_util::client::legacy::connect::HttpConnector, Empty<Bytes>> =
+            Client::builder(TokioExecutor::new()).build_http();
+        let uri: Uri = "http://127.0.0.1:1/".parse().expect("valid local uri");
+
+        client
+            .get(uri)
+            .await
+            .expect_err("connect to unused port should fail")
+    }
 
     fn retry_facts() -> RetryPolicyFacts {
         RetryPolicyFacts {
@@ -527,6 +543,33 @@ mod tests {
             classify_retryability(&ProxyError::Tls("unknown issuer".to_string())),
             UpstreamRetryability::Terminal(UpstreamTerminalErrorKind::Tls)
         );
+    }
+
+    #[tokio::test]
+    async fn classify_retryability_keeps_pool_send_terminal_and_internal_pool_paths_retryable() {
+        assert_eq!(
+            classify_retryability(&ProxyError::Pool(PoolError::InflightLimiterClosed)),
+            UpstreamRetryability::Retryable(UpstreamRetryReason::Pool)
+        );
+        assert_eq!(
+            classify_retryability(&ProxyError::Pool(PoolError::BackendOverloaded(
+                "busy".to_string()
+            ))),
+            UpstreamRetryability::Retryable(UpstreamRetryReason::Pool)
+        );
+
+        assert_eq!(
+            classify_retryability(&ProxyError::Pool(PoolError::Send(
+                connect_send_error().await
+            ))),
+            UpstreamRetryability::Terminal(UpstreamTerminalErrorKind::PoolSend)
+        );
+        assert!(is_retryable(&ProxyError::Pool(PoolError::UnknownBackend(
+            "missing".to_string()
+        ))));
+        assert!(!is_retryable(&ProxyError::Pool(PoolError::Send(
+            connect_send_error().await
+        ))));
     }
 
     fn hedge_facts() -> HedgePolicyFacts {

--- a/crates/errors/src/upstream.rs
+++ b/crates/errors/src/upstream.rs
@@ -259,6 +259,22 @@ mod tests {
         }
 
         #[test]
+        fn classify_upstream_error_detail_is_case_insensitive_for_timeout_and_tls_signals() {
+            assert_eq!(
+                classify_upstream_error_detail("Request TIMED OUT while reading body", false),
+                UpstreamErrorClassification::timeout()
+            );
+            assert_eq!(
+                classify_upstream_error_detail("RUSTLS alert HANDSHAKE failure", true),
+                UpstreamErrorClassification::tls(UpstreamTlsReason::Handshake)
+            );
+            assert_eq!(
+                classify_upstream_error_detail("UNKNOWN ISSUER from backend cert", true),
+                UpstreamErrorClassification::tls(UpstreamTlsReason::UnknownIssuer)
+            );
+        }
+
+        #[test]
         fn upstream_error_details_classify_matches_shared_detail_classifier() {
             let details = UpstreamErrorDetails::new(
                 "certificate not valid for dns name api.example.com".to_string(),
@@ -280,6 +296,15 @@ mod tests {
             let formatted = format_error_chain(&ErrorChainOuter(ErrorChainInner));
 
             assert_eq!(formatted, "outer error: inner error");
+        }
+
+        #[test]
+        fn upstream_error_details_from_error_chain_preserves_stable_joined_detail() {
+            let details =
+                UpstreamErrorDetails::from_error_chain(&ErrorChainOuter(ErrorChainInner), true);
+
+            assert_eq!(details.detail, "outer error: inner error");
+            assert!(details.is_connect);
         }
     }
 
@@ -350,6 +375,32 @@ mod tests {
                     failure_reason: HealthFailureReason::Tls,
                     metrics_reason: "handshake",
                 }
+            );
+        }
+
+        #[test]
+        fn protocol_and_internal_classifications_share_transport_health_mapping_contract() {
+            assert_eq!(
+                UpstreamErrorClassification::protocol().health_failure_mapping(),
+                UpstreamHealthFailureMapping {
+                    failure_reason: HealthFailureReason::Transport,
+                    metrics_reason: "transport",
+                }
+            );
+            assert_eq!(
+                UpstreamErrorClassification::internal().health_failure_mapping(),
+                UpstreamHealthFailureMapping {
+                    failure_reason: HealthFailureReason::Transport,
+                    metrics_reason: "transport",
+                }
+            );
+            assert_eq!(
+                UpstreamErrorClassification::protocol().category,
+                UpstreamErrorCategory::Protocol
+            );
+            assert_eq!(
+                UpstreamErrorClassification::internal().category,
+                UpstreamErrorCategory::Internal
             );
         }
     }

--- a/crates/errors/src/upstream.rs
+++ b/crates/errors/src/upstream.rs
@@ -212,133 +212,145 @@ mod tests {
 
     impl StdError for ErrorChainInner {}
 
-    #[test]
-    fn classify_upstream_error_detail_covers_canonical_tls_and_transport_cases() {
-        assert_eq!(
-            classify_upstream_error_detail("request timed out", false),
-            UpstreamErrorClassification::timeout()
-        );
-        assert_eq!(
-            classify_upstream_error_detail("tls handshake failed: UnknownIssuer", true),
-            UpstreamErrorClassification::tls(UpstreamTlsReason::UnknownIssuer)
-        );
-        assert_eq!(
-            classify_upstream_error_detail("certificate expired while verifying backend", true),
-            UpstreamErrorClassification::tls(UpstreamTlsReason::ExpiredCertificate)
-        );
-        assert_eq!(
-            classify_upstream_error_detail(
-                "certificate not valid for dns name api.example.com",
+    mod classification_contracts {
+        use super::*;
+
+        #[test]
+        fn classify_upstream_error_detail_covers_canonical_tls_and_transport_cases() {
+            assert_eq!(
+                classify_upstream_error_detail("request timed out", false),
+                UpstreamErrorClassification::timeout()
+            );
+            assert_eq!(
+                classify_upstream_error_detail("tls handshake failed: UnknownIssuer", true),
+                UpstreamErrorClassification::tls(UpstreamTlsReason::UnknownIssuer)
+            );
+            assert_eq!(
+                classify_upstream_error_detail("certificate expired while verifying backend", true),
+                UpstreamErrorClassification::tls(UpstreamTlsReason::ExpiredCertificate)
+            );
+            assert_eq!(
+                classify_upstream_error_detail(
+                    "certificate not valid for dns name api.example.com",
+                    true,
+                ),
+                UpstreamErrorClassification::tls(UpstreamTlsReason::HostnameMismatch)
+            );
+            assert_eq!(
+                classify_upstream_error_detail("ALPN negotiation failed", true),
+                UpstreamErrorClassification::tls(UpstreamTlsReason::Alpn)
+            );
+            assert_eq!(
+                classify_upstream_error_detail("connection reset by peer", false),
+                UpstreamErrorClassification::transport()
+            );
+            assert_eq!(
+                classify_upstream_error_detail("x509 certificate validity error", true),
+                UpstreamErrorClassification::tls(UpstreamTlsReason::ExpiredCertificate)
+            );
+            assert_eq!(
+                classify_upstream_error_detail("subjectAltName mismatch for backend", true),
+                UpstreamErrorClassification::tls(UpstreamTlsReason::HostnameMismatch)
+            );
+            assert_eq!(
+                classify_upstream_error_detail("rustls alert handshake failure", true),
+                UpstreamErrorClassification::tls(UpstreamTlsReason::Handshake)
+            );
+        }
+
+        #[test]
+        fn upstream_error_details_classify_matches_shared_detail_classifier() {
+            let details = UpstreamErrorDetails::new(
+                "certificate not valid for dns name api.example.com".to_string(),
                 true,
-            ),
-            UpstreamErrorClassification::tls(UpstreamTlsReason::HostnameMismatch)
-        );
-        assert_eq!(
-            classify_upstream_error_detail("ALPN negotiation failed", true),
-            UpstreamErrorClassification::tls(UpstreamTlsReason::Alpn)
-        );
-        assert_eq!(
-            classify_upstream_error_detail("connection reset by peer", false),
-            UpstreamErrorClassification::transport()
-        );
-        assert_eq!(
-            classify_upstream_error_detail("x509 certificate validity error", true),
-            UpstreamErrorClassification::tls(UpstreamTlsReason::ExpiredCertificate)
-        );
-        assert_eq!(
-            classify_upstream_error_detail("subjectAltName mismatch for backend", true),
-            UpstreamErrorClassification::tls(UpstreamTlsReason::HostnameMismatch)
-        );
-        assert_eq!(
-            classify_upstream_error_detail("rustls alert handshake failure", true),
-            UpstreamErrorClassification::tls(UpstreamTlsReason::Handshake)
-        );
+            );
+
+            assert_eq!(
+                details.classify(),
+                classify_upstream_error_detail(&details.detail, details.is_connect)
+            );
+        }
     }
 
-    #[test]
-    fn upstream_error_details_classify_matches_shared_detail_classifier() {
-        let details = UpstreamErrorDetails::new(
-            "certificate not valid for dns name api.example.com".to_string(),
-            true,
-        );
+    mod formatting_contracts {
+        use super::*;
 
-        assert_eq!(
-            details.classify(),
-            classify_upstream_error_detail(&details.detail, details.is_connect)
-        );
+        #[test]
+        fn format_error_chain_flattens_all_sources() {
+            let formatted = format_error_chain(&ErrorChainOuter(ErrorChainInner));
+
+            assert_eq!(formatted, "outer error: inner error");
+        }
     }
 
-    #[test]
-    fn format_error_chain_flattens_all_sources() {
-        let formatted = format_error_chain(&ErrorChainOuter(ErrorChainInner));
+    mod health_mapping_contracts {
+        use super::*;
 
-        assert_eq!(formatted, "outer error: inner error");
-    }
-
-    #[test]
-    fn health_failure_mapping_preserves_tls_and_transport_reasoning() {
-        assert_eq!(
-            UpstreamErrorClassification::timeout().health_failure_mapping(),
-            UpstreamHealthFailureMapping {
-                failure_reason: HealthFailureReason::Timeout,
-                metrics_reason: "timeout",
-            }
-        );
-        assert_eq!(
-            UpstreamErrorClassification::tls(UpstreamTlsReason::UnknownIssuer)
+        #[test]
+        fn health_failure_mapping_preserves_tls_and_transport_reasoning() {
+            assert_eq!(
+                UpstreamErrorClassification::timeout().health_failure_mapping(),
+                UpstreamHealthFailureMapping {
+                    failure_reason: HealthFailureReason::Timeout,
+                    metrics_reason: "timeout",
+                }
+            );
+            assert_eq!(
+                UpstreamErrorClassification::tls(UpstreamTlsReason::UnknownIssuer)
+                    .health_failure_mapping(),
+                UpstreamHealthFailureMapping {
+                    failure_reason: HealthFailureReason::Tls,
+                    metrics_reason: "unknown_issuer",
+                }
+            );
+            assert_eq!(
+                UpstreamErrorClassification::tls(UpstreamTlsReason::ExpiredCertificate)
+                    .health_failure_mapping(),
+                UpstreamHealthFailureMapping {
+                    failure_reason: HealthFailureReason::Tls,
+                    metrics_reason: "expired_certificate",
+                }
+            );
+            assert_eq!(
+                UpstreamErrorClassification::tls(UpstreamTlsReason::HostnameMismatch)
+                    .health_failure_mapping(),
+                UpstreamHealthFailureMapping {
+                    failure_reason: HealthFailureReason::Tls,
+                    metrics_reason: "hostname_mismatch",
+                }
+            );
+            assert_eq!(
+                UpstreamErrorClassification::tls(UpstreamTlsReason::Alpn).health_failure_mapping(),
+                UpstreamHealthFailureMapping {
+                    failure_reason: HealthFailureReason::Tls,
+                    metrics_reason: "alpn",
+                }
+            );
+            assert_eq!(
+                UpstreamErrorClassification::transport().health_failure_mapping(),
+                UpstreamHealthFailureMapping {
+                    failure_reason: HealthFailureReason::Transport,
+                    metrics_reason: "transport",
+                }
+            );
+            assert_eq!(
+                UpstreamErrorClassification::protocol().health_failure_mapping(),
+                UpstreamHealthFailureMapping {
+                    failure_reason: HealthFailureReason::Transport,
+                    metrics_reason: "transport",
+                }
+            );
+            assert_eq!(
+                UpstreamErrorClassification {
+                    category: UpstreamErrorCategory::Tls,
+                    tls_reason: None,
+                }
                 .health_failure_mapping(),
-            UpstreamHealthFailureMapping {
-                failure_reason: HealthFailureReason::Tls,
-                metrics_reason: "unknown_issuer",
-            }
-        );
-        assert_eq!(
-            UpstreamErrorClassification::tls(UpstreamTlsReason::ExpiredCertificate)
-                .health_failure_mapping(),
-            UpstreamHealthFailureMapping {
-                failure_reason: HealthFailureReason::Tls,
-                metrics_reason: "expired_certificate",
-            }
-        );
-        assert_eq!(
-            UpstreamErrorClassification::tls(UpstreamTlsReason::HostnameMismatch)
-                .health_failure_mapping(),
-            UpstreamHealthFailureMapping {
-                failure_reason: HealthFailureReason::Tls,
-                metrics_reason: "hostname_mismatch",
-            }
-        );
-        assert_eq!(
-            UpstreamErrorClassification::tls(UpstreamTlsReason::Alpn).health_failure_mapping(),
-            UpstreamHealthFailureMapping {
-                failure_reason: HealthFailureReason::Tls,
-                metrics_reason: "alpn",
-            }
-        );
-        assert_eq!(
-            UpstreamErrorClassification::transport().health_failure_mapping(),
-            UpstreamHealthFailureMapping {
-                failure_reason: HealthFailureReason::Transport,
-                metrics_reason: "transport",
-            }
-        );
-        assert_eq!(
-            UpstreamErrorClassification::protocol().health_failure_mapping(),
-            UpstreamHealthFailureMapping {
-                failure_reason: HealthFailureReason::Transport,
-                metrics_reason: "transport",
-            }
-        );
-        assert_eq!(
-            UpstreamErrorClassification {
-                category: UpstreamErrorCategory::Tls,
-                tls_reason: None,
-            }
-            .health_failure_mapping(),
-            UpstreamHealthFailureMapping {
-                failure_reason: HealthFailureReason::Tls,
-                metrics_reason: "handshake",
-            }
-        );
+                UpstreamHealthFailureMapping {
+                    failure_reason: HealthFailureReason::Tls,
+                    metrics_reason: "handshake",
+                }
+            );
+        }
     }
 }

--- a/crates/lb/src/alternate_backend.rs
+++ b/crates/lb/src/alternate_backend.rs
@@ -206,6 +206,21 @@ mod tests {
     }
 
     #[test]
+    fn readonly_lb_pick_respects_lb_key_input_when_returning_typed_selection_mode() {
+        let pool = pool_for("round-robin", &["http://a", "http://b", "http://c"]);
+
+        let decision = choose_alternate_backend(&pool, &[1, 2], Some("tenant-a"));
+
+        assert_eq!(
+            decision,
+            AlternateBackendDecision::Select(AlternateBackendChoice {
+                index: 0,
+                mode: AlternateBackendSelectionMode::LoadBalancerReadonly,
+            })
+        );
+    }
+
+    #[test]
     fn non_readonly_strategies_use_healthy_fallback_for_alternates() {
         let pool = pool_for("consistent-hash", &["http://a", "http://b", "http://c"]);
 
@@ -231,6 +246,27 @@ mod tests {
             decision,
             AlternateBackendDecision::DoNotSelect {
                 denial: AlternateBackendFailureReason::NoHealthyBackends,
+            }
+        );
+    }
+
+    #[test]
+    fn alternate_selection_denials_remain_distinct_between_no_healthy_and_only_excluded() {
+        let mut no_healthy = pool_for("round-robin", &["http://a", "http://b"]);
+        let _ = no_healthy.mark_backend_failure_from_active_check(0);
+        let _ = no_healthy.mark_backend_failure_from_active_check(1);
+        assert_eq!(
+            choose_alternate_backend(&no_healthy, &[], None),
+            AlternateBackendDecision::DoNotSelect {
+                denial: AlternateBackendFailureReason::NoHealthyBackends,
+            }
+        );
+
+        let only_excluded = pool_for("round-robin", &["http://a", "http://b"]);
+        assert_eq!(
+            choose_alternate_backend(&only_excluded, &[0, 1], None),
+            AlternateBackendDecision::DoNotSelect {
+                denial: AlternateBackendFailureReason::OnlyExcludedBackendsHealthy,
             }
         );
     }


### PR DESCRIPTION
## Summary
This PR tightens the unit-contract coverage for shared edge policy and runtime ownership layers.

It adds and cleans up focused tests around:
- shared outcome classification and backend accounting behavior
- runtime generation ownership helpers and bundle replacement behavior
- generation-scoped task retirement during runtime swaps
- edge policy/runtime test organization, helper reuse, and contract-oriented naming

## What Changed
- Added outcome-classification tests covering:
  - success
  - timeout
  - overload
  - rate-limit
  - auth deny
  - unrouted failure
  - upstream failure
- Added backend-accounting hook tests covering:
  - canonical success/failure feedback
  - cleanup gating
  - stable health-mapping behavior
  - forwarding/bootstrap parity at the recorder layer
- Added runtime generation helper tests covering:
  - `current_view`
  - `current_generation`
  - `with_current_generation`
  - `with_current_view`
  - startup-owned vs generation-owned behavior across bundle replacement
  - generation-scoped task retirement on runtime swap
- Cleaned up test structure by:
  - reducing repeated local setup
  - introducing small local helper functions
  - grouping tests more clearly by policy/runtime domain
  - renaming tests to describe contracts rather than implementation details

## Validation
- Ran `cargo test -p spooky-edge --lib`
- Edge lib test suite passed

## Why
These tests lock the shared policy/runtime contracts directly, without relying on full request-path orchestration. That makes future refactors safer and keeps the intended ownership boundaries explicit.