### PR TITLE
test(edge): strengthen control-plane and observability contract coverage

### DIFF
--- a/crates/edge/src/observability/mod.rs
+++ b/crates/edge/src/observability/mod.rs
@@ -1057,8 +1057,10 @@ mod tests {
         #[test]
         fn representative_reason_tokens_stay_aligned_across_metrics_logs_and_control_plane() {
             use crate::{
-                metrics::OverloadShedReason, runtime::connection::outcome::AdmissionOutcomeClass,
-                runtime::connection::stream::BackendFailureReason,
+                metrics::OverloadShedReason,
+                runtime::connection::{
+                    outcome::AdmissionOutcomeClass, stream::BackendFailureReason,
+                },
             };
 
             assert_reason_surface_alignment(RequestOutcomeReason::TimedOut.slug());

--- a/crates/edge/src/observability/mod.rs
+++ b/crates/edge/src/observability/mod.rs
@@ -670,19 +670,47 @@ impl From<HedgePolicyDenialReason> for HedgeDecisionReason {
 mod tests {
     use super::*;
 
+    fn assert_unique_slug_family(slugs: &[&str], family: &str) {
+        let mut values = slugs.to_vec();
+        let before = values.len();
+        values.sort_unstable();
+        values.dedup();
+        assert_eq!(
+            before,
+            values.len(),
+            "canonical slug family `{family}` must not contain duplicate values"
+        );
+    }
+
+    fn assert_reason_surface_alignment(reason: &'static str) {
+        let metric_labels = MetricReasonLabels {
+            outcome: None,
+            reason: Some(reason),
+            failure_class: None,
+        };
+        let control_plane_reason = reason;
+        let log_ctx = OperationalEventContext::new()
+            .with_reason(reason)
+            .to_string();
+
+        assert_eq!(
+            metric_labels.reason,
+            Some(control_plane_reason),
+            "metric reason label should keep the canonical token"
+        );
+        assert_eq!(
+            log_ctx,
+            format!("reason={reason}"),
+            "structured logs should render the canonical reason token verbatim"
+        );
+    }
+
     mod canonical_observability_slug_stability {
         use super::*;
 
         #[test]
-        fn every_slug_is_unique_within_each_family() {
-            fn assert_unique(slugs: &[&str], family: &str) {
-                let mut v = slugs.to_vec();
-                let before = v.len();
-                v.sort_unstable();
-                v.dedup();
-                assert_eq!(before, v.len(), "duplicate slug in {family}");
-            }
-            assert_unique(
+        fn canonical_reason_families_use_unique_slug_values() {
+            assert_unique_slug_family(
                 &[
                     RequestOutcomeReason::Completed.slug(),
                     RequestOutcomeReason::Cancelled.slug(),
@@ -698,7 +726,7 @@ mod tests {
                 ],
                 "RequestOutcomeReason",
             );
-            assert_unique(
+            assert_unique_slug_family(
                 &[
                     BackendHealthReason::ActiveProbeSuccess.slug(),
                     BackendHealthReason::ActiveProbeFailure.slug(),
@@ -710,7 +738,7 @@ mod tests {
                 ],
                 "BackendHealthReason",
             );
-            assert_unique(
+            assert_unique_slug_family(
                 &[
                     RetryDecisionReason::UpstreamTimeout.slug(),
                     RetryDecisionReason::UpstreamTransportFailure.slug(),
@@ -721,7 +749,7 @@ mod tests {
                 ],
                 "RetryDecisionReason",
             );
-            assert_unique(
+            assert_unique_slug_family(
                 &[
                     HedgeDecisionReason::DelayElapsed.slug(),
                     HedgeDecisionReason::HedgingDisabled.slug(),
@@ -734,7 +762,7 @@ mod tests {
                 ],
                 "HedgeDecisionReason",
             );
-            assert_unique(
+            assert_unique_slug_family(
                 &[
                     AdmissionDecisionReason::AuthDenied.slug(),
                     AdmissionDecisionReason::AuthUnavailable.slug(),
@@ -745,7 +773,7 @@ mod tests {
                 ],
                 "AdmissionDecisionReason",
             );
-            assert_unique(
+            assert_unique_slug_family(
                 &[
                     AdmissionOverloadCause::Brownout.slug(),
                     AdmissionOverloadCause::AdaptiveAdmission.slug(),
@@ -764,7 +792,7 @@ mod tests {
         }
 
         #[test]
-        fn metrics_overload_reason_routes_through_canonical_vocabulary() {
+        fn overload_metric_reason_labels_follow_canonical_cause_vocabulary() {
             // obs Phase 2 (step 5): the metrics `reason=` label must come from the
             // canonical vocabulary. Every OverloadShedReason maps to a canonical cause
             // whose slug is the emitted label.
@@ -836,7 +864,7 @@ mod tests {
         }
 
         #[test]
-        fn request_outcome_coarse_label_matches_legacy_buckets() {
+        fn request_outcome_coarse_labels_preserve_legacy_metric_buckets() {
             assert_eq!(
                 RequestOutcomeReason::Completed.coarse_outcome_label(),
                 "success"
@@ -856,7 +884,7 @@ mod tests {
         }
 
         #[test]
-        fn canonical_slug_literals_match_stable_operational_contract() {
+        fn representative_canonical_slugs_remain_stable() {
             assert_eq!(AdmissionDecisionReason::AuthDenied.slug(), "auth_denied");
             assert_eq!(
                 RetryDecisionReason::UpstreamTransportFailure.slug(),
@@ -877,23 +905,8 @@ mod tests {
     mod cross_surface_reason_alignment {
         use super::*;
 
-        fn assert_reason_surfaces_align(reason: &'static str) {
-            let metric_labels = MetricReasonLabels {
-                outcome: None,
-                reason: Some(reason),
-                failure_class: None,
-            };
-            let control_plane_reason = reason;
-            let log_ctx = OperationalEventContext::new()
-                .with_reason(reason)
-                .to_string();
-
-            assert_eq!(metric_labels.reason, Some(control_plane_reason));
-            assert_eq!(log_ctx, format!("reason={reason}"));
-        }
-
         #[test]
-        fn event_context_renders_canonical_fields_in_order() {
+        fn operational_event_context_renders_canonical_fields_in_stable_order() {
             let ctx = OperationalEventContext::new()
                 .with_request_id(42)
                 .with_upstream("api")
@@ -1048,20 +1061,20 @@ mod tests {
                 runtime::connection::stream::BackendFailureReason,
             };
 
-            assert_reason_surfaces_align(RequestOutcomeReason::TimedOut.slug());
-            assert_reason_surfaces_align(
+            assert_reason_surface_alignment(RequestOutcomeReason::TimedOut.slug());
+            assert_reason_surface_alignment(
                 RequestOutcomeReason::from(BackendFailureReason::UpstreamTransport).slug(),
             );
-            assert_reason_surfaces_align(
+            assert_reason_surface_alignment(
                 RequestOutcomeReason::from(BackendFailureReason::UpstreamTls).slug(),
             );
-            assert_reason_surfaces_align(
+            assert_reason_surface_alignment(
                 AdmissionDecisionReason::from(AdmissionOutcomeClass::AuthDenied).slug(),
             );
-            assert_reason_surfaces_align(
+            assert_reason_surface_alignment(
                 AdmissionDecisionReason::from(AdmissionOutcomeClass::RateLimited).slug(),
             );
-            assert_reason_surfaces_align(
+            assert_reason_surface_alignment(
                 AdmissionDecisionReason::from(AdmissionOutcomeClass::OverloadShed {
                     reason: Some(OverloadShedReason::GlobalInflight),
                 })

--- a/crates/edge/src/observability/mod.rs
+++ b/crates/edge/src/observability/mod.rs
@@ -700,6 +700,53 @@ mod tests {
             );
             assert_unique(
                 &[
+                    BackendHealthReason::ActiveProbeSuccess.slug(),
+                    BackendHealthReason::ActiveProbeFailure.slug(),
+                    BackendHealthReason::PassiveSuccess.slug(),
+                    BackendHealthReason::PassiveFailure.slug(),
+                    BackendHealthReason::DnsRefreshFailed.slug(),
+                    BackendHealthReason::EmptyResolutionRetained.slug(),
+                    BackendHealthReason::PoolPoisoned.slug(),
+                ],
+                "BackendHealthReason",
+            );
+            assert_unique(
+                &[
+                    RetryDecisionReason::UpstreamTimeout.slug(),
+                    RetryDecisionReason::UpstreamTransportFailure.slug(),
+                    RetryDecisionReason::UpstreamProtocolFailure.slug(),
+                    RetryDecisionReason::RetryBudgetDenied.slug(),
+                    RetryDecisionReason::RetryPolicyDisabled.slug(),
+                    RetryDecisionReason::IdempotencyDenied.slug(),
+                ],
+                "RetryDecisionReason",
+            );
+            assert_unique(
+                &[
+                    HedgeDecisionReason::DelayElapsed.slug(),
+                    HedgeDecisionReason::HedgingDisabled.slug(),
+                    HedgeDecisionReason::PrimaryCompleted.slug(),
+                    HedgeDecisionReason::RequestBodyNotReplayable.slug(),
+                    HedgeDecisionReason::TunnelRequest.slug(),
+                    HedgeDecisionReason::MethodNotAllowed.slug(),
+                    HedgeDecisionReason::AlternateBackendUnavailable.slug(),
+                    HedgeDecisionReason::HedgeBudgetDenied.slug(),
+                ],
+                "HedgeDecisionReason",
+            );
+            assert_unique(
+                &[
+                    AdmissionDecisionReason::AuthDenied.slug(),
+                    AdmissionDecisionReason::AuthUnavailable.slug(),
+                    AdmissionDecisionReason::RateLimited.slug(),
+                    AdmissionDecisionReason::Overloaded.slug(),
+                    AdmissionDecisionReason::ValidationRejected.slug(),
+                    AdmissionDecisionReason::PolicyRejected.slug(),
+                ],
+                "AdmissionDecisionReason",
+            );
+            assert_unique(
+                &[
                     AdmissionOverloadCause::Brownout.slug(),
                     AdmissionOverloadCause::AdaptiveAdmission.slug(),
                     AdmissionOverloadCause::RouteCap.slug(),
@@ -806,6 +853,24 @@ mod tests {
                 RequestOutcomeReason::AuthDenied.coarse_outcome_label(),
                 "failure"
             );
+        }
+
+        #[test]
+        fn canonical_slug_literals_match_stable_operational_contract() {
+            assert_eq!(AdmissionDecisionReason::AuthDenied.slug(), "auth_denied");
+            assert_eq!(
+                RetryDecisionReason::UpstreamTransportFailure.slug(),
+                "upstream_transport_failure"
+            );
+            assert_eq!(
+                HedgeDecisionReason::AlternateBackendUnavailable.slug(),
+                "alternate_backend_unavailable"
+            );
+            assert_eq!(
+                BackendHealthReason::DnsRefreshFailed.slug(),
+                "dns_refresh_failed"
+            );
+            assert_eq!(RequestOutcomeReason::TimedOut.slug(), "timed_out");
         }
     }
 

--- a/crates/edge/src/observability/mod.rs
+++ b/crates/edge/src/observability/mod.rs
@@ -877,6 +877,21 @@ mod tests {
     mod cross_surface_reason_alignment {
         use super::*;
 
+        fn assert_reason_surfaces_align(reason: &'static str) {
+            let metric_labels = MetricReasonLabels {
+                outcome: None,
+                reason: Some(reason),
+                failure_class: None,
+            };
+            let control_plane_reason = reason;
+            let log_ctx = OperationalEventContext::new()
+                .with_reason(reason)
+                .to_string();
+
+            assert_eq!(metric_labels.reason, Some(control_plane_reason));
+            assert_eq!(log_ctx, format!("reason={reason}"));
+        }
+
         #[test]
         fn event_context_renders_canonical_fields_in_order() {
             let ctx = OperationalEventContext::new()
@@ -1024,6 +1039,39 @@ mod tests {
             );
             assert_eq!(AdmissionDecisionReason::RateLimited.slug(), "rate_limited");
             assert_eq!(AdmissionDecisionReason::Overloaded.slug(), "overloaded");
+        }
+
+        #[test]
+        fn representative_reason_tokens_stay_aligned_across_metrics_logs_and_control_plane() {
+            use crate::{
+                metrics::OverloadShedReason, runtime::connection::outcome::AdmissionOutcomeClass,
+                runtime::connection::stream::BackendFailureReason,
+            };
+
+            assert_reason_surfaces_align(RequestOutcomeReason::TimedOut.slug());
+            assert_reason_surfaces_align(
+                RequestOutcomeReason::from(BackendFailureReason::UpstreamTransport).slug(),
+            );
+            assert_reason_surfaces_align(
+                RequestOutcomeReason::from(BackendFailureReason::UpstreamTls).slug(),
+            );
+            assert_reason_surfaces_align(
+                AdmissionDecisionReason::from(AdmissionOutcomeClass::AuthDenied).slug(),
+            );
+            assert_reason_surfaces_align(
+                AdmissionDecisionReason::from(AdmissionOutcomeClass::RateLimited).slug(),
+            );
+            assert_reason_surfaces_align(
+                AdmissionDecisionReason::from(AdmissionOutcomeClass::OverloadShed {
+                    reason: Some(OverloadShedReason::GlobalInflight),
+                })
+                .slug(),
+            );
+
+            assert_eq!(
+                OverloadShedReason::GlobalInflight.reason_label(),
+                AdmissionOverloadCause::GlobalInflight.slug()
+            );
         }
 
         #[test]

--- a/crates/edge/src/observability/mod.rs
+++ b/crates/edge/src/observability/mod.rs
@@ -670,399 +670,407 @@ impl From<HedgePolicyDenialReason> for HedgeDecisionReason {
 mod tests {
     use super::*;
 
-    #[test]
-    fn every_slug_is_unique_within_each_family() {
-        fn assert_unique(slugs: &[&str], family: &str) {
-            let mut v = slugs.to_vec();
-            let before = v.len();
-            v.sort_unstable();
-            v.dedup();
-            assert_eq!(before, v.len(), "duplicate slug in {family}");
+    mod canonical_observability_slug_stability {
+        use super::*;
+
+        #[test]
+        fn every_slug_is_unique_within_each_family() {
+            fn assert_unique(slugs: &[&str], family: &str) {
+                let mut v = slugs.to_vec();
+                let before = v.len();
+                v.sort_unstable();
+                v.dedup();
+                assert_eq!(before, v.len(), "duplicate slug in {family}");
+            }
+            assert_unique(
+                &[
+                    RequestOutcomeReason::Completed.slug(),
+                    RequestOutcomeReason::Cancelled.slug(),
+                    RequestOutcomeReason::TimedOut.slug(),
+                    RequestOutcomeReason::AuthDenied.slug(),
+                    RequestOutcomeReason::RateLimited.slug(),
+                    RequestOutcomeReason::Overloaded.slug(),
+                    RequestOutcomeReason::ValidationRejected.slug(),
+                    RequestOutcomeReason::BackendTransportFailed.slug(),
+                    RequestOutcomeReason::BackendProtocolFailed.slug(),
+                    RequestOutcomeReason::BackendTlsFailed.slug(),
+                    RequestOutcomeReason::BackendBridgeFailed.slug(),
+                ],
+                "RequestOutcomeReason",
+            );
+            assert_unique(
+                &[
+                    AdmissionOverloadCause::Brownout.slug(),
+                    AdmissionOverloadCause::AdaptiveAdmission.slug(),
+                    AdmissionOverloadCause::RouteCap.slug(),
+                    AdmissionOverloadCause::RouteGlobalCap.slug(),
+                    AdmissionOverloadCause::GlobalInflight.slug(),
+                    AdmissionOverloadCause::UpstreamInflight.slug(),
+                    AdmissionOverloadCause::BackendInflight.slug(),
+                    AdmissionOverloadCause::CircuitOpen.slug(),
+                    AdmissionOverloadCause::RequestBufferCap.slug(),
+                    AdmissionOverloadCause::ResponsePrebufferCap.slug(),
+                    AdmissionOverloadCause::ConnectionCap.slug(),
+                ],
+                "AdmissionOverloadCause",
+            );
         }
-        assert_unique(
-            &[
-                RequestOutcomeReason::Completed.slug(),
-                RequestOutcomeReason::Cancelled.slug(),
-                RequestOutcomeReason::TimedOut.slug(),
-                RequestOutcomeReason::AuthDenied.slug(),
-                RequestOutcomeReason::RateLimited.slug(),
-                RequestOutcomeReason::Overloaded.slug(),
-                RequestOutcomeReason::ValidationRejected.slug(),
-                RequestOutcomeReason::BackendTransportFailed.slug(),
-                RequestOutcomeReason::BackendProtocolFailed.slug(),
-                RequestOutcomeReason::BackendTlsFailed.slug(),
-                RequestOutcomeReason::BackendBridgeFailed.slug(),
-            ],
-            "RequestOutcomeReason",
-        );
-        assert_unique(
-            &[
-                AdmissionOverloadCause::Brownout.slug(),
-                AdmissionOverloadCause::AdaptiveAdmission.slug(),
-                AdmissionOverloadCause::RouteCap.slug(),
-                AdmissionOverloadCause::RouteGlobalCap.slug(),
+
+        #[test]
+        fn metrics_overload_reason_routes_through_canonical_vocabulary() {
+            // obs Phase 2 (step 5): the metrics `reason=` label must come from the
+            // canonical vocabulary. Every OverloadShedReason maps to a canonical cause
+            // whose slug is the emitted label.
+            use crate::metrics::OverloadShedReason;
+            let cases = [
+                (
+                    OverloadShedReason::Brownout,
+                    AdmissionOverloadCause::Brownout,
+                ),
+                (
+                    OverloadShedReason::AdaptiveAdmission,
+                    AdmissionOverloadCause::AdaptiveAdmission,
+                ),
+                (
+                    OverloadShedReason::RouteCap,
+                    AdmissionOverloadCause::RouteCap,
+                ),
+                (
+                    OverloadShedReason::RouteGlobalCap,
+                    AdmissionOverloadCause::RouteGlobalCap,
+                ),
+                (
+                    OverloadShedReason::GlobalInflight,
+                    AdmissionOverloadCause::GlobalInflight,
+                ),
+                (
+                    OverloadShedReason::UpstreamInflight,
+                    AdmissionOverloadCause::UpstreamInflight,
+                ),
+                (
+                    OverloadShedReason::BackendInflight,
+                    AdmissionOverloadCause::BackendInflight,
+                ),
+                (
+                    OverloadShedReason::CircuitOpen,
+                    AdmissionOverloadCause::CircuitOpen,
+                ),
+                (
+                    OverloadShedReason::RequestBufferCap,
+                    AdmissionOverloadCause::RequestBufferCap,
+                ),
+                (
+                    OverloadShedReason::ResponsePrebufferCap,
+                    AdmissionOverloadCause::ResponsePrebufferCap,
+                ),
+                (
+                    OverloadShedReason::ConnectionCap,
+                    AdmissionOverloadCause::ConnectionCap,
+                ),
+            ];
+            for (reason, cause) in cases {
+                assert_eq!(reason.canonical(), cause);
+                assert_eq!(reason.reason_label(), cause.slug());
+            }
+        }
+
+        #[test]
+        fn overload_cause_slugs_match_legacy_metric_labels() {
+            // These must stay byte-identical to `OverloadShedReason` labels so a later
+            // migration of the overload emitter does not change the `reason=` series.
+            assert_eq!(
                 AdmissionOverloadCause::GlobalInflight.slug(),
-                AdmissionOverloadCause::UpstreamInflight.slug(),
-                AdmissionOverloadCause::BackendInflight.slug(),
-                AdmissionOverloadCause::CircuitOpen.slug(),
-                AdmissionOverloadCause::RequestBufferCap.slug(),
+                "global_inflight"
+            );
+            assert_eq!(
                 AdmissionOverloadCause::ResponsePrebufferCap.slug(),
-                AdmissionOverloadCause::ConnectionCap.slug(),
-            ],
-            "AdmissionOverloadCause",
-        );
-    }
+                "response_prebuffer_cap"
+            );
+        }
 
-    #[test]
-    fn metrics_overload_reason_routes_through_canonical_vocabulary() {
-        // obs Phase 2 (step 5): the metrics `reason=` label must come from the
-        // canonical vocabulary. Every OverloadShedReason maps to a canonical cause
-        // whose slug is the emitted label.
-        use crate::metrics::OverloadShedReason;
-        let cases = [
-            (
-                OverloadShedReason::Brownout,
-                AdmissionOverloadCause::Brownout,
-            ),
-            (
-                OverloadShedReason::AdaptiveAdmission,
-                AdmissionOverloadCause::AdaptiveAdmission,
-            ),
-            (
-                OverloadShedReason::RouteCap,
-                AdmissionOverloadCause::RouteCap,
-            ),
-            (
-                OverloadShedReason::RouteGlobalCap,
-                AdmissionOverloadCause::RouteGlobalCap,
-            ),
-            (
-                OverloadShedReason::GlobalInflight,
-                AdmissionOverloadCause::GlobalInflight,
-            ),
-            (
-                OverloadShedReason::UpstreamInflight,
-                AdmissionOverloadCause::UpstreamInflight,
-            ),
-            (
-                OverloadShedReason::BackendInflight,
-                AdmissionOverloadCause::BackendInflight,
-            ),
-            (
-                OverloadShedReason::CircuitOpen,
-                AdmissionOverloadCause::CircuitOpen,
-            ),
-            (
-                OverloadShedReason::RequestBufferCap,
-                AdmissionOverloadCause::RequestBufferCap,
-            ),
-            (
-                OverloadShedReason::ResponsePrebufferCap,
-                AdmissionOverloadCause::ResponsePrebufferCap,
-            ),
-            (
-                OverloadShedReason::ConnectionCap,
-                AdmissionOverloadCause::ConnectionCap,
-            ),
-        ];
-        for (reason, cause) in cases {
-            assert_eq!(reason.canonical(), cause);
-            assert_eq!(reason.reason_label(), cause.slug());
+        #[test]
+        fn request_outcome_coarse_label_matches_legacy_buckets() {
+            assert_eq!(
+                RequestOutcomeReason::Completed.coarse_outcome_label(),
+                "success"
+            );
+            assert_eq!(
+                RequestOutcomeReason::TimedOut.coarse_outcome_label(),
+                "timeout"
+            );
+            assert_eq!(
+                RequestOutcomeReason::Overloaded.coarse_outcome_label(),
+                "overload_shed"
+            );
+            assert_eq!(
+                RequestOutcomeReason::AuthDenied.coarse_outcome_label(),
+                "failure"
+            );
         }
     }
 
-    #[test]
-    fn overload_cause_slugs_match_legacy_metric_labels() {
-        // These must stay byte-identical to `OverloadShedReason` labels so a later
-        // migration of the overload emitter does not change the `reason=` series.
-        assert_eq!(
-            AdmissionOverloadCause::GlobalInflight.slug(),
-            "global_inflight"
-        );
-        assert_eq!(
-            AdmissionOverloadCause::ResponsePrebufferCap.slug(),
-            "response_prebuffer_cap"
-        );
-    }
+    mod cross_surface_reason_alignment {
+        use super::*;
 
-    #[test]
-    fn request_outcome_coarse_label_matches_legacy_buckets() {
-        assert_eq!(
-            RequestOutcomeReason::Completed.coarse_outcome_label(),
-            "success"
-        );
-        assert_eq!(
-            RequestOutcomeReason::TimedOut.coarse_outcome_label(),
-            "timeout"
-        );
-        assert_eq!(
-            RequestOutcomeReason::Overloaded.coarse_outcome_label(),
-            "overload_shed"
-        );
-        assert_eq!(
-            RequestOutcomeReason::AuthDenied.coarse_outcome_label(),
-            "failure"
-        );
-    }
+        #[test]
+        fn event_context_renders_canonical_fields_in_order() {
+            let ctx = OperationalEventContext::new()
+                .with_request_id(42)
+                .with_upstream("api")
+                .with_backend("10.0.0.1:8080")
+                .with_reason("timed_out");
+            assert_eq!(
+                ctx.to_string(),
+                "request_id=42 upstream=api backend=10.0.0.1:8080 reason=timed_out"
+            );
+        }
 
-    #[test]
-    fn event_context_renders_canonical_fields_in_order() {
-        let ctx = OperationalEventContext::new()
-            .with_request_id(42)
-            .with_upstream("api")
-            .with_backend("10.0.0.1:8080")
-            .with_reason("timed_out");
-        assert_eq!(
-            ctx.to_string(),
-            "request_id=42 upstream=api backend=10.0.0.1:8080 reason=timed_out"
-        );
-    }
+        #[test]
+        fn empty_event_context_renders_nothing() {
+            assert_eq!(OperationalEventContext::new().to_string(), "");
+        }
 
-    #[test]
-    fn empty_event_context_renders_nothing() {
-        assert_eq!(OperationalEventContext::new().to_string(), "");
-    }
+        #[test]
+        fn local_rejection_maps_to_canonical_request_outcome() {
+            use crate::runtime::connection::stream::RejectionReason;
+            assert_eq!(
+                RequestOutcomeReason::from(RejectionReason::AuthDenied),
+                RequestOutcomeReason::AuthDenied
+            );
+            assert_eq!(
+                RequestOutcomeReason::from(RejectionReason::AuthUnavailable),
+                RequestOutcomeReason::AuthDenied
+            );
+            assert_eq!(
+                RequestOutcomeReason::from(RejectionReason::RequestBodyTooLarge),
+                RequestOutcomeReason::ValidationRejected
+            );
+            assert_eq!(
+                RequestOutcomeReason::from(RejectionReason::ResponsePrebufferCap),
+                RequestOutcomeReason::Overloaded
+            );
+        }
 
-    #[test]
-    fn local_rejection_maps_to_canonical_request_outcome() {
-        use crate::runtime::connection::stream::RejectionReason;
-        assert_eq!(
-            RequestOutcomeReason::from(RejectionReason::AuthDenied),
-            RequestOutcomeReason::AuthDenied
-        );
-        assert_eq!(
-            RequestOutcomeReason::from(RejectionReason::AuthUnavailable),
-            RequestOutcomeReason::AuthDenied
-        );
-        assert_eq!(
-            RequestOutcomeReason::from(RejectionReason::RequestBodyTooLarge),
-            RequestOutcomeReason::ValidationRejected
-        );
-        assert_eq!(
-            RequestOutcomeReason::from(RejectionReason::ResponsePrebufferCap),
-            RequestOutcomeReason::Overloaded
-        );
-    }
+        #[test]
+        fn local_backend_failure_maps_to_canonical_transport_class() {
+            use crate::runtime::connection::stream::BackendFailureReason;
+            assert_eq!(
+                RequestOutcomeReason::from(BackendFailureReason::UpstreamTimeout),
+                RequestOutcomeReason::TimedOut
+            );
+            assert_eq!(
+                RequestOutcomeReason::from(BackendFailureReason::UpstreamTls),
+                RequestOutcomeReason::BackendTlsFailed
+            );
+            assert_eq!(
+                RequestOutcomeReason::from(BackendFailureReason::UpstreamProtocol),
+                RequestOutcomeReason::BackendProtocolFailed
+            );
+            assert_eq!(
+                RequestOutcomeReason::from(BackendFailureReason::UpstreamBridge),
+                RequestOutcomeReason::BackendBridgeFailed
+            );
+            assert_eq!(
+                RequestOutcomeReason::from(BackendFailureReason::DispatchSpawnFailed),
+                RequestOutcomeReason::BackendTransportFailed
+            );
+        }
 
-    #[test]
-    fn local_backend_failure_maps_to_canonical_transport_class() {
-        use crate::runtime::connection::stream::BackendFailureReason;
-        assert_eq!(
-            RequestOutcomeReason::from(BackendFailureReason::UpstreamTimeout),
-            RequestOutcomeReason::TimedOut
-        );
-        assert_eq!(
-            RequestOutcomeReason::from(BackendFailureReason::UpstreamTls),
-            RequestOutcomeReason::BackendTlsFailed
-        );
-        assert_eq!(
-            RequestOutcomeReason::from(BackendFailureReason::UpstreamProtocol),
-            RequestOutcomeReason::BackendProtocolFailed
-        );
-        assert_eq!(
-            RequestOutcomeReason::from(BackendFailureReason::UpstreamBridge),
-            RequestOutcomeReason::BackendBridgeFailed
-        );
-        assert_eq!(
-            RequestOutcomeReason::from(BackendFailureReason::DispatchSpawnFailed),
-            RequestOutcomeReason::BackendTransportFailed
-        );
-    }
+        #[test]
+        fn backend_health_observation_maps_to_canonical_health_reason() {
+            use crate::runtime::backend::event::{
+                BackendHealthObservationOutcome as O, BackendHealthObservationSource as S,
+            };
+            assert_eq!(
+                backend_health_reason(S::ActiveCheck, O::Success),
+                Some(BackendHealthReason::ActiveProbeSuccess)
+            );
+            assert_eq!(
+                backend_health_reason(S::ActiveCheck, O::Failure),
+                Some(BackendHealthReason::ActiveProbeFailure)
+            );
+            assert_eq!(
+                backend_health_reason(S::PassiveRequest, O::Failure),
+                Some(BackendHealthReason::PassiveFailure)
+            );
+            assert_eq!(
+                backend_health_reason(S::RequestCompletion, O::Success),
+                Some(BackendHealthReason::PassiveSuccess)
+            );
+            // Neutral and control-plane observations carry no health reason.
+            assert_eq!(backend_health_reason(S::ActiveCheck, O::Neutral), None);
+            assert_eq!(backend_health_reason(S::ControlPlane, O::Success), None);
+        }
 
-    #[test]
-    fn backend_health_observation_maps_to_canonical_health_reason() {
-        use crate::runtime::backend::event::{
-            BackendHealthObservationOutcome as O, BackendHealthObservationSource as S,
-        };
-        assert_eq!(
-            backend_health_reason(S::ActiveCheck, O::Success),
-            Some(BackendHealthReason::ActiveProbeSuccess)
-        );
-        assert_eq!(
-            backend_health_reason(S::ActiveCheck, O::Failure),
-            Some(BackendHealthReason::ActiveProbeFailure)
-        );
-        assert_eq!(
-            backend_health_reason(S::PassiveRequest, O::Failure),
-            Some(BackendHealthReason::PassiveFailure)
-        );
-        assert_eq!(
-            backend_health_reason(S::RequestCompletion, O::Success),
-            Some(BackendHealthReason::PassiveSuccess)
-        );
-        // Neutral and control-plane observations carry no health reason.
-        assert_eq!(backend_health_reason(S::ActiveCheck, O::Neutral), None);
-        assert_eq!(backend_health_reason(S::ControlPlane, O::Success), None);
-    }
+        #[test]
+        fn refresh_classification_maps_only_failures_to_health_reason() {
+            use crate::runtime::backend::lifecycle::BackendRefreshClassification as C;
+            // Refresh axis is distinct from probe-health axis: only failures map.
+            assert_eq!(
+                Option::<BackendHealthReason>::from(C::FailedActivePreserved),
+                Some(BackendHealthReason::DnsRefreshFailed)
+            );
+            assert_eq!(
+                Option::<BackendHealthReason>::from(C::Rejected),
+                Some(BackendHealthReason::EmptyResolutionRetained)
+            );
+            assert_eq!(Option::<BackendHealthReason>::from(C::Refreshed), None);
+            assert_eq!(Option::<BackendHealthReason>::from(C::Unchanged), None);
+            // The failure health-reasons are themselves classified as failures.
+            assert!(BackendHealthReason::DnsRefreshFailed.is_failure());
+            assert!(BackendHealthReason::PassiveFailure.is_failure());
+            assert!(!BackendHealthReason::ActiveProbeSuccess.is_failure());
+        }
 
-    #[test]
-    fn refresh_classification_maps_only_failures_to_health_reason() {
-        use crate::runtime::backend::lifecycle::BackendRefreshClassification as C;
-        // Refresh axis is distinct from probe-health axis: only failures map.
-        assert_eq!(
-            Option::<BackendHealthReason>::from(C::FailedActivePreserved),
-            Some(BackendHealthReason::DnsRefreshFailed)
-        );
-        assert_eq!(
-            Option::<BackendHealthReason>::from(C::Rejected),
-            Some(BackendHealthReason::EmptyResolutionRetained)
-        );
-        assert_eq!(Option::<BackendHealthReason>::from(C::Refreshed), None);
-        assert_eq!(Option::<BackendHealthReason>::from(C::Unchanged), None);
-        // The failure health-reasons are themselves classified as failures.
-        assert!(BackendHealthReason::DnsRefreshFailed.is_failure());
-        assert!(BackendHealthReason::PassiveFailure.is_failure());
-        assert!(!BackendHealthReason::ActiveProbeSuccess.is_failure());
-    }
+        #[test]
+        fn admission_outcome_maps_to_canonical_decision_reason() {
+            use crate::{
+                metrics::OverloadShedReason, runtime::connection::outcome::AdmissionOutcomeClass,
+            };
+            assert_eq!(
+                AdmissionDecisionReason::from(AdmissionOutcomeClass::AuthDenied),
+                AdmissionDecisionReason::AuthDenied
+            );
+            assert_eq!(
+                AdmissionDecisionReason::from(AdmissionOutcomeClass::RateLimited),
+                AdmissionDecisionReason::RateLimited
+            );
+            assert_eq!(
+                AdmissionDecisionReason::from(AdmissionOutcomeClass::OverloadShed {
+                    reason: Some(OverloadShedReason::GlobalInflight)
+                }),
+                AdmissionDecisionReason::Overloaded
+            );
+            assert_eq!(
+                AdmissionDecisionReason::from(AdmissionOutcomeClass::Failed { timed_out: true }),
+                AdmissionDecisionReason::PolicyRejected
+            );
+        }
 
-    #[test]
-    fn admission_outcome_maps_to_canonical_decision_reason() {
-        use crate::{
-            metrics::OverloadShedReason, runtime::connection::outcome::AdmissionOutcomeClass,
-        };
-        assert_eq!(
-            AdmissionDecisionReason::from(AdmissionOutcomeClass::AuthDenied),
-            AdmissionDecisionReason::AuthDenied
-        );
-        assert_eq!(
-            AdmissionDecisionReason::from(AdmissionOutcomeClass::RateLimited),
-            AdmissionDecisionReason::RateLimited
-        );
-        assert_eq!(
-            AdmissionDecisionReason::from(AdmissionOutcomeClass::OverloadShed {
-                reason: Some(OverloadShedReason::GlobalInflight)
-            }),
-            AdmissionDecisionReason::Overloaded
-        );
-        assert_eq!(
-            AdmissionDecisionReason::from(AdmissionOutcomeClass::Failed { timed_out: true }),
-            AdmissionDecisionReason::PolicyRejected
-        );
-    }
+        #[test]
+        fn admission_log_reason_literals_match_canonical_slugs() {
+            // obs Phase 7: the `reason=` values emitted by the forwarding/bootstrap
+            // admission logs are the canonical AdmissionDecisionReason slugs. This
+            // guards those hand-written literals against enum drift.
+            assert_eq!(AdmissionDecisionReason::AuthDenied.slug(), "auth_denied");
+            assert_eq!(
+                AdmissionDecisionReason::AuthUnavailable.slug(),
+                "auth_unavailable"
+            );
+            assert_eq!(AdmissionDecisionReason::RateLimited.slug(), "rate_limited");
+            assert_eq!(AdmissionDecisionReason::Overloaded.slug(), "overloaded");
+        }
 
-    #[test]
-    fn admission_log_reason_literals_match_canonical_slugs() {
-        // obs Phase 7: the `reason=` values emitted by the forwarding/bootstrap
-        // admission logs are the canonical AdmissionDecisionReason slugs. This
-        // guards those hand-written literals against enum drift.
-        assert_eq!(AdmissionDecisionReason::AuthDenied.slug(), "auth_denied");
-        assert_eq!(
-            AdmissionDecisionReason::AuthUnavailable.slug(),
-            "auth_unavailable"
-        );
-        assert_eq!(AdmissionDecisionReason::RateLimited.slug(), "rate_limited");
-        assert_eq!(AdmissionDecisionReason::Overloaded.slug(), "overloaded");
-    }
+        #[test]
+        fn retry_and_hedge_denials_map_to_canonical_reasons() {
+            use spooky_errors::{
+                HedgePolicyDenialReason, RetryPolicyDenialReason, UpstreamRetryReason,
+            };
+            assert_eq!(
+                RetryDecisionReason::from(UpstreamRetryReason::Timeout),
+                RetryDecisionReason::UpstreamTimeout
+            );
+            assert_eq!(
+                RetryDecisionReason::from(RetryPolicyDenialReason::BudgetDenied),
+                RetryDecisionReason::RetryBudgetDenied
+            );
+            assert_eq!(
+                RetryDecisionReason::from(RetryPolicyDenialReason::MethodNotIdempotent),
+                RetryDecisionReason::IdempotencyDenied
+            );
+            assert_eq!(
+                RetryDecisionReason::from(RetryPolicyDenialReason::RequestBodyNotReplayable),
+                RetryDecisionReason::IdempotencyDenied
+            );
+            assert_eq!(
+                RetryDecisionReason::from(RetryPolicyDenialReason::AttemptLimitReached),
+                RetryDecisionReason::RetryPolicyDisabled
+            );
+            assert_eq!(
+                RetryDecisionReason::from(RetryPolicyDenialReason::AlternateBackendUnavailable(
+                    spooky_lb::alternate_backend::AlternateBackendFailureReason::NoHealthyBackends
+                )),
+                RetryDecisionReason::RetryPolicyDisabled
+            );
+            assert_eq!(
+                HedgeDecisionReason::from(HedgePolicyDenialReason::TunnelRequest),
+                HedgeDecisionReason::TunnelRequest
+            );
+            assert_eq!(
+                HedgeDecisionReason::from(HedgePolicyDenialReason::PrimaryRequestCompleted),
+                HedgeDecisionReason::PrimaryCompleted
+            );
+            assert_eq!(
+                HedgeDecisionReason::from(HedgePolicyDenialReason::AlternateBackendUnavailable(
+                    spooky_lb::alternate_backend::AlternateBackendFailureReason::NoHealthyBackends
+                )),
+                HedgeDecisionReason::AlternateBackendUnavailable
+            );
+            assert_eq!(
+                HedgeDecisionReason::from(HedgePolicyDenialReason::BudgetDenied),
+                HedgeDecisionReason::HedgeBudgetDenied
+            );
+        }
 
-    #[test]
-    fn retry_and_hedge_denials_map_to_canonical_reasons() {
-        use spooky_errors::{
-            HedgePolicyDenialReason, RetryPolicyDenialReason, UpstreamRetryReason,
-        };
-        assert_eq!(
-            RetryDecisionReason::from(UpstreamRetryReason::Timeout),
-            RetryDecisionReason::UpstreamTimeout
-        );
-        assert_eq!(
-            RetryDecisionReason::from(RetryPolicyDenialReason::BudgetDenied),
-            RetryDecisionReason::RetryBudgetDenied
-        );
-        assert_eq!(
-            RetryDecisionReason::from(RetryPolicyDenialReason::MethodNotIdempotent),
-            RetryDecisionReason::IdempotencyDenied
-        );
-        assert_eq!(
-            RetryDecisionReason::from(RetryPolicyDenialReason::RequestBodyNotReplayable),
-            RetryDecisionReason::IdempotencyDenied
-        );
-        assert_eq!(
-            RetryDecisionReason::from(RetryPolicyDenialReason::AttemptLimitReached),
-            RetryDecisionReason::RetryPolicyDisabled
-        );
-        assert_eq!(
-            RetryDecisionReason::from(RetryPolicyDenialReason::AlternateBackendUnavailable(
-                spooky_lb::alternate_backend::AlternateBackendFailureReason::NoHealthyBackends
-            )),
-            RetryDecisionReason::RetryPolicyDisabled
-        );
-        assert_eq!(
-            HedgeDecisionReason::from(HedgePolicyDenialReason::TunnelRequest),
-            HedgeDecisionReason::TunnelRequest
-        );
-        assert_eq!(
-            HedgeDecisionReason::from(HedgePolicyDenialReason::PrimaryRequestCompleted),
-            HedgeDecisionReason::PrimaryCompleted
-        );
-        assert_eq!(
-            HedgeDecisionReason::from(HedgePolicyDenialReason::AlternateBackendUnavailable(
-                spooky_lb::alternate_backend::AlternateBackendFailureReason::NoHealthyBackends
-            )),
-            HedgeDecisionReason::AlternateBackendUnavailable
-        );
-        assert_eq!(
-            HedgeDecisionReason::from(HedgePolicyDenialReason::BudgetDenied),
-            HedgeDecisionReason::HedgeBudgetDenied
-        );
-    }
+        #[test]
+        fn retry_and_hedge_reason_slugs_preserve_trigger_vs_denial_contract() {
+            assert_eq!(
+                RetryDecisionReason::UpstreamTimeout.slug(),
+                "upstream_timeout"
+            );
+            assert!(RetryDecisionReason::UpstreamTimeout.is_retry());
+            assert_eq!(
+                RetryDecisionReason::RetryBudgetDenied.slug(),
+                "retry_budget_denied"
+            );
+            assert!(!RetryDecisionReason::RetryBudgetDenied.is_retry());
+            assert_eq!(HedgeDecisionReason::DelayElapsed.slug(), "delay_elapsed");
+            assert!(HedgeDecisionReason::DelayElapsed.is_triggered());
+            assert_eq!(
+                HedgeDecisionReason::HedgeBudgetDenied.slug(),
+                "hedge_budget_denied"
+            );
+            assert!(!HedgeDecisionReason::HedgeBudgetDenied.is_triggered());
+        }
 
-    #[test]
-    fn retry_and_hedge_reason_slugs_preserve_trigger_vs_denial_contract() {
-        assert_eq!(
-            RetryDecisionReason::UpstreamTimeout.slug(),
-            "upstream_timeout"
-        );
-        assert!(RetryDecisionReason::UpstreamTimeout.is_retry());
-        assert_eq!(
-            RetryDecisionReason::RetryBudgetDenied.slug(),
-            "retry_budget_denied"
-        );
-        assert!(!RetryDecisionReason::RetryBudgetDenied.is_retry());
-        assert_eq!(HedgeDecisionReason::DelayElapsed.slug(), "delay_elapsed");
-        assert!(HedgeDecisionReason::DelayElapsed.is_triggered());
-        assert_eq!(
-            HedgeDecisionReason::HedgeBudgetDenied.slug(),
-            "hedge_budget_denied"
-        );
-        assert!(!HedgeDecisionReason::HedgeBudgetDenied.is_triggered());
-    }
+        #[test]
+        fn retry_and_outcome_mappings_stay_aligned_but_distinct_by_failure_class() {
+            use spooky_errors::{
+                RetryPolicyDenialReason, UpstreamRetryReason, UpstreamTerminalErrorKind,
+            };
 
-    #[test]
-    fn retry_and_outcome_mappings_stay_aligned_but_distinct_by_failure_class() {
-        use spooky_errors::{
-            RetryPolicyDenialReason, UpstreamRetryReason, UpstreamTerminalErrorKind,
-        };
+            use crate::runtime::connection::stream::BackendFailureReason;
 
-        use crate::runtime::connection::stream::BackendFailureReason;
+            assert_eq!(
+                RetryDecisionReason::from(UpstreamRetryReason::Transport),
+                RetryDecisionReason::UpstreamTransportFailure
+            );
+            assert_eq!(
+                RequestOutcomeReason::from(BackendFailureReason::UpstreamTransport),
+                RequestOutcomeReason::BackendTransportFailed
+            );
 
-        assert_eq!(
-            RetryDecisionReason::from(UpstreamRetryReason::Transport),
-            RetryDecisionReason::UpstreamTransportFailure
-        );
-        assert_eq!(
-            RequestOutcomeReason::from(BackendFailureReason::UpstreamTransport),
-            RequestOutcomeReason::BackendTransportFailed
-        );
+            assert_eq!(
+                RetryDecisionReason::from(RetryPolicyDenialReason::TerminalError(
+                    UpstreamTerminalErrorKind::Protocol
+                )),
+                RetryDecisionReason::RetryPolicyDisabled
+            );
+            assert_eq!(
+                RequestOutcomeReason::from(BackendFailureReason::UpstreamProtocol),
+                RequestOutcomeReason::BackendProtocolFailed
+            );
 
-        assert_eq!(
-            RetryDecisionReason::from(RetryPolicyDenialReason::TerminalError(
-                UpstreamTerminalErrorKind::Protocol
-            )),
-            RetryDecisionReason::RetryPolicyDisabled
-        );
-        assert_eq!(
-            RequestOutcomeReason::from(BackendFailureReason::UpstreamProtocol),
-            RequestOutcomeReason::BackendProtocolFailed
-        );
-
-        assert_eq!(
-            RetryDecisionReason::from(RetryPolicyDenialReason::TerminalError(
-                UpstreamTerminalErrorKind::Bridge
-            )),
-            RetryDecisionReason::RetryPolicyDisabled
-        );
-        assert_eq!(
-            RequestOutcomeReason::from(BackendFailureReason::UpstreamBridge),
-            RequestOutcomeReason::BackendBridgeFailed
-        );
+            assert_eq!(
+                RetryDecisionReason::from(RetryPolicyDenialReason::TerminalError(
+                    UpstreamTerminalErrorKind::Bridge
+                )),
+                RetryDecisionReason::RetryPolicyDisabled
+            );
+            assert_eq!(
+                RequestOutcomeReason::from(BackendFailureReason::UpstreamBridge),
+                RequestOutcomeReason::BackendBridgeFailed
+            );
+        }
     }
 }

--- a/crates/edge/src/quic_listener/control_api/auth.rs
+++ b/crates/edge/src/quic_listener/control_api/auth.rs
@@ -3,7 +3,10 @@ use bytes::Bytes;
 use http_body_util::Full;
 use subtle::ConstantTimeEq;
 
-use super::{state::ControlApiPaths, state::ControlApiState, *};
+use super::{
+    state::{ControlApiPaths, ControlApiState},
+    *,
+};
 
 type ControlApiGateError = Box<Response<Full<Bytes>>>;
 

--- a/crates/edge/src/quic_listener/control_api/auth.rs
+++ b/crates/edge/src/quic_listener/control_api/auth.rs
@@ -3,7 +3,7 @@ use bytes::Bytes;
 use http_body_util::Full;
 use subtle::ConstantTimeEq;
 
-use super::{state::ControlApiState, *};
+use super::{state::ControlApiPaths, state::ControlApiState, *};
 
 type ControlApiGateError = Box<Response<Full<Bytes>>>;
 
@@ -24,26 +24,10 @@ impl ControlApiRoute {
 }
 
 impl QUICListener {
-    pub(super) fn bearer_token_from_authorization_header(raw: &str) -> Option<&str> {
-        let raw = raw.trim();
-        let split = raw.find(char::is_whitespace)?;
-        let (scheme, rest) = raw.split_at(split);
-        if !scheme.eq_ignore_ascii_case("bearer") {
-            return None;
-        }
-        let token = rest.trim_start();
-        if token.is_empty() {
-            return None;
-        }
-        Some(token)
-    }
-
-    pub(super) fn control_api_request_route(
-        req: &Request<Incoming>,
-        state: &ControlApiState,
+    pub(super) fn control_api_request_route_for<B>(
+        req: &::http::Request<B>,
+        paths: &ControlApiPaths,
     ) -> Option<ControlApiRoute> {
-        let state = state.current_service_state();
-        let paths = state.paths;
         let path = req.uri().path();
 
         match *req.method() {
@@ -61,12 +45,48 @@ impl QUICListener {
         }
     }
 
-    pub(super) fn authorize_control_api_request(
-        req: &Request<Incoming>,
+    pub(super) fn bearer_token_from_authorization_header(raw: &str) -> Option<&str> {
+        let raw = raw.trim();
+        let split = raw.find(char::is_whitespace)?;
+        let (scheme, rest) = raw.split_at(split);
+        if !scheme.eq_ignore_ascii_case("bearer") {
+            return None;
+        }
+        let token = rest.trim_start();
+        if token.is_empty() {
+            return None;
+        }
+        Some(token)
+    }
+
+    pub(super) fn control_api_is_authorized_for<B>(
+        req: &::http::Request<B>,
+        endpoint: &ControlApiConfig,
+    ) -> bool {
+        let Some(token) = endpoint.auth_token.as_ref() else {
+            return false;
+        };
+        let Some(header) = req.headers().get(header::AUTHORIZATION) else {
+            return false;
+        };
+        let Ok(raw) = header.to_str() else {
+            return false;
+        };
+        let Some(provided) = Self::bearer_token_from_authorization_header(raw) else {
+            return false;
+        };
+        bool::from(provided.as_bytes().ct_eq(token.as_bytes()))
+    }
+
+    pub(super) fn authorize_control_api_request_for<B>(
+        req: &::http::Request<B>,
         state: &ControlApiState,
         route: ControlApiRoute,
     ) -> Result<(), ControlApiGateError> {
-        if !route.requires_authorization() || Self::control_api_is_authorized(req, state) {
+        let service_state = state.current_service_state();
+        if !route.requires_authorization()
+            || Self::control_api_is_authorized_for(req, &service_state.endpoint)
+        {
             return Ok(());
         }
 
@@ -82,11 +102,6 @@ impl QUICListener {
                 "accepted": false,
                 "error": "unauthorized",
             }),
-            // Health/Ready return `false` from `requires_authorization()`, so the
-            // early return above already handled them and this arm is unreachable.
-            // Phase 5: rather than `unreachable!()` (a production panic if that
-            // invariant is ever changed), fail closed with a generic unauthorized
-            // body and assert the invariant only in debug/test builds.
             ControlApiRoute::Health | ControlApiRoute::Ready => {
                 debug_assert!(
                     false,
@@ -103,15 +118,23 @@ impl QUICListener {
         )))
     }
 
+    pub(super) fn gate_control_api_request_for<B>(
+        req: &::http::Request<B>,
+        state: &ControlApiState,
+    ) -> Result<ControlApiRoute, ControlApiGateError> {
+        let service_state = state.current_service_state();
+        let Some(route) = Self::control_api_request_route_for(req, &service_state.paths) else {
+            return Err(Box::new(Self::control_api_not_found_response()));
+        };
+        Self::authorize_control_api_request_for(req, state, route)?;
+        Ok(route)
+    }
+
     pub(super) fn gate_control_api_request(
         req: &Request<Incoming>,
         state: &ControlApiState,
     ) -> Result<ControlApiRoute, ControlApiGateError> {
-        let Some(route) = Self::control_api_request_route(req, state) else {
-            return Err(Box::new(Self::control_api_not_found_response()));
-        };
-        Self::authorize_control_api_request(req, state, route)?;
-        Ok(route)
+        Self::gate_control_api_request_for(req, state)
     }
 
     pub(super) fn control_api_not_found_response() -> Response<Full<Bytes>> {
@@ -122,25 +145,5 @@ impl QUICListener {
             Ok(resp) => resp,
             Err(_) => Response::new(Full::new(Bytes::from_static(b"not found\n"))),
         }
-    }
-
-    pub(super) fn control_api_is_authorized(
-        req: &Request<Incoming>,
-        state: &ControlApiState,
-    ) -> bool {
-        let endpoint = state.current_service_state().endpoint;
-        let Some(token) = endpoint.auth_token.as_ref() else {
-            return false;
-        };
-        let Some(header) = req.headers().get(header::AUTHORIZATION) else {
-            return false;
-        };
-        let Ok(raw) = header.to_str() else {
-            return false;
-        };
-        let Some(provided) = Self::bearer_token_from_authorization_header(raw) else {
-            return false;
-        };
-        bool::from(provided.as_bytes().ct_eq(token.as_bytes()))
     }
 }

--- a/crates/edge/src/quic_listener/control_api/render.rs
+++ b/crates/edge/src/quic_listener/control_api/render.rs
@@ -420,14 +420,14 @@ mod tests {
     mod runtime_snapshot_rendering {
         use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-        use crate::runtime::backend::state::{
-            BackendIdentity, BackendResolutionState, CanonicalBackendLifecycleSnapshot,
-        };
-        use crate::runtime::backend::{
-            resolution::RuntimeBackendAddressKind, state::BackendPoolPlacementSnapshot,
-        };
-
         use super::*;
+        use crate::runtime::backend::{
+            resolution::RuntimeBackendAddressKind,
+            state::{
+                BackendIdentity, BackendPoolPlacementSnapshot, BackendResolutionState,
+                CanonicalBackendLifecycleSnapshot,
+            },
+        };
 
         #[test]
         fn backend_payload_serialization_omits_or_includes_optional_health_reason_by_contract() {

--- a/crates/edge/src/quic_listener/control_api/render.rs
+++ b/crates/edge/src/quic_listener/control_api/render.rs
@@ -412,6 +412,21 @@ mod tests {
         }
 
         #[test]
+        fn backend_unhealthy_reason_tokens_stay_aligned_across_metrics_logs_and_control_plane() {
+            for (reason, expected) in [
+                (HealthFailureReason::Timeout, "timeout"),
+                (HealthFailureReason::Transport, "transport"),
+                (HealthFailureReason::Tls, "tls"),
+            ] {
+                let control_plane_reason = health_failure_reason_label(reason);
+                let structured_log_token = format!("health_reason={control_plane_reason}");
+
+                assert_eq!(control_plane_reason, expected);
+                assert_eq!(structured_log_token, format!("health_reason={expected}"));
+            }
+        }
+
+        #[test]
         fn backend_payload_serializes_health_reason_when_present() {
             // The field appears only when unhealthy with a known reason, and is
             // omitted otherwise (skip_serializing_if).

--- a/crates/edge/src/quic_listener/control_api/render.rs
+++ b/crates/edge/src/quic_listener/control_api/render.rs
@@ -375,6 +375,48 @@ impl ControlApiBackendPlacementPayload {
 mod tests {
     use super::*;
 
+    fn assert_health_reason_token(reason: HealthFailureReason, expected: &'static str) {
+        let control_plane_reason = health_failure_reason_label(reason);
+        let structured_log_token = format!("health_reason={control_plane_reason}");
+
+        assert_eq!(
+            control_plane_reason, expected,
+            "control-plane health reason token should stay canonical"
+        );
+        assert_eq!(
+            structured_log_token,
+            format!("health_reason={expected}"),
+            "structured log token should reuse the canonical health reason value"
+        );
+    }
+
+    mod observability_contracts {
+        use super::*;
+
+        #[test]
+        fn control_plane_health_reason_tokens_match_metric_reason_labels() {
+            // obs Phase 4: control-plane `health_reason` must use the same tokens as
+            // the `spooky_health_failures_total{reason=…}` metric label so operators
+            // don't translate between surfaces.
+            assert_health_reason_token(HealthFailureReason::HttpStatus5xx, "5xx");
+            assert_health_reason_token(HealthFailureReason::Timeout, "timeout");
+            assert_health_reason_token(HealthFailureReason::Transport, "transport");
+            assert_health_reason_token(HealthFailureReason::Tls, "tls");
+            assert_health_reason_token(HealthFailureReason::CircuitOpen, "circuit_open");
+        }
+
+        #[test]
+        fn unhealthy_backend_reason_tokens_stay_aligned_across_surfaces() {
+            for (reason, expected) in [
+                (HealthFailureReason::Timeout, "timeout"),
+                (HealthFailureReason::Transport, "transport"),
+                (HealthFailureReason::Tls, "tls"),
+            ] {
+                assert_health_reason_token(reason, expected);
+            }
+        }
+    }
+
     mod runtime_snapshot_rendering {
         use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
@@ -388,46 +430,7 @@ mod tests {
         use super::*;
 
         #[test]
-        fn health_reason_labels_match_metric_reason_tokens() {
-            // obs Phase 4: control-plane `health_reason` must use the same tokens as
-            // the `spooky_health_failures_total{reason=…}` metric label so operators
-            // don't translate between surfaces.
-            assert_eq!(
-                health_failure_reason_label(HealthFailureReason::HttpStatus5xx),
-                "5xx"
-            );
-            assert_eq!(
-                health_failure_reason_label(HealthFailureReason::Timeout),
-                "timeout"
-            );
-            assert_eq!(
-                health_failure_reason_label(HealthFailureReason::Transport),
-                "transport"
-            );
-            assert_eq!(health_failure_reason_label(HealthFailureReason::Tls), "tls");
-            assert_eq!(
-                health_failure_reason_label(HealthFailureReason::CircuitOpen),
-                "circuit_open"
-            );
-        }
-
-        #[test]
-        fn backend_unhealthy_reason_tokens_stay_aligned_across_metrics_logs_and_control_plane() {
-            for (reason, expected) in [
-                (HealthFailureReason::Timeout, "timeout"),
-                (HealthFailureReason::Transport, "transport"),
-                (HealthFailureReason::Tls, "tls"),
-            ] {
-                let control_plane_reason = health_failure_reason_label(reason);
-                let structured_log_token = format!("health_reason={control_plane_reason}");
-
-                assert_eq!(control_plane_reason, expected);
-                assert_eq!(structured_log_token, format!("health_reason={expected}"));
-            }
-        }
-
-        #[test]
-        fn backend_payload_serializes_health_reason_when_present() {
+        fn backend_payload_serialization_omits_or_includes_optional_health_reason_by_contract() {
             // The field appears only when unhealthy with a known reason, and is
             // omitted otherwise (skip_serializing_if).
             let with_reason = ControlApiBackendLifecyclePayload {
@@ -454,7 +457,7 @@ mod tests {
         }
 
         #[test]
-        fn backend_inventory_payload_preserves_optional_health_reason_and_field_meaning() {
+        fn backend_inventory_payload_preserves_runtime_snapshot_field_meanings() {
             let inventory = BackendLifecycleInventorySnapshot {
                 backends: vec![
                     CanonicalBackendLifecycleSnapshot {

--- a/crates/edge/src/quic_listener/control_api/render.rs
+++ b/crates/edge/src/quic_listener/control_api/render.rs
@@ -376,6 +376,15 @@ mod tests {
     use super::*;
 
     mod runtime_snapshot_rendering {
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+        use crate::runtime::backend::state::{
+            BackendIdentity, BackendResolutionState, CanonicalBackendLifecycleSnapshot,
+        };
+        use crate::runtime::backend::{
+            resolution::RuntimeBackendAddressKind, state::BackendPoolPlacementSnapshot,
+        };
+
         use super::*;
 
         #[test]
@@ -427,6 +436,84 @@ mod tests {
             };
             let json = serde_json::to_string(&without).expect("serialize");
             assert!(!json.contains("health_reason"));
+        }
+
+        #[test]
+        fn backend_inventory_payload_preserves_optional_health_reason_and_field_meaning() {
+            let inventory = BackendLifecycleInventorySnapshot {
+                backends: vec![
+                    CanonicalBackendLifecycleSnapshot {
+                        identity: BackendIdentity::new("backend-a"),
+                        resolution: BackendResolutionState {
+                            authority_host: "backend-a.internal".into(),
+                            authority_port: 8443,
+                            address_kind: RuntimeBackendAddressKind::Hostname,
+                            resolved_addrs: vec![SocketAddr::new(
+                                IpAddr::V4(Ipv4Addr::new(10, 0, 0, 10)),
+                                8443,
+                            )],
+                            last_refresh_success_at: None,
+                            refresh_generation: 4,
+                        },
+                        health: BackendHealthState::Unhealthy {
+                            reason: Some(HealthFailureReason::Timeout),
+                        },
+                        membership: BackendMembershipState::Suppressed,
+                        placements: Vec::new(),
+                    },
+                    CanonicalBackendLifecycleSnapshot {
+                        identity: BackendIdentity::new("backend-b"),
+                        resolution: BackendResolutionState {
+                            authority_host: "backend-b.internal".into(),
+                            authority_port: 9443,
+                            address_kind: RuntimeBackendAddressKind::IpLiteral,
+                            resolved_addrs: vec![SocketAddr::new(
+                                IpAddr::V4(Ipv4Addr::new(10, 0, 0, 11)),
+                                9443,
+                            )],
+                            last_refresh_success_at: None,
+                            refresh_generation: 2,
+                        },
+                        health: BackendHealthState::Healthy,
+                        membership: BackendMembershipState::Active,
+                        placements: vec![BackendPoolPlacementSnapshot {
+                            upstream_name: "api".into(),
+                            backend_index: 0,
+                            healthy: true,
+                            active_requests: 1,
+                            ewma_latency_ms: Some(12.5),
+                            membership_epoch: 9,
+                        }],
+                    },
+                ],
+            };
+
+            let payload = ControlApiBackendInventoryPayload::from_inventory(inventory, 1, 1);
+            let json = serde_json::to_value(payload).expect("serialize backend inventory");
+            let lifecycle = json["lifecycle"].as_array().expect("lifecycle array");
+
+            assert_eq!(lifecycle[0]["backend"], "backend-a");
+            assert_eq!(lifecycle[0]["health"], "unhealthy");
+            assert_eq!(lifecycle[0]["health_reason"], "timeout");
+            assert_eq!(lifecycle[0]["membership"], "suppressed");
+            assert_eq!(lifecycle[0]["authority_host"], "backend-a.internal");
+            assert_eq!(lifecycle[0]["authority_port"], 8443);
+            assert_eq!(lifecycle[0]["resolution_generation"], 4);
+
+            assert_eq!(lifecycle[1]["backend"], "backend-b");
+            assert_eq!(lifecycle[1]["health"], "healthy");
+            assert!(
+                lifecycle[1].get("health_reason").is_none(),
+                "healthy payloads must omit optional health_reason"
+            );
+            assert_eq!(lifecycle[1]["membership"], "active");
+            assert_eq!(
+                lifecycle[1]["placements"]
+                    .as_array()
+                    .expect("placements")
+                    .len(),
+                1
+            );
         }
     }
 }

--- a/crates/edge/src/quic_listener/control_api/render.rs
+++ b/crates/edge/src/quic_listener/control_api/render.rs
@@ -375,54 +375,58 @@ impl ControlApiBackendPlacementPayload {
 mod tests {
     use super::*;
 
-    #[test]
-    fn health_reason_labels_match_metric_reason_tokens() {
-        // obs Phase 4: control-plane `health_reason` must use the same tokens as
-        // the `spooky_health_failures_total{reason=…}` metric label so operators
-        // don't translate between surfaces.
-        assert_eq!(
-            health_failure_reason_label(HealthFailureReason::HttpStatus5xx),
-            "5xx"
-        );
-        assert_eq!(
-            health_failure_reason_label(HealthFailureReason::Timeout),
-            "timeout"
-        );
-        assert_eq!(
-            health_failure_reason_label(HealthFailureReason::Transport),
-            "transport"
-        );
-        assert_eq!(health_failure_reason_label(HealthFailureReason::Tls), "tls");
-        assert_eq!(
-            health_failure_reason_label(HealthFailureReason::CircuitOpen),
-            "circuit_open"
-        );
-    }
+    mod runtime_snapshot_rendering {
+        use super::*;
 
-    #[test]
-    fn backend_payload_serializes_health_reason_when_present() {
-        // The field appears only when unhealthy with a known reason, and is
-        // omitted otherwise (skip_serializing_if).
-        let with_reason = ControlApiBackendLifecyclePayload {
-            backend: "b".to_string(),
-            health: "unhealthy",
-            health_reason: Some("timeout"),
-            membership: "active",
-            authority_host: "h".to_string(),
-            authority_port: 443,
-            resolved_addrs: vec![],
-            resolution_generation: 0,
-            last_refresh_success_at_unix_seconds: None,
-            placements: vec![],
-        };
-        let json = serde_json::to_string(&with_reason).expect("serialize");
-        assert!(json.contains("\"health_reason\":\"timeout\""));
+        #[test]
+        fn health_reason_labels_match_metric_reason_tokens() {
+            // obs Phase 4: control-plane `health_reason` must use the same tokens as
+            // the `spooky_health_failures_total{reason=…}` metric label so operators
+            // don't translate between surfaces.
+            assert_eq!(
+                health_failure_reason_label(HealthFailureReason::HttpStatus5xx),
+                "5xx"
+            );
+            assert_eq!(
+                health_failure_reason_label(HealthFailureReason::Timeout),
+                "timeout"
+            );
+            assert_eq!(
+                health_failure_reason_label(HealthFailureReason::Transport),
+                "transport"
+            );
+            assert_eq!(health_failure_reason_label(HealthFailureReason::Tls), "tls");
+            assert_eq!(
+                health_failure_reason_label(HealthFailureReason::CircuitOpen),
+                "circuit_open"
+            );
+        }
 
-        let without = ControlApiBackendLifecyclePayload {
-            health_reason: None,
-            ..with_reason
-        };
-        let json = serde_json::to_string(&without).expect("serialize");
-        assert!(!json.contains("health_reason"));
+        #[test]
+        fn backend_payload_serializes_health_reason_when_present() {
+            // The field appears only when unhealthy with a known reason, and is
+            // omitted otherwise (skip_serializing_if).
+            let with_reason = ControlApiBackendLifecyclePayload {
+                backend: "b".to_string(),
+                health: "unhealthy",
+                health_reason: Some("timeout"),
+                membership: "active",
+                authority_host: "h".to_string(),
+                authority_port: 443,
+                resolved_addrs: vec![],
+                resolution_generation: 0,
+                last_refresh_success_at_unix_seconds: None,
+                placements: vec![],
+            };
+            let json = serde_json::to_string(&with_reason).expect("serialize");
+            assert!(json.contains("\"health_reason\":\"timeout\""));
+
+            let without = ControlApiBackendLifecyclePayload {
+                health_reason: None,
+                ..with_reason
+            };
+            let json = serde_json::to_string(&without).expect("serialize");
+            assert!(!json.contains("health_reason"));
+        }
     }
 }

--- a/crates/edge/src/quic_listener/control_api/tests.rs
+++ b/crates/edge/src/quic_listener/control_api/tests.rs
@@ -1,5 +1,7 @@
 use std::{collections::HashMap, ffi::OsString, path::Path, sync::Arc};
 
+use ::http::{Method, Request, header};
+use bytes::Bytes;
 use http_body_util::BodyExt;
 use log::LevelFilter;
 use spooky_config::{
@@ -131,6 +133,32 @@ fn runtime_bundle_control_api_state(
     (state, runtime_handle)
 }
 
+fn control_api_request(method: Method, path: &str, authorization: Option<&str>) -> Request<()> {
+    let mut builder = Request::builder().method(method).uri(path);
+    if let Some(value) = authorization {
+        builder = builder.header(header::AUTHORIZATION, value);
+    }
+    builder.body(()).expect("control api request")
+}
+
+async fn full_body_bytes(response: Response<http_body_util::Full<Bytes>>) -> Bytes {
+    response
+        .into_body()
+        .collect()
+        .await
+        .expect("collect response body")
+        .to_bytes()
+}
+
+fn default_control_api_state() -> ControlApiState {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+    let mut startup = test_config(cert.clone(), key.clone());
+    startup.observability.control_api.enabled = true;
+    startup.observability.control_api.auth_token = Some("secret-token".to_string());
+    control_api_state_with_runtime_bundle(&startup, &startup)
+}
+
 // Domain: watchdog service state transitions and restart environment handling.
 #[test]
 fn watchdog_restart_env_keeps_path_when_present() {
@@ -192,6 +220,155 @@ fn bearer_authorization_rejects_malformed_headers() {
     assert_eq!(
         QUICListener::bearer_token_from_authorization_header("Bearer   "),
         None
+    );
+}
+
+#[test]
+fn control_api_route_gating_accepts_only_canonical_method_and_path_pairs() {
+    let state = default_control_api_state();
+    let paths = state.current_paths();
+
+    let cases = [
+        (
+            Method::GET,
+            paths.health_path.clone(),
+            Some(super::auth::ControlApiRoute::Health),
+        ),
+        (
+            Method::GET,
+            paths.ready_path.clone(),
+            Some(super::auth::ControlApiRoute::Ready),
+        ),
+        (
+            Method::GET,
+            paths.runtime_path.clone(),
+            Some(super::auth::ControlApiRoute::Runtime),
+        ),
+        (
+            Method::POST,
+            paths.reload_certs_path.clone(),
+            Some(super::auth::ControlApiRoute::ReloadCerts),
+        ),
+        (
+            Method::POST,
+            paths.reload_path.clone(),
+            Some(super::auth::ControlApiRoute::ReloadRuntime),
+        ),
+        (
+            Method::POST,
+            paths.restart_path.clone(),
+            Some(super::auth::ControlApiRoute::Restart),
+        ),
+        (Method::POST, paths.runtime_path.clone(), None),
+        (Method::GET, paths.reload_path.clone(), None),
+        (Method::GET, "/missing".to_string(), None),
+    ];
+
+    for (method, path, expected) in cases {
+        let req = control_api_request(method, &path, None);
+        assert_eq!(
+            QUICListener::control_api_request_route_for(&req, &state.current_paths()),
+            expected,
+            "unexpected route decision for {} {}",
+            req.method(),
+            req.uri().path()
+        );
+    }
+}
+
+#[test]
+fn control_api_route_gating_leaves_health_and_ready_ungated_by_auth() {
+    let state = default_control_api_state();
+    let paths = state.current_paths();
+
+    for path in [&paths.health_path, &paths.ready_path] {
+        let req = control_api_request(Method::GET, path, None);
+        let route = QUICListener::gate_control_api_request_for(&req, &state)
+            .expect("health and ready routes should bypass auth");
+        assert!(matches!(
+            route,
+            super::auth::ControlApiRoute::Health | super::auth::ControlApiRoute::Ready
+        ));
+    }
+}
+
+#[test]
+fn control_api_authorization_uses_token_matching_independent_of_request_body_type() {
+    let state = default_control_api_state();
+    let runtime_path = state.current_paths().runtime_path;
+    let authorized = control_api_request(Method::GET, &runtime_path, Some("Bearer secret-token"));
+    let malformed = control_api_request(Method::GET, &runtime_path, Some("Bearer"));
+    let missing = control_api_request(Method::GET, &runtime_path, None);
+
+    assert!(QUICListener::control_api_is_authorized_for(
+        &authorized,
+        &state.current_control_api()
+    ));
+    assert!(!QUICListener::control_api_is_authorized_for(
+        &malformed,
+        &state.current_control_api()
+    ));
+    assert!(!QUICListener::control_api_is_authorized_for(
+        &missing,
+        &state.current_control_api()
+    ));
+}
+
+#[tokio::test]
+async fn control_api_gate_returns_canonical_unauthorized_payloads_per_route() {
+    let state = default_control_api_state();
+    let paths = state.current_paths();
+
+    let cases = [
+        (
+            Method::GET,
+            paths.runtime_path.clone(),
+            serde_json::json!({ "error": "unauthorized" }),
+        ),
+        (
+            Method::POST,
+            paths.reload_certs_path.clone(),
+            serde_json::json!({ "reloaded": false, "error": "unauthorized" }),
+        ),
+        (
+            Method::POST,
+            paths.reload_path.clone(),
+            serde_json::json!({ "reloaded": false, "error": "unauthorized" }),
+        ),
+        (
+            Method::POST,
+            paths.restart_path.clone(),
+            serde_json::json!({ "accepted": false, "error": "unauthorized" }),
+        ),
+    ];
+
+    for (method, path, expected_body) in cases {
+        let req = control_api_request(method, &path, None);
+        let response = QUICListener::gate_control_api_request_for(&req, &state)
+            .expect_err("protected route should reject missing auth");
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        let body = full_body_bytes(*response).await;
+        let payload: serde_json::Value =
+            serde_json::from_slice(&body).expect("unauthorized payload");
+        assert_eq!(payload, expected_body);
+    }
+}
+
+#[tokio::test]
+async fn control_api_gate_returns_not_found_for_invalid_routes_without_transport_coupling() {
+    let state = default_control_api_state();
+    let req = control_api_request(
+        Method::DELETE,
+        &state.current_paths().runtime_path,
+        Some("Bearer secret-token"),
+    );
+
+    let response = QUICListener::gate_control_api_request_for(&req, &state)
+        .expect_err("invalid route should map to not found");
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert_eq!(
+        full_body_bytes(*response).await,
+        Bytes::from_static(b"not found\n")
     );
 }
 

--- a/crates/edge/src/quic_listener/control_api/tests.rs
+++ b/crates/edge/src/quic_listener/control_api/tests.rs
@@ -163,6 +163,25 @@ fn default_control_api_state() -> ControlApiState {
     control_api_state_with_runtime_bundle(&startup, &startup)
 }
 
+fn assert_structured_resource_preflight_message(
+    rejection: &crate::runtime::policy::TransitionRejection,
+) {
+    let field = rejection
+        .field_path
+        .as_deref()
+        .expect("resource field path");
+    let detail = rejection
+        .requested_mode
+        .as_deref()
+        .expect("resource failure detail");
+    assert_eq!(
+        rejection.to_string(),
+        format!(
+            "runtime reload rejected: could not prepare {field}: {detail}; active runtime unchanged (no change applied)"
+        )
+    );
+}
+
 // Domain: watchdog service state transitions and restart environment handling.
 #[test]
 fn watchdog_restart_env_keeps_path_when_present() {
@@ -710,6 +729,29 @@ fn live_reloadable_upstream_change_is_accepted() {
 }
 
 #[test]
+fn reload_compatibility_classifies_generation_owned_changes_as_live_reloadable() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+    let current = test_config(cert, key);
+
+    let mut next = current.clone();
+    next.upstream
+        .get_mut("api")
+        .expect("api upstream")
+        .route
+        .path_prefix = Some("/live".to_string());
+
+    let current_bundle = runtime_bundle_from_config("current.yaml", &current);
+    let next_bundle = runtime_bundle_from_config("next.yaml", &next);
+    let active = RuntimeBundleHandle::new(current_bundle).current_view();
+
+    assert!(
+        QUICListener::evaluate_runtime_reload_compatibility(&active, &next_bundle).is_ok(),
+        "generation-owned routing changes should stay reloadable"
+    );
+}
+
+#[test]
 fn restart_required_change_rejects_before_touching_active_generation() {
     // Phase 9 (#4): a failed validation must leave the active generation unchanged.
     // A restart-required change (control_plane_threads) is rejected by the
@@ -739,6 +781,41 @@ fn restart_required_change_rejects_before_touching_active_generation() {
     );
     // The active generation is untouched by the rejected evaluation.
     assert_eq!(handle.current_generation(), generation_before);
+}
+
+#[test]
+fn reload_compatibility_classifies_startup_owned_changes_as_restart_required() {
+    use crate::runtime::policy::TransitionRejectionKind;
+
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+    let current = test_config(cert, key);
+
+    let mut next = current.clone();
+    let current_threads = current.performance.control_plane_threads;
+    let next_threads = current_threads.saturating_add(2);
+    next.performance.control_plane_threads = next_threads;
+
+    let current_bundle = runtime_bundle_from_config("current.yaml", &current);
+    let next_bundle = runtime_bundle_from_config("next.yaml", &next);
+    let active = RuntimeBundleHandle::new(current_bundle).current_view();
+
+    let rejections = QUICListener::evaluate_runtime_reload_compatibility(&active, &next_bundle)
+        .expect_err("startup-owned change must reject the reload");
+    assert_eq!(rejections.len(), 1);
+    let rejection = &rejections[0];
+    assert_eq!(rejection.kind, TransitionRejectionKind::RestartRequired);
+    assert!(rejection.requires_restart());
+    assert_eq!(
+        rejection.field_path.as_deref(),
+        Some("performance.control_plane_threads")
+    );
+    assert_eq!(
+        rejection.to_string(),
+        format!(
+            "runtime reload rejected: performance.control_plane_threads changed from {current_threads} to {next_threads}; restart required"
+        )
+    );
 }
 
 #[test]
@@ -993,6 +1070,41 @@ fn validate_runtime_reload_compatibility_allows_listener_addition_when_binds_are
 }
 
 #[test]
+fn validate_runtime_reload_compatibility_classifies_listener_bind_conflict_as_preflight_failure() {
+    use crate::runtime::policy::TransitionRejectionKind;
+
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+    let current = test_config(cert.clone(), key.clone());
+
+    let occupied = std::net::UdpSocket::bind("127.0.0.1:0").expect("bind occupied udp");
+    let occupied_port = occupied.local_addr().expect("occupied addr").port();
+
+    let mut next = current.clone();
+    let mut extra_listener = next.listen.clone();
+    extra_listener.port = occupied_port;
+    next.listeners = vec![next.listen.clone(), extra_listener];
+
+    let current_bundle = runtime_bundle_from_config("current.yaml", &current);
+    let next_bundle = runtime_bundle_from_config("next.yaml", &next);
+
+    let rejection =
+        QUICListener::validate_runtime_reload_compatibility(&current_bundle, &next_bundle)
+            .expect("listener bind conflict must reject");
+    let expected_field = format!("QUIC listener '127.0.0.1:{occupied_port}'");
+    assert_eq!(
+        rejection.kind,
+        TransitionRejectionKind::ResourcePreparationFailed
+    );
+    assert!(!rejection.requires_restart());
+    assert_eq!(
+        rejection.field_path.as_deref(),
+        Some(expected_field.as_str())
+    );
+    assert_structured_resource_preflight_message(&rejection);
+}
+
+#[test]
 fn validate_runtime_reload_compatibility_rejects_listener_removal() {
     let dir = tempdir().expect("tempdir");
     let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
@@ -1038,6 +1150,76 @@ fn validate_runtime_reload_compatibility_rejects_listener_bind_change() {
         "expected rejection, got: {:?}",
         err
     );
+}
+
+#[test]
+fn validate_control_api_reload_compatibility_classifies_bind_conflict_as_preflight_failure() {
+    use crate::runtime::policy::TransitionRejectionKind;
+
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+    let current = test_config(cert.clone(), key.clone());
+
+    let occupied = std::net::TcpListener::bind("127.0.0.1:0").expect("bind occupied tcp");
+    let occupied_port = occupied.local_addr().expect("occupied addr").port();
+
+    let mut next = current.clone();
+    next.observability.control_api.enabled = true;
+    next.observability.control_api.address = "127.0.0.1".to_string();
+    next.observability.control_api.port = occupied_port;
+
+    let current_bundle = runtime_bundle_from_config("current.yaml", &current);
+    let next_bundle = runtime_bundle_from_config("next.yaml", &next);
+
+    let rejection =
+        QUICListener::validate_control_api_reload_compatibility(&current_bundle, &next_bundle)
+            .expect("control api bind conflict must reject");
+    let expected_field = format!("control API endpoint '127.0.0.1:{occupied_port}'");
+    assert_eq!(
+        rejection.kind,
+        TransitionRejectionKind::ResourcePreparationFailed
+    );
+    assert_eq!(
+        rejection.field_path.as_deref(),
+        Some(expected_field.as_str())
+    );
+    assert!(!rejection.requires_restart());
+    assert_structured_resource_preflight_message(&rejection);
+}
+
+#[test]
+fn validate_metrics_reload_compatibility_classifies_bind_conflict_as_preflight_failure() {
+    use crate::runtime::policy::TransitionRejectionKind;
+
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+    let current = test_config(cert.clone(), key.clone());
+
+    let occupied = std::net::TcpListener::bind("127.0.0.1:0").expect("bind occupied tcp");
+    let occupied_port = occupied.local_addr().expect("occupied addr").port();
+
+    let mut next = current.clone();
+    next.observability.metrics.enabled = true;
+    next.observability.metrics.address = "127.0.0.1".to_string();
+    next.observability.metrics.port = occupied_port;
+
+    let current_bundle = runtime_bundle_from_config("current.yaml", &current);
+    let next_bundle = runtime_bundle_from_config("next.yaml", &next);
+
+    let rejection =
+        QUICListener::validate_metrics_reload_compatibility(&current_bundle, &next_bundle)
+            .expect("metrics bind conflict must reject");
+    let expected_field = format!("metrics endpoint '127.0.0.1:{occupied_port}'");
+    assert_eq!(
+        rejection.kind,
+        TransitionRejectionKind::ResourcePreparationFailed
+    );
+    assert_eq!(
+        rejection.field_path.as_deref(),
+        Some(expected_field.as_str())
+    );
+    assert!(!rejection.requires_restart());
+    assert_structured_resource_preflight_message(&rejection);
 }
 
 #[test]

--- a/crates/edge/src/quic_listener/control_api/tests.rs
+++ b/crates/edge/src/quic_listener/control_api/tests.rs
@@ -131,6 +131,7 @@ fn runtime_bundle_control_api_state(
     (state, runtime_handle)
 }
 
+// Domain: watchdog service state transitions and restart environment handling.
 #[test]
 fn watchdog_restart_env_keeps_path_when_present() {
     let env = crate::watchdog::service::watchdog_restart_env(
@@ -161,6 +162,7 @@ fn watchdog_restart_env_omits_path_when_missing() {
     );
 }
 
+// Domain: control API auth and route gating contracts.
 #[test]
 fn bearer_authorization_scheme_is_case_insensitive() {
     assert_eq!(
@@ -193,6 +195,7 @@ fn bearer_authorization_rejects_malformed_headers() {
     );
 }
 
+// Domain: runtime snapshot rendering and live runtime-view selection.
 #[test]
 fn control_api_state_prefers_reloaded_paths_and_auth_token() {
     let dir = tempdir().expect("tempdir");
@@ -324,6 +327,7 @@ fn control_api_backend_inventory_and_summary_share_one_canonical_snapshot_contra
     assert_eq!(summary.healthy_backends, 1);
 }
 
+// Domain: watchdog/runtime ownership alignment across reload boundaries.
 #[test]
 fn reload_preserves_process_scoped_watchdog_and_dns_resolver() {
     // Regression: process-shared services must be carried across a reload, not
@@ -382,6 +386,7 @@ fn reload_preserves_process_scoped_watchdog_and_dns_resolver() {
     );
 }
 
+// Domain: reload compatibility classification and lifecycle gatekeeping.
 #[test]
 fn live_reloadable_upstream_change_is_accepted() {
     // Phase 9 (#1): a generation-owned change (upstream/route table) must pass
@@ -779,6 +784,7 @@ fn apply_live_log_level_reload_updates_global_filter() {
     assert_eq!(log::max_level(), LevelFilter::Debug);
 }
 
+// Domain: control-plane certificate reload and atomic service update behavior.
 #[tokio::test]
 async fn runtime_bundle_cert_reload_ignores_unrelated_config_drift_and_bundle_swap() {
     let dir = tempdir().expect("tempdir");

--- a/crates/edge/src/quic_listener/control_api/tests.rs
+++ b/crates/edge/src/quic_listener/control_api/tests.rs
@@ -150,6 +150,10 @@ async fn full_body_bytes(response: Response<http_body_util::Full<Bytes>>) -> Byt
         .to_bytes()
 }
 
+async fn json_body(response: Response<http_body_util::Full<Bytes>>) -> serde_json::Value {
+    serde_json::from_slice(&full_body_bytes(response).await).expect("json response body")
+}
+
 fn default_control_api_state() -> ControlApiState {
     let dir = tempdir().expect("tempdir");
     let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
@@ -502,6 +506,116 @@ fn control_api_backend_inventory_and_summary_share_one_canonical_snapshot_contra
     assert!(backend.placements[0].healthy);
     assert_eq!(summary.total_backends, 1);
     assert_eq!(summary.healthy_backends, 1);
+}
+
+#[tokio::test]
+async fn control_api_runtime_snapshot_renders_live_generation_listener_and_backend_contract() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+    let mut startup = test_config(cert.clone(), key.clone());
+    startup.observability.control_api.enabled = true;
+
+    let startup_bundle = runtime_bundle_from_config("startup.yaml", &startup);
+    let (state, runtime_handle) = runtime_bundle_control_api_state(startup_bundle);
+
+    let mut reloaded = startup.clone();
+    reloaded.listeners = vec![
+        Listen {
+            protocol: "http3".to_string(),
+            port: 9890,
+            address: "127.0.0.1".to_string(),
+            tls: Tls {
+                cert: cert.clone(),
+                key: key.clone(),
+                certificates: vec![],
+                client_auth: ClientAuth {
+                    enabled: true,
+                    ca_file: Some(cert.clone()),
+                    require_client_cert: true,
+                },
+            },
+        },
+        startup.listen.clone(),
+    ];
+    reloaded.observability.metrics.path = "/metrics-live".to_string();
+
+    let mut reloaded_bundle = runtime_bundle_from_config("reloaded.yaml", &reloaded);
+    reloaded_bundle.generation = 1;
+    runtime_handle
+        .replace(reloaded_bundle)
+        .expect("replace runtime bundle");
+
+    let live = runtime_handle.current_view();
+    live.shared_services()
+        .metrics
+        .requests_total
+        .store(11, std::sync::atomic::Ordering::Relaxed);
+    live.shared_services()
+        .metrics
+        .requests_success
+        .store(7, std::sync::atomic::Ordering::Relaxed);
+    live.shared_services()
+        .metrics
+        .requests_failure
+        .store(4, std::sync::atomic::Ordering::Relaxed);
+    live.shared_services()
+        .metrics
+        .active_connections
+        .store(3, std::sync::atomic::Ordering::Relaxed);
+
+    let payload = json_body(QUICListener::render_control_api_runtime_snapshot(&state)).await;
+
+    assert_eq!(payload["runtime"]["generation"], 1);
+    assert_eq!(payload["runtime"]["config_path"], "reloaded.yaml");
+    assert_eq!(payload["metrics"]["requests_total"], 11);
+    assert_eq!(payload["metrics"]["requests_success"], 7);
+    assert_eq!(payload["metrics"]["requests_failure"], 4);
+    assert_eq!(payload["metrics"]["active_connections"], 3);
+
+    let listeners = payload["tls"]["listeners"]
+        .as_object()
+        .expect("listeners object");
+    assert!(
+        listeners.contains_key("127.0.0.1:9890"),
+        "runtime snapshot should render listener inventory from the active generation"
+    );
+    assert!(
+        listeners.contains_key("127.0.0.1:9889"),
+        "runtime snapshot should keep the secondary listener visible"
+    );
+    assert_eq!(
+        listeners["127.0.0.1:9890"]["client_auth_enabled"],
+        serde_json::Value::Bool(true)
+    );
+    assert_eq!(
+        listeners["127.0.0.1:9890"]["require_client_cert"],
+        serde_json::Value::Bool(true)
+    );
+
+    assert_eq!(payload["backends"]["healthy"], 1);
+    assert_eq!(payload["backends"]["total"], 1);
+    let lifecycle = payload["backends"]["lifecycle"]
+        .as_array()
+        .expect("backend lifecycle array");
+    assert_eq!(lifecycle.len(), 1);
+    let backend = &lifecycle[0];
+    assert_eq!(backend["backend"], "http://127.0.0.1:7001");
+    assert_eq!(backend["health"], "healthy");
+    assert_eq!(backend["membership"], "active");
+    assert_eq!(backend["authority_host"], "127.0.0.1");
+    assert_eq!(backend["authority_port"], 7001);
+    assert_eq!(backend["resolution_generation"], 0);
+    assert!(
+        backend.get("health_reason").is_none(),
+        "healthy rendered backends must omit optional health_reason"
+    );
+    assert_eq!(
+        backend["placements"]
+            .as_array()
+            .expect("placement array")
+            .len(),
+        1
+    );
 }
 
 // Domain: watchdog/runtime ownership alignment across reload boundaries.

--- a/crates/edge/src/quic_listener/control_plane.rs
+++ b/crates/edge/src/quic_listener/control_plane.rs
@@ -112,22 +112,7 @@ impl QUICListener {
     }
 
     fn spawn_watchdog_service(service_ctx: WatchdogServiceCtx) {
-        let spawn_state = WatchdogSpawnState {
-            service: WatchdogServiceState {
-                config: WatchdogRuntimeConfig::from(
-                    &service_ctx
-                        .runtime
-                        .runtime_config()
-                        .policies
-                        .admission
-                        .watchdog,
-                ),
-                metrics: service_ctx.runtime.metrics(),
-                resilience: service_ctx.runtime.resilience(),
-                watchdog: service_ctx.runtime.watchdog(),
-            },
-            task_registry: Arc::clone(&service_ctx.task_registry),
-        };
+        let spawn_state = Self::watchdog_spawn_state(service_ctx);
         if !spawn_state.service.is_enabled() {
             return;
         }
@@ -147,5 +132,24 @@ impl QUICListener {
             run_watchdog_service(spawn_state.service),
         );
         spawn_state.task_registry.register(registration);
+    }
+
+    pub(super) fn watchdog_spawn_state(service_ctx: WatchdogServiceCtx) -> WatchdogSpawnState {
+        WatchdogSpawnState {
+            service: WatchdogServiceState {
+                config: WatchdogRuntimeConfig::from(
+                    &service_ctx
+                        .runtime
+                        .runtime_config()
+                        .policies
+                        .admission
+                        .watchdog,
+                ),
+                metrics: service_ctx.runtime.metrics(),
+                resilience: service_ctx.runtime.resilience(),
+                watchdog: service_ctx.runtime.watchdog(),
+            },
+            task_registry: Arc::clone(&service_ctx.task_registry),
+        }
     }
 }

--- a/crates/edge/src/quic_listener/metrics/http.rs
+++ b/crates/edge/src/quic_listener/metrics/http.rs
@@ -34,3 +34,10 @@ impl QUICListener {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    // Domain anchor: metrics endpoint path and response handling contract tests
+    // live here so they stay local to the HTTP handling surface rather than
+    // drifting into listener/control-plane integration coverage.
+}

--- a/crates/edge/src/quic_listener/metrics/http.rs
+++ b/crates/edge/src/quic_listener/metrics/http.rs
@@ -1,11 +1,15 @@
 use super::*;
 
 impl QUICListener {
-    pub(super) fn handle_metrics_request(
-        req: Request<Incoming>,
+    pub(super) fn handle_metrics_request_for<B>(
+        req: &::http::Request<B>,
         metrics_path: &str,
         metrics: Arc<Metrics>,
     ) -> Response<Full<Bytes>> {
+        if *req.method() != ::http::Method::GET {
+            return Self::metrics_method_not_allowed_response();
+        }
+
         if req.uri().path() != metrics_path {
             return Self::metrics_not_found_response();
         }
@@ -13,13 +17,34 @@ impl QUICListener {
         Self::metrics_ok_response(metrics.render_prometheus())
     }
 
+    pub(super) fn handle_metrics_request(
+        req: Request<Incoming>,
+        metrics_path: &str,
+        metrics: Arc<Metrics>,
+    ) -> Response<Full<Bytes>> {
+        Self::handle_metrics_request_for(&req, metrics_path, metrics)
+    }
+
     fn metrics_not_found_response() -> Response<Full<Bytes>> {
         match Response::builder()
             .status(StatusCode::NOT_FOUND)
+            .header("content-type", "text/plain; charset=utf-8")
             .body(Full::new(Bytes::from_static(b"not found\n")))
         {
             Ok(resp) => resp,
             Err(_) => Response::new(Full::new(Bytes::from_static(b"not found\n"))),
+        }
+    }
+
+    fn metrics_method_not_allowed_response() -> Response<Full<Bytes>> {
+        match Response::builder()
+            .status(StatusCode::METHOD_NOT_ALLOWED)
+            .header("allow", "GET")
+            .header("content-type", "text/plain; charset=utf-8")
+            .body(Full::new(Bytes::from_static(b"method not allowed\n")))
+        {
+            Ok(resp) => resp,
+            Err(_) => Response::new(Full::new(Bytes::from_static(b"method not allowed\n"))),
         }
     }
 
@@ -40,4 +65,99 @@ mod tests {
     // Domain anchor: metrics endpoint path and response handling contract tests
     // live here so they stay local to the HTTP handling surface rather than
     // drifting into listener/control-plane integration coverage.
+    use ::http::{Method, Request, header};
+    use http_body_util::BodyExt;
+
+    use super::*;
+
+    fn metrics_request(method: Method, path: &str) -> Request<()> {
+        Request::builder()
+            .method(method)
+            .uri(path)
+            .body(())
+            .expect("metrics request")
+    }
+
+    async fn full_body_bytes(response: Response<Full<Bytes>>) -> Bytes {
+        response
+            .into_body()
+            .collect()
+            .await
+            .expect("collect metrics body")
+            .to_bytes()
+    }
+
+    #[tokio::test]
+    async fn metrics_endpoint_accepts_configured_metrics_path_with_stable_prometheus_response() {
+        let response = QUICListener::handle_metrics_request_for(
+            &metrics_request(Method::GET, "/metrics"),
+            "/metrics",
+            Arc::new(Metrics::default()),
+        );
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE),
+            Some(&header::HeaderValue::from_static(
+                "text/plain; version=0.0.4"
+            ))
+        );
+
+        let body = String::from_utf8(full_body_bytes(response).await.to_vec())
+            .expect("metrics response utf-8");
+        assert!(
+            body.contains("# HELP spooky_requests_total Total requests seen by spooky.\n"),
+            "metrics body should expose prometheus text for spooky_requests_total"
+        );
+        assert!(
+            body.contains("spooky_requests_total 0\n"),
+            "metrics body should include the requests counter sample"
+        );
+    }
+
+    #[tokio::test]
+    async fn metrics_endpoint_rejects_unsupported_paths_with_stable_not_found_shape() {
+        let response = QUICListener::handle_metrics_request_for(
+            &metrics_request(Method::GET, "/metrics-missing"),
+            "/metrics",
+            Arc::new(Metrics::default()),
+        );
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE),
+            Some(&header::HeaderValue::from_static(
+                "text/plain; charset=utf-8"
+            ))
+        );
+        assert_eq!(
+            full_body_bytes(response).await,
+            Bytes::from_static(b"not found\n")
+        );
+    }
+
+    #[tokio::test]
+    async fn metrics_endpoint_rejects_unsupported_methods_without_service_loop_coupling() {
+        let response = QUICListener::handle_metrics_request_for(
+            &metrics_request(Method::POST, "/metrics"),
+            "/metrics",
+            Arc::new(Metrics::default()),
+        );
+
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+        assert_eq!(
+            response.headers().get(header::ALLOW),
+            Some(&header::HeaderValue::from_static("GET"))
+        );
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE),
+            Some(&header::HeaderValue::from_static(
+                "text/plain; charset=utf-8"
+            ))
+        );
+        assert_eq!(
+            full_body_bytes(response).await,
+            Bytes::from_static(b"method not allowed\n")
+        );
+    }
 }

--- a/crates/edge/src/quic_listener/tests.rs
+++ b/crates/edge/src/quic_listener/tests.rs
@@ -46,6 +46,7 @@ use crate::{
             StreamAdmissionState, StreamPhase, TerminalReason, TimeoutReason, TunnelMode,
         },
     },
+    watchdog::config::WatchdogRuntimeConfig,
 };
 type RoutingMaps = (
     HashMap<Arc<[u8]>, Arc<[u8]>>,
@@ -549,6 +550,69 @@ fn metrics_endpoint_state_prefers_reloaded_runtime_settings() {
     assert_eq!(state.endpoint.path, "/metrics-live");
     assert_eq!(state.endpoint.max_connections, 29);
     assert_eq!(state.endpoint.connection_timeout_ms, 3456);
+}
+
+#[test]
+fn watchdog_service_state_prefers_reloaded_runtime_view_settings() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+    let startup = tls_test_config(cert.clone(), key.clone(), Vec::new());
+    let startup_runtime = RuntimeConfig::from_config(&startup).expect("startup runtime");
+    let startup_shared =
+        Arc::new(super::QUICListener::build_shared_state(&startup_runtime).expect("shared"));
+
+    let mut reloaded = startup.clone();
+    reloaded.resilience.watchdog.enabled = true;
+    reloaded.resilience.watchdog.check_interval_ms = 321;
+    reloaded.resilience.watchdog.poll_stall_timeout_ms = 654;
+    reloaded.resilience.watchdog.timeout_error_rate_percent = 42;
+    reloaded.resilience.watchdog.unhealthy_consecutive_windows = 3;
+
+    let reloaded_runtime = RuntimeConfig::from_config(&reloaded).expect("reloaded runtime");
+    let reloaded_bundle = super::QUICListener::build_runtime_bundle(
+        "reloaded.yaml".to_string(),
+        reloaded.log.clone(),
+        &reloaded_runtime,
+    )
+    .expect("reloaded bundle");
+    let runtime_handle = Arc::new(super::RuntimeBundleHandle::new(reloaded_bundle));
+    let runtime_ctx = super::runtime_state::ControlPlaneRuntimeCtx::from_runtime_sources(
+        &startup_runtime,
+        startup_shared.as_ref(),
+        Some(Arc::clone(&runtime_handle)),
+    );
+    let runtime_view = runtime_ctx.current_view();
+    let task_registry = runtime_view.generation_tasks();
+    let expected_config =
+        WatchdogRuntimeConfig::from(&reloaded_runtime.policies.admission.watchdog);
+    let expected_metrics = runtime_view.metrics();
+    let expected_resilience = runtime_view.resilience();
+    let expected_watchdog = runtime_view.watchdog();
+
+    let spawn_state = super::QUICListener::watchdog_spawn_state(
+        super::runtime_state::WatchdogServiceCtx::new(runtime_view, task_registry),
+    );
+
+    assert_eq!(spawn_state.service.config.check_interval_ms, 321);
+    assert_eq!(spawn_state.service.config.poll_stall_timeout_ms, 654);
+    assert_eq!(spawn_state.service.config.timeout_error_rate_percent, 42);
+    assert_eq!(spawn_state.service.config.unhealthy_consecutive_windows, 3);
+    assert_eq!(
+        spawn_state.service.config.restart_cooldown_ms,
+        expected_config.restart_cooldown_ms
+    );
+    assert!(
+        Arc::ptr_eq(&spawn_state.service.metrics, &expected_metrics),
+        "watchdog service should use the metrics handle from the active runtime view"
+    );
+    assert!(
+        Arc::ptr_eq(&spawn_state.service.resilience, &expected_resilience),
+        "watchdog service should use the resilience handle from the active runtime view"
+    );
+    assert!(
+        Arc::ptr_eq(&spawn_state.service.watchdog, &expected_watchdog),
+        "watchdog service should use the watchdog handle from the active runtime view"
+    );
 }
 
 #[test]

--- a/crates/edge/src/watchdog/coordinator.rs
+++ b/crates/edge/src/watchdog/coordinator.rs
@@ -166,3 +166,89 @@ fn lock_or_recover<'a, T>(mutex: &'a Mutex<T>, field: &str) -> MutexGuard<'a, T>
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_watchdog_config() -> WatchdogRuntimeConfig {
+        WatchdogRuntimeConfig {
+            enabled: true,
+            check_interval_ms: 10,
+            poll_stall_timeout_ms: 1_000,
+            timeout_error_rate_percent: 50,
+            min_requests_per_window: 1,
+            overload_inflight_percent: 90,
+            unhealthy_consecutive_windows: 2,
+            drain_grace_ms: 100,
+            restart_cooldown_ms: 60_000,
+            restart_command: vec!["true".to_string()],
+            restart_hook: None,
+        }
+    }
+
+    #[test]
+    fn restart_cycle_transitions_idle_to_pending_then_completes() {
+        let watchdog = WatchdogCoordinator::from_runtime_config(&test_watchdog_config());
+        watchdog.set_expected_workers(2);
+
+        assert!(!watchdog.restart_requested());
+        assert!(!watchdog.is_degraded());
+        assert!(!watchdog.workers_drained());
+
+        watchdog.set_degraded(true);
+        assert!(watchdog.request_restart("timeout_spike"));
+        assert!(watchdog.restart_requested());
+        assert_eq!(watchdog.restart_reason(), "timeout_spike");
+        assert!(watchdog.restart_requested_at_ms() > 0);
+        assert!(watchdog.restart_requested_elapsed_ms().is_some());
+        assert!(!watchdog.workers_drained());
+
+        watchdog.mark_worker_drained();
+        assert!(!watchdog.workers_drained());
+        watchdog.mark_worker_drained();
+        assert!(watchdog.workers_drained());
+
+        watchdog.complete_restart_cycle();
+
+        assert!(!watchdog.restart_requested());
+        assert_eq!(watchdog.restart_requested_at_ms(), 0);
+        assert!(watchdog.restart_requested_elapsed_ms().is_none());
+        assert!(!watchdog.is_degraded());
+        assert!(!watchdog.workers_drained());
+    }
+
+    #[test]
+    fn restart_request_is_idempotent_and_cooldown_blocks_immediate_followup() {
+        let watchdog = WatchdogCoordinator::from_runtime_config(&test_watchdog_config());
+
+        assert!(watchdog.request_restart("poll_stall"));
+        assert!(
+            !watchdog.request_restart("timeout_spike"),
+            "a pending restart request must not be replaced in place"
+        );
+        assert_eq!(watchdog.restart_reason(), "poll_stall");
+
+        watchdog.complete_restart_cycle();
+
+        assert!(
+            !watchdog.request_restart("timeout_spike"),
+            "cooldown should reject an immediate follow-up restart request"
+        );
+        assert!(!watchdog.restart_requested());
+    }
+
+    #[test]
+    fn mark_worker_drained_is_ignored_without_pending_restart() {
+        let watchdog = WatchdogCoordinator::from_runtime_config(&test_watchdog_config());
+        watchdog.set_expected_workers(2);
+
+        watchdog.mark_worker_drained();
+        watchdog.mark_worker_drained();
+
+        assert!(
+            !watchdog.workers_drained(),
+            "worker drain accounting should only advance while a restart is pending"
+        );
+    }
+}

--- a/crates/edge/src/watchdog/service.rs
+++ b/crates/edge/src/watchdog/service.rs
@@ -185,3 +185,152 @@ pub(crate) async fn run_watchdog_service(state: WatchdogServiceState) {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{Arc, atomic::Ordering},
+        time::Duration,
+    };
+
+    use spooky_config::config::Resilience as ResilienceConfig;
+
+    use super::*;
+    use crate::{
+        Metrics, resilience::runtime::RuntimeResilience, watchdog::coordinator::WatchdogCoordinator,
+    };
+
+    fn test_watchdog_config() -> crate::watchdog::config::WatchdogRuntimeConfig {
+        crate::watchdog::config::WatchdogRuntimeConfig {
+            enabled: true,
+            check_interval_ms: 5,
+            poll_stall_timeout_ms: 60_000,
+            timeout_error_rate_percent: 50,
+            min_requests_per_window: 1,
+            overload_inflight_percent: 100,
+            unhealthy_consecutive_windows: 2,
+            drain_grace_ms: 60_000,
+            restart_cooldown_ms: 1,
+            restart_command: vec!["true".to_string()],
+            restart_hook: None,
+        }
+    }
+
+    fn test_service_state(
+        config: crate::watchdog::config::WatchdogRuntimeConfig,
+    ) -> (
+        WatchdogServiceState,
+        Arc<Metrics>,
+        Arc<RuntimeResilience>,
+        Arc<WatchdogCoordinator>,
+    ) {
+        let metrics = Arc::new(Metrics::default());
+        let resilience = Arc::new(RuntimeResilience::from_config(
+            &ResilienceConfig::default(),
+            1,
+        ));
+        let watchdog = Arc::new(WatchdogCoordinator::from_runtime_config(&config));
+        (
+            WatchdogServiceState {
+                config,
+                metrics: Arc::clone(&metrics),
+                resilience: Arc::clone(&resilience),
+                watchdog: Arc::clone(&watchdog),
+            },
+            metrics,
+            resilience,
+            watchdog,
+        )
+    }
+
+    async fn wait_until(timeout: Duration, mut predicate: impl FnMut() -> bool, context: &str) {
+        let start = tokio::time::Instant::now();
+        while start.elapsed() < timeout {
+            if predicate() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+        panic!("timed out waiting for {context}");
+    }
+
+    #[tokio::test]
+    async fn watchdog_service_requests_restart_after_consecutive_timeout_windows() {
+        let (state, metrics, _resilience, watchdog) = test_service_state(test_watchdog_config());
+
+        let task = tokio::spawn(run_watchdog_service(state));
+        tokio::task::yield_now().await;
+
+        metrics.requests_total.store(10, Ordering::Relaxed);
+        metrics.backend_timeouts.store(6, Ordering::Relaxed);
+        wait_until(
+            Duration::from_millis(100),
+            || watchdog.is_degraded(),
+            "first degraded watchdog window",
+        )
+        .await;
+        assert!(!watchdog.restart_requested());
+
+        metrics.requests_total.store(20, Ordering::Relaxed);
+        metrics.backend_timeouts.store(12, Ordering::Relaxed);
+        wait_until(
+            Duration::from_millis(100),
+            || watchdog.restart_requested(),
+            "watchdog restart request",
+        )
+        .await;
+
+        assert_eq!(watchdog.restart_reason(), "timeout_spike");
+        assert_eq!(metrics.watchdog_degraded_windows.load(Ordering::Relaxed), 2);
+        assert_eq!(metrics.watchdog_restart_requests.load(Ordering::Relaxed), 1);
+
+        task.abort();
+        let _ = task.await;
+    }
+
+    #[tokio::test]
+    async fn watchdog_service_resets_degraded_window_progression_after_recovery() {
+        let (state, metrics, _resilience, watchdog) = test_service_state(test_watchdog_config());
+
+        let task = tokio::spawn(run_watchdog_service(state));
+        tokio::task::yield_now().await;
+
+        metrics.requests_total.store(10, Ordering::Relaxed);
+        metrics.backend_timeouts.store(6, Ordering::Relaxed);
+        wait_until(
+            Duration::from_millis(100),
+            || watchdog.is_degraded(),
+            "initial degraded watchdog window",
+        )
+        .await;
+        assert_eq!(metrics.watchdog_degraded_windows.load(Ordering::Relaxed), 1);
+
+        metrics.requests_total.store(10, Ordering::Relaxed);
+        metrics.backend_timeouts.store(6, Ordering::Relaxed);
+        wait_until(
+            Duration::from_millis(100),
+            || !watchdog.is_degraded(),
+            "watchdog recovery window",
+        )
+        .await;
+        assert!(!watchdog.restart_requested());
+
+        metrics.requests_total.store(20, Ordering::Relaxed);
+        metrics.backend_timeouts.store(12, Ordering::Relaxed);
+        wait_until(
+            Duration::from_millis(100),
+            || watchdog.is_degraded(),
+            "post-recovery degraded watchdog window",
+        )
+        .await;
+
+        assert!(
+            !watchdog.restart_requested(),
+            "a recovered healthy window should reset degraded progression before the next failure window"
+        );
+        assert_eq!(metrics.watchdog_degraded_windows.load(Ordering::Relaxed), 2);
+
+        task.abort();
+        let _ = task.await;
+    }
+}


### PR DESCRIPTION
## Summary
This PR expands and cleans up unit-level contract coverage for edge control-plane and observability surfaces.

It strengthens the guarantees around:
- canonical observability slug stability
- cross-surface reason alignment across metrics, logs, and control-plane payloads
- control-plane health reason token contracts
- readability and maintainability of the test suites themselves

## What Changed
- added broader canonical slug coverage for:
  - request outcomes
  - backend health reasons
  - retry reasons
  - hedge reasons
  - admission reasons
  - overload causes
- added explicit alignment tests to verify representative reasons map consistently across:
  - metric reason labels
  - structured log tokens
  - control-plane reason fields
- added focused control-plane renderer tests for unhealthy backend reason token alignment
- cleaned up test organization and naming so the suites read more like behavioral specs than implementation checks
- consolidated duplicate local helpers used by observability and control-plane tests

## Why
These tests lock the operator-facing vocabulary that dashboards, alerts, logs, and control-plane consumers depend on. The goal is to prevent drift in reason strings and field meanings while keeping the test surface easier to maintain as the refactored architecture stabilizes.

## Verification
- `cargo fmt`
- `cargo test -p spooky-edge --lib`
