### PR TITLE
test(edge): add end-to-end QUIC request path integration coverage

### DIFF
--- a/crates/edge/tests/request_path_harness.rs
+++ b/crates/edge/tests/request_path_harness.rs
@@ -76,9 +76,47 @@ fn configure_http_external_auth(
     harness.make_config(upstreams)
 }
 
+fn single_route_upstreams(
+    path: &str,
+    backend_id: &str,
+    backend_address: String,
+    tls: Option<UpstreamTls>,
+) -> HashMap<String, spooky_config::config::Upstream> {
+    let mut upstreams = HashMap::new();
+    upstreams.insert(
+        "api".to_string(),
+        make_upstream(
+            path,
+            vec![make_backend(backend_id, backend_address)],
+            tls,
+            "round-robin",
+        ),
+    );
+    upstreams
+}
+
+fn start_single_route_listener(
+    harness: &mut QuicRequestPathHarness,
+    path: &str,
+    backend_id: &str,
+    backend_address: String,
+    tls: Option<UpstreamTls>,
+) {
+    harness
+        .start_listener(harness.make_config(single_route_upstreams(
+            path,
+            backend_id,
+            backend_address,
+            tls,
+        )))
+        .expect("listener");
+}
+
+// Success path contracts
+
 #[test]
 #[serial]
-fn request_path_harness_supports_h1_upstream_fixture_round_trip() {
+fn quic_request_path_h1_round_trip_returns_backend_response() {
     if !local_listener_bind_available() {
         return;
     }
@@ -86,20 +124,13 @@ fn request_path_harness_supports_h1_upstream_fixture_round_trip() {
     let mut harness = QuicRequestPathHarness::new();
     let backend_addr = harness.start_h1_static_backend(b"h1 harness ok");
 
-    let mut upstreams = HashMap::new();
-    upstreams.insert(
-        "api".to_string(),
-        make_upstream(
-            "/",
-            vec![make_backend("h1-1", format!("http://{backend_addr}"))],
-            None,
-            "round-robin",
-        ),
+    start_single_route_listener(
+        &mut harness,
+        "/",
+        "h1-1",
+        format!("http://{backend_addr}"),
+        None,
     );
-
-    harness
-        .start_listener(harness.make_config(upstreams))
-        .expect("listener");
 
     let response = harness
         .run_request(H3RequestSpec::get("localhost", "/"))
@@ -110,7 +141,7 @@ fn request_path_harness_supports_h1_upstream_fixture_round_trip() {
 
 #[test]
 #[serial]
-fn request_path_harness_supports_h2_upstream_fixture_round_trip() {
+fn quic_request_path_h2_round_trip_returns_backend_response() {
     if !local_listener_bind_available() {
         return;
     }
@@ -118,24 +149,17 @@ fn request_path_harness_supports_h2_upstream_fixture_round_trip() {
     let mut harness = QuicRequestPathHarness::new();
     let backend_addr = harness.start_h2_static_backend(b"h2 harness ok");
 
-    let mut upstreams = HashMap::new();
-    upstreams.insert(
-        "api".to_string(),
-        make_upstream(
-            "/",
-            vec![make_backend("h2-1", format!("https://{backend_addr}"))],
-            Some(UpstreamTls {
-                verify_certificates: false,
-                strict_sni: false,
-                ..UpstreamTls::default()
-            }),
-            "round-robin",
-        ),
+    start_single_route_listener(
+        &mut harness,
+        "/",
+        "h2-1",
+        format!("https://{backend_addr}"),
+        Some(UpstreamTls {
+            verify_certificates: false,
+            strict_sni: false,
+            ..UpstreamTls::default()
+        }),
     );
-
-    harness
-        .start_listener(harness.make_config(upstreams))
-        .expect("listener");
 
     let response = harness
         .run_request(H3RequestSpec::get("localhost", "/"))
@@ -264,20 +288,13 @@ fn quic_to_h1_success_path_streams_response_body_to_completion() {
     let mut harness = QuicRequestPathHarness::new();
     let backend_addr = harness.start_h1_chunked_backend(vec![b"chunk-1:", b"chunk-2:", b"chunk-3"]);
 
-    let mut upstreams = HashMap::new();
-    upstreams.insert(
-        "api".to_string(),
-        make_upstream(
-            "/stream",
-            vec![make_backend("h1-stream", format!("http://{backend_addr}"))],
-            None,
-            "round-robin",
-        ),
+    start_single_route_listener(
+        &mut harness,
+        "/stream",
+        "h1-stream",
+        format!("http://{backend_addr}"),
+        None,
     );
-
-    harness
-        .start_listener(harness.make_config(upstreams))
-        .expect("listener");
 
     let response = harness
         .run_request(H3RequestSpec::get("stream.example.com", "/stream"))
@@ -414,24 +431,17 @@ fn quic_to_h2_success_path_streams_response_body_to_completion() {
     let backend_addr =
         harness.start_h2_streaming_backend(vec![b"h2-chunk-1:", b"h2-chunk-2:", b"h2-chunk-3"]);
 
-    let mut upstreams = HashMap::new();
-    upstreams.insert(
-        "api".to_string(),
-        make_upstream(
-            "/stream-h2",
-            vec![make_backend("h2-stream", format!("https://{backend_addr}"))],
-            Some(UpstreamTls {
-                verify_certificates: false,
-                strict_sni: false,
-                ..UpstreamTls::default()
-            }),
-            "round-robin",
-        ),
+    start_single_route_listener(
+        &mut harness,
+        "/stream-h2",
+        "h2-stream",
+        format!("https://{backend_addr}"),
+        Some(UpstreamTls {
+            verify_certificates: false,
+            strict_sni: false,
+            ..UpstreamTls::default()
+        }),
     );
-
-    harness
-        .start_listener(harness.make_config(upstreams))
-        .expect("listener");
 
     let response = harness
         .run_request(H3RequestSpec::get("stream.example.com", "/stream-h2"))
@@ -439,6 +449,8 @@ fn quic_to_h2_success_path_streams_response_body_to_completion() {
     response.assert_status(200);
     response.assert_body_text("h2-chunk-1:h2-chunk-2:h2-chunk-3");
 }
+
+// Rejection path contracts
 
 #[test]
 #[serial]
@@ -979,6 +991,8 @@ fn quic_request_path_external_auth_timeout_fail_open_allows_backend() {
     assert_eq!(backend_calls.load(Ordering::Relaxed), 1);
 }
 
+// Upstream failure contracts
+
 #[test]
 #[serial]
 fn quic_request_path_backend_timeout_maps_to_upstream_timeout() {
@@ -1106,6 +1120,8 @@ fn quic_request_path_malformed_upstream_response_maps_to_upstream_error() {
         "expected canonical malformed upstream response failure body"
     );
 }
+
+// Body and stream guardrail contracts
 
 #[test]
 #[serial]
@@ -1285,6 +1301,8 @@ fn quic_request_path_slow_response_body_before_first_chunk_returns_timeout() {
         "expected canonical upstream timeout body for stalled response body stream"
     );
 }
+
+// Observable outcome parity contracts
 
 #[test]
 #[serial]

--- a/crates/edge/tests/request_path_harness.rs
+++ b/crates/edge/tests/request_path_harness.rs
@@ -34,6 +34,18 @@ fn response_line(body: &str, prefix: &str) -> String {
         .unwrap_or_else(|| panic!("missing response line with prefix `{prefix}` in body: {body}"))
 }
 
+fn metrics_counter(metrics: &str, prefix: &str) -> u64 {
+    metrics
+        .lines()
+        .find_map(|line| line.strip_prefix(prefix))
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or_else(|| panic!("missing metrics counter `{prefix}` in metrics:\n{metrics}"))
+}
+
+fn metrics_delta(before: &str, after: &str, prefix: &str) -> u64 {
+    metrics_counter(after, prefix).saturating_sub(metrics_counter(before, prefix))
+}
+
 fn configure_http_external_auth(
     harness: &QuicRequestPathHarness,
     backend_address: String,
@@ -1271,5 +1283,409 @@ fn quic_request_path_slow_response_body_before_first_chunk_returns_timeout() {
     assert!(
         response.body_text().contains("upstream timeout"),
         "expected canonical upstream timeout body for stalled response body stream"
+    );
+}
+
+#[test]
+#[serial]
+fn quic_request_path_success_outcome_records_success_bucket() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = QuicRequestPathHarness::new();
+    let backend_addr = harness.start_h1_static_backend(b"ok");
+
+    let mut upstreams = HashMap::new();
+    upstreams.insert(
+        "api".to_string(),
+        make_upstream(
+            "/metrics-success",
+            vec![make_backend("h1-success", format!("http://{backend_addr}"))],
+            None,
+            "round-robin",
+        ),
+    );
+
+    harness
+        .start_listener(harness.make_config(upstreams))
+        .expect("listener");
+    let before = harness
+        .metrics_text()
+        .expect("metrics snapshot before request");
+
+    let response = harness
+        .run_request(H3RequestSpec::get("localhost", "/metrics-success"))
+        .expect("success request should complete");
+    response.assert_status(200);
+
+    let after = harness
+        .metrics_text()
+        .expect("metrics snapshot after request");
+    assert!(
+        metrics_delta(&before, &after, "spooky_requests_success ") > 0,
+        "success request should increment success counter"
+    );
+    assert_eq!(
+        metrics_delta(&before, &after, "spooky_requests_failure "),
+        0
+    );
+    assert!(
+        metrics_delta(
+            &before,
+            &after,
+            "spooky_route_requests_total{route=\"api\"} "
+        ) > 0,
+        "success request should increment route request counter"
+    );
+    assert!(
+        metrics_delta(
+            &before,
+            &after,
+            "spooky_route_success_total{route=\"api\"} "
+        ) > 0,
+        "success request should increment route success counter"
+    );
+    assert_eq!(
+        metrics_delta(
+            &before,
+            &after,
+            "spooky_route_failure_total{route=\"api\"} "
+        ),
+        0
+    );
+    assert_eq!(
+        metrics_delta(
+            &before,
+            &after,
+            "spooky_route_timeout_total{route=\"api\"} "
+        ),
+        0
+    );
+}
+
+#[test]
+#[serial]
+fn quic_request_path_timeout_outcome_records_timeout_bucket() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = QuicRequestPathHarness::new();
+    let backend_addr = harness.start_h1_backend(|_req: hyper::Request<Incoming>| async move {
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        Ok::<_, std::convert::Infallible>(Response::new(Full::new(Bytes::from_static(b"late"))))
+    });
+
+    let mut upstreams = HashMap::new();
+    upstreams.insert(
+        "api".to_string(),
+        make_upstream(
+            "/metrics-timeout",
+            vec![make_backend("h1-timeout", format!("http://{backend_addr}"))],
+            None,
+            "round-robin",
+        ),
+    );
+
+    let mut config = harness.make_config(upstreams);
+    config.performance.backend_timeout_ms = 150;
+    config.performance.backend_connect_timeout_ms = 150;
+    harness.start_listener(config).expect("listener");
+    let before = harness
+        .metrics_text()
+        .expect("metrics snapshot before request");
+
+    let response = harness
+        .run_request(H3RequestSpec::get("localhost", "/metrics-timeout"))
+        .expect("timeout request should complete");
+    response.assert_status(503);
+    assert!(response.body_text().contains("upstream timeout"));
+
+    let after = harness
+        .metrics_text()
+        .expect("metrics snapshot after request");
+    assert!(
+        metrics_delta(&before, &after, "spooky_backend_timeouts ") > 0,
+        "timeout request should increment backend timeout counter"
+    );
+    assert!(
+        metrics_delta(&before, &after, "spooky_requests_failure ") > 0,
+        "timeout request should increment failure counter"
+    );
+    assert!(
+        metrics_delta(
+            &before,
+            &after,
+            "spooky_route_timeout_total{route=\"api\"} "
+        ) > 0,
+        "timeout request should increment timeout bucket"
+    );
+    assert_eq!(
+        metrics_delta(
+            &before,
+            &after,
+            "spooky_route_success_total{route=\"api\"} "
+        ),
+        0
+    );
+}
+
+#[test]
+#[serial]
+fn quic_request_path_failure_outcome_records_failure_bucket() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = QuicRequestPathHarness::new();
+    let unused_listener = TcpListener::bind("127.0.0.1:0").expect("bind unused backend port");
+    let unused_addr = unused_listener.local_addr().expect("unused backend addr");
+    drop(unused_listener);
+
+    let mut upstreams = HashMap::new();
+    upstreams.insert(
+        "api".to_string(),
+        make_upstream(
+            "/metrics-failure",
+            vec![make_backend("h1-failure", format!("http://{unused_addr}"))],
+            None,
+            "round-robin",
+        ),
+    );
+
+    let mut config = harness.make_config(upstreams);
+    config.performance.backend_timeout_ms = 150;
+    config.performance.backend_connect_timeout_ms = 150;
+    harness.start_listener(config).expect("listener");
+    let before = harness
+        .metrics_text()
+        .expect("metrics snapshot before request");
+
+    let response = harness
+        .run_request(H3RequestSpec::get("localhost", "/metrics-failure"))
+        .expect("failure request should complete");
+    response.assert_status(502);
+    assert!(response.body_text().contains("upstream error"));
+
+    let after = harness
+        .metrics_text()
+        .expect("metrics snapshot after request");
+    assert!(
+        metrics_delta(&before, &after, "spooky_backend_errors ") > 0,
+        "upstream failure should increment backend error counter"
+    );
+    assert!(
+        metrics_delta(&before, &after, "spooky_requests_failure ") > 0,
+        "upstream failure should increment failure counter"
+    );
+    assert!(
+        metrics_delta(
+            &before,
+            &after,
+            "spooky_route_failure_total{route=\"api\"} "
+        ) > 0,
+        "upstream failure should increment failure bucket"
+    );
+    assert_eq!(
+        metrics_delta(
+            &before,
+            &after,
+            "spooky_route_timeout_total{route=\"api\"} "
+        ),
+        0
+    );
+    assert_eq!(
+        metrics_delta(
+            &before,
+            &after,
+            "spooky_route_overload_shed_total{route=\"api\"} "
+        ),
+        0
+    );
+}
+
+#[test]
+#[serial]
+fn quic_request_path_rate_limit_outcome_records_rate_limited_bucket() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = QuicRequestPathHarness::new();
+    let backend_addr = harness.start_h1_static_backend(b"rate-limit ok");
+
+    let mut upstreams = HashMap::new();
+    upstreams.insert(
+        "api".to_string(),
+        make_upstream(
+            "/metrics-rate-limit",
+            vec![make_backend(
+                "h1-rate-limit",
+                format!("http://{backend_addr}"),
+            )],
+            None,
+            "round-robin",
+        ),
+    );
+
+    let mut config = harness.make_config(upstreams);
+    config.resilience.scoped_rate_limits = vec![ScopedRateLimit {
+        name: "route-cap".to_string(),
+        scope: ScopedRateLimitScope::Route,
+        requests_per_sec: 1,
+        burst: 1,
+        key: None,
+        route_allowlist: vec!["api".to_string()],
+        idle_ttl_secs: 300,
+    }];
+    harness.start_listener(config).expect("listener");
+    let before = harness
+        .metrics_text()
+        .expect("metrics snapshot before requests");
+
+    let first = harness
+        .run_request(H3RequestSpec::get("localhost", "/metrics-rate-limit"))
+        .expect("first request should complete");
+    first.assert_status(200);
+
+    let second = harness
+        .run_request(H3RequestSpec::get("localhost", "/metrics-rate-limit"))
+        .expect("rate-limited request should complete");
+    second.assert_status(429);
+
+    let after = harness
+        .metrics_text()
+        .expect("metrics snapshot after requests");
+    assert!(
+        metrics_delta(&before, &after, "spooky_request_rate_limited ") > 0,
+        "rate-limited request should increment rate-limit counter"
+    );
+    assert!(
+        metrics_delta(
+            &before,
+            &after,
+            "spooky_route_rate_limited_total{route=\"api\"} "
+        ) > 0,
+        "rate-limited request should increment route rate-limit bucket"
+    );
+    assert!(
+        metrics_delta(&before, &after, "spooky_requests_success ") > 0,
+        "admitted request should increment success counter"
+    );
+    assert!(
+        metrics_delta(&before, &after, "spooky_requests_failure ") > 0,
+        "rate-limited request should increment failure counter"
+    );
+    assert_eq!(
+        metrics_delta(
+            &before,
+            &after,
+            "spooky_route_overload_shed_total{route=\"api\"} "
+        ),
+        0
+    );
+}
+
+#[test]
+#[serial]
+fn quic_request_path_overload_outcome_records_overload_bucket() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = QuicRequestPathHarness::new();
+    let backend_addr = harness.start_h1_backend(|_req: hyper::Request<Incoming>| async move {
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        Ok::<_, std::convert::Infallible>(Response::new(Full::new(Bytes::from_static(b"slow ok"))))
+    });
+
+    let mut upstreams = HashMap::new();
+    upstreams.insert(
+        "api".to_string(),
+        make_upstream(
+            "/metrics-overload",
+            vec![make_backend(
+                "h1-overload",
+                format!("http://{backend_addr}"),
+            )],
+            None,
+            "round-robin",
+        ),
+    );
+
+    let mut config = harness.make_config(upstreams);
+    config.performance.global_inflight_limit = 64;
+    config.performance.per_upstream_inflight_limit = 1;
+    let listen_addr = harness.start_listener(config).expect("listener");
+    let before = harness
+        .metrics_text()
+        .expect("metrics snapshot before requests");
+    let barrier = Arc::new(Barrier::new(2));
+
+    let responses = thread::scope(|scope| {
+        let first_barrier = Arc::clone(&barrier);
+        let first = scope.spawn(move || {
+            first_barrier.wait();
+            run_request_to(
+                listen_addr,
+                H3RequestSpec::get("localhost", "/metrics-overload"),
+            )
+        });
+
+        let second_barrier = Arc::clone(&barrier);
+        let second = scope.spawn(move || {
+            second_barrier.wait();
+            run_request_to(
+                listen_addr,
+                H3RequestSpec::get("localhost", "/metrics-overload"),
+            )
+        });
+
+        [
+            first.join().expect("first request thread"),
+            second.join().expect("second request thread"),
+        ]
+    });
+
+    let mut saw_success = false;
+    let mut saw_overload = false;
+    for response in responses {
+        let response = response.expect("concurrent request should complete");
+        match response.status {
+            200 => saw_success = true,
+            503 => saw_overload = true,
+            other => panic!("unexpected status in overload metrics test: {other}"),
+        }
+    }
+    assert!(saw_success, "expected one successful request");
+    assert!(saw_overload, "expected one overload-shed request");
+
+    let after = harness
+        .metrics_text()
+        .expect("metrics snapshot after requests");
+    assert!(
+        metrics_delta(
+            &before,
+            &after,
+            "spooky_route_overload_shed_total{route=\"api\"} "
+        ) > 0,
+        "overload request should increment route overload bucket"
+    );
+    assert!(
+        metrics_delta(&before, &after, "spooky_requests_success ") > 0,
+        "one admitted request should increment success counter"
+    );
+    assert!(
+        metrics_delta(&before, &after, "spooky_requests_failure ") > 0,
+        "one shed request should increment failure counter"
+    );
+    assert_eq!(
+        metrics_delta(
+            &before,
+            &after,
+            "spooky_route_rate_limited_total{route=\"api\"} "
+        ),
+        0
     );
 }

--- a/crates/edge/tests/request_path_harness.rs
+++ b/crates/edge/tests/request_path_harness.rs
@@ -1,5 +1,8 @@
 use std::collections::HashMap;
 
+use bytes::Bytes;
+use http_body_util::{BodyExt, Full};
+use hyper::{Response, body::Incoming};
 use serial_test::serial;
 use spooky_config::config::UpstreamTls;
 
@@ -9,6 +12,12 @@ use support::{
     net::local_listener_bind_available,
     request_path::{H3RequestSpec, QuicRequestPathHarness, make_backend, make_upstream},
 };
+
+fn response_line(body: &str, prefix: &str) -> String {
+    body.lines()
+        .find_map(|line| line.strip_prefix(prefix).map(str::to_string))
+        .unwrap_or_else(|| panic!("missing response line with prefix `{prefix}` in body: {body}"))
+}
 
 #[test]
 #[serial]
@@ -76,4 +85,146 @@ fn request_path_harness_supports_h2_upstream_fixture_round_trip() {
         .expect("h3 request");
     response.assert_status(200);
     response.assert_body_text("h2 harness ok");
+}
+
+#[test]
+#[serial]
+fn quic_to_h1_success_path_normalizes_headers_and_keeps_get_bodyless() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = QuicRequestPathHarness::new();
+    let backend_addr = harness.start_h1_backend(|req: hyper::Request<Incoming>| async move {
+        let header_value = |name: &str| {
+            req.headers()
+                .get(name)
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or("<missing>")
+                .to_string()
+        };
+        let method = req.method().to_string();
+        let path = req.uri().path().to_string();
+        let host = header_value("host");
+        let forwarded = header_value("forwarded");
+        let xff = header_value("x-forwarded-for");
+        let xfp = header_value("x-forwarded-proto");
+        let xfh = header_value("x-forwarded-host");
+        let user_agent = header_value("user-agent");
+        let request_id = header_value("x-request-id");
+        let content_length = req
+            .headers()
+            .get("content-length")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or("<missing>")
+            .to_string();
+        let has_connection = req.headers().contains_key("connection");
+        let body = req
+            .into_body()
+            .collect()
+            .await
+            .expect("collect request body")
+            .to_bytes();
+        let body = format!(
+            "method={method}\npath={path}\nhost={}\nforwarded={}\nxff={}\nxfp={}\nxfh={}\nuser_agent={}\nx_request_id={}\ncontent_length={content_length}\nbody_len={}\nhas_connection={}\n",
+            host,
+            forwarded,
+            xff,
+            xfp,
+            xfh,
+            user_agent,
+            request_id,
+            body.len(),
+            has_connection,
+        );
+        Ok::<_, std::convert::Infallible>(Response::new(Full::new(Bytes::from(body))))
+    });
+
+    let mut upstreams = HashMap::new();
+    upstreams.insert(
+        "api".to_string(),
+        make_upstream(
+            "/headers",
+            vec![make_backend("h1-headers", format!("http://{backend_addr}"))],
+            None,
+            "round-robin",
+        ),
+    );
+
+    harness
+        .start_listener(harness.make_config(upstreams))
+        .expect("listener");
+
+    let response = harness
+        .run_request(H3RequestSpec {
+            method: "GET",
+            authority: "public.example.com",
+            path: "/headers",
+            headers: &[
+                ("forwarded", "for=1.2.3.4;proto=http;host=\"evil.example\""),
+                ("x-forwarded-for", "1.2.3.4"),
+                ("x-forwarded-proto", "http"),
+                ("x-forwarded-host", "evil.example"),
+                ("connection", "keep-alive, x-secret"),
+                ("x-secret", "strip-me"),
+            ],
+            body: None,
+            user_agent: "spooky-success-h1",
+        })
+        .expect("h3 request");
+
+    response.assert_status(200);
+    let body = response.body_text();
+    assert_eq!(response_line(&body, "method="), "GET");
+    assert_eq!(response_line(&body, "path="), "/headers");
+    assert_eq!(response_line(&body, "host="), "public.example.com");
+    assert_eq!(
+        response_line(&body, "forwarded="),
+        "for=127.0.0.1;proto=https;host=\"public.example.com\""
+    );
+    assert_eq!(response_line(&body, "xff="), "127.0.0.1");
+    assert_eq!(response_line(&body, "xfp="), "https");
+    assert_eq!(response_line(&body, "xfh="), "public.example.com");
+    assert_eq!(response_line(&body, "user_agent="), "spooky-success-h1");
+    assert_eq!(response_line(&body, "content_length="), "<missing>");
+    assert_eq!(response_line(&body, "body_len="), "0");
+    assert_eq!(response_line(&body, "has_connection="), "false");
+
+    let request_id = response_line(&body, "x_request_id=");
+    assert!(
+        !request_id.is_empty() && request_id.chars().all(|ch| ch.is_ascii_digit()),
+        "x-request-id should be a generated numeric request identifier, got `{request_id}`"
+    );
+}
+
+#[test]
+#[serial]
+fn quic_to_h1_success_path_streams_response_body_to_completion() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = QuicRequestPathHarness::new();
+    let backend_addr = harness.start_h1_chunked_backend(vec![b"chunk-1:", b"chunk-2:", b"chunk-3"]);
+
+    let mut upstreams = HashMap::new();
+    upstreams.insert(
+        "api".to_string(),
+        make_upstream(
+            "/stream",
+            vec![make_backend("h1-stream", format!("http://{backend_addr}"))],
+            None,
+            "round-robin",
+        ),
+    );
+
+    harness
+        .start_listener(harness.make_config(upstreams))
+        .expect("listener");
+
+    let response = harness
+        .run_request(H3RequestSpec::get("stream.example.com", "/stream"))
+        .expect("h3 request");
+    response.assert_status(200);
+    response.assert_body_text("chunk-1:chunk-2:chunk-3");
 }

--- a/crates/edge/tests/request_path_harness.rs
+++ b/crates/edge/tests/request_path_harness.rs
@@ -24,6 +24,7 @@ use support::{
     net::local_listener_bind_available,
     request_path::{
         H3RequestSpec, QuicRequestPathHarness, make_backend, make_upstream, run_request_to,
+        run_two_chunk_post_to,
     },
 };
 
@@ -1091,5 +1092,184 @@ fn quic_request_path_malformed_upstream_response_maps_to_upstream_error() {
     assert!(
         response.body_text().contains("upstream error"),
         "expected canonical malformed upstream response failure body"
+    );
+}
+
+#[test]
+#[serial]
+fn quic_request_path_request_body_too_large_returns_413() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = QuicRequestPathHarness::new();
+    let backend_addr = harness.start_h1_static_backend(b"backend upload");
+
+    let mut upstreams = HashMap::new();
+    upstreams.insert(
+        "api".to_string(),
+        make_upstream(
+            "/upload",
+            vec![make_backend("h1-upload", format!("http://{backend_addr}"))],
+            None,
+            "round-robin",
+        ),
+    );
+
+    let mut config = harness.make_config(upstreams);
+    config.performance.max_request_body_bytes = 1024;
+    let listen_addr = harness.start_listener(config).expect("listener");
+
+    let (response, got_reset) = run_two_chunk_post_to(
+        listen_addr,
+        "localhost",
+        "/upload",
+        vec![0u8; 600],
+        vec![0u8; 600],
+        Duration::ZERO,
+    )
+    .expect("oversized request should complete");
+
+    response.assert_status(413);
+    assert!(
+        response.body_text().contains("request body too large"),
+        "expected canonical request-body-too-large response body"
+    );
+    assert!(
+        !got_reset,
+        "oversized request should terminate with HTTP response"
+    );
+}
+
+#[test]
+#[serial]
+fn quic_request_path_stalled_request_body_producer_returns_408() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = QuicRequestPathHarness::new();
+    let backend_addr = harness.start_h1_static_backend(b"unexpected backend call");
+
+    let mut upstreams = HashMap::new();
+    upstreams.insert(
+        "api".to_string(),
+        make_upstream(
+            "/upload-idle",
+            vec![make_backend(
+                "h1-upload-idle",
+                format!("http://{backend_addr}"),
+            )],
+            None,
+            "round-robin",
+        ),
+    );
+
+    let mut config = harness.make_config(upstreams);
+    config.performance.client_body_idle_timeout_ms = 120;
+    config.performance.backend_body_total_timeout_ms = 10_000;
+    config.performance.backend_total_request_timeout_ms = 10_000;
+    let listen_addr = harness.start_listener(config).expect("listener");
+
+    let (response, got_reset) = run_two_chunk_post_to(
+        listen_addr,
+        "localhost",
+        "/upload-idle",
+        vec![0u8; 512],
+        vec![0u8; 512],
+        Duration::from_millis(250),
+    )
+    .expect("slow request producer should complete");
+
+    response.assert_status(408);
+    assert!(
+        response.body_text().contains("request body idle timeout"),
+        "expected canonical request body idle-timeout response body"
+    );
+    assert!(
+        !got_reset,
+        "request body idle timeout should return HTTP response, not reset"
+    );
+}
+
+#[test]
+#[serial]
+fn quic_request_path_unknown_length_response_prebuffer_cap_returns_503() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = QuicRequestPathHarness::new();
+    let backend_addr = harness.start_h1_chunked_backend(vec![b"chunk-1", b"chunk-2"]);
+
+    let mut upstreams = HashMap::new();
+    upstreams.insert(
+        "api".to_string(),
+        make_upstream(
+            "/long-stream",
+            vec![make_backend(
+                "h1-long-stream",
+                format!("http://{backend_addr}"),
+            )],
+            None,
+            "round-robin",
+        ),
+    );
+
+    let mut config = harness.make_config(upstreams);
+    config.performance.max_response_body_bytes = 64 * 1024;
+    config.performance.unknown_length_response_prebuffer_bytes = 8;
+    harness.start_listener(config).expect("listener");
+
+    let response = harness
+        .run_request(H3RequestSpec::get("localhost", "/long-stream"))
+        .expect("unknown-length response cap request should complete");
+
+    response.assert_status(503);
+    response.assert_body_text("upstream response body too large\n");
+}
+
+#[test]
+#[serial]
+fn quic_request_path_slow_response_body_before_first_chunk_returns_timeout() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = QuicRequestPathHarness::new();
+    let backend_addr = harness.start_h1_delayed_chunked_backend(vec![
+        (b"chunk-1".to_vec(), Duration::from_millis(250)),
+        (b"chunk-2".to_vec(), Duration::ZERO),
+    ]);
+
+    let mut upstreams = HashMap::new();
+    upstreams.insert(
+        "api".to_string(),
+        make_upstream(
+            "/slow-stream",
+            vec![make_backend(
+                "h1-slow-stream",
+                format!("http://{backend_addr}"),
+            )],
+            None,
+            "round-robin",
+        ),
+    );
+
+    let mut config = harness.make_config(upstreams);
+    config.performance.backend_timeout_ms = 100;
+    config.performance.backend_connect_timeout_ms = 100;
+    config.performance.backend_body_total_timeout_ms = 5_000;
+    config.performance.backend_body_idle_timeout_ms = 120;
+    harness.start_listener(config).expect("listener");
+
+    let response = harness
+        .run_request(H3RequestSpec::get("localhost", "/slow-stream"))
+        .expect("slow response stream request should complete");
+
+    response.assert_status(503);
+    assert!(
+        response.body_text().contains("upstream timeout"),
+        "expected canonical upstream timeout body for stalled response body stream"
     );
 }

--- a/crates/edge/tests/request_path_harness.rs
+++ b/crates/edge/tests/request_path_harness.rs
@@ -13,7 +13,8 @@ use http_body_util::{BodyExt, Full};
 use hyper::{Response, body::Incoming};
 use serial_test::serial;
 use spooky_config::config::{
-    ApiKeyAuth, RouteAuth, ScopedRateLimit, ScopedRateLimitScope, UpstreamTls,
+    ApiKeyAuth, ExternalAuth, ExternalAuthFailureMode, ExternalAuthRequestHeader, RouteAuth,
+    ScopedRateLimit, ScopedRateLimitScope, UpstreamTls,
 };
 
 mod support;
@@ -29,6 +30,36 @@ fn response_line(body: &str, prefix: &str) -> String {
     body.lines()
         .find_map(|line| line.strip_prefix(prefix).map(str::to_string))
         .unwrap_or_else(|| panic!("missing response line with prefix `{prefix}` in body: {body}"))
+}
+
+fn configure_http_external_auth(
+    harness: &QuicRequestPathHarness,
+    backend_address: String,
+    auth_endpoint: String,
+    timeout_ms: u64,
+    failure_mode: ExternalAuthFailureMode,
+    response_header_allowlist: Vec<String>,
+) -> spooky_config::config::Config {
+    let mut upstream = make_upstream(
+        "/auth",
+        vec![make_backend("auth-backend", backend_address)],
+        None,
+        "round-robin",
+    );
+    upstream.auth.external_auth = Some(ExternalAuth::Http {
+        endpoint: auth_endpoint,
+        request_headers: vec![ExternalAuthRequestHeader {
+            name: "x-auth-static".to_string(),
+            value: "1".to_string(),
+        }],
+        response_header_allowlist,
+        timeout_ms,
+        failure_mode,
+    });
+
+    let mut upstreams = HashMap::new();
+    upstreams.insert("api".to_string(), upstream);
+    harness.make_config(upstreams)
 }
 
 #[test]
@@ -604,4 +635,332 @@ fn quic_request_path_upstream_overload_sheds_before_second_upstream_dispatch() {
         1,
         "upstream overload rejection must happen before the second request reaches the backend"
     );
+}
+
+#[test]
+#[serial]
+fn quic_request_path_external_auth_allow_injects_headers_before_forwarding() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = QuicRequestPathHarness::new();
+    let backend_calls = Arc::new(AtomicUsize::new(0));
+    let backend_observed = Arc::clone(&backend_calls);
+    let backend_addr = harness.start_h1_backend(move |req: hyper::Request<Incoming>| {
+        let backend_observed = Arc::clone(&backend_observed);
+        async move {
+            backend_observed.fetch_add(1, Ordering::Relaxed);
+            let user = req
+                .headers()
+                .get("x-user-id")
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or("missing")
+                .to_string();
+            Ok::<_, std::convert::Infallible>(Response::new(Full::new(Bytes::from(format!(
+                "backend user={user}"
+            )))))
+        }
+    });
+
+    let auth_calls = Arc::new(AtomicUsize::new(0));
+    let auth_observed = Arc::clone(&auth_calls);
+    let auth_addr = harness.start_h1_backend(move |req: hyper::Request<Incoming>| {
+        let auth_observed = Arc::clone(&auth_observed);
+        async move {
+            auth_observed.fetch_add(1, Ordering::Relaxed);
+            assert_eq!(req.uri().path(), "/check");
+            assert_eq!(req.method(), hyper::Method::GET);
+            assert_eq!(
+                req.headers()
+                    .get("x-spooky-original-method")
+                    .and_then(|value| value.to_str().ok()),
+                Some("GET")
+            );
+            assert_eq!(
+                req.headers()
+                    .get("x-auth-static")
+                    .and_then(|value| value.to_str().ok()),
+                Some("1")
+            );
+            Ok::<_, std::convert::Infallible>(
+                Response::builder()
+                    .status(hyper::StatusCode::NO_CONTENT)
+                    .header("x-user-id", "alice")
+                    .body(Full::new(Bytes::new()))
+                    .expect("auth allow response"),
+            )
+        }
+    });
+
+    let config = configure_http_external_auth(
+        &harness,
+        format!("http://{backend_addr}"),
+        format!("http://{auth_addr}/check"),
+        250,
+        ExternalAuthFailureMode::FailClosed,
+        vec!["x-user-id".to_string()],
+    );
+
+    harness.start_listener(config).expect("listener");
+
+    let response = harness
+        .run_request(H3RequestSpec::get("localhost", "/auth"))
+        .expect("allow request should complete");
+    response.assert_status(200);
+    response.assert_body_text("backend user=alice");
+    assert_eq!(auth_calls.load(Ordering::Relaxed), 1);
+    assert_eq!(backend_calls.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+#[serial]
+fn quic_request_path_external_auth_deny_returns_canonical_denial_without_forwarding() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = QuicRequestPathHarness::new();
+    let backend_calls = Arc::new(AtomicUsize::new(0));
+    let backend_observed = Arc::clone(&backend_calls);
+    let backend_addr = harness.start_h1_backend(move |_req: hyper::Request<Incoming>| {
+        let backend_observed = Arc::clone(&backend_observed);
+        async move {
+            backend_observed.fetch_add(1, Ordering::Relaxed);
+            Ok::<_, std::convert::Infallible>(Response::new(Full::new(Bytes::from_static(
+                b"unexpected backend call",
+            ))))
+        }
+    });
+
+    let auth_addr = harness.start_h1_backend(|_req: hyper::Request<Incoming>| async move {
+        Ok::<_, std::convert::Infallible>(
+            Response::builder()
+                .status(hyper::StatusCode::FORBIDDEN)
+                .header("x-auth-reason", "policy")
+                .body(Full::new(Bytes::from_static(b"denied by auth")))
+                .expect("auth deny response"),
+        )
+    });
+
+    let config = configure_http_external_auth(
+        &harness,
+        format!("http://{backend_addr}"),
+        format!("http://{auth_addr}/check"),
+        250,
+        ExternalAuthFailureMode::FailClosed,
+        vec!["x-auth-reason".to_string()],
+    );
+
+    harness.start_listener(config).expect("listener");
+
+    let response = harness
+        .run_request(H3RequestSpec::get("localhost", "/auth"))
+        .expect("deny request should complete");
+    response.assert_status(403);
+    assert_eq!(response.header("x-auth-reason"), Some("policy"));
+    assert!(
+        response.body_text().contains("denied by auth"),
+        "expected canonical auth denial body"
+    );
+    assert_eq!(backend_calls.load(Ordering::Relaxed), 0);
+}
+
+#[test]
+#[serial]
+fn quic_request_path_external_auth_challenge_preserves_www_authenticate() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = QuicRequestPathHarness::new();
+    let backend_calls = Arc::new(AtomicUsize::new(0));
+    let backend_observed = Arc::clone(&backend_calls);
+    let backend_addr = harness.start_h1_backend(move |_req: hyper::Request<Incoming>| {
+        let backend_observed = Arc::clone(&backend_observed);
+        async move {
+            backend_observed.fetch_add(1, Ordering::Relaxed);
+            Ok::<_, std::convert::Infallible>(Response::new(Full::new(Bytes::from_static(
+                b"unexpected backend call",
+            ))))
+        }
+    });
+
+    let auth_addr = harness.start_h1_backend(|_req: hyper::Request<Incoming>| async move {
+        Ok::<_, std::convert::Infallible>(
+            Response::builder()
+                .status(hyper::StatusCode::UNAUTHORIZED)
+                .header("www-authenticate", "Bearer realm=\"spooky\"")
+                .header("x-auth-reason", "expired")
+                .body(Full::new(Bytes::from_static(b"token expired")))
+                .expect("auth challenge response"),
+        )
+    });
+
+    let config = configure_http_external_auth(
+        &harness,
+        format!("http://{backend_addr}"),
+        format!("http://{auth_addr}/check"),
+        250,
+        ExternalAuthFailureMode::FailClosed,
+        vec!["x-auth-reason".to_string()],
+    );
+
+    harness.start_listener(config).expect("listener");
+
+    let response = harness
+        .run_request(H3RequestSpec::get("localhost", "/auth"))
+        .expect("challenge request should complete");
+    response.assert_status(401);
+    assert_eq!(
+        response.header("www-authenticate"),
+        Some("Bearer realm=\"spooky\"")
+    );
+    assert_eq!(response.header("x-auth-reason"), Some("expired"));
+    assert!(response.body_text().contains("token expired"));
+    assert_eq!(backend_calls.load(Ordering::Relaxed), 0);
+}
+
+#[test]
+#[serial]
+fn quic_request_path_external_auth_redirect_preserves_location() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = QuicRequestPathHarness::new();
+    let backend_calls = Arc::new(AtomicUsize::new(0));
+    let backend_observed = Arc::clone(&backend_calls);
+    let backend_addr = harness.start_h1_backend(move |_req: hyper::Request<Incoming>| {
+        let backend_observed = Arc::clone(&backend_observed);
+        async move {
+            backend_observed.fetch_add(1, Ordering::Relaxed);
+            Ok::<_, std::convert::Infallible>(Response::new(Full::new(Bytes::from_static(
+                b"unexpected backend call",
+            ))))
+        }
+    });
+
+    let auth_addr = harness.start_h1_backend(|_req: hyper::Request<Incoming>| async move {
+        Ok::<_, std::convert::Infallible>(
+            Response::builder()
+                .status(hyper::StatusCode::FOUND)
+                .header("location", "https://login.example.com/")
+                .body(Full::new(Bytes::new()))
+                .expect("auth redirect response"),
+        )
+    });
+
+    let config = configure_http_external_auth(
+        &harness,
+        format!("http://{backend_addr}"),
+        format!("http://{auth_addr}/check"),
+        250,
+        ExternalAuthFailureMode::FailClosed,
+        vec![],
+    );
+
+    harness.start_listener(config).expect("listener");
+
+    let response = harness
+        .run_request(H3RequestSpec::get("localhost", "/auth"))
+        .expect("redirect request should complete");
+    response.assert_status(302);
+    assert_eq!(
+        response.header("location"),
+        Some("https://login.example.com/")
+    );
+    assert!(response.body.is_empty(), "redirect body should be empty");
+    assert_eq!(backend_calls.load(Ordering::Relaxed), 0);
+}
+
+#[test]
+#[serial]
+fn quic_request_path_external_auth_timeout_fail_closed_returns_gateway_timeout() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = QuicRequestPathHarness::new();
+    let backend_calls = Arc::new(AtomicUsize::new(0));
+    let backend_observed = Arc::clone(&backend_calls);
+    let backend_addr = harness.start_h1_backend(move |_req: hyper::Request<Incoming>| {
+        let backend_observed = Arc::clone(&backend_observed);
+        async move {
+            backend_observed.fetch_add(1, Ordering::Relaxed);
+            Ok::<_, std::convert::Infallible>(Response::new(Full::new(Bytes::from_static(
+                b"unexpected backend call",
+            ))))
+        }
+    });
+
+    let auth_addr = harness.start_h1_backend(|_req: hyper::Request<Incoming>| async move {
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        Ok::<_, std::convert::Infallible>(Response::new(Full::new(Bytes::new())))
+    });
+
+    let config = configure_http_external_auth(
+        &harness,
+        format!("http://{backend_addr}"),
+        format!("http://{auth_addr}/check"),
+        15,
+        ExternalAuthFailureMode::FailClosed,
+        vec![],
+    );
+
+    harness.start_listener(config).expect("listener");
+
+    let response = harness
+        .run_request(H3RequestSpec::get("localhost", "/auth"))
+        .expect("timeout fail-closed request should complete");
+    response.assert_status(504);
+    assert!(
+        response.body_text().contains("external auth timeout"),
+        "expected canonical external auth timeout body"
+    );
+    assert_eq!(backend_calls.load(Ordering::Relaxed), 0);
+}
+
+#[test]
+#[serial]
+fn quic_request_path_external_auth_timeout_fail_open_allows_backend() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = QuicRequestPathHarness::new();
+    let backend_calls = Arc::new(AtomicUsize::new(0));
+    let backend_observed = Arc::clone(&backend_calls);
+    let backend_addr = harness.start_h1_backend(move |_req: hyper::Request<Incoming>| {
+        let backend_observed = Arc::clone(&backend_observed);
+        async move {
+            backend_observed.fetch_add(1, Ordering::Relaxed);
+            Ok::<_, std::convert::Infallible>(Response::new(Full::new(Bytes::from_static(
+                b"backend after fail-open",
+            ))))
+        }
+    });
+
+    let auth_addr = harness.start_h1_backend(|_req: hyper::Request<Incoming>| async move {
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        Ok::<_, std::convert::Infallible>(Response::new(Full::new(Bytes::new())))
+    });
+
+    let config = configure_http_external_auth(
+        &harness,
+        format!("http://{backend_addr}"),
+        format!("http://{auth_addr}/check"),
+        15,
+        ExternalAuthFailureMode::FailOpen,
+        vec![],
+    );
+
+    harness.start_listener(config).expect("listener");
+
+    let response = harness
+        .run_request(H3RequestSpec::get("localhost", "/auth"))
+        .expect("timeout fail-open request should complete");
+    response.assert_status(200);
+    response.assert_body_text("backend after fail-open");
+    assert_eq!(backend_calls.load(Ordering::Relaxed), 1);
 }

--- a/crates/edge/tests/request_path_harness.rs
+++ b/crates/edge/tests/request_path_harness.rs
@@ -1,0 +1,79 @@
+use std::collections::HashMap;
+
+use serial_test::serial;
+use spooky_config::config::UpstreamTls;
+
+mod support;
+
+use support::{
+    net::local_listener_bind_available,
+    request_path::{H3RequestSpec, QuicRequestPathHarness, make_backend, make_upstream},
+};
+
+#[test]
+#[serial]
+fn request_path_harness_supports_h1_upstream_fixture_round_trip() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = QuicRequestPathHarness::new();
+    let backend_addr = harness.start_h1_static_backend(b"h1 harness ok");
+
+    let mut upstreams = HashMap::new();
+    upstreams.insert(
+        "api".to_string(),
+        make_upstream(
+            "/",
+            vec![make_backend("h1-1", format!("http://{backend_addr}"))],
+            None,
+            "round-robin",
+        ),
+    );
+
+    harness
+        .start_listener(harness.make_config(upstreams))
+        .expect("listener");
+
+    let response = harness
+        .run_request(H3RequestSpec::get("localhost", "/"))
+        .expect("h3 request");
+    response.assert_status(200);
+    response.assert_body_bytes(b"h1 harness ok");
+}
+
+#[test]
+#[serial]
+fn request_path_harness_supports_h2_upstream_fixture_round_trip() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = QuicRequestPathHarness::new();
+    let backend_addr = harness.start_h2_static_backend(b"h2 harness ok");
+
+    let mut upstreams = HashMap::new();
+    upstreams.insert(
+        "api".to_string(),
+        make_upstream(
+            "/",
+            vec![make_backend("h2-1", format!("https://{backend_addr}"))],
+            Some(UpstreamTls {
+                verify_certificates: false,
+                strict_sni: false,
+                ..UpstreamTls::default()
+            }),
+            "round-robin",
+        ),
+    );
+
+    harness
+        .start_listener(harness.make_config(upstreams))
+        .expect("listener");
+
+    let response = harness
+        .run_request(H3RequestSpec::get("localhost", "/"))
+        .expect("h3 request");
+    response.assert_status(200);
+    response.assert_body_text("h2 harness ok");
+}

--- a/crates/edge/tests/request_path_harness.rs
+++ b/crates/edge/tests/request_path_harness.rs
@@ -1,16 +1,28 @@
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc, Barrier,
+        atomic::{AtomicUsize, Ordering},
+    },
+    thread,
+    time::Duration,
+};
 
 use bytes::Bytes;
 use http_body_util::{BodyExt, Full};
 use hyper::{Response, body::Incoming};
 use serial_test::serial;
-use spooky_config::config::UpstreamTls;
+use spooky_config::config::{
+    ApiKeyAuth, RouteAuth, ScopedRateLimit, ScopedRateLimitScope, UpstreamTls,
+};
 
 mod support;
 
 use support::{
     net::local_listener_bind_available,
-    request_path::{H3RequestSpec, QuicRequestPathHarness, make_backend, make_upstream},
+    request_path::{
+        H3RequestSpec, QuicRequestPathHarness, make_backend, make_upstream, run_request_to,
+    },
 };
 
 fn response_line(body: &str, prefix: &str) -> String {
@@ -381,4 +393,215 @@ fn quic_to_h2_success_path_streams_response_body_to_completion() {
         .expect("h3 request");
     response.assert_status(200);
     response.assert_body_text("h2-chunk-1:h2-chunk-2:h2-chunk-3");
+}
+
+#[test]
+#[serial]
+fn quic_request_path_auth_deny_rejects_before_upstream_dispatch() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = QuicRequestPathHarness::new();
+    let upstream_calls = Arc::new(AtomicUsize::new(0));
+    let backend_observed = Arc::clone(&upstream_calls);
+    let backend_addr = harness.start_h1_backend(move |_req: hyper::Request<Incoming>| {
+        let backend_observed = Arc::clone(&backend_observed);
+        async move {
+            backend_observed.fetch_add(1, Ordering::Relaxed);
+            Ok::<_, std::convert::Infallible>(Response::new(Full::new(Bytes::from_static(
+                b"unexpected upstream call",
+            ))))
+        }
+    });
+
+    let mut upstream = make_upstream(
+        "/protected",
+        vec![make_backend(
+            "h1-protected",
+            format!("http://{backend_addr}"),
+        )],
+        None,
+        "round-robin",
+    );
+    upstream.auth = RouteAuth {
+        api_key: Some(ApiKeyAuth {
+            header_name: "x-api-key".to_string(),
+            keys: vec!["edge-key".to_string()],
+        }),
+        ..RouteAuth::default()
+    };
+
+    let mut upstreams = HashMap::new();
+    upstreams.insert("api".to_string(), upstream);
+
+    harness
+        .start_listener(harness.make_config(upstreams))
+        .expect("listener");
+
+    let response = harness
+        .run_request(H3RequestSpec::get("localhost", "/protected"))
+        .expect("unauthorized request should complete");
+
+    response.assert_status(401);
+    assert_eq!(response.header("www-authenticate"), Some("ApiKey"));
+    assert!(
+        response.body_text().contains("unauthorized"),
+        "expected canonical unauthorized response body"
+    );
+    assert_eq!(
+        upstream_calls.load(Ordering::Relaxed),
+        0,
+        "pre-dispatch auth rejection must not contact upstream"
+    );
+}
+
+#[test]
+#[serial]
+fn quic_request_path_rate_limit_deny_rejects_before_second_upstream_dispatch() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = QuicRequestPathHarness::new();
+    let upstream_calls = Arc::new(AtomicUsize::new(0));
+    let backend_observed = Arc::clone(&upstream_calls);
+    let backend_addr = harness.start_h1_backend(move |_req: hyper::Request<Incoming>| {
+        let backend_observed = Arc::clone(&backend_observed);
+        async move {
+            backend_observed.fetch_add(1, Ordering::Relaxed);
+            Ok::<_, std::convert::Infallible>(Response::new(Full::new(Bytes::from_static(
+                b"rate-limit ok",
+            ))))
+        }
+    });
+
+    let mut upstreams = HashMap::new();
+    upstreams.insert(
+        "api".to_string(),
+        make_upstream(
+            "/limited",
+            vec![make_backend("h1-limited", format!("http://{backend_addr}"))],
+            None,
+            "round-robin",
+        ),
+    );
+
+    let mut config = harness.make_config(upstreams);
+    config.resilience.scoped_rate_limits = vec![ScopedRateLimit {
+        name: "route-cap".to_string(),
+        scope: ScopedRateLimitScope::Route,
+        requests_per_sec: 1,
+        burst: 1,
+        key: None,
+        route_allowlist: vec!["api".to_string()],
+        idle_ttl_secs: 300,
+    }];
+
+    harness.start_listener(config).expect("listener");
+
+    let first = harness
+        .run_request(H3RequestSpec::get("localhost", "/limited"))
+        .expect("first request should complete");
+    first.assert_status(200);
+    first.assert_body_text("rate-limit ok");
+
+    let second = harness
+        .run_request(H3RequestSpec::get("localhost", "/limited"))
+        .expect("second request should complete");
+    second.assert_status(429);
+    assert!(
+        second.body_text().contains("request rate limited"),
+        "expected canonical rate-limit rejection body"
+    );
+    assert_eq!(
+        upstream_calls.load(Ordering::Relaxed),
+        1,
+        "rate-limit rejection must stop before contacting upstream on the second request"
+    );
+}
+
+#[test]
+#[serial]
+fn quic_request_path_upstream_overload_sheds_before_second_upstream_dispatch() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = QuicRequestPathHarness::new();
+    let upstream_calls = Arc::new(AtomicUsize::new(0));
+    let backend_observed = Arc::clone(&upstream_calls);
+    let backend_addr = harness.start_h1_backend(move |_req: hyper::Request<Incoming>| {
+        let backend_observed = Arc::clone(&backend_observed);
+        async move {
+            backend_observed.fetch_add(1, Ordering::Relaxed);
+            tokio::time::sleep(Duration::from_millis(250)).await;
+            Ok::<_, std::convert::Infallible>(Response::new(Full::new(Bytes::from_static(
+                b"slow ok",
+            ))))
+        }
+    });
+
+    let mut upstreams = HashMap::new();
+    upstreams.insert(
+        "api".to_string(),
+        make_upstream(
+            "/slow",
+            vec![make_backend("h1-slow", format!("http://{backend_addr}"))],
+            None,
+            "round-robin",
+        ),
+    );
+
+    let mut config = harness.make_config(upstreams);
+    config.performance.global_inflight_limit = 64;
+    config.performance.per_upstream_inflight_limit = 1;
+    let listen_addr = harness.start_listener(config).expect("listener");
+    let barrier = Arc::new(Barrier::new(2));
+
+    let responses = thread::scope(|scope| {
+        let first_barrier = Arc::clone(&barrier);
+        let first = scope.spawn(move || {
+            first_barrier.wait();
+            run_request_to(listen_addr, H3RequestSpec::get("localhost", "/slow"))
+        });
+
+        let second_barrier = Arc::clone(&barrier);
+        let second = scope.spawn(move || {
+            second_barrier.wait();
+            run_request_to(listen_addr, H3RequestSpec::get("localhost", "/slow"))
+        });
+
+        [
+            first.join().expect("first request thread"),
+            second.join().expect("second request thread"),
+        ]
+    });
+
+    let mut status_200 = 0usize;
+    let mut status_503 = 0usize;
+    let mut shed_body = String::new();
+    for response in responses {
+        let response = response.expect("concurrent request should complete");
+        match response.status {
+            200 => status_200 += 1,
+            503 => {
+                status_503 += 1;
+                shed_body = response.body_text();
+            }
+            other => panic!("unexpected status in overload test: {other}"),
+        }
+    }
+
+    assert_eq!(status_200, 1, "expected one successful request");
+    assert_eq!(status_503, 1, "expected one shed request");
+    assert!(
+        shed_body.contains("upstream overloaded"),
+        "expected canonical overload response body, got `{shed_body}`"
+    );
+    assert_eq!(
+        upstream_calls.load(Ordering::Relaxed),
+        1,
+        "upstream overload rejection must happen before the second request reaches the backend"
+    );
 }

--- a/crates/edge/tests/request_path_harness.rs
+++ b/crates/edge/tests/request_path_harness.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashMap,
+    net::TcpListener,
     sync::{
         Arc, Barrier,
         atomic::{AtomicUsize, Ordering},
@@ -963,4 +964,132 @@ fn quic_request_path_external_auth_timeout_fail_open_allows_backend() {
     response.assert_status(200);
     response.assert_body_text("backend after fail-open");
     assert_eq!(backend_calls.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+#[serial]
+fn quic_request_path_backend_timeout_maps_to_upstream_timeout() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = QuicRequestPathHarness::new();
+    let backend_calls = Arc::new(AtomicUsize::new(0));
+    let backend_observed = Arc::clone(&backend_calls);
+    let backend_addr = harness.start_h1_backend(move |_req: hyper::Request<Incoming>| {
+        let backend_observed = Arc::clone(&backend_observed);
+        async move {
+            backend_observed.fetch_add(1, Ordering::Relaxed);
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            Ok::<_, std::convert::Infallible>(Response::new(Full::new(Bytes::from_static(
+                b"too late",
+            ))))
+        }
+    });
+
+    let mut upstreams = HashMap::new();
+    upstreams.insert(
+        "api".to_string(),
+        make_upstream(
+            "/timeout",
+            vec![make_backend("h1-timeout", format!("http://{backend_addr}"))],
+            None,
+            "round-robin",
+        ),
+    );
+
+    let mut config = harness.make_config(upstreams);
+    config.performance.backend_timeout_ms = 150;
+    config.performance.backend_connect_timeout_ms = 150;
+    harness.start_listener(config).expect("listener");
+
+    let response = harness
+        .run_request(H3RequestSpec::get("localhost", "/timeout"))
+        .expect("timeout request should complete");
+    response.assert_status(503);
+    assert!(
+        response.body_text().contains("upstream timeout"),
+        "expected canonical upstream timeout body"
+    );
+    assert_eq!(backend_calls.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+#[serial]
+fn quic_request_path_connect_failure_maps_to_upstream_error() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = QuicRequestPathHarness::new();
+    let unused_listener = TcpListener::bind("127.0.0.1:0").expect("bind unused backend port");
+    let unused_addr = unused_listener.local_addr().expect("unused backend addr");
+    drop(unused_listener);
+
+    let mut upstreams = HashMap::new();
+    upstreams.insert(
+        "api".to_string(),
+        make_upstream(
+            "/connect-fail",
+            vec![make_backend(
+                "h1-connect-fail",
+                format!("http://{unused_addr}"),
+            )],
+            None,
+            "round-robin",
+        ),
+    );
+
+    let mut config = harness.make_config(upstreams);
+    config.performance.backend_timeout_ms = 150;
+    config.performance.backend_connect_timeout_ms = 150;
+    harness.start_listener(config).expect("listener");
+
+    let response = harness
+        .run_request(H3RequestSpec::get("localhost", "/connect-fail"))
+        .expect("connect failure request should complete");
+    response.assert_status(502);
+    assert!(
+        response.body_text().contains("upstream error"),
+        "expected canonical upstream transport failure body"
+    );
+}
+
+#[test]
+#[serial]
+fn quic_request_path_malformed_upstream_response_maps_to_upstream_error() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = QuicRequestPathHarness::new();
+    let backend_addr = harness.start_h1_raw_response_backend(b"NOT_HTTP\r\n\r\n".to_vec());
+
+    let mut upstreams = HashMap::new();
+    upstreams.insert(
+        "api".to_string(),
+        make_upstream(
+            "/malformed",
+            vec![make_backend(
+                "h1-malformed",
+                format!("http://{backend_addr}"),
+            )],
+            None,
+            "round-robin",
+        ),
+    );
+
+    let mut config = harness.make_config(upstreams);
+    config.performance.backend_timeout_ms = 150;
+    config.performance.backend_connect_timeout_ms = 150;
+    harness.start_listener(config).expect("listener");
+
+    let response = harness
+        .run_request(H3RequestSpec::get("localhost", "/malformed"))
+        .expect("malformed upstream response request should complete");
+    response.assert_status(502);
+    assert!(
+        response.body_text().contains("upstream error"),
+        "expected canonical malformed upstream response failure body"
+    );
 }

--- a/crates/edge/tests/request_path_harness.rs
+++ b/crates/edge/tests/request_path_harness.rs
@@ -228,3 +228,157 @@ fn quic_to_h1_success_path_streams_response_body_to_completion() {
     response.assert_status(200);
     response.assert_body_text("chunk-1:chunk-2:chunk-3");
 }
+
+#[test]
+#[serial]
+fn quic_to_h2_success_path_normalizes_headers_and_keeps_get_bodyless() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = QuicRequestPathHarness::new();
+    let backend_addr = harness.start_h2_backend(|req: hyper::Request<Incoming>| async move {
+        let header_value = |name: &str| {
+            req.headers()
+                .get(name)
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or("<missing>")
+                .to_string()
+        };
+        let method = req.method().to_string();
+        let path = req.uri().path().to_string();
+        let host = header_value("host");
+        let forwarded = header_value("forwarded");
+        let xff = header_value("x-forwarded-for");
+        let xfp = header_value("x-forwarded-proto");
+        let xfh = header_value("x-forwarded-host");
+        let user_agent = header_value("user-agent");
+        let request_id = header_value("x-request-id");
+        let content_length = req
+            .headers()
+            .get("content-length")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or("<missing>")
+            .to_string();
+        let has_connection = req.headers().contains_key("connection");
+        let body = req
+            .into_body()
+            .collect()
+            .await
+            .expect("collect request body")
+            .to_bytes();
+        let body = format!(
+            "method={method}\npath={path}\nhost={}\nforwarded={}\nxff={}\nxfp={}\nxfh={}\nuser_agent={}\nx_request_id={}\ncontent_length={content_length}\nbody_len={}\nhas_connection={}\n",
+            host,
+            forwarded,
+            xff,
+            xfp,
+            xfh,
+            user_agent,
+            request_id,
+            body.len(),
+            has_connection,
+        );
+        Ok::<_, std::convert::Infallible>(Response::new(Full::new(Bytes::from(body))))
+    });
+
+    let mut upstreams = HashMap::new();
+    upstreams.insert(
+        "api".to_string(),
+        make_upstream(
+            "/headers-h2",
+            vec![make_backend(
+                "h2-headers",
+                format!("https://{backend_addr}"),
+            )],
+            Some(UpstreamTls {
+                verify_certificates: false,
+                strict_sni: false,
+                ..UpstreamTls::default()
+            }),
+            "round-robin",
+        ),
+    );
+
+    harness
+        .start_listener(harness.make_config(upstreams))
+        .expect("listener");
+
+    let response = harness
+        .run_request(H3RequestSpec {
+            method: "GET",
+            authority: "public.example.com",
+            path: "/headers-h2",
+            headers: &[
+                ("forwarded", "for=1.2.3.4;proto=http;host=\"evil.example\""),
+                ("x-forwarded-for", "1.2.3.4"),
+                ("x-forwarded-proto", "http"),
+                ("x-forwarded-host", "evil.example"),
+                ("connection", "keep-alive, x-secret"),
+                ("x-secret", "strip-me"),
+            ],
+            body: None,
+            user_agent: "spooky-success-h2",
+        })
+        .expect("h3 request");
+
+    response.assert_status(200);
+    let body = response.body_text();
+    assert_eq!(response_line(&body, "method="), "GET");
+    assert_eq!(response_line(&body, "path="), "/headers-h2");
+    assert_eq!(response_line(&body, "host="), "public.example.com");
+    assert_eq!(
+        response_line(&body, "forwarded="),
+        "for=127.0.0.1;proto=https;host=\"public.example.com\""
+    );
+    assert_eq!(response_line(&body, "xff="), "127.0.0.1");
+    assert_eq!(response_line(&body, "xfp="), "https");
+    assert_eq!(response_line(&body, "xfh="), "public.example.com");
+    assert_eq!(response_line(&body, "user_agent="), "spooky-success-h2");
+    assert_eq!(response_line(&body, "content_length="), "<missing>");
+    assert_eq!(response_line(&body, "body_len="), "0");
+    assert_eq!(response_line(&body, "has_connection="), "false");
+
+    let request_id = response_line(&body, "x_request_id=");
+    assert!(
+        !request_id.is_empty() && request_id.chars().all(|ch| ch.is_ascii_digit()),
+        "x-request-id should be a generated numeric request identifier, got `{request_id}`"
+    );
+}
+
+#[test]
+#[serial]
+fn quic_to_h2_success_path_streams_response_body_to_completion() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = QuicRequestPathHarness::new();
+    let backend_addr =
+        harness.start_h2_streaming_backend(vec![b"h2-chunk-1:", b"h2-chunk-2:", b"h2-chunk-3"]);
+
+    let mut upstreams = HashMap::new();
+    upstreams.insert(
+        "api".to_string(),
+        make_upstream(
+            "/stream-h2",
+            vec![make_backend("h2-stream", format!("https://{backend_addr}"))],
+            Some(UpstreamTls {
+                verify_certificates: false,
+                strict_sni: false,
+                ..UpstreamTls::default()
+            }),
+            "round-robin",
+        ),
+    );
+
+    harness
+        .start_listener(harness.make_config(upstreams))
+        .expect("listener");
+
+    let response = harness
+        .run_request(H3RequestSpec::get("stream.example.com", "/stream-h2"))
+        .expect("h3 request");
+    response.assert_status(200);
+    response.assert_body_text("h2-chunk-1:h2-chunk-2:h2-chunk-3");
+}

--- a/crates/edge/tests/support/mod.rs
+++ b/crates/edge/tests/support/mod.rs
@@ -1,1 +1,2 @@
 pub mod net;
+pub mod request_path;

--- a/crates/edge/tests/support/request_path.rs
+++ b/crates/edge/tests/support/request_path.rs
@@ -356,6 +356,10 @@ impl H3Response {
     }
 }
 
+pub fn run_request_to(addr: SocketAddr, request: H3RequestSpec<'_>) -> Result<H3Response, String> {
+    run_h3_request(addr, request)
+}
+
 pub async fn start_h1_backend<F, Fut>(handler: F) -> BackendFixture
 where
     F: Fn(Request<Incoming>) -> Fut + Send + Sync + 'static,

--- a/crates/edge/tests/support/request_path.rs
+++ b/crates/edge/tests/support/request_path.rs
@@ -32,9 +32,10 @@ use spooky_config::{
     validator::validate,
 };
 use spooky_edge::{
-    MAX_DATAGRAM_SIZE_BYTES, MAX_UDP_PAYLOAD_BYTES, QUIC_IDLE_TIMEOUT_MS, QUIC_INITIAL_MAX_DATA,
-    QUIC_INITIAL_MAX_STREAMS_BIDI, QUIC_INITIAL_MAX_STREAMS_UNI, QUIC_INITIAL_STREAM_DATA,
-    REQUEST_TIMEOUT_SECS, UDP_READ_TIMEOUT_MS, runtime::listener::QUICListener,
+    MAX_DATAGRAM_SIZE_BYTES, MAX_UDP_PAYLOAD_BYTES, Metrics, QUIC_IDLE_TIMEOUT_MS,
+    QUIC_INITIAL_MAX_DATA, QUIC_INITIAL_MAX_STREAMS_BIDI, QUIC_INITIAL_MAX_STREAMS_UNI,
+    QUIC_INITIAL_STREAM_DATA, REQUEST_TIMEOUT_SECS, UDP_READ_TIMEOUT_MS,
+    runtime::listener::QUICListener,
 };
 use tempfile::{TempDir, tempdir};
 use tokio::{
@@ -119,6 +120,7 @@ impl Drop for ListenerTaskGuard {
 pub struct QuicRequestPathHarness {
     backends: Vec<BackendFixture>,
     listener_task: Option<ListenerTaskGuard>,
+    metrics: Option<Arc<Metrics>>,
     rt: tokio::runtime::Runtime,
     pub tls: TestTlsMaterial,
     pub listen_addr: Option<SocketAddr>,
@@ -129,6 +131,7 @@ impl QuicRequestPathHarness {
         Self {
             backends: Vec::new(),
             listener_task: None,
+            metrics: None,
             rt: tokio::runtime::Runtime::new().expect("runtime"),
             tls: TestTlsMaterial::localhost(),
             listen_addr: None,
@@ -171,6 +174,7 @@ impl QuicRequestPathHarness {
     pub fn start_listener(&mut self, config: Config) -> Result<SocketAddr, String> {
         validate(&config).map_err(|err| format!("config validation failed: {err}"))?;
         let listener = QUICListener::new(config).map_err(|err| format!("listener: {err}"))?;
+        self.metrics = Some(Arc::clone(&listener.metrics));
         let listen_addr = listener
             .socket
             .local_addr()
@@ -260,6 +264,12 @@ impl QuicRequestPathHarness {
             .listen_addr
             .ok_or_else(|| "listener not started".to_string())?;
         run_h3_request(listen_addr, request)
+    }
+
+    pub fn metrics_text(&self) -> Option<String> {
+        self.metrics
+            .as_ref()
+            .map(|metrics| metrics.render_prometheus())
     }
 }
 

--- a/crates/edge/tests/support/request_path.rs
+++ b/crates/edge/tests/support/request_path.rs
@@ -204,6 +204,15 @@ impl QuicRequestPathHarness {
         addr
     }
 
+    pub fn start_h1_raw_response_backend(&mut self, response_bytes: Vec<u8>) -> SocketAddr {
+        let fixture = self
+            .rt
+            .block_on(start_h1_raw_response_backend(response_bytes));
+        let addr = fixture.addr;
+        self.backends.push(fixture);
+        addr
+    }
+
     pub fn start_h2_backend<F, Fut>(&mut self, handler: F) -> SocketAddr
     where
         F: Fn(Request<Incoming>) -> Fut + Send + Sync + 'static,
@@ -555,6 +564,48 @@ pub async fn start_h1_chunked_backend(chunks: Vec<&'static [u8]>) -> BackendFixt
                 }
 
                 let _ = stream.write_all(b"0\r\n\r\n").await;
+                let _ = stream.shutdown().await;
+            });
+        }
+    });
+
+    BackendFixture {
+        addr,
+        stop,
+        accept_task,
+    }
+}
+
+pub async fn start_h1_raw_response_backend(response_bytes: Vec<u8>) -> BackendFixture {
+    let listener = bind_tcp_listener();
+    let addr = listener.local_addr().expect("h1 raw local addr");
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_flag = Arc::clone(&stop);
+
+    let accept_task = tokio::spawn(async move {
+        while !stop_flag.load(Ordering::Relaxed) {
+            let (mut stream, _) = match listener.accept().await {
+                Ok(value) => value,
+                Err(_) => break,
+            };
+            let response_bytes = response_bytes.clone();
+            tokio::spawn(async move {
+                let mut buf = [0u8; 4096];
+                let mut request = Vec::new();
+                loop {
+                    match stream.read(&mut buf).await {
+                        Ok(0) => return,
+                        Ok(read) => {
+                            request.extend_from_slice(&buf[..read]);
+                            if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                                break;
+                            }
+                        }
+                        Err(_) => return,
+                    }
+                }
+
+                let _ = stream.write_all(&response_bytes).await;
                 let _ = stream.shutdown().await;
             });
         }

--- a/crates/edge/tests/support/request_path.rs
+++ b/crates/edge/tests/support/request_path.rs
@@ -33,7 +33,10 @@ use spooky_edge::{
     REQUEST_TIMEOUT_SECS, UDP_READ_TIMEOUT_MS, runtime::listener::QUICListener,
 };
 use tempfile::{TempDir, tempdir};
-use tokio::net::TcpListener;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+};
 use tokio_rustls::{TlsAcceptor, rustls::ServerConfig};
 
 pub struct TestTlsMaterial {
@@ -188,6 +191,13 @@ impl QuicRequestPathHarness {
         self.start_h1_backend(move |_req| async move {
             Ok::<_, Infallible>(Response::new(Full::new(Bytes::from_static(body))))
         })
+    }
+
+    pub fn start_h1_chunked_backend(&mut self, chunks: Vec<&'static [u8]>) -> SocketAddr {
+        let fixture = self.rt.block_on(start_h1_chunked_backend(chunks));
+        let addr = fixture.addr;
+        self.backends.push(fixture);
+        addr
     }
 
     pub fn start_h2_backend<F, Fut>(&mut self, handler: F) -> SocketAddr
@@ -408,6 +418,71 @@ where
                 let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
                     .serve_connection(TokioIo::new(tls_stream), service)
                     .await;
+            });
+        }
+    });
+
+    BackendFixture {
+        addr,
+        stop,
+        accept_task,
+    }
+}
+
+pub async fn start_h1_chunked_backend(chunks: Vec<&'static [u8]>) -> BackendFixture {
+    let listener = bind_tcp_listener();
+    let addr = listener.local_addr().expect("h1 chunked local addr");
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_flag = Arc::clone(&stop);
+
+    let accept_task = tokio::spawn(async move {
+        while !stop_flag.load(Ordering::Relaxed) {
+            let (mut stream, _) = match listener.accept().await {
+                Ok(value) => value,
+                Err(_) => break,
+            };
+            let chunks = chunks.clone();
+            tokio::spawn(async move {
+                let mut buf = [0u8; 4096];
+                let mut request = Vec::new();
+                loop {
+                    match stream.read(&mut buf).await {
+                        Ok(0) => return,
+                        Ok(read) => {
+                            request.extend_from_slice(&buf[..read]);
+                            if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                                break;
+                            }
+                        }
+                        Err(_) => return,
+                    }
+                }
+
+                if stream
+                    .write_all(
+                        b"HTTP/1.1 200 OK\r\ncontent-type: text/plain\r\ntransfer-encoding: chunked\r\nconnection: close\r\n\r\n",
+                    )
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+
+                for chunk in chunks {
+                    let prefix = format!("{:x}\r\n", chunk.len());
+                    if stream.write_all(prefix.as_bytes()).await.is_err() {
+                        return;
+                    }
+                    if stream.write_all(chunk).await.is_err() {
+                        return;
+                    }
+                    if stream.write_all(b"\r\n").await.is_err() {
+                        return;
+                    }
+                }
+
+                let _ = stream.write_all(b"0\r\n\r\n").await;
+                let _ = stream.shutdown().await;
             });
         }
     });

--- a/crates/edge/tests/support/request_path.rs
+++ b/crates/edge/tests/support/request_path.rs
@@ -1,0 +1,614 @@
+#![allow(dead_code)]
+
+use std::{
+    collections::HashMap,
+    convert::Infallible,
+    future::Future,
+    net::{IpAddr, SocketAddr, TcpListener as StdTcpListener, UdpSocket},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+use bytes::Bytes;
+use http_body_util::Full;
+use hyper::{Request, Response, body::Incoming, service::service_fn};
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use quiche::h3::NameValue;
+use rand::RngCore;
+use rcgen::{Certificate, CertificateParams, SanType};
+use rustls_pki_types::{CertificateDer, PrivateKeyDer, pem::PemObject};
+use spooky_config::{
+    config::{
+        Backend, ClientAuth, Config, Listen, LoadBalancing, Log, LogFormat, RouteMatch, Security,
+        Tls, Upstream, UpstreamTls,
+    },
+    validator::validate,
+};
+use spooky_edge::{
+    MAX_DATAGRAM_SIZE_BYTES, MAX_UDP_PAYLOAD_BYTES, QUIC_IDLE_TIMEOUT_MS, QUIC_INITIAL_MAX_DATA,
+    QUIC_INITIAL_MAX_STREAMS_BIDI, QUIC_INITIAL_MAX_STREAMS_UNI, QUIC_INITIAL_STREAM_DATA,
+    REQUEST_TIMEOUT_SECS, UDP_READ_TIMEOUT_MS, runtime::listener::QUICListener,
+};
+use tempfile::{TempDir, tempdir};
+use tokio::net::TcpListener;
+use tokio_rustls::{TlsAcceptor, rustls::ServerConfig};
+
+pub struct TestTlsMaterial {
+    _dir: TempDir,
+    pub cert_path: String,
+    pub key_path: String,
+}
+
+impl TestTlsMaterial {
+    pub fn localhost() -> Self {
+        let dir = tempdir().expect("tempdir");
+        let mut params = CertificateParams::new(vec!["localhost".into()]);
+        params
+            .subject_alt_names
+            .push(SanType::DnsName("localhost".to_string()));
+        params
+            .subject_alt_names
+            .push(SanType::IpAddress(IpAddr::from([127, 0, 0, 1])));
+        let cert = Certificate::from_params(params).expect("failed to build cert");
+
+        let cert_path = dir.path().join("cert.pem");
+        let key_path = dir.path().join("key.pem");
+
+        std::fs::write(&cert_path, cert.serialize_pem().expect("serialize cert"))
+            .expect("write cert");
+        std::fs::write(&key_path, cert.serialize_private_key_pem()).expect("write key");
+
+        Self {
+            _dir: dir,
+            cert_path: cert_path.to_string_lossy().to_string(),
+            key_path: key_path.to_string_lossy().to_string(),
+        }
+    }
+}
+
+pub struct BackendFixture {
+    pub addr: SocketAddr,
+    stop: Arc<AtomicBool>,
+    accept_task: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for BackendFixture {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        self.accept_task.abort();
+    }
+}
+
+pub struct ListenerTaskGuard {
+    stop: Arc<AtomicBool>,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl ListenerTaskGuard {
+    pub fn spawn(rt: &tokio::runtime::Runtime, mut listener: QUICListener) -> Self {
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_flag = Arc::clone(&stop);
+        let runtime_handle = rt.handle().clone();
+        let handle = rt.spawn_blocking(move || {
+            let _enter = runtime_handle.enter();
+            while !stop_flag.load(Ordering::Relaxed) {
+                listener.poll();
+            }
+        });
+        Self { stop, handle }
+    }
+}
+
+impl Drop for ListenerTaskGuard {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        self.handle.abort();
+    }
+}
+
+pub struct QuicRequestPathHarness {
+    backends: Vec<BackendFixture>,
+    listener_task: Option<ListenerTaskGuard>,
+    rt: tokio::runtime::Runtime,
+    pub tls: TestTlsMaterial,
+    pub listen_addr: Option<SocketAddr>,
+}
+
+impl QuicRequestPathHarness {
+    pub fn new() -> Self {
+        Self {
+            backends: Vec::new(),
+            listener_task: None,
+            rt: tokio::runtime::Runtime::new().expect("runtime"),
+            tls: TestTlsMaterial::localhost(),
+            listen_addr: None,
+        }
+    }
+
+    pub fn make_config(&self, upstreams: HashMap<String, Upstream>) -> Config {
+        Config {
+            version: 1,
+            listen: Listen {
+                protocol: "http3".to_string(),
+                port: reserve_unused_udp_port(),
+                address: "127.0.0.1".to_string(),
+                tls: Tls {
+                    cert: self.tls.cert_path.clone(),
+                    key: self.tls.key_path.clone(),
+                    certificates: Vec::new(),
+                    client_auth: ClientAuth::default(),
+                },
+            },
+            listeners: Vec::new(),
+            upstream: upstreams,
+            load_balancing: Some(LoadBalancing {
+                lb_type: "round-robin".to_string(),
+                key: None,
+            }),
+            upstream_tls: UpstreamTls::default(),
+            log: Log {
+                level: "info".to_string(),
+                file: Default::default(),
+                format: LogFormat::Plain,
+            },
+            performance: spooky_config::config::Performance::default(),
+            observability: spooky_config::config::Observability::default(),
+            resilience: spooky_config::config::Resilience::default(),
+            security: Security::default(),
+        }
+    }
+
+    pub fn start_listener(&mut self, config: Config) -> Result<SocketAddr, String> {
+        validate(&config).map_err(|err| format!("config validation failed: {err}"))?;
+        let listener = QUICListener::new(config).map_err(|err| format!("listener: {err}"))?;
+        let listen_addr = listener
+            .socket
+            .local_addr()
+            .map_err(|err| format!("listen addr: {err}"))?;
+        self.listener_task = Some(ListenerTaskGuard::spawn(&self.rt, listener));
+        self.listen_addr = Some(listen_addr);
+        Ok(listen_addr)
+    }
+
+    pub fn start_h1_backend<F, Fut>(&mut self, handler: F) -> SocketAddr
+    where
+        F: Fn(Request<Incoming>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<Response<Full<Bytes>>, Infallible>> + Send + 'static,
+    {
+        let fixture = self.rt.block_on(start_h1_backend(handler));
+        let addr = fixture.addr;
+        self.backends.push(fixture);
+        addr
+    }
+
+    pub fn start_h1_static_backend(&mut self, body: &'static [u8]) -> SocketAddr {
+        self.start_h1_backend(move |_req| async move {
+            Ok::<_, Infallible>(Response::new(Full::new(Bytes::from_static(body))))
+        })
+    }
+
+    pub fn start_h2_backend<F, Fut>(&mut self, handler: F) -> SocketAddr
+    where
+        F: Fn(Request<Incoming>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<Response<Full<Bytes>>, Infallible>> + Send + 'static,
+    {
+        let fixture = self.rt.block_on(start_h2_backend(
+            &self.tls.cert_path,
+            &self.tls.key_path,
+            handler,
+        ));
+        let addr = fixture.addr;
+        self.backends.push(fixture);
+        addr
+    }
+
+    pub fn start_h2_static_backend(&mut self, body: &'static [u8]) -> SocketAddr {
+        self.start_h2_backend(move |_req| async move {
+            Ok::<_, Infallible>(Response::new(Full::new(Bytes::from_static(body))))
+        })
+    }
+
+    pub fn run_request(&self, request: H3RequestSpec<'_>) -> Result<H3Response, String> {
+        let listen_addr = self
+            .listen_addr
+            .ok_or_else(|| "listener not started".to_string())?;
+        run_h3_request(listen_addr, request)
+    }
+}
+
+impl Default for QuicRequestPathHarness {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub fn make_upstream(
+    path_prefix: &str,
+    backends: Vec<Backend>,
+    tls: Option<UpstreamTls>,
+    lb_type: &str,
+) -> Upstream {
+    Upstream {
+        load_balancing: LoadBalancing {
+            lb_type: lb_type.to_string(),
+            key: None,
+        },
+        auth: Default::default(),
+        host_policy: Default::default(),
+        forwarded_headers: Default::default(),
+        tls,
+        route: RouteMatch {
+            host: None,
+            path_prefix: Some(path_prefix.to_string()),
+            method: None,
+        },
+        backends,
+    }
+}
+
+pub fn make_backend(id: &str, address: impl Into<String>) -> Backend {
+    Backend {
+        id: id.to_string(),
+        address: normalize_backend_address(address.into()),
+        weight: 1,
+        health_check: None,
+    }
+}
+
+pub fn normalize_backend_address(address: String) -> String {
+    if address.contains("://") {
+        address
+    } else {
+        format!("http://{address}")
+    }
+}
+
+pub struct H3RequestSpec<'a> {
+    pub method: &'a str,
+    pub authority: &'a str,
+    pub path: &'a str,
+    pub headers: &'a [(&'a str, &'a str)],
+    pub body: Option<&'a [u8]>,
+    pub user_agent: &'a str,
+}
+
+impl<'a> H3RequestSpec<'a> {
+    pub fn get(authority: &'a str, path: &'a str) -> Self {
+        Self {
+            method: "GET",
+            authority,
+            path,
+            headers: &[],
+            body: None,
+            user_agent: "spooky-request-path-test",
+        }
+    }
+}
+
+pub struct H3Response {
+    pub status: u16,
+    pub headers: Vec<(String, String)>,
+    pub body: Vec<u8>,
+}
+
+impl H3Response {
+    pub fn body_text(&self) -> String {
+        String::from_utf8_lossy(&self.body).into_owned()
+    }
+
+    pub fn header(&self, name: &str) -> Option<&str> {
+        self.headers.iter().find_map(|(header_name, value)| {
+            header_name
+                .eq_ignore_ascii_case(name)
+                .then_some(value.as_str())
+        })
+    }
+
+    pub fn assert_status(&self, expected: u16) {
+        assert_eq!(
+            self.status, expected,
+            "unexpected H3 response status for request-path integration response"
+        );
+    }
+
+    pub fn assert_body_bytes(&self, expected: &[u8]) {
+        assert_eq!(
+            self.body.as_slice(),
+            expected,
+            "unexpected H3 response body for request-path integration response"
+        );
+    }
+
+    pub fn assert_body_text(&self, expected: &str) {
+        assert_eq!(
+            self.body_text(),
+            expected,
+            "unexpected H3 response text body for request-path integration response"
+        );
+    }
+}
+
+pub async fn start_h1_backend<F, Fut>(handler: F) -> BackendFixture
+where
+    F: Fn(Request<Incoming>) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<Response<Full<Bytes>>, Infallible>> + Send + 'static,
+{
+    let listener = bind_tcp_listener();
+    let addr = listener.local_addr().expect("h1 local addr");
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_flag = Arc::clone(&stop);
+    let handler = Arc::new(handler);
+
+    let accept_task = tokio::spawn(async move {
+        while !stop_flag.load(Ordering::Relaxed) {
+            let (stream, _) = match listener.accept().await {
+                Ok(value) => value,
+                Err(_) => break,
+            };
+            let handler = Arc::clone(&handler);
+            tokio::spawn(async move {
+                let service = service_fn(move |req: Request<Incoming>| {
+                    let handler = Arc::clone(&handler);
+                    async move { handler(req).await }
+                });
+
+                let _ = hyper::server::conn::http1::Builder::new()
+                    .serve_connection(TokioIo::new(stream), service)
+                    .await;
+            });
+        }
+    });
+
+    BackendFixture {
+        addr,
+        stop,
+        accept_task,
+    }
+}
+
+pub async fn start_h2_backend<F, Fut>(cert_path: &str, key_path: &str, handler: F) -> BackendFixture
+where
+    F: Fn(Request<Incoming>) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<Response<Full<Bytes>>, Infallible>> + Send + 'static,
+{
+    let mut tls_config = ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(read_test_chain(cert_path), read_test_key(key_path))
+        .expect("server tls config");
+    tls_config.alpn_protocols = vec![b"h2".to_vec()];
+    let acceptor = TlsAcceptor::from(Arc::new(tls_config));
+
+    let listener = bind_tcp_listener();
+    let addr = listener.local_addr().expect("h2 local addr");
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_flag = Arc::clone(&stop);
+    let handler = Arc::new(handler);
+
+    let accept_task = tokio::spawn(async move {
+        while !stop_flag.load(Ordering::Relaxed) {
+            let (stream, _) = match listener.accept().await {
+                Ok(value) => value,
+                Err(_) => break,
+            };
+            let acceptor = acceptor.clone();
+            let handler = Arc::clone(&handler);
+            tokio::spawn(async move {
+                let tls_stream = match acceptor.accept(stream).await {
+                    Ok(stream) => stream,
+                    Err(_) => return,
+                };
+                let service = service_fn(move |req: Request<Incoming>| {
+                    let handler = Arc::clone(&handler);
+                    async move { handler(req).await }
+                });
+
+                let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
+                    .serve_connection(TokioIo::new(tls_stream), service)
+                    .await;
+            });
+        }
+    });
+
+    BackendFixture {
+        addr,
+        stop,
+        accept_task,
+    }
+}
+
+pub fn reserve_unused_udp_port() -> u16 {
+    let socket = UdpSocket::bind("127.0.0.1:0").expect("reserve udp port");
+    let port = socket.local_addr().expect("udp local addr").port();
+    drop(socket);
+    port
+}
+
+fn bind_tcp_listener() -> TcpListener {
+    let listener = StdTcpListener::bind("127.0.0.1:0").expect("bind test backend listener");
+    listener
+        .set_nonblocking(true)
+        .expect("set test backend listener nonblocking");
+    TcpListener::from_std(listener).expect("register test backend listener")
+}
+
+fn quic_read_timeout(conn: &quiche::Connection) -> Duration {
+    conn.timeout()
+        .filter(|timeout| !timeout.is_zero())
+        .unwrap_or(Duration::from_millis(UDP_READ_TIMEOUT_MS))
+}
+
+fn run_h3_request(addr: SocketAddr, request: H3RequestSpec<'_>) -> Result<H3Response, String> {
+    let socket = UdpSocket::bind("0.0.0.0:0").map_err(|err| err.to_string())?;
+    let local_addr = socket.local_addr().map_err(|err| err.to_string())?;
+
+    let mut config =
+        quiche::Config::new(quiche::PROTOCOL_VERSION).map_err(|err| format!("config: {err:?}"))?;
+    config.verify_peer(false);
+    config
+        .set_application_protos(quiche::h3::APPLICATION_PROTOCOL)
+        .map_err(|err| format!("alpn: {err:?}"))?;
+    config.set_max_idle_timeout(QUIC_IDLE_TIMEOUT_MS);
+    config.set_max_recv_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    config.set_max_send_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    config.set_initial_max_data(QUIC_INITIAL_MAX_DATA);
+    config.set_initial_max_stream_data_bidi_local(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_stream_data_bidi_remote(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_stream_data_uni(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_streams_bidi(QUIC_INITIAL_MAX_STREAMS_BIDI);
+    config.set_initial_max_streams_uni(QUIC_INITIAL_MAX_STREAMS_UNI);
+    config.set_disable_active_migration(true);
+
+    let mut scid_bytes = [0u8; quiche::MAX_CONN_ID_LEN];
+    rand::thread_rng().fill_bytes(&mut scid_bytes);
+    let scid = quiche::ConnectionId::from_ref(&scid_bytes);
+
+    let mut conn = quiche::connect(Some("localhost"), &scid, local_addr, addr, &mut config)
+        .map_err(|err| format!("connect: {err:?}"))?;
+    let h3_config = quiche::h3::Config::new().map_err(|err| format!("h3: {err:?}"))?;
+    let mut h3: Option<quiche::h3::Connection> = None;
+
+    let mut out = [0u8; MAX_UDP_PAYLOAD_BYTES];
+    let mut buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
+    let mut status = 0;
+    let mut headers = Vec::new();
+    let mut body = Vec::new();
+    let mut request_sent = false;
+    let start = Instant::now();
+
+    let (write, send_info) = conn
+        .send(&mut out)
+        .map_err(|err| format!("send: {err:?}"))?;
+    socket
+        .send_to(&out[..write], send_info.to)
+        .map_err(|err| format!("send_to: {err:?}"))?;
+
+    loop {
+        loop {
+            match conn.send(&mut out) {
+                Ok((write, send_info)) => {
+                    let _ = socket.send_to(&out[..write], send_info.to);
+                }
+                Err(quiche::Error::Done) => break,
+                Err(err) => return Err(format!("send loop: {err:?}")),
+            }
+        }
+
+        socket
+            .set_read_timeout(Some(quic_read_timeout(&conn)))
+            .map_err(|err| format!("timeout: {err:?}"))?;
+
+        match socket.recv_from(&mut buf) {
+            Ok((len, from)) => {
+                conn.recv(
+                    &mut buf[..len],
+                    quiche::RecvInfo {
+                        from,
+                        to: local_addr,
+                    },
+                )
+                .map_err(|err| format!("recv: {err:?}"))?;
+            }
+            Err(ref err)
+                if err.kind() == std::io::ErrorKind::WouldBlock
+                    || err.kind() == std::io::ErrorKind::TimedOut =>
+            {
+                conn.on_timeout();
+            }
+            Err(err) => return Err(format!("recv: {err:?}")),
+        }
+
+        if conn.is_established() && h3.is_none() {
+            h3 = Some(
+                quiche::h3::Connection::with_transport(&mut conn, &h3_config)
+                    .map_err(|err| format!("h3 conn: {err:?}"))?,
+            );
+        }
+
+        if let Some(h3_conn) = h3.as_mut() {
+            if conn.is_established() && !request_sent {
+                let mut request_headers = vec![
+                    quiche::h3::Header::new(b":method", request.method.as_bytes()),
+                    quiche::h3::Header::new(b":scheme", b"https"),
+                    quiche::h3::Header::new(b":authority", request.authority.as_bytes()),
+                    quiche::h3::Header::new(b":path", request.path.as_bytes()),
+                    quiche::h3::Header::new(b"user-agent", request.user_agent.as_bytes()),
+                ];
+                request_headers.extend(request.headers.iter().map(|(name, value)| {
+                    quiche::h3::Header::new(name.as_bytes(), value.as_bytes())
+                }));
+                if let Some(body) = request.body {
+                    request_headers.push(quiche::h3::Header::new(
+                        b"content-length",
+                        body.len().to_string().as_bytes(),
+                    ));
+                }
+                let stream_id = h3_conn
+                    .send_request(&mut conn, &request_headers, request.body.is_none())
+                    .map_err(|err| format!("send_request: {err:?}"))?;
+                if let Some(body) = request.body {
+                    h3_conn
+                        .send_body(&mut conn, stream_id, body, true)
+                        .map_err(|err| format!("send_body: {err:?}"))?;
+                }
+                request_sent = true;
+            }
+
+            loop {
+                match h3_conn.poll(&mut conn) {
+                    Ok((_stream_id, quiche::h3::Event::Headers { list, .. })) => {
+                        for header in &list {
+                            let name = String::from_utf8_lossy(header.name()).to_string();
+                            let value = String::from_utf8_lossy(header.value()).to_string();
+                            if name == ":status" {
+                                status = value.parse::<u16>().unwrap_or_default();
+                            }
+                            headers.push((name, value));
+                        }
+                    }
+                    Ok((stream_id, quiche::h3::Event::Data)) => loop {
+                        match h3_conn.recv_body(&mut conn, stream_id, &mut buf) {
+                            Ok(read) => body.extend_from_slice(&buf[..read]),
+                            Err(quiche::h3::Error::Done) => break,
+                            Err(err) => return Err(format!("recv_body: {err:?}")),
+                        }
+                    },
+                    Ok((_stream_id, quiche::h3::Event::Finished)) => {
+                        return Ok(H3Response {
+                            status,
+                            headers,
+                            body,
+                        });
+                    }
+                    Ok((_stream_id, quiche::h3::Event::Reset(_))) => {
+                        return Err("stream reset".to_string());
+                    }
+                    Ok((_stream_id, quiche::h3::Event::PriorityUpdate)) => {}
+                    Ok((_stream_id, quiche::h3::Event::GoAway)) => {}
+                    Err(quiche::h3::Error::Done) => break,
+                    Err(err) => return Err(format!("poll: {err:?}")),
+                }
+            }
+        }
+
+        if start.elapsed() > Duration::from_secs(REQUEST_TIMEOUT_SECS) {
+            return Err(format!(
+                "timeout waiting for response (status={status}, body_len={})",
+                body.len()
+            ));
+        }
+    }
+}
+
+fn read_test_chain(cert_path: &str) -> Vec<CertificateDer<'static>> {
+    CertificateDer::pem_file_iter(cert_path)
+        .expect("open cert file")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("parse certs")
+}
+
+fn read_test_key(key_path: &str) -> PrivateKeyDer<'static> {
+    PrivateKeyDer::from_pem_file(key_path).expect("parse private key")
+}

--- a/crates/edge/tests/support/request_path.rs
+++ b/crates/edge/tests/support/request_path.rs
@@ -204,6 +204,16 @@ impl QuicRequestPathHarness {
         addr
     }
 
+    pub fn start_h1_delayed_chunked_backend(
+        &mut self,
+        chunks: Vec<(Vec<u8>, Duration)>,
+    ) -> SocketAddr {
+        let fixture = self.rt.block_on(start_h1_delayed_chunked_backend(chunks));
+        let addr = fixture.addr;
+        self.backends.push(fixture);
+        addr
+    }
+
     pub fn start_h1_raw_response_backend(&mut self, response_bytes: Vec<u8>) -> SocketAddr {
         let fixture = self
             .rt
@@ -367,6 +377,203 @@ impl H3Response {
 
 pub fn run_request_to(addr: SocketAddr, request: H3RequestSpec<'_>) -> Result<H3Response, String> {
     run_h3_request(addr, request)
+}
+
+pub fn run_two_chunk_post_to(
+    addr: SocketAddr,
+    authority: &str,
+    path: &str,
+    chunk1: Vec<u8>,
+    chunk2: Vec<u8>,
+    delay_between_chunks: Duration,
+) -> Result<(H3Response, bool), String> {
+    let socket = UdpSocket::bind("0.0.0.0:0").map_err(|err| err.to_string())?;
+    let local_addr = socket.local_addr().map_err(|err| err.to_string())?;
+
+    let total_len = chunk1.len() + chunk2.len();
+    let mut config =
+        quiche::Config::new(quiche::PROTOCOL_VERSION).map_err(|err| format!("config: {err:?}"))?;
+    config.verify_peer(false);
+    config
+        .set_application_protos(quiche::h3::APPLICATION_PROTOCOL)
+        .map_err(|err| format!("alpn: {err:?}"))?;
+    config.set_max_idle_timeout(QUIC_IDLE_TIMEOUT_MS);
+    config.set_max_recv_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    config.set_max_send_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    let window = (total_len as u64 + 1) * 2;
+    config.set_initial_max_data(window * 4);
+    config.set_initial_max_stream_data_bidi_local(window);
+    config.set_initial_max_stream_data_bidi_remote(window);
+    config.set_initial_max_stream_data_uni(window);
+    config.set_initial_max_streams_bidi(QUIC_INITIAL_MAX_STREAMS_BIDI);
+    config.set_initial_max_streams_uni(QUIC_INITIAL_MAX_STREAMS_UNI);
+    config.set_disable_active_migration(true);
+
+    let mut scid_bytes = [0u8; quiche::MAX_CONN_ID_LEN];
+    rand::thread_rng().fill_bytes(&mut scid_bytes);
+    let scid = quiche::ConnectionId::from_ref(&scid_bytes);
+    let mut conn = quiche::connect(Some("localhost"), &scid, local_addr, addr, &mut config)
+        .map_err(|err| format!("connect: {err:?}"))?;
+    let h3_config = quiche::h3::Config::new().map_err(|err| format!("h3: {err:?}"))?;
+    let mut h3: Option<quiche::h3::Connection> = None;
+
+    let mut out = [0u8; MAX_UDP_PAYLOAD_BYTES];
+    let mut buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
+    let start = Instant::now();
+    let mut stream_id: Option<u64> = None;
+    let mut chunk1_written = 0usize;
+    let mut chunk2_written = 0usize;
+    let mut chunk2_ready_at: Option<Instant> = None;
+    let mut status = 0u16;
+    let mut headers = Vec::new();
+    let mut body = Vec::new();
+    let mut got_reset = false;
+
+    let (write, send_info) = conn
+        .send(&mut out)
+        .map_err(|err| format!("send: {err:?}"))?;
+    socket
+        .send_to(&out[..write], send_info.to)
+        .map_err(|err| format!("send_to: {err:?}"))?;
+
+    loop {
+        loop {
+            match conn.send(&mut out) {
+                Ok((write, send_info)) => {
+                    let _ = socket.send_to(&out[..write], send_info.to);
+                }
+                Err(quiche::Error::Done) => break,
+                Err(err) => return Err(format!("send loop: {err:?}")),
+            }
+        }
+
+        socket
+            .set_read_timeout(Some(quic_read_timeout(&conn)))
+            .map_err(|err| format!("timeout: {err:?}"))?;
+
+        match socket.recv_from(&mut buf) {
+            Ok((len, from)) => {
+                conn.recv(
+                    &mut buf[..len],
+                    quiche::RecvInfo {
+                        from,
+                        to: local_addr,
+                    },
+                )
+                .map_err(|err| format!("recv: {err:?}"))?;
+            }
+            Err(ref err)
+                if err.kind() == std::io::ErrorKind::WouldBlock
+                    || err.kind() == std::io::ErrorKind::TimedOut =>
+            {
+                conn.on_timeout();
+            }
+            Err(err) => return Err(format!("recv: {err:?}")),
+        }
+
+        if conn.is_established() && h3.is_none() {
+            h3 = Some(
+                quiche::h3::Connection::with_transport(&mut conn, &h3_config)
+                    .map_err(|err| format!("h3 conn: {err:?}"))?,
+            );
+        }
+
+        if let Some(h3_conn) = h3.as_mut() {
+            if stream_id.is_none() && conn.is_established() {
+                let content_length = total_len.to_string();
+                let headers_list = vec![
+                    quiche::h3::Header::new(b":method", b"POST"),
+                    quiche::h3::Header::new(b":scheme", b"https"),
+                    quiche::h3::Header::new(b":authority", authority.as_bytes()),
+                    quiche::h3::Header::new(b":path", path.as_bytes()),
+                    quiche::h3::Header::new(b"user-agent", b"spooky-request-path-test"),
+                    quiche::h3::Header::new(b"content-length", content_length.as_bytes()),
+                ];
+                stream_id = Some(
+                    h3_conn
+                        .send_request(&mut conn, &headers_list, false)
+                        .map_err(|err| format!("send_request: {err:?}"))?,
+                );
+            }
+
+            if let Some(sid) = stream_id {
+                if chunk1_written < chunk1.len() {
+                    match h3_conn.send_body(&mut conn, sid, &chunk1[chunk1_written..], false) {
+                        Ok(written) => {
+                            chunk1_written += written;
+                            if chunk1_written == chunk1.len() {
+                                chunk2_ready_at = Some(Instant::now() + delay_between_chunks);
+                            }
+                        }
+                        Err(quiche::h3::Error::Done | quiche::h3::Error::StreamBlocked) => {}
+                        Err(err) => return Err(format!("send_body chunk1: {err:?}")),
+                    }
+                } else if chunk2_written < chunk2.len()
+                    && chunk2_ready_at.is_some_and(|deadline| Instant::now() >= deadline)
+                {
+                    match h3_conn.send_body(&mut conn, sid, &chunk2[chunk2_written..], true) {
+                        Ok(written) => chunk2_written += written,
+                        Err(quiche::h3::Error::Done | quiche::h3::Error::StreamBlocked) => {}
+                        Err(err) => return Err(format!("send_body chunk2: {err:?}")),
+                    }
+                }
+            }
+
+            loop {
+                match h3_conn.poll(&mut conn) {
+                    Ok((_stream_id, quiche::h3::Event::Headers { list, .. })) => {
+                        for header in &list {
+                            let name = String::from_utf8_lossy(header.name()).to_string();
+                            let value = String::from_utf8_lossy(header.value()).to_string();
+                            if name == ":status" {
+                                status = value.parse::<u16>().unwrap_or_default();
+                            }
+                            headers.push((name, value));
+                        }
+                    }
+                    Ok((stream_id, quiche::h3::Event::Data)) => loop {
+                        match h3_conn.recv_body(&mut conn, stream_id, &mut buf) {
+                            Ok(read) => body.extend_from_slice(&buf[..read]),
+                            Err(quiche::h3::Error::Done) => break,
+                            Err(err) => return Err(format!("recv_body: {err:?}")),
+                        }
+                    },
+                    Ok((_stream_id, quiche::h3::Event::Finished)) => {
+                        return Ok((
+                            H3Response {
+                                status,
+                                headers,
+                                body,
+                            },
+                            got_reset,
+                        ));
+                    }
+                    Ok((_stream_id, quiche::h3::Event::Reset(_))) => {
+                        got_reset = true;
+                        return Ok((
+                            H3Response {
+                                status,
+                                headers,
+                                body,
+                            },
+                            got_reset,
+                        ));
+                    }
+                    Ok((_stream_id, quiche::h3::Event::PriorityUpdate)) => {}
+                    Ok((_stream_id, quiche::h3::Event::GoAway)) => {}
+                    Err(quiche::h3::Error::Done) => break,
+                    Err(err) => return Err(format!("poll: {err:?}")),
+                }
+            }
+        }
+
+        if start.elapsed() > Duration::from_secs(REQUEST_TIMEOUT_SECS + 4) {
+            return Err(format!(
+                "timeout waiting for response (status={status}, body_len={}, got_reset={got_reset})",
+                body.len()
+            ));
+        }
+    }
 }
 
 pub async fn start_h1_backend<F, Fut>(handler: F) -> BackendFixture
@@ -556,6 +763,76 @@ pub async fn start_h1_chunked_backend(chunks: Vec<&'static [u8]>) -> BackendFixt
                         return;
                     }
                     if stream.write_all(chunk).await.is_err() {
+                        return;
+                    }
+                    if stream.write_all(b"\r\n").await.is_err() {
+                        return;
+                    }
+                }
+
+                let _ = stream.write_all(b"0\r\n\r\n").await;
+                let _ = stream.shutdown().await;
+            });
+        }
+    });
+
+    BackendFixture {
+        addr,
+        stop,
+        accept_task,
+    }
+}
+
+pub async fn start_h1_delayed_chunked_backend(chunks: Vec<(Vec<u8>, Duration)>) -> BackendFixture {
+    let listener = bind_tcp_listener();
+    let addr = listener
+        .local_addr()
+        .expect("h1 delayed chunked local addr");
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_flag = Arc::clone(&stop);
+
+    let accept_task = tokio::spawn(async move {
+        while !stop_flag.load(Ordering::Relaxed) {
+            let (mut stream, _) = match listener.accept().await {
+                Ok(value) => value,
+                Err(_) => break,
+            };
+            let chunks = chunks.clone();
+            tokio::spawn(async move {
+                let mut buf = [0u8; 4096];
+                let mut request = Vec::new();
+                loop {
+                    match stream.read(&mut buf).await {
+                        Ok(0) => return,
+                        Ok(read) => {
+                            request.extend_from_slice(&buf[..read]);
+                            if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                                break;
+                            }
+                        }
+                        Err(_) => return,
+                    }
+                }
+
+                if stream
+                    .write_all(
+                        b"HTTP/1.1 200 OK\r\ncontent-type: text/plain\r\ntransfer-encoding: chunked\r\nconnection: close\r\n\r\n",
+                    )
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+
+                for (chunk, delay) in chunks {
+                    if !delay.is_zero() {
+                        tokio::time::sleep(delay).await;
+                    }
+                    let prefix = format!("{:x}\r\n", chunk.len());
+                    if stream.write_all(prefix.as_bytes()).await.is_err() {
+                        return;
+                    }
+                    if stream.write_all(&chunk).await.is_err() {
                         return;
                     }
                     if stream.write_all(b"\r\n").await.is_err() {

--- a/crates/edge/tests/support/request_path.rs
+++ b/crates/edge/tests/support/request_path.rs
@@ -14,7 +14,11 @@ use std::{
 
 use bytes::Bytes;
 use http_body_util::Full;
-use hyper::{Request, Response, body::Incoming, service::service_fn};
+use hyper::{
+    Request, Response,
+    body::{Body, Frame, Incoming},
+    service::service_fn,
+};
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use quiche::h3::NameValue;
 use rand::RngCore;
@@ -221,6 +225,17 @@ impl QuicRequestPathHarness {
         })
     }
 
+    pub fn start_h2_streaming_backend(&mut self, chunks: Vec<&'static [u8]>) -> SocketAddr {
+        let fixture = self.rt.block_on(start_h2_streaming_backend(
+            &self.tls.cert_path,
+            &self.tls.key_path,
+            chunks,
+        ));
+        let addr = fixture.addr;
+        self.backends.push(fixture);
+        addr
+    }
+
     pub fn run_request(&self, request: H3RequestSpec<'_>) -> Result<H3Response, String> {
         let listen_addr = self
             .listen_addr
@@ -413,6 +428,60 @@ where
                 let service = service_fn(move |req: Request<Incoming>| {
                     let handler = Arc::clone(&handler);
                     async move { handler(req).await }
+                });
+
+                let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
+                    .serve_connection(TokioIo::new(tls_stream), service)
+                    .await;
+            });
+        }
+    });
+
+    BackendFixture {
+        addr,
+        stop,
+        accept_task,
+    }
+}
+
+pub async fn start_h2_streaming_backend(
+    cert_path: &str,
+    key_path: &str,
+    chunks: Vec<&'static [u8]>,
+) -> BackendFixture {
+    let mut tls_config = ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(read_test_chain(cert_path), read_test_key(key_path))
+        .expect("server tls config");
+    tls_config.alpn_protocols = vec![b"h2".to_vec()];
+    let acceptor = TlsAcceptor::from(Arc::new(tls_config));
+
+    let listener = bind_tcp_listener();
+    let addr = listener.local_addr().expect("h2 streaming local addr");
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_flag = Arc::clone(&stop);
+
+    let accept_task = tokio::spawn(async move {
+        while !stop_flag.load(Ordering::Relaxed) {
+            let (stream, _) = match listener.accept().await {
+                Ok(value) => value,
+                Err(_) => break,
+            };
+            let acceptor = acceptor.clone();
+            let chunks = chunks.clone();
+            tokio::spawn(async move {
+                let tls_stream = match acceptor.accept(stream).await {
+                    Ok(stream) => stream,
+                    Err(_) => return,
+                };
+                let service = service_fn(move |_req: Request<Incoming>| {
+                    let body = ChunkSequenceBody::new(
+                        chunks
+                            .iter()
+                            .map(|chunk| Bytes::from_static(chunk))
+                            .collect::<Vec<_>>(),
+                    );
+                    async move { Ok::<_, hyper::Error>(Response::new(body)) }
                 });
 
                 let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
@@ -686,4 +755,28 @@ fn read_test_chain(cert_path: &str) -> Vec<CertificateDer<'static>> {
 
 fn read_test_key(key_path: &str) -> PrivateKeyDer<'static> {
     PrivateKeyDer::from_pem_file(key_path).expect("parse private key")
+}
+
+struct ChunkSequenceBody {
+    chunks: std::vec::IntoIter<Bytes>,
+}
+
+impl ChunkSequenceBody {
+    fn new(chunks: Vec<Bytes>) -> Self {
+        Self {
+            chunks: chunks.into_iter(),
+        }
+    }
+}
+
+impl Body for ChunkSequenceBody {
+    type Data = Bytes;
+    type Error = Infallible;
+
+    fn poll_frame(
+        mut self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        std::task::Poll::Ready(self.chunks.next().map(|chunk| Ok(Frame::data(chunk))))
+    }
 }


### PR DESCRIPTION
## Summary
Adds a canonical QUIC request-path integration suite for `spooky-edge` that exercises the full data-plane flow through real listener/upstream fixtures and validates downstream behavior plus observable outcome parity.

## What’s Included
- Adds a reusable QUIC request-path harness under `crates/edge/tests/support/request_path.rs`
- Covers end-to-end success paths for H1 and H2 upstreams
- Covers pre-dispatch rejection paths:
  - auth deny
  - scoped rate limit deny
  - upstream overload shed
- Covers external auth flow end to end:
  - allow
  - deny
  - challenge
  - redirect
  - timeout fail-closed
  - timeout fail-open
- Covers upstream failure handling:
  - backend timeout
  - connect failure
  - malformed upstream response
- Covers request/response guardrails:
  - request body too large
  - stalled request body producer
  - unknown-length response prebuffer cap
  - slow response body before first chunk
- Covers outcome-recording parity by asserting request-path behavior against emitted coarse Prometheus buckets
- Cleans up the suite structure so the file reads as the canonical QUIC request-path integration spec

## Test Structure
The suite is organized into:
- success path contracts
- rejection path contracts
- upstream failure contracts
- body and stream guardrail contracts
- observable outcome parity contracts

## Why This Matters
This locks the real QUIC ingress contract at the request-path level, not just through unit tests. It gives a stable integration spec for future refactors across admission, auth, dispatch, guardrails, and outcome recording without depending on internal implementation details.