### PR TITLE
test(edge): add bootstrap vs quic parity coverage for outcomes and upgrade boundaries

### DIFF
--- a/crates/edge/src/quic_listener/bootstrap/listener.rs
+++ b/crates/edge/src/quic_listener/bootstrap/listener.rs
@@ -27,6 +27,7 @@ use super::{
     request::{
         BootstrapBuildRequestInput, BootstrapPolicyEvaluationInput, BootstrapRequestMode,
         BootstrapTerminalOutcome, build_bootstrap_upstream_request,
+        evaluate_bootstrap_external_auth,
         evaluate_bootstrap_request_policy,
     },
     response::{BootstrapWritebackInput, boxed_full, write_bootstrap_response},
@@ -348,6 +349,21 @@ pub(in crate::quic_listener) fn spawn_bootstrap_tls_listener(
                                 request_mode,
                                 client_upgrade: None,
                             };
+                            let request_header_mutations = match evaluate_bootstrap_external_auth(
+                                &req,
+                                &intake_for_build,
+                                &prepared_route,
+                                request_ctx,
+                                request_id,
+                                traceparent.as_deref(),
+                            )
+                            .await
+                            {
+                                Ok(mutations) => mutations,
+                                Err(terminal) => {
+                                    return Ok(terminal.into_observed_response(request_id));
+                                }
+                            };
                             let upstream_req = match build_bootstrap_upstream_request(
                                 BootstrapBuildRequestInput {
                                     request: req,
@@ -356,6 +372,7 @@ pub(in crate::quic_listener) fn spawn_bootstrap_tls_listener(
                                     request_ctx,
                                     request_id,
                                     traceparent: traceparent.as_deref(),
+                                    request_header_mutations,
                                 },
                             ) {
                                 Ok(request) => request,

--- a/crates/edge/src/quic_listener/bootstrap/listener.rs
+++ b/crates/edge/src/quic_listener/bootstrap/listener.rs
@@ -27,8 +27,7 @@ use super::{
     request::{
         BootstrapBuildRequestInput, BootstrapPolicyEvaluationInput, BootstrapRequestMode,
         BootstrapTerminalOutcome, build_bootstrap_upstream_request,
-        evaluate_bootstrap_external_auth,
-        evaluate_bootstrap_request_policy,
+        evaluate_bootstrap_external_auth, evaluate_bootstrap_request_policy,
     },
     response::{BootstrapWritebackInput, boxed_full, write_bootstrap_response},
     startup::{

--- a/crates/edge/src/quic_listener/bootstrap/request.rs
+++ b/crates/edge/src/quic_listener/bootstrap/request.rs
@@ -28,14 +28,21 @@ use super::{
             AdmissionPolicyDecision, admission_rejection_response,
             evaluate_forwarding_pre_admission_policy,
         },
-        forwarding::BootstrapTargetResolutionInput,
+        forwarding::{BootstrapTargetResolutionInput, evaluate_pending_forward_external_auth},
     },
     context::BootstrapRequestCtx,
     intake::{BootstrapRequestIntake, bootstrap_error_response},
     outcome::{observe_bootstrap_admission_outcome, observe_bootstrap_request_proxy_error},
     response::{BootstrapStreamingBody, boxed_full},
 };
-use crate::runtime::connection::outcome::AdmissionOutcomeClass;
+use crate::runtime::connection::{
+    auth::{
+        ExternalAuthDecision, ExternalAuthStateTransition, PendingHeaderMutation,
+        apply_auth_request_mutations,
+    },
+    outcome::AdmissionOutcomeClass,
+    request::PendingForward,
+};
 
 /// The bootstrap request lifecycle stages, mirroring the QUIC data path so the
 /// same reasoning applies at the currently emitted terminal boundaries.
@@ -236,6 +243,7 @@ pub(in crate::quic_listener) struct BootstrapBuildRequestInput<'a> {
     pub(in crate::quic_listener) request_ctx: BootstrapRequestCtx<'a>,
     pub(in crate::quic_listener) request_id: u64,
     pub(in crate::quic_listener) traceparent: Option<&'a str>,
+    pub(in crate::quic_listener) request_header_mutations: Vec<PendingHeaderMutation>,
 }
 
 fn bootstrap_bridge_headers(headers: &HeaderMap) -> Vec<quiche::h3::Header> {
@@ -243,6 +251,139 @@ fn bootstrap_bridge_headers(headers: &HeaderMap) -> Vec<quiche::h3::Header> {
         .iter()
         .map(|(name, value)| quiche::h3::Header::new(name.as_str().as_bytes(), value.as_bytes()))
         .collect()
+}
+
+fn bootstrap_pending_forward(
+    request: &Request<Incoming>,
+    intake: &BootstrapRequestIntake,
+    prepared_route: &BootstrapPreparedRoute,
+    request_ctx: BootstrapRequestCtx<'_>,
+    request_id: u64,
+    traceparent: Option<&str>,
+) -> Arc<PendingForward> {
+    Arc::new(PendingForward {
+        method: Arc::<str>::from(intake.method.as_str()),
+        path: Arc::<str>::from(intake.path.as_str()),
+        authority: intake.authority.as_deref().map(Arc::<str>::from),
+        headers: Arc::new(bootstrap_bridge_headers(request.headers())),
+        upstream_name: Arc::<str>::from(prepared_route.upstream_name.as_str()),
+        route_reason: Arc::<str>::from("bootstrap"),
+        route_path_len: intake.path.len(),
+        route_host_specific: intake.authority.is_some(),
+        backend_addr: Arc::<str>::from(prepared_route.backend_addr.as_str()),
+        backend_index: prepared_route.backend_index,
+        backend_lb: None,
+        client_addr: request_ctx.peer,
+        request_id,
+        trace_id: None,
+        span_id: None,
+        traceparent: traceparent.map(Arc::<str>::from),
+        host_policy: prepared_route.upstream_policy.host.0.clone(),
+        forwarded_header_policy: prepared_route.upstream_policy.forwarded_headers.0.clone(),
+        auth_header_mutations: Vec::new(),
+    })
+}
+
+fn bootstrap_external_auth_response(
+    alt_svc: &str,
+    decision: &ExternalAuthDecision,
+) -> Response<BoxBody<Bytes, Infallible>> {
+    let mut builder = Response::builder().header("alt-svc", alt_svc);
+    match decision {
+        ExternalAuthDecision::Allow {
+            request_header_mutations: _,
+        } => Response::new(boxed_full(Bytes::new())),
+        ExternalAuthDecision::Deny(response) => {
+            builder = builder.status(response.status);
+            for (name, value) in &response.headers {
+                builder = builder.header(name, value);
+            }
+            builder
+                .body(boxed_full(Bytes::copy_from_slice(&response.body)))
+                .unwrap_or_else(|_| Response::new(boxed_full(Bytes::from_static(b"error\n"))))
+        }
+        ExternalAuthDecision::Redirect(response) => {
+            builder = builder.status(response.status);
+            for (name, value) in &response.headers {
+                builder = builder.header(name, value);
+            }
+            builder = builder.header("location", &response.location);
+            builder
+                .body(boxed_full(Bytes::new()))
+                .unwrap_or_else(|_| Response::new(boxed_full(Bytes::from_static(b"error\n"))))
+        }
+        ExternalAuthDecision::Challenge(response) => {
+            builder = builder.status(response.status);
+            for (name, value) in &response.headers {
+                builder = builder.header(name, value);
+            }
+            builder = builder.header("www-authenticate", &response.www_authenticate);
+            builder
+                .body(boxed_full(Bytes::copy_from_slice(&response.body)))
+                .unwrap_or_else(|_| Response::new(boxed_full(Bytes::from_static(b"error\n"))))
+        }
+    }
+}
+
+pub(in crate::quic_listener) async fn evaluate_bootstrap_external_auth(
+    request: &Request<Incoming>,
+    intake: &BootstrapRequestIntake,
+    prepared_route: &BootstrapPreparedRoute,
+    request_ctx: BootstrapRequestCtx<'_>,
+    request_id: u64,
+    traceparent: Option<&str>,
+) -> BootstrapTerminalResult<Vec<PendingHeaderMutation>> {
+    let Some(external_auth) = prepared_route
+        .upstream_policy
+        .upstream_auth
+        .external_auth
+        .clone()
+    else {
+        return Ok(Vec::new());
+    };
+
+    let pending_forward = bootstrap_pending_forward(
+        request,
+        intake,
+        prepared_route,
+        request_ctx,
+        request_id,
+        traceparent,
+    );
+    match evaluate_pending_forward_external_auth(pending_forward, external_auth).await {
+        ExternalAuthStateTransition::Admitted {
+            request_header_mutations,
+        } => {
+            request_ctx.runtime.metrics.inc_external_auth_allowed();
+            Ok(request_header_mutations)
+        }
+        ExternalAuthStateTransition::RejectedAuthDenied { decision } => {
+            request_ctx.runtime.metrics.inc_external_auth_denied();
+            Err(BootstrapTerminalResponse::new(
+                BootstrapLifecycleStage::AdmitOrReject,
+                BootstrapTerminalOutcome::Rejected(BootstrapRejectionReason::AuthDenied),
+                bootstrap_external_auth_response(&request_ctx.runtime.alt_svc, &decision),
+            ))
+        }
+        ExternalAuthStateTransition::RejectedAuthUnavailable { status, body, .. } => {
+            request_ctx.runtime.metrics.inc_external_auth_error();
+            Err(BootstrapTerminalResponse::new(
+                BootstrapLifecycleStage::AdmitOrReject,
+                BootstrapTerminalOutcome::BackendFailed(
+                    BootstrapBackendFailureReason::DispatchFailed,
+                ),
+                bootstrap_error_response(&request_ctx.runtime.alt_svc, status, body),
+            ))
+        }
+        ExternalAuthStateTransition::TimedOutAuth { status, body } => {
+            request_ctx.runtime.metrics.inc_external_auth_timeout();
+            Err(BootstrapTerminalResponse::new(
+                BootstrapLifecycleStage::AdmitOrReject,
+                BootstrapTerminalOutcome::TimedOut(BootstrapTimeoutReason::Upstream),
+                bootstrap_error_response(&request_ctx.runtime.alt_svc, status, body),
+            ))
+        }
+    }
 }
 
 fn bootstrap_request_build_target<'a>(
@@ -577,7 +718,8 @@ pub(in crate::quic_listener) fn evaluate_bootstrap_request_policy(
 pub(in crate::quic_listener) fn build_bootstrap_upstream_request(
     input: BootstrapBuildRequestInput<'_>,
 ) -> Result<Request<BoxBody<Bytes, Infallible>>, BridgeError> {
-    let bridge_headers = bootstrap_bridge_headers(input.request.headers());
+    let mut bridge_headers = bootstrap_bridge_headers(input.request.headers());
+    apply_auth_request_mutations(&mut bridge_headers, &input.request_header_mutations);
     let request_target = bootstrap_request_build_target(
         &input.prepared_route.endpoint,
         &input.prepared_route.upstream_policy,

--- a/crates/edge/src/quic_listener/forwarding/auth.rs
+++ b/crates/edge/src/quic_listener/forwarding/auth.rs
@@ -438,6 +438,16 @@ pub(super) fn start_external_auth_task(
     })
 }
 
+pub(in crate::quic_listener) async fn evaluate_pending_forward_external_auth(
+    pending_forward: Arc<PendingForward>,
+    external_auth: RuntimeExternalAuth,
+) -> ExternalAuthStateTransition {
+    let task_config = ExternalAuthTaskConfig::from_external_auth(&external_auth);
+    let result =
+        run_external_auth_with_timeout(pending_forward, external_auth, task_config.timeout).await;
+    resolve_external_auth_state_transition(result, task_config.disposition)
+}
+
 impl QUICListener {
     pub(super) fn complete_auth_result(
         stream_id: u64,

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -12,11 +12,12 @@ use http_body_util::Full;
 use spooky_config::config::ScopedRateLimitScope;
 use spooky_errors::ClassifiedUpstreamProxyError;
 
-pub(in crate::quic_listener) use self::auth::evaluate_pending_forward_external_auth;
 use self::prepare::{RequestFinalizationConfig, StartedRequestEnvelope};
-pub(in crate::quic_listener) use self::resolve::BootstrapTargetResolutionInput;
 #[cfg(test)]
 pub(in crate::quic_listener) use self::resolve::TargetResolutionRequest as TestTargetResolutionRequest;
+pub(in crate::quic_listener) use self::{
+    auth::evaluate_pending_forward_external_auth, resolve::BootstrapTargetResolutionInput,
+};
 use super::*;
 use crate::runtime::connection::{
     outcome::{

--- a/crates/edge/src/quic_listener/forwarding/mod.rs
+++ b/crates/edge/src/quic_listener/forwarding/mod.rs
@@ -12,6 +12,7 @@ use http_body_util::Full;
 use spooky_config::config::ScopedRateLimitScope;
 use spooky_errors::ClassifiedUpstreamProxyError;
 
+pub(in crate::quic_listener) use self::auth::evaluate_pending_forward_external_auth;
 use self::prepare::{RequestFinalizationConfig, StartedRequestEnvelope};
 pub(in crate::quic_listener) use self::resolve::BootstrapTargetResolutionInput;
 #[cfg(test)]

--- a/crates/edge/src/quic_listener/forwarding/prepare.rs
+++ b/crates/edge/src/quic_listener/forwarding/prepare.rs
@@ -638,12 +638,11 @@ impl QUICListener {
                 })
             }
             Err(err) => {
-                let (status, body): (http::StatusCode, &[u8]) = match err {
-                    ProxyError::Transport(_) => (
-                        http::StatusCode::SERVICE_UNAVAILABLE,
-                        b"no upstream available\n",
-                    ),
+                let (status, body): (http::StatusCode, &[u8]) = match &err {
                     ProxyError::Bridge(_) => (http::StatusCode::BAD_REQUEST, b"invalid request\n"),
+                    ProxyError::Transport(_) | ProxyError::Pool(_) => {
+                        Self::bootstrap_route_resolution_error_response(&err)
+                    }
                     _ => (
                         http::StatusCode::INTERNAL_SERVER_ERROR,
                         b"internal proxy error\n",

--- a/crates/edge/tests/bootstrap_quic_parity.rs
+++ b/crates/edge/tests/bootstrap_quic_parity.rs
@@ -1,11 +1,21 @@
-use std::{collections::HashMap, convert::Infallible};
+use std::{
+    collections::HashMap,
+    convert::Infallible,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    thread,
+    time::Duration,
+};
 
 use bytes::Bytes;
 use http_body_util::Full;
 use hyper::{Request, Response, body::Incoming};
+use serial_test::serial;
 use spooky_config::config::{
     ApiKeyAuth, ExternalAuth, ExternalAuthFailureMode, ExternalAuthRequestHeader, JwtAuth,
-    LoadBalancing, RouteAuth, RouteMatch, Upstream,
+    LoadBalancing, RouteAuth, RouteMatch, ScopedRateLimit, ScopedRateLimitScope, Upstream,
 };
 
 mod support;
@@ -13,6 +23,7 @@ mod support;
 use support::{
     net::local_listener_bind_available,
     parity::{BootstrapQuicParityHarness, ParityRequestSpec, make_backend, make_upstream},
+    request_path::{BootstrapRequestSpec, H3RequestSpec, run_bootstrap_request_to, run_request_to},
 };
 
 #[test]
@@ -508,6 +519,74 @@ fn bootstrap_and_quic_external_auth_decisions_match() {
     }
 }
 
+#[test]
+#[serial]
+fn bootstrap_and_quic_admission_rate_limit_rejections_match() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let quic = run_scoped_rate_limit_scenario(IngressKind::Quic);
+    let bootstrap = run_scoped_rate_limit_scenario(IngressKind::Bootstrap);
+
+    assert_eq!(quic.status, 429);
+    assert_eq!(bootstrap.status, 429);
+    assert_eq!(bootstrap.status, quic.status);
+    assert_eq!(bootstrap.body, quic.body);
+    assert!(
+        quic.body.contains("request rate limited"),
+        "expected canonical rate-limit rejection body, got `{}`",
+        quic.body
+    );
+    assert_eq!(bootstrap.headers, quic.headers);
+    assert_eq!(
+        quic.headers,
+        vec![(String::from("retry-after"), String::from("1"))]
+    );
+    assert_eq!(
+        quic.upstream_calls, 1,
+        "quic rate-limit path should reject before the second upstream dispatch"
+    );
+    assert_eq!(
+        bootstrap.upstream_calls, 1,
+        "bootstrap rate-limit path should reject before the second upstream dispatch"
+    );
+}
+
+#[test]
+#[serial]
+#[ignore = "bootstrap path does not yet share post-auth admission overload semantics"]
+fn bootstrap_and_quic_admission_overload_shed_contracts_match() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let quic = run_overload_shed_scenario(IngressKind::Quic);
+    let bootstrap = run_overload_shed_scenario(IngressKind::Bootstrap);
+
+    assert_eq!(quic.status, 503);
+    assert_eq!(bootstrap.status, 503);
+    assert_eq!(bootstrap.body, quic.body);
+    assert!(
+        quic.body.contains("route queue cap exceeded"),
+        "expected canonical overload body, got `{}`",
+        quic.body
+    );
+    assert_eq!(bootstrap.headers, quic.headers);
+    assert_eq!(
+        quic.headers,
+        vec![(String::from("retry-after"), String::from("1"))]
+    );
+    assert_eq!(
+        quic.upstream_calls, 1,
+        "quic overload shedding should stop the second request before backend dispatch"
+    );
+    assert_eq!(
+        bootstrap.upstream_calls, 1,
+        "bootstrap overload shedding should stop the second request before backend dispatch"
+    );
+}
+
 fn routed_upstream(
     host: Option<&str>,
     path_prefix: &str,
@@ -602,4 +681,260 @@ struct ExternalAuthParityCase<'a> {
     expected_status: u16,
     expected_body: &'a [u8],
     expected_headers: &'a [(&'a str, &'a str)],
+}
+
+#[derive(Clone, Copy)]
+enum IngressKind {
+    Quic,
+    Bootstrap,
+}
+
+struct RejectionObservation {
+    status: u16,
+    body: String,
+    headers: Vec<(String, String)>,
+    upstream_calls: usize,
+}
+
+fn run_scoped_rate_limit_scenario(ingress: IngressKind) -> RejectionObservation {
+    let mut harness = BootstrapQuicParityHarness::new();
+    let upstream_calls = Arc::new(AtomicUsize::new(0));
+    let backend_observed = Arc::clone(&upstream_calls);
+    let backend_addr = harness.start_h1_backend(move |_req: Request<Incoming>| {
+        let backend_observed = Arc::clone(&backend_observed);
+        async move {
+            backend_observed.fetch_add(1, Ordering::Relaxed);
+            Ok::<_, Infallible>(Response::new(Full::new(Bytes::from_static(
+                b"rate-limit ok",
+            ))))
+        }
+    });
+
+    let mut config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        make_upstream(
+            "/limited",
+            vec![make_backend("backend-a", backend_addr.to_string())],
+            None,
+            "round-robin",
+        ),
+    )]));
+    config.resilience.scoped_rate_limits = vec![ScopedRateLimit {
+        name: "route-cap".to_string(),
+        scope: ScopedRateLimitScope::Route,
+        requests_per_sec: 1,
+        burst: 1,
+        key: None,
+        route_allowlist: vec!["api".to_string()],
+        idle_ttl_secs: 300,
+    }];
+
+    harness.start_listener(config).expect("listener with bootstrap");
+
+    let success = run_parity_ingress_request(
+        ingress,
+        &harness,
+        ParityRequestSpec {
+            method: "GET",
+            authority: "localhost",
+            path: "/limited",
+            headers: &[],
+            body: None,
+            user_agent: "spooky-bootstrap-quic-parity-test",
+            selected_response_headers: &[],
+            capture_metrics_delta: false,
+        },
+    )
+    .expect("first request should complete");
+    assert_eq!(success.status, 200);
+
+    let rejection = run_parity_ingress_request(
+        ingress,
+        &harness,
+        ParityRequestSpec {
+            method: "GET",
+            authority: "localhost",
+            path: "/limited",
+            headers: &[],
+            body: None,
+            user_agent: "spooky-bootstrap-quic-parity-test",
+            selected_response_headers: &["retry-after", "www-authenticate"],
+            capture_metrics_delta: false,
+        },
+    )
+    .expect("second request should complete");
+
+    RejectionObservation {
+        status: rejection.status,
+        body: String::from_utf8_lossy(&rejection.body).into_owned(),
+        headers: rejection.selected_headers,
+        upstream_calls: upstream_calls.load(Ordering::Relaxed),
+    }
+}
+
+fn run_overload_shed_scenario(ingress: IngressKind) -> RejectionObservation {
+    let mut harness = BootstrapQuicParityHarness::new();
+    let upstream_calls = Arc::new(AtomicUsize::new(0));
+    let backend_observed = Arc::clone(&upstream_calls);
+    let backend_addr = harness.start_h1_backend(move |_req: Request<Incoming>| {
+        let backend_observed = Arc::clone(&backend_observed);
+        async move {
+            backend_observed.fetch_add(1, Ordering::Relaxed);
+            tokio::time::sleep(Duration::from_millis(250)).await;
+            Ok::<_, Infallible>(Response::new(Full::new(Bytes::from_static(b"slow ok"))))
+        }
+    });
+
+    let mut config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        make_upstream(
+            "/slow",
+            vec![make_backend("backend-a", backend_addr.to_string())],
+            None,
+            "round-robin",
+        ),
+    )]));
+    config.performance.global_inflight_limit = 64;
+    config.resilience.route_queue.default_cap = 1;
+    config.resilience.route_queue.global_cap = 64;
+    harness.start_listener(config).expect("listener with bootstrap");
+    let listen_addr = harness.listen_addr();
+    let cert_path = harness.cert_path().to_string();
+
+    let first_request = thread::spawn({
+        let cert_path = cert_path.clone();
+        move || {
+            execute_ingress_request(
+                ingress,
+                listen_addr,
+                &cert_path,
+                ParityRequestSpec::get("localhost", "/slow"),
+            )
+        }
+    });
+
+    for _ in 0..50 {
+        if upstream_calls.load(Ordering::Relaxed) > 0 {
+            break;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    let rejection = execute_ingress_request(
+        ingress,
+        listen_addr,
+        &cert_path,
+        ParityRequestSpec {
+            method: "GET",
+            authority: "localhost",
+            path: "/slow",
+            headers: &[],
+            body: None,
+            user_agent: "spooky-bootstrap-quic-parity-test",
+            selected_response_headers: &["retry-after", "www-authenticate"],
+            capture_metrics_delta: false,
+        },
+    )
+    .expect("second request should complete");
+    let first_response = first_request
+        .join()
+        .expect("first request thread")
+        .expect("first request should complete");
+    assert_eq!(first_response.status, 200);
+
+    RejectionObservation {
+        status: rejection.status,
+        body: String::from_utf8_lossy(&rejection.body).into_owned(),
+        headers: rejection.selected_headers,
+        upstream_calls: upstream_calls.load(Ordering::Relaxed),
+    }
+}
+
+fn run_parity_ingress_request(
+    ingress: IngressKind,
+    harness: &BootstrapQuicParityHarness,
+    request: ParityRequestSpec<'_>,
+) -> Result<support::parity::ParityResponseSnapshot, String> {
+    let observation = match ingress {
+        IngressKind::Quic => harness.run_quic(request)?,
+        IngressKind::Bootstrap => harness.run_bootstrap(request)?,
+    };
+    Ok(observation.response)
+}
+
+fn execute_ingress_request(
+    ingress: IngressKind,
+    listen_addr: std::net::SocketAddr,
+    cert_path: &str,
+    request: ParityRequestSpec<'_>,
+) -> Result<support::parity::ParityResponseSnapshot, String> {
+    match ingress {
+        IngressKind::Quic => {
+            let response = run_request_to(
+                listen_addr,
+                H3RequestSpec {
+                    method: request.method,
+                    authority: request.authority,
+                    path: request.path,
+                    headers: request.headers,
+                    body: request.body,
+                    user_agent: request.user_agent,
+                },
+            )?;
+            Ok(parity_snapshot_from_response(
+                response.status,
+                response.body,
+                response.headers,
+                request.selected_response_headers,
+            ))
+        }
+        IngressKind::Bootstrap => {
+            let response = run_bootstrap_request_to(
+                listen_addr,
+                cert_path,
+                BootstrapRequestSpec {
+                    method: request.method,
+                    authority: request.authority,
+                    path: request.path,
+                    headers: request.headers,
+                    body: request.body,
+                    user_agent: request.user_agent,
+                },
+            )?;
+            Ok(parity_snapshot_from_response(
+                response.status,
+                response.body,
+                response.headers,
+                request.selected_response_headers,
+            ))
+        }
+    }
+}
+
+fn parity_snapshot_from_response(
+    status: u16,
+    body: Vec<u8>,
+    headers: Vec<(String, String)>,
+    selected_response_headers: &[&str],
+) -> support::parity::ParityResponseSnapshot {
+    let mut selected_headers = headers
+        .into_iter()
+        .filter(|(name, _)| {
+            selected_response_headers
+                .iter()
+                .any(|selected| name.eq_ignore_ascii_case(selected))
+        })
+        .collect::<Vec<_>>();
+    selected_headers.sort_by(|left, right| {
+        left.0
+            .to_ascii_lowercase()
+            .cmp(&right.0.to_ascii_lowercase())
+            .then_with(|| left.1.cmp(&right.1))
+    });
+
+    support::parity::ParityResponseSnapshot {
+        status,
+        body,
+        selected_headers,
+    }
 }

--- a/crates/edge/tests/bootstrap_quic_parity.rs
+++ b/crates/edge/tests/bootstrap_quic_parity.rs
@@ -1,0 +1,62 @@
+use std::{collections::HashMap, convert::Infallible};
+
+use bytes::Bytes;
+use http_body_util::Full;
+use hyper::{Request, Response, body::Incoming};
+
+mod support;
+
+use support::{
+    net::local_listener_bind_available,
+    parity::{BootstrapQuicParityHarness, ParityRequestSpec, make_backend, make_upstream},
+};
+
+#[test]
+fn bootstrap_and_quic_parity_harness_collects_canonical_response_shape() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = BootstrapQuicParityHarness::new();
+    let backend_addr = harness.start_h1_backend(|_req: Request<Incoming>| async move {
+        Ok::<_, Infallible>(
+            Response::builder()
+                .status(200)
+                .header("x-parity", "ok")
+                .body(Full::new(Bytes::from_static(b"parity ok\n")))
+                .expect("response"),
+        )
+    });
+
+    let mut upstreams = HashMap::new();
+    upstreams.insert(
+        "api".to_string(),
+        make_upstream(
+            "/",
+            vec![make_backend("backend-a", backend_addr.to_string())],
+            None,
+            "round-robin",
+        ),
+    );
+
+    let config = harness.make_config(upstreams);
+    harness.start_listener(config).expect("listener with bootstrap");
+
+    let mut request = ParityRequestSpec::get("localhost", "/");
+    request.selected_response_headers = &["x-parity"];
+    request.capture_metrics_delta = true;
+
+    let pair = harness.run_parity_pair(request).expect("parity pair");
+
+    assert_eq!(pair.quic.response.status, 200);
+    assert_eq!(pair.bootstrap.response.status, 200);
+    assert_eq!(pair.quic.response.body, pair.bootstrap.response.body);
+    assert_eq!(pair.quic.response.body, b"parity ok\n");
+    assert_eq!(pair.quic.response.selected_headers, pair.bootstrap.response.selected_headers);
+    assert_eq!(
+        pair.quic.response.selected_headers,
+        vec![(String::from("x-parity"), String::from("ok"))]
+    );
+    assert!(pair.quic.metrics_delta.is_some());
+    assert!(pair.bootstrap.metrics_delta.is_some());
+}

--- a/crates/edge/tests/bootstrap_quic_parity.rs
+++ b/crates/edge/tests/bootstrap_quic_parity.rs
@@ -1125,6 +1125,228 @@ fn bootstrap_and_quic_admission_overload_shed_contracts_match() {
     );
 }
 
+#[test]
+#[serial]
+fn bootstrap_and_quic_outcome_recording_success_bucket_matches() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = BootstrapQuicParityHarness::new();
+    let backend_addr = harness.start_h1_static_backend(b"metrics success");
+
+    let config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        make_upstream(
+            "/metrics-success",
+            vec![make_backend("backend-a", backend_addr.to_string())],
+            None,
+            "round-robin",
+        ),
+    )]));
+    harness.start_listener(config).expect("listener with bootstrap");
+
+    let request = ParityRequestSpec {
+        method: "GET",
+        authority: "localhost",
+        path: "/metrics-success",
+        headers: &[],
+        body: None,
+        user_agent: "spooky-bootstrap-quic-parity-test",
+        selected_response_headers: &[],
+        capture_metrics_delta: true,
+    };
+    let pair = harness
+        .run_parity_pair(request)
+        .expect("success outcome parity pair");
+
+    assert_eq!(pair.quic.response.status, 200);
+    assert_eq!(pair.bootstrap.response.status, 200);
+
+    let quic = OutcomeRecordingDelta::from_snapshot(require_metrics_delta(&pair.quic), "api");
+    let bootstrap =
+        OutcomeRecordingDelta::from_snapshot(require_metrics_delta(&pair.bootstrap), "api");
+    let expected = OutcomeRecordingBuckets {
+        success: true,
+        failure: false,
+        timeout: false,
+        overload_shed: false,
+        rate_limited: false,
+    };
+    assert_eq!(quic.coarse_buckets(), expected);
+    assert_eq!(bootstrap.coarse_buckets(), expected);
+}
+
+#[test]
+#[serial]
+fn bootstrap_and_quic_outcome_recording_failure_bucket_matches() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = BootstrapQuicParityHarness::new();
+    let unused_listener = TcpListener::bind("127.0.0.1:0").expect("bind unused backend port");
+    let unused_addr = unused_listener.local_addr().expect("unused backend addr");
+    drop(unused_listener);
+
+    let mut config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        make_upstream(
+            "/metrics-failure",
+            vec![make_backend("backend-a", format!("http://{unused_addr}"))],
+            None,
+            "round-robin",
+        ),
+    )]));
+    config.performance.backend_timeout_ms = 150;
+    config.performance.backend_connect_timeout_ms = 150;
+    harness.start_listener(config).expect("listener with bootstrap");
+
+    let request = ParityRequestSpec {
+        method: "GET",
+        authority: "localhost",
+        path: "/metrics-failure",
+        headers: &[],
+        body: None,
+        user_agent: "spooky-bootstrap-quic-parity-test",
+        selected_response_headers: &[],
+        capture_metrics_delta: true,
+    };
+    let pair = harness
+        .run_parity_pair(request)
+        .expect("failure outcome parity pair");
+
+    assert_eq!(pair.quic.response.status, 502);
+    assert_eq!(pair.bootstrap.response.status, 502);
+
+    let quic = OutcomeRecordingDelta::from_snapshot(require_metrics_delta(&pair.quic), "api");
+    let bootstrap =
+        OutcomeRecordingDelta::from_snapshot(require_metrics_delta(&pair.bootstrap), "api");
+    let expected = OutcomeRecordingBuckets {
+        success: false,
+        failure: true,
+        timeout: false,
+        overload_shed: false,
+        rate_limited: false,
+    };
+    assert_eq!(quic.coarse_buckets(), expected);
+    assert_eq!(bootstrap.coarse_buckets(), expected);
+}
+
+#[test]
+#[serial]
+fn bootstrap_and_quic_outcome_recording_timeout_bucket_matches() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = BootstrapQuicParityHarness::new();
+    let backend_addr = harness.start_h1_backend(|_req: Request<Incoming>| async move {
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        Ok::<_, Infallible>(Response::new(Full::new(Bytes::from_static(
+            b"too late",
+        ))))
+    });
+
+    let mut config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        make_upstream(
+            "/metrics-timeout",
+            vec![make_backend("backend-a", backend_addr.to_string())],
+            None,
+            "round-robin",
+        ),
+    )]));
+    config.performance.backend_timeout_ms = 150;
+    config.performance.backend_connect_timeout_ms = 150;
+    harness.start_listener(config).expect("listener with bootstrap");
+
+    let request = ParityRequestSpec {
+        method: "GET",
+        authority: "localhost",
+        path: "/metrics-timeout",
+        headers: &[],
+        body: None,
+        user_agent: "spooky-bootstrap-quic-parity-test",
+        selected_response_headers: &[],
+        capture_metrics_delta: true,
+    };
+    let pair = harness
+        .run_parity_pair(request)
+        .expect("timeout outcome parity pair");
+
+    assert_timeout_bucket(&pair.quic.response);
+    assert_timeout_bucket(&pair.bootstrap.response);
+
+    let quic = OutcomeRecordingDelta::from_snapshot(require_metrics_delta(&pair.quic), "api");
+    let bootstrap =
+        OutcomeRecordingDelta::from_snapshot(require_metrics_delta(&pair.bootstrap), "api");
+    let expected = OutcomeRecordingBuckets {
+        success: false,
+        failure: true,
+        timeout: true,
+        overload_shed: false,
+        rate_limited: false,
+    };
+    assert_eq!(quic.coarse_buckets(), expected);
+    assert_eq!(bootstrap.coarse_buckets(), expected);
+}
+
+#[test]
+#[serial]
+fn bootstrap_and_quic_outcome_recording_rate_limited_bucket_matches() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let quic = run_rate_limit_outcome_recording_scenario(IngressKind::Quic);
+    let bootstrap = run_rate_limit_outcome_recording_scenario(IngressKind::Bootstrap);
+
+    assert_eq!(quic.response.status, 429);
+    assert_eq!(bootstrap.response.status, 429);
+    assert_eq!(bootstrap.response.body, quic.response.body);
+    assert_eq!(bootstrap.response.selected_headers, quic.response.selected_headers);
+    let expected = OutcomeRecordingBuckets {
+        success: true,
+        failure: true,
+        timeout: false,
+        overload_shed: false,
+        rate_limited: true,
+    };
+    assert_eq!(quic.metrics.coarse_buckets(), expected);
+    assert_eq!(bootstrap.metrics.coarse_buckets(), expected);
+    assert_eq!(quic.upstream_calls, 1);
+    assert_eq!(bootstrap.upstream_calls, 1);
+}
+
+#[test]
+#[serial]
+#[ignore = "bootstrap path does not yet share post-auth admission overload semantics"]
+fn bootstrap_and_quic_outcome_recording_overload_bucket_matches() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let quic = run_overload_outcome_recording_scenario(IngressKind::Quic);
+    let bootstrap = run_overload_outcome_recording_scenario(IngressKind::Bootstrap);
+
+    assert_eq!(quic.rejection.status, 503);
+    assert_eq!(bootstrap.rejection.status, 503);
+    assert_eq!(bootstrap.rejection.body, quic.rejection.body);
+    assert_eq!(bootstrap.rejection.selected_headers, quic.rejection.selected_headers);
+    let expected = OutcomeRecordingBuckets {
+        success: true,
+        failure: true,
+        timeout: false,
+        overload_shed: true,
+        rate_limited: false,
+    };
+    assert_eq!(quic.metrics.coarse_buckets(), expected);
+    assert_eq!(bootstrap.metrics.coarse_buckets(), expected);
+    assert_eq!(quic.upstream_calls, 1);
+    assert_eq!(bootstrap.upstream_calls, 1);
+}
+
 fn routed_upstream(
     host: Option<&str>,
     path_prefix: &str,
@@ -1233,6 +1455,111 @@ fn assert_timeout_bucket(response: &support::parity::ParityResponseSnapshot) {
     );
 }
 
+fn require_metrics_delta(
+    observation: &support::parity::ParityObservation,
+) -> &support::parity::MetricsDeltaSnapshot {
+    observation
+        .metrics_delta
+        .as_ref()
+        .expect("parity observation should include metrics delta")
+}
+
+fn metrics_counter(metrics: &str, prefix: &str) -> u64 {
+    metrics
+        .lines()
+        .find_map(|line| line.strip_prefix(prefix))
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or_else(|| panic!("missing metrics counter `{prefix}` in metrics:\n{metrics}"))
+}
+
+fn metrics_delta(before: &str, after: &str, prefix: &str) -> u64 {
+    metrics_counter(after, prefix).saturating_sub(metrics_counter(before, prefix))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct OutcomeRecordingDelta {
+    requests_success: u64,
+    requests_failure: u64,
+    route_success: u64,
+    route_failure: u64,
+    route_timeout: u64,
+    route_overload_shed: u64,
+    route_rate_limited: u64,
+}
+
+impl OutcomeRecordingDelta {
+    fn from_snapshot(snapshot: &support::parity::MetricsDeltaSnapshot, route: &str) -> Self {
+        Self::from_texts(&snapshot.before, &snapshot.after, route)
+    }
+
+    fn from_texts(before: &str, after: &str, route: &str) -> Self {
+        Self {
+            requests_success: metrics_delta(before, after, "spooky_requests_success "),
+            requests_failure: metrics_delta(before, after, "spooky_requests_failure "),
+            route_success: metrics_delta(
+                before,
+                after,
+                &format!("spooky_route_success_total{{route=\"{route}\"}} "),
+            ),
+            route_failure: metrics_delta(
+                before,
+                after,
+                &format!("spooky_route_failure_total{{route=\"{route}\"}} "),
+            ),
+            route_timeout: metrics_delta(
+                before,
+                after,
+                &format!("spooky_route_timeout_total{{route=\"{route}\"}} "),
+            ),
+            route_overload_shed: metrics_delta(
+                before,
+                after,
+                &format!("spooky_route_overload_shed_total{{route=\"{route}\"}} "),
+            ),
+            route_rate_limited: metrics_delta(
+                before,
+                after,
+                &format!("spooky_route_rate_limited_total{{route=\"{route}\"}} "),
+            ),
+        }
+    }
+
+    fn saturating_add(self, other: Self) -> Self {
+        Self {
+            requests_success: self.requests_success.saturating_add(other.requests_success),
+            requests_failure: self.requests_failure.saturating_add(other.requests_failure),
+            route_success: self.route_success.saturating_add(other.route_success),
+            route_failure: self.route_failure.saturating_add(other.route_failure),
+            route_timeout: self.route_timeout.saturating_add(other.route_timeout),
+            route_overload_shed: self
+                .route_overload_shed
+                .saturating_add(other.route_overload_shed),
+            route_rate_limited: self
+                .route_rate_limited
+                .saturating_add(other.route_rate_limited),
+        }
+    }
+
+    fn coarse_buckets(self) -> OutcomeRecordingBuckets {
+        OutcomeRecordingBuckets {
+            success: self.requests_success > 0 || self.route_success > 0,
+            failure: self.requests_failure > 0 || self.route_failure > 0,
+            timeout: self.route_timeout > 0,
+            overload_shed: self.route_overload_shed > 0,
+            rate_limited: self.route_rate_limited > 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct OutcomeRecordingBuckets {
+    success: bool,
+    failure: bool,
+    timeout: bool,
+    overload_shed: bool,
+    rate_limited: bool,
+}
+
 #[derive(Clone, Copy)]
 struct ExternalAuthParityCase<'a> {
     name: &'a str,
@@ -1255,6 +1582,18 @@ struct RejectionObservation {
     status: u16,
     body: String,
     headers: Vec<(String, String)>,
+    upstream_calls: usize,
+}
+
+struct OutcomeRecordingObservation {
+    response: support::parity::ParityResponseSnapshot,
+    metrics: OutcomeRecordingDelta,
+    upstream_calls: usize,
+}
+
+struct OverloadOutcomeRecordingObservation {
+    rejection: support::parity::ParityResponseSnapshot,
+    metrics: OutcomeRecordingDelta,
     upstream_calls: usize,
 }
 
@@ -1412,6 +1751,173 @@ fn run_overload_shed_scenario(ingress: IngressKind) -> RejectionObservation {
     }
 }
 
+fn run_rate_limit_outcome_recording_scenario(ingress: IngressKind) -> OutcomeRecordingObservation {
+    let mut harness = BootstrapQuicParityHarness::new();
+    let upstream_calls = Arc::new(AtomicUsize::new(0));
+    let backend_observed = Arc::clone(&upstream_calls);
+    let backend_addr = harness.start_h1_backend(move |_req: Request<Incoming>| {
+        let backend_observed = Arc::clone(&backend_observed);
+        async move {
+            backend_observed.fetch_add(1, Ordering::Relaxed);
+            Ok::<_, Infallible>(Response::new(Full::new(Bytes::from_static(
+                b"rate-limit ok",
+            ))))
+        }
+    });
+
+    let mut config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        make_upstream(
+            "/metrics-rate-limit",
+            vec![make_backend("backend-a", backend_addr.to_string())],
+            None,
+            "round-robin",
+        ),
+    )]));
+    config.resilience.scoped_rate_limits = vec![ScopedRateLimit {
+        name: "route-cap".to_string(),
+        scope: ScopedRateLimitScope::Route,
+        requests_per_sec: 1,
+        burst: 1,
+        key: None,
+        route_allowlist: vec!["api".to_string()],
+        idle_ttl_secs: 300,
+    }];
+    harness.start_listener(config).expect("listener with bootstrap");
+
+    let success = run_parity_ingress_observation(
+        ingress,
+        &harness,
+        ParityRequestSpec {
+            method: "GET",
+            authority: "localhost",
+            path: "/metrics-rate-limit",
+            headers: &[],
+            body: None,
+            user_agent: "spooky-bootstrap-quic-parity-test",
+            selected_response_headers: &[],
+            capture_metrics_delta: true,
+        },
+    )
+    .expect("first request should complete");
+    assert_eq!(success.response.status, 200);
+
+    let rejection = run_parity_ingress_observation(
+        ingress,
+        &harness,
+        ParityRequestSpec {
+            method: "GET",
+            authority: "localhost",
+            path: "/metrics-rate-limit",
+            headers: &[],
+            body: None,
+            user_agent: "spooky-bootstrap-quic-parity-test",
+            selected_response_headers: &["retry-after"],
+            capture_metrics_delta: true,
+        },
+    )
+    .expect("rate-limited request should complete");
+
+    let metrics = OutcomeRecordingDelta::from_snapshot(require_metrics_delta(&success), "api")
+        .saturating_add(OutcomeRecordingDelta::from_snapshot(
+            require_metrics_delta(&rejection),
+            "api",
+        ));
+
+    OutcomeRecordingObservation {
+        response: rejection.response,
+        metrics,
+        upstream_calls: upstream_calls.load(Ordering::Relaxed),
+    }
+}
+
+fn run_overload_outcome_recording_scenario(
+    ingress: IngressKind,
+) -> OverloadOutcomeRecordingObservation {
+    let mut harness = BootstrapQuicParityHarness::new();
+    let upstream_calls = Arc::new(AtomicUsize::new(0));
+    let backend_observed = Arc::clone(&upstream_calls);
+    let backend_addr = harness.start_h1_backend(move |_req: Request<Incoming>| {
+        let backend_observed = Arc::clone(&backend_observed);
+        async move {
+            backend_observed.fetch_add(1, Ordering::Relaxed);
+            tokio::time::sleep(Duration::from_millis(250)).await;
+            Ok::<_, Infallible>(Response::new(Full::new(Bytes::from_static(b"slow ok"))))
+        }
+    });
+
+    let mut config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        make_upstream(
+            "/metrics-overload",
+            vec![make_backend("backend-a", backend_addr.to_string())],
+            None,
+            "round-robin",
+        ),
+    )]));
+    config.performance.global_inflight_limit = 64;
+    config.resilience.route_queue.default_cap = 1;
+    config.resilience.route_queue.global_cap = 64;
+    harness.start_listener(config).expect("listener with bootstrap");
+
+    let before = harness
+        .metrics_text()
+        .expect("metrics snapshot before overload scenario");
+    let listen_addr = harness.listen_addr();
+    let cert_path = harness.cert_path().to_string();
+
+    let first_request = thread::spawn({
+        let cert_path = cert_path.clone();
+        move || {
+            execute_ingress_request(
+                ingress,
+                listen_addr,
+                &cert_path,
+                ParityRequestSpec::get("localhost", "/metrics-overload"),
+            )
+        }
+    });
+
+    for _ in 0..50 {
+        if upstream_calls.load(Ordering::Relaxed) > 0 {
+            break;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    let rejection = execute_ingress_request(
+        ingress,
+        listen_addr,
+        &cert_path,
+        ParityRequestSpec {
+            method: "GET",
+            authority: "localhost",
+            path: "/metrics-overload",
+            headers: &[],
+            body: None,
+            user_agent: "spooky-bootstrap-quic-parity-test",
+            selected_response_headers: &["retry-after"],
+            capture_metrics_delta: false,
+        },
+    )
+    .expect("second request should complete");
+    let first_response = first_request
+        .join()
+        .expect("first request thread")
+        .expect("first request should complete");
+    assert_eq!(first_response.status, 200);
+
+    let after = harness
+        .metrics_text()
+        .expect("metrics snapshot after overload scenario");
+
+    OverloadOutcomeRecordingObservation {
+        rejection,
+        metrics: OutcomeRecordingDelta::from_texts(&before, &after, "api"),
+        upstream_calls: upstream_calls.load(Ordering::Relaxed),
+    }
+}
+
 fn run_parity_ingress_request(
     ingress: IngressKind,
     harness: &BootstrapQuicParityHarness,
@@ -1422,6 +1928,17 @@ fn run_parity_ingress_request(
         IngressKind::Bootstrap => harness.run_bootstrap(request)?,
     };
     Ok(observation.response)
+}
+
+fn run_parity_ingress_observation(
+    ingress: IngressKind,
+    harness: &BootstrapQuicParityHarness,
+    request: ParityRequestSpec<'_>,
+) -> Result<support::parity::ParityObservation, String> {
+    match ingress {
+        IngressKind::Quic => harness.run_quic(request),
+        IngressKind::Bootstrap => harness.run_bootstrap(request),
+    }
 }
 
 fn execute_ingress_request(

--- a/crates/edge/tests/bootstrap_quic_parity.rs
+++ b/crates/edge/tests/bootstrap_quic_parity.rs
@@ -520,6 +520,236 @@ fn bootstrap_and_quic_external_auth_decisions_match() {
 }
 
 #[test]
+fn bootstrap_and_quic_response_normalization_strip_same_hop_headers() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = BootstrapQuicParityHarness::new();
+    let backend_addr = harness.start_h1_backend(|_req: Request<Incoming>| async move {
+        Ok::<_, Infallible>(
+            Response::builder()
+                .status(200)
+                .header("connection", "x-hop-token")
+                .header("x-hop-token", "secret")
+                .header("content-length", "9")
+                .header("content-type", "text/plain")
+                .header("cache-control", "max-age=60")
+                .header("etag", "\"etag-1\"")
+                .body(Full::new(Bytes::from_static(b"strip hop")))
+                .expect("response"),
+        )
+    });
+
+    let config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        make_upstream(
+            "/normalize-hop",
+            vec![make_backend("backend-a", backend_addr.to_string())],
+            None,
+            "round-robin",
+        ),
+    )]));
+    harness.start_listener(config).expect("listener with bootstrap");
+
+    let request = ParityRequestSpec {
+        method: "GET",
+        authority: "localhost",
+        path: "/normalize-hop",
+        headers: &[],
+        body: None,
+        user_agent: "spooky-bootstrap-quic-parity-test",
+        selected_response_headers: &[
+            "cache-control",
+            "connection",
+            "content-length",
+            "content-type",
+            "etag",
+            "x-hop-token",
+        ],
+        capture_metrics_delta: false,
+    };
+    let pair = harness
+        .run_parity_pair(request)
+        .expect("response normalization parity pair");
+
+    assert_eq!(pair.quic.response.status, 200);
+    assert_eq!(pair.bootstrap.response.status, 200);
+    assert_eq!(pair.quic.response.body, b"strip hop");
+    assert_eq!(pair.bootstrap.response.body, pair.quic.response.body);
+    assert_eq!(
+        selected_header_value(&pair.quic.response, "cache-control"),
+        Some("max-age=60")
+    );
+    assert_eq!(
+        selected_header_value(&pair.bootstrap.response, "cache-control"),
+        Some("max-age=60")
+    );
+    assert_eq!(
+        selected_header_value(&pair.quic.response, "etag"),
+        Some("\"etag-1\"")
+    );
+    assert_eq!(
+        selected_header_value(&pair.bootstrap.response, "etag"),
+        Some("\"etag-1\"")
+    );
+    for stripped in ["connection", "x-hop-token"] {
+        assert_eq!(
+            selected_header_value(&pair.quic.response, stripped),
+            None,
+            "quic should strip hop header `{stripped}`"
+        );
+        assert_eq!(
+            selected_header_value(&pair.bootstrap.response, stripped),
+            None,
+            "bootstrap should strip hop header `{stripped}`"
+        );
+    }
+    assert_eq!(
+        selected_header_value(&pair.quic.response, "content-type"),
+        Some("text/plain")
+    );
+    assert_eq!(
+        selected_header_value(&pair.bootstrap.response, "content-type"),
+        Some("text/plain")
+    );
+    assert_eq!(
+        selected_header_value(&pair.quic.response, "content-length"),
+        None,
+        "quic should omit downstream content-length under HTTP/3 framing"
+    );
+    assert_eq!(
+        selected_header_value(&pair.bootstrap.response, "content-length"),
+        Some("9"),
+        "bootstrap should preserve explicit content-length under HTTP compatibility ingress"
+    );
+}
+
+#[test]
+fn bootstrap_and_quic_response_normalization_head_bodyless_contract_matches() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = BootstrapQuicParityHarness::new();
+    let backend_addr = harness.start_h1_backend(|_req: Request<Incoming>| async move {
+        Ok::<_, Infallible>(
+            Response::builder()
+                .status(200)
+                .body(Full::new(Bytes::from_static(b"hidden head body")))
+                .expect("response"),
+        )
+    });
+
+    let config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        make_upstream(
+            "/head",
+            vec![make_backend("backend-a", backend_addr.to_string())],
+            None,
+            "round-robin",
+        ),
+    )]));
+    harness.start_listener(config).expect("listener with bootstrap");
+
+    let request = ParityRequestSpec {
+        method: "HEAD",
+        authority: "localhost",
+        path: "/head",
+        headers: &[],
+        body: None,
+        user_agent: "spooky-bootstrap-quic-parity-test",
+        selected_response_headers: &["content-length", "content-type"],
+        capture_metrics_delta: false,
+    };
+    let pair = harness.run_parity_pair(request).expect("head parity pair");
+
+    assert_eq!(pair.quic.response.status, 200);
+    assert_eq!(pair.bootstrap.response.status, 200);
+    assert!(pair.quic.response.body.is_empty());
+    assert!(pair.bootstrap.response.body.is_empty());
+    assert_eq!(
+        selected_header_value(&pair.quic.response, "content-type"),
+        None
+    );
+    assert_eq!(
+        selected_header_value(&pair.bootstrap.response, "content-type"),
+        None
+    );
+    assert_eq!(
+        selected_header_value(&pair.quic.response, "content-length"),
+        None
+    );
+    assert_eq!(
+        selected_header_value(&pair.bootstrap.response, "content-length"),
+        Some("16")
+    );
+}
+
+#[test]
+fn bootstrap_and_quic_response_normalization_no_content_contract_matches() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = BootstrapQuicParityHarness::new();
+    let backend_addr = harness.start_h1_backend(|_req: Request<Incoming>| async move {
+        Ok::<_, Infallible>(
+            Response::builder()
+                .status(204)
+                .body(Full::new(Bytes::new()))
+                .expect("response"),
+        )
+    });
+
+    let config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        make_upstream(
+            "/no-content",
+            vec![make_backend("backend-a", backend_addr.to_string())],
+            None,
+            "round-robin",
+        ),
+    )]));
+    harness.start_listener(config).expect("listener with bootstrap");
+
+    let request = ParityRequestSpec {
+        method: "GET",
+        authority: "localhost",
+        path: "/no-content",
+        headers: &[],
+        body: None,
+        user_agent: "spooky-bootstrap-quic-parity-test",
+        selected_response_headers: &["content-length", "content-type"],
+        capture_metrics_delta: false,
+    };
+    let pair = harness
+        .run_parity_pair(request)
+        .expect("no content parity pair");
+
+    assert_eq!(pair.quic.response.status, 204);
+    assert_eq!(pair.bootstrap.response.status, 204);
+    assert!(pair.quic.response.body.is_empty());
+    assert!(pair.bootstrap.response.body.is_empty());
+    assert_eq!(
+        selected_header_value(&pair.quic.response, "content-type"),
+        None
+    );
+    assert_eq!(
+        selected_header_value(&pair.bootstrap.response, "content-type"),
+        None
+    );
+    assert_eq!(
+        selected_header_value(&pair.quic.response, "content-length"),
+        None
+    );
+    assert_eq!(
+        selected_header_value(&pair.bootstrap.response, "content-length"),
+        None
+    );
+}
+
+#[test]
 #[serial]
 fn bootstrap_and_quic_admission_rate_limit_rejections_match() {
     if !local_listener_bind_available() {
@@ -669,6 +899,17 @@ fn expected_selected_headers(headers: &[(&str, &str)]) -> Vec<(String, String)> 
         .iter()
         .map(|(name, value)| (name.to_string(), value.to_string()))
         .collect()
+}
+
+fn selected_header_value<'a>(
+    response: &'a support::parity::ParityResponseSnapshot,
+    name: &str,
+) -> Option<&'a str> {
+    response
+        .selected_headers
+        .iter()
+        .find(|(header_name, _)| header_name.eq_ignore_ascii_case(name))
+        .map(|(_, value)| value.as_str())
 }
 
 #[derive(Clone, Copy)]

--- a/crates/edge/tests/bootstrap_quic_parity.rs
+++ b/crates/edge/tests/bootstrap_quic_parity.rs
@@ -25,8 +25,8 @@ use support::{
     net::local_listener_bind_available,
     parity::{BootstrapQuicParityHarness, ParityRequestSpec, make_backend, make_upstream},
     request_path::{
-        BootstrapRequestSpec, H3RequestSpec, run_bootstrap_request_to, run_request_to,
-        run_bootstrap_h1_websocket_handshake_to, run_two_chunk_bootstrap_post_to,
+        BootstrapRequestSpec, H3RequestSpec, run_bootstrap_h1_websocket_handshake_to,
+        run_bootstrap_request_to, run_request_to, run_two_chunk_bootstrap_post_to,
         run_two_chunk_post_to,
     },
 };
@@ -62,7 +62,9 @@ fn bootstrap_and_quic_parity_harness_collects_canonical_response_shape() {
     );
 
     let config = harness.make_config(upstreams);
-    harness.start_listener(config).expect("listener with bootstrap");
+    harness
+        .start_listener(config)
+        .expect("listener with bootstrap");
 
     let mut request = ParityRequestSpec::get("localhost", "/");
     request.selected_response_headers = &["x-parity"];
@@ -74,7 +76,10 @@ fn bootstrap_and_quic_parity_harness_collects_canonical_response_shape() {
     assert_eq!(pair.bootstrap.response.status, 200);
     assert_eq!(pair.quic.response.body, pair.bootstrap.response.body);
     assert_eq!(pair.quic.response.body, b"parity ok\n");
-    assert_eq!(pair.quic.response.selected_headers, pair.bootstrap.response.selected_headers);
+    assert_eq!(
+        pair.quic.response.selected_headers,
+        pair.bootstrap.response.selected_headers
+    );
     assert_eq!(
         pair.quic.response.selected_headers,
         vec![(String::from("x-parity"), String::from("ok"))]
@@ -152,12 +157,32 @@ fn bootstrap_and_quic_route_resolution_choose_the_same_route_and_backend_result(
     ]);
 
     let config = harness.make_config(upstreams);
-    harness.start_listener(config).expect("listener with bootstrap");
+    harness
+        .start_listener(config)
+        .expect("listener with bootstrap");
 
     let cases = [
-        ("GET", "api.example.com", "/payments/charge", "payments get\n", "payments-get"),
-        ("POST", "api.example.com", "/payments/charge", "payments post\n", "payments-post"),
-        ("GET", "admin.example.com", "/admin/audit", "admin get\n", "admin-get"),
+        (
+            "GET",
+            "api.example.com",
+            "/payments/charge",
+            "payments get\n",
+            "payments-get",
+        ),
+        (
+            "POST",
+            "api.example.com",
+            "/payments/charge",
+            "payments post\n",
+            "payments-post",
+        ),
+        (
+            "GET",
+            "admin.example.com",
+            "/admin/audit",
+            "admin get\n",
+            "admin-get",
+        ),
     ];
 
     for (method, authority, path, expected_body, expected_backend) in cases {
@@ -198,8 +223,7 @@ fn bootstrap_and_quic_route_resolution_choose_the_same_route_and_backend_result(
             "quic should surface the selected backend marker for {method} {authority}{path}"
         );
         assert_eq!(
-            pair.bootstrap.response.selected_headers,
-            pair.quic.response.selected_headers,
+            pair.bootstrap.response.selected_headers, pair.quic.response.selected_headers,
             "bootstrap and quic should expose the same backend-selection result for {method} {authority}{path}"
         );
     }
@@ -226,10 +250,14 @@ fn bootstrap_and_quic_route_resolution_share_observable_unrouted_behavior() {
     )]);
 
     let config = harness.make_config(upstreams);
-    harness.start_listener(config).expect("listener with bootstrap");
+    harness
+        .start_listener(config)
+        .expect("listener with bootstrap");
 
     let request = ParityRequestSpec::get("unknown.example.com", "/missing");
-    let pair = harness.run_parity_pair(request).expect("unrouted parity pair");
+    let pair = harness
+        .run_parity_pair(request)
+        .expect("unrouted parity pair");
 
     assert_eq!(pair.quic.response.status, 502);
     assert_eq!(pair.bootstrap.response.status, 502);
@@ -264,7 +292,9 @@ fn bootstrap_and_quic_local_api_key_auth_decisions_match() {
     )]);
 
     let config = harness.make_config(upstreams);
-    harness.start_listener(config).expect("listener with bootstrap");
+    harness
+        .start_listener(config)
+        .expect("listener with bootstrap");
 
     let deny_request = ParityRequestSpec {
         method: "GET",
@@ -287,7 +317,10 @@ fn bootstrap_and_quic_local_api_key_auth_decisions_match() {
         deny_pair.bootstrap.response.selected_headers,
         deny_pair.quic.response.selected_headers
     );
-    assert_eq!(deny_pair.bootstrap.response.body, deny_pair.quic.response.body);
+    assert_eq!(
+        deny_pair.bootstrap.response.body,
+        deny_pair.quic.response.body
+    );
     assert!(
         String::from_utf8_lossy(&deny_pair.quic.response.body).contains("unauthorized"),
         "expected canonical unauthorized body for api key rejection"
@@ -297,11 +330,16 @@ fn bootstrap_and_quic_local_api_key_auth_decisions_match() {
         headers: &[("x-api-key", "edge-key")],
         ..deny_request
     };
-    let allow_pair = harness.run_parity_pair(allow_request).expect("api key allow");
+    let allow_pair = harness
+        .run_parity_pair(allow_request)
+        .expect("api key allow");
     assert_eq!(allow_pair.quic.response.status, 200);
     assert_eq!(allow_pair.bootstrap.response.status, 200);
     assert_eq!(allow_pair.quic.response.body, b"api key ok\n");
-    assert_eq!(allow_pair.bootstrap.response.body, allow_pair.quic.response.body);
+    assert_eq!(
+        allow_pair.bootstrap.response.body,
+        allow_pair.quic.response.body
+    );
 }
 
 #[test]
@@ -334,7 +372,9 @@ fn bootstrap_and_quic_local_jwt_auth_decisions_match() {
     )]);
 
     let config = harness.make_config(upstreams);
-    harness.start_listener(config).expect("listener with bootstrap");
+    harness
+        .start_listener(config)
+        .expect("listener with bootstrap");
 
     let deny_request = ParityRequestSpec {
         method: "GET",
@@ -357,7 +397,10 @@ fn bootstrap_and_quic_local_jwt_auth_decisions_match() {
         deny_pair.bootstrap.response.selected_headers,
         deny_pair.quic.response.selected_headers
     );
-    assert_eq!(deny_pair.bootstrap.response.body, deny_pair.quic.response.body);
+    assert_eq!(
+        deny_pair.bootstrap.response.body,
+        deny_pair.quic.response.body
+    );
     assert!(
         String::from_utf8_lossy(&deny_pair.quic.response.body).contains("unauthorized"),
         "expected canonical unauthorized body for jwt rejection"
@@ -382,7 +425,10 @@ fn bootstrap_and_quic_local_jwt_auth_decisions_match() {
     assert_eq!(allow_pair.quic.response.status, 200);
     assert_eq!(allow_pair.bootstrap.response.status, 200);
     assert_eq!(allow_pair.quic.response.body, b"jwt ok\n");
-    assert_eq!(allow_pair.bootstrap.response.body, allow_pair.quic.response.body);
+    assert_eq!(
+        allow_pair.bootstrap.response.body,
+        allow_pair.quic.response.body
+    );
 }
 
 #[test]
@@ -473,9 +519,14 @@ fn bootstrap_and_quic_external_auth_decisions_match() {
             format!("http://{auth_addr}/check"),
             250,
             ExternalAuthFailureMode::FailClosed,
-            case.allowlist.iter().map(|value| (*value).to_string()).collect(),
+            case.allowlist
+                .iter()
+                .map(|value| (*value).to_string())
+                .collect(),
         );
-        harness.start_listener(config).expect("listener with bootstrap");
+        harness
+            .start_listener(config)
+            .expect("listener with bootstrap");
 
         let request = ParityRequestSpec {
             method: "GET",
@@ -502,14 +553,12 @@ fn bootstrap_and_quic_external_auth_decisions_match() {
             case.name
         );
         assert_eq!(
-            pair.quic.response.body,
-            case.expected_body,
+            pair.quic.response.body, case.expected_body,
             "quic external auth body mismatch for case `{}`",
             case.name
         );
         assert_eq!(
-            pair.bootstrap.response.body,
-            case.expected_body,
+            pair.bootstrap.response.body, case.expected_body,
             "bootstrap external auth body mismatch for case `{}`",
             case.name
         );
@@ -520,8 +569,7 @@ fn bootstrap_and_quic_external_auth_decisions_match() {
             case.name
         );
         assert_eq!(
-            pair.bootstrap.response.selected_headers,
-            pair.quic.response.selected_headers,
+            pair.bootstrap.response.selected_headers, pair.quic.response.selected_headers,
             "bootstrap and quic external auth headers should match for case `{}`",
             case.name
         );
@@ -620,11 +668,7 @@ fn bootstrap_and_quic_response_normalization_strip_same_hop_headers() {
         )
     });
 
-    start_single_route_listener(
-        &mut harness,
-        "/normalize-hop",
-        backend_addr.to_string(),
-    );
+    start_single_route_listener(&mut harness, "/normalize-hop", backend_addr.to_string());
 
     let request = ParityRequestSpec {
         method: "GET",
@@ -822,9 +866,7 @@ fn bootstrap_and_quic_upstream_timeout_failures_share_observable_bucket() {
         async move {
             backend_observed.fetch_add(1, Ordering::Relaxed);
             tokio::time::sleep(Duration::from_millis(300)).await;
-            Ok::<_, Infallible>(Response::new(Full::new(Bytes::from_static(
-                b"too late",
-            ))))
+            Ok::<_, Infallible>(Response::new(Full::new(Bytes::from_static(b"too late"))))
         }
     });
 
@@ -839,10 +881,14 @@ fn bootstrap_and_quic_upstream_timeout_failures_share_observable_bucket() {
     )]));
     config.performance.backend_timeout_ms = 150;
     config.performance.backend_connect_timeout_ms = 150;
-    harness.start_listener(config).expect("listener with bootstrap");
+    harness
+        .start_listener(config)
+        .expect("listener with bootstrap");
 
     let request = ParityRequestSpec::get("localhost", "/timeout");
-    let pair = harness.run_parity_pair(request).expect("timeout parity pair");
+    let pair = harness
+        .run_parity_pair(request)
+        .expect("timeout parity pair");
 
     assert_timeout_bucket(&pair.quic.response);
     assert_timeout_bucket(&pair.bootstrap.response);
@@ -873,7 +919,9 @@ fn bootstrap_and_quic_connect_failures_share_observable_bucket() {
     )]));
     config.performance.backend_timeout_ms = 150;
     config.performance.backend_connect_timeout_ms = 150;
-    harness.start_listener(config).expect("listener with bootstrap");
+    harness
+        .start_listener(config)
+        .expect("listener with bootstrap");
 
     let request = ParityRequestSpec::get("localhost", "/connect-fail");
     let pair = harness
@@ -910,7 +958,9 @@ fn bootstrap_and_quic_malformed_upstream_responses_share_observable_bucket() {
     )]));
     config.performance.backend_timeout_ms = 150;
     config.performance.backend_connect_timeout_ms = 150;
-    harness.start_listener(config).expect("listener with bootstrap");
+    harness
+        .start_listener(config)
+        .expect("listener with bootstrap");
 
     let request = ParityRequestSpec::get("localhost", "/malformed");
     let pair = harness
@@ -946,7 +996,9 @@ fn bootstrap_and_quic_request_body_too_large_guardrail_contract_matches() {
         ),
     )]));
     config.performance.max_request_body_bytes = 1024;
-    let listen_addr = harness.start_listener(config).expect("listener with bootstrap");
+    let listen_addr = harness
+        .start_listener(config)
+        .expect("listener with bootstrap");
 
     let (quic_response, got_reset) = run_two_chunk_post_to(
         listen_addr,
@@ -1004,7 +1056,9 @@ fn bootstrap_and_quic_request_body_idle_timeout_guardrail_contract_matches() {
     config.performance.client_body_idle_timeout_ms = 120;
     config.performance.backend_body_total_timeout_ms = 10_000;
     config.performance.backend_total_request_timeout_ms = 10_000;
-    let listen_addr = harness.start_listener(config).expect("listener with bootstrap");
+    let listen_addr = harness
+        .start_listener(config)
+        .expect("listener with bootstrap");
 
     let (quic_response, got_reset) = run_two_chunk_post_to(
         listen_addr,
@@ -1030,7 +1084,9 @@ fn bootstrap_and_quic_request_body_idle_timeout_guardrail_contract_matches() {
     assert_eq!(bootstrap_response.status, 408);
     assert_eq!(bootstrap_response.body, quic_response.body);
     assert!(
-        quic_response.body_text().contains("request body idle timeout"),
+        quic_response
+            .body_text()
+            .contains("request body idle timeout"),
         "expected canonical request body idle-timeout body"
     );
     assert!(
@@ -1061,7 +1117,9 @@ fn bootstrap_and_quic_unknown_length_response_prebuffer_guardrail_contract_match
     )]));
     config.performance.max_response_body_bytes = 64 * 1024;
     config.performance.unknown_length_response_prebuffer_bytes = 8;
-    harness.start_listener(config).expect("listener with bootstrap");
+    harness
+        .start_listener(config)
+        .expect("listener with bootstrap");
 
     let pair = harness
         .run_parity_pair(ParityRequestSpec::get("localhost", "/long-stream"))
@@ -1070,7 +1128,10 @@ fn bootstrap_and_quic_unknown_length_response_prebuffer_guardrail_contract_match
     assert_eq!(pair.quic.response.status, 503);
     assert_eq!(pair.bootstrap.response.status, 503);
     assert_eq!(pair.bootstrap.response.body, pair.quic.response.body);
-    assert_eq!(pair.quic.response.body, b"upstream response body too large\n");
+    assert_eq!(
+        pair.quic.response.body,
+        b"upstream response body too large\n"
+    );
 }
 
 #[test]
@@ -1100,7 +1161,9 @@ fn bootstrap_and_quic_slow_response_body_timeout_guardrail_contract_matches() {
     config.performance.backend_connect_timeout_ms = 100;
     config.performance.backend_body_total_timeout_ms = 5_000;
     config.performance.backend_body_idle_timeout_ms = 120;
-    harness.start_listener(config).expect("listener with bootstrap");
+    harness
+        .start_listener(config)
+        .expect("listener with bootstrap");
 
     let pair = harness
         .run_parity_pair(ParityRequestSpec::get("localhost", "/slow-stream"))
@@ -1176,7 +1239,9 @@ fn bootstrap_and_quic_outcome_recording_failure_bucket_matches() {
     )]));
     config.performance.backend_timeout_ms = 150;
     config.performance.backend_connect_timeout_ms = 150;
-    harness.start_listener(config).expect("listener with bootstrap");
+    harness
+        .start_listener(config)
+        .expect("listener with bootstrap");
 
     let request = ParityRequestSpec {
         method: "GET",
@@ -1219,9 +1284,7 @@ fn bootstrap_and_quic_outcome_recording_timeout_bucket_matches() {
     let mut harness = BootstrapQuicParityHarness::new();
     let backend_addr = harness.start_h1_backend(|_req: Request<Incoming>| async move {
         tokio::time::sleep(Duration::from_millis(300)).await;
-        Ok::<_, Infallible>(Response::new(Full::new(Bytes::from_static(
-            b"too late",
-        ))))
+        Ok::<_, Infallible>(Response::new(Full::new(Bytes::from_static(b"too late"))))
     });
 
     let mut config = harness.make_config(HashMap::from([(
@@ -1235,7 +1298,9 @@ fn bootstrap_and_quic_outcome_recording_timeout_bucket_matches() {
     )]));
     config.performance.backend_timeout_ms = 150;
     config.performance.backend_connect_timeout_ms = 150;
-    harness.start_listener(config).expect("listener with bootstrap");
+    harness
+        .start_listener(config)
+        .expect("listener with bootstrap");
 
     let request = ParityRequestSpec {
         method: "GET",
@@ -1281,7 +1346,10 @@ fn bootstrap_and_quic_outcome_recording_rate_limited_bucket_matches() {
     assert_eq!(quic.response.status, 429);
     assert_eq!(bootstrap.response.status, 429);
     assert_eq!(bootstrap.response.body, quic.response.body);
-    assert_eq!(bootstrap.response.selected_headers, quic.response.selected_headers);
+    assert_eq!(
+        bootstrap.response.selected_headers,
+        quic.response.selected_headers
+    );
     let expected = OutcomeRecordingBuckets {
         success: true,
         failure: true,
@@ -1309,7 +1377,10 @@ fn bootstrap_and_quic_outcome_recording_overload_bucket_matches() {
     assert_eq!(quic.rejection.status, 503);
     assert_eq!(bootstrap.rejection.status, 503);
     assert_eq!(bootstrap.rejection.body, quic.rejection.body);
-    assert_eq!(bootstrap.rejection.selected_headers, quic.rejection.selected_headers);
+    assert_eq!(
+        bootstrap.rejection.selected_headers,
+        quic.rejection.selected_headers
+    );
     let expected = OutcomeRecordingBuckets {
         success: true,
         failure: true,
@@ -1367,7 +1438,9 @@ fn start_single_route_listener(
             "round-robin",
         ),
     )]));
-    harness.start_listener(config).expect("listener with bootstrap");
+    harness
+        .start_listener(config)
+        .expect("listener with bootstrap");
 }
 
 fn configure_http_external_auth(
@@ -1623,7 +1696,9 @@ fn run_scoped_rate_limit_scenario(ingress: IngressKind) -> RejectionObservation 
         idle_ttl_secs: 300,
     }];
 
-    harness.start_listener(config).expect("listener with bootstrap");
+    harness
+        .start_listener(config)
+        .expect("listener with bootstrap");
 
     let success = run_parity_ingress_request(
         ingress,
@@ -1691,7 +1766,9 @@ fn run_overload_shed_scenario(ingress: IngressKind) -> RejectionObservation {
     config.performance.global_inflight_limit = 64;
     config.resilience.route_queue.default_cap = 1;
     config.resilience.route_queue.global_cap = 64;
-    harness.start_listener(config).expect("listener with bootstrap");
+    harness
+        .start_listener(config)
+        .expect("listener with bootstrap");
     let listen_addr = harness.listen_addr();
     let cert_path = harness.cert_path().to_string();
 
@@ -1789,7 +1866,10 @@ fn bootstrap_websocket_upgrade_is_an_explicit_quic_parity_boundary() {
     assert!(bootstrap.body.is_empty());
     assert_eq!(bootstrap.header("connection"), Some("upgrade"));
     assert_eq!(bootstrap.header("upgrade"), Some("websocket"));
-    assert_eq!(bootstrap.header("sec-websocket-accept"), Some("test-accept"));
+    assert_eq!(
+        bootstrap.header("sec-websocket-accept"),
+        Some("test-accept")
+    );
 
     assert_eq!(
         quic.status, 200,
@@ -1847,7 +1927,9 @@ fn run_rate_limit_outcome_recording_scenario(ingress: IngressKind) -> OutcomeRec
         route_allowlist: vec!["api".to_string()],
         idle_ttl_secs: 300,
     }];
-    harness.start_listener(config).expect("listener with bootstrap");
+    harness
+        .start_listener(config)
+        .expect("listener with bootstrap");
 
     let success = run_parity_ingress_observation(
         ingress,
@@ -1922,7 +2004,9 @@ fn run_overload_outcome_recording_scenario(
     config.performance.global_inflight_limit = 64;
     config.resilience.route_queue.default_cap = 1;
     config.resilience.route_queue.global_cap = 64;
-    harness.start_listener(config).expect("listener with bootstrap");
+    harness
+        .start_listener(config)
+        .expect("listener with bootstrap");
 
     let before = harness
         .metrics_text()

--- a/crates/edge/tests/bootstrap_quic_parity.rs
+++ b/crates/edge/tests/bootstrap_quic_parity.rs
@@ -3,7 +3,10 @@ use std::{collections::HashMap, convert::Infallible};
 use bytes::Bytes;
 use http_body_util::Full;
 use hyper::{Request, Response, body::Incoming};
-use spooky_config::config::{LoadBalancing, RouteMatch, Upstream};
+use spooky_config::config::{
+    ApiKeyAuth, ExternalAuth, ExternalAuthFailureMode, ExternalAuthRequestHeader, JwtAuth,
+    LoadBalancing, RouteAuth, RouteMatch, Upstream,
+};
 
 mod support;
 
@@ -216,6 +219,295 @@ fn bootstrap_and_quic_route_resolution_share_observable_unrouted_behavior() {
     assert_eq!(pair.bootstrap.response.body, pair.quic.response.body);
 }
 
+#[test]
+fn bootstrap_and_quic_local_api_key_auth_decisions_match() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = BootstrapQuicParityHarness::new();
+    let backend_addr = harness.start_h1_static_backend(b"api key ok\n");
+
+    let upstreams = HashMap::from([(
+        "api".to_string(),
+        auth_protected_upstream(
+            "/protected",
+            vec![make_backend("backend-a", backend_addr.to_string())],
+            RouteAuth {
+                api_key: Some(ApiKeyAuth {
+                    header_name: "x-api-key".to_string(),
+                    keys: vec!["edge-key".to_string()],
+                }),
+                ..RouteAuth::default()
+            },
+        ),
+    )]);
+
+    let config = harness.make_config(upstreams);
+    harness.start_listener(config).expect("listener with bootstrap");
+
+    let deny_request = ParityRequestSpec {
+        method: "GET",
+        authority: "localhost",
+        path: "/protected",
+        headers: &[],
+        body: None,
+        user_agent: "spooky-bootstrap-quic-parity-test",
+        selected_response_headers: &["www-authenticate"],
+        capture_metrics_delta: false,
+    };
+    let deny_pair = harness.run_parity_pair(deny_request).expect("api key deny");
+    assert_eq!(deny_pair.quic.response.status, 401);
+    assert_eq!(deny_pair.bootstrap.response.status, 401);
+    assert_eq!(
+        deny_pair.quic.response.selected_headers,
+        vec![(String::from("www-authenticate"), String::from("ApiKey"))]
+    );
+    assert_eq!(
+        deny_pair.bootstrap.response.selected_headers,
+        deny_pair.quic.response.selected_headers
+    );
+    assert_eq!(deny_pair.bootstrap.response.body, deny_pair.quic.response.body);
+    assert!(
+        String::from_utf8_lossy(&deny_pair.quic.response.body).contains("unauthorized"),
+        "expected canonical unauthorized body for api key rejection"
+    );
+
+    let allow_request = ParityRequestSpec {
+        headers: &[("x-api-key", "edge-key")],
+        ..deny_request
+    };
+    let allow_pair = harness.run_parity_pair(allow_request).expect("api key allow");
+    assert_eq!(allow_pair.quic.response.status, 200);
+    assert_eq!(allow_pair.bootstrap.response.status, 200);
+    assert_eq!(allow_pair.quic.response.body, b"api key ok\n");
+    assert_eq!(allow_pair.bootstrap.response.body, allow_pair.quic.response.body);
+}
+
+#[test]
+fn bootstrap_and_quic_local_jwt_auth_decisions_match() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = BootstrapQuicParityHarness::new();
+    let backend_addr = harness.start_h1_static_backend(b"jwt ok\n");
+
+    let upstreams = HashMap::from([(
+        "api".to_string(),
+        auth_protected_upstream(
+            "/jwt",
+            vec![make_backend("backend-a", backend_addr.to_string())],
+            RouteAuth {
+                api_key: None,
+                jwt: Some(JwtAuth {
+                    secret: "jwt-secret".to_string(),
+                    issuer: Some("issuer-1".to_string()),
+                    audience: Some("aud-1".to_string()),
+                    clock_skew_secs: 30,
+                }),
+                external_auth: None,
+                required_scopes: vec!["read:parity".to_string()],
+                required_roles: Vec::new(),
+            },
+        ),
+    )]);
+
+    let config = harness.make_config(upstreams);
+    harness.start_listener(config).expect("listener with bootstrap");
+
+    let deny_request = ParityRequestSpec {
+        method: "GET",
+        authority: "localhost",
+        path: "/jwt",
+        headers: &[],
+        body: None,
+        user_agent: "spooky-bootstrap-quic-parity-test",
+        selected_response_headers: &["www-authenticate"],
+        capture_metrics_delta: false,
+    };
+    let deny_pair = harness.run_parity_pair(deny_request).expect("jwt deny");
+    assert_eq!(deny_pair.quic.response.status, 401);
+    assert_eq!(deny_pair.bootstrap.response.status, 401);
+    assert_eq!(
+        deny_pair.quic.response.selected_headers,
+        vec![(String::from("www-authenticate"), String::from("Bearer"))]
+    );
+    assert_eq!(
+        deny_pair.bootstrap.response.selected_headers,
+        deny_pair.quic.response.selected_headers
+    );
+    assert_eq!(deny_pair.bootstrap.response.body, deny_pair.quic.response.body);
+    assert!(
+        String::from_utf8_lossy(&deny_pair.quic.response.body).contains("unauthorized"),
+        "expected canonical unauthorized body for jwt rejection"
+    );
+
+    let token = encode_test_hs256_jwt(
+        "jwt-secret",
+        serde_json::json!({
+            "sub": "user-1",
+            "iss": "issuer-1",
+            "aud": "aud-1",
+            "exp": 4_000_000_000u64,
+            "scope": "read:parity",
+        }),
+    );
+    let authorization = format!("Bearer {token}");
+    let allow_request = ParityRequestSpec {
+        headers: &[("authorization", authorization.as_str())],
+        ..deny_request
+    };
+    let allow_pair = harness.run_parity_pair(allow_request).expect("jwt allow");
+    assert_eq!(allow_pair.quic.response.status, 200);
+    assert_eq!(allow_pair.bootstrap.response.status, 200);
+    assert_eq!(allow_pair.quic.response.body, b"jwt ok\n");
+    assert_eq!(allow_pair.bootstrap.response.body, allow_pair.quic.response.body);
+}
+
+#[test]
+fn bootstrap_and_quic_external_auth_decisions_match() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let cases = [
+        ExternalAuthParityCase {
+            name: "allow",
+            auth_status: 204,
+            auth_headers: &[("x-user-id", "alice")],
+            auth_body: b"",
+            allowlist: &["x-user-id"],
+            expected_status: 200,
+            expected_body: b"backend user=alice",
+            expected_headers: &[],
+        },
+        ExternalAuthParityCase {
+            name: "deny",
+            auth_status: 403,
+            auth_headers: &[("x-auth-reason", "policy")],
+            auth_body: b"denied by auth",
+            allowlist: &["x-auth-reason"],
+            expected_status: 403,
+            expected_body: b"denied by auth",
+            expected_headers: &[("x-auth-reason", "policy")],
+        },
+        ExternalAuthParityCase {
+            name: "challenge",
+            auth_status: 401,
+            auth_headers: &[
+                ("www-authenticate", "Bearer realm=\"spooky\""),
+                ("x-auth-reason", "expired"),
+            ],
+            auth_body: b"token expired",
+            allowlist: &["x-auth-reason"],
+            expected_status: 401,
+            expected_body: b"token expired",
+            expected_headers: &[
+                ("www-authenticate", "Bearer realm=\"spooky\""),
+                ("x-auth-reason", "expired"),
+            ],
+        },
+        ExternalAuthParityCase {
+            name: "redirect",
+            auth_status: 302,
+            auth_headers: &[("location", "https://login.example.com/")],
+            auth_body: b"",
+            allowlist: &[],
+            expected_status: 302,
+            expected_body: b"",
+            expected_headers: &[("location", "https://login.example.com/")],
+        },
+    ];
+
+    for case in cases {
+        let mut harness = BootstrapQuicParityHarness::new();
+        let backend_addr = harness.start_h1_backend(|req: Request<Incoming>| async move {
+            let user = req
+                .headers()
+                .get("x-user-id")
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or("missing");
+            Ok::<_, Infallible>(Response::new(Full::new(Bytes::from(format!(
+                "backend user={user}"
+            )))))
+        });
+        let auth_addr = harness.start_h1_backend(move |_req: Request<Incoming>| {
+            let case = case;
+            async move {
+                let mut builder = Response::builder().status(case.auth_status);
+                for (name, value) in case.auth_headers {
+                    builder = builder.header(*name, *value);
+                }
+                Ok::<_, Infallible>(
+                    builder
+                        .body(Full::new(Bytes::from_static(case.auth_body)))
+                        .expect("auth response"),
+                )
+            }
+        });
+
+        let config = configure_http_external_auth(
+            &harness,
+            format!("http://{backend_addr}"),
+            format!("http://{auth_addr}/check"),
+            250,
+            ExternalAuthFailureMode::FailClosed,
+            case.allowlist.iter().map(|value| (*value).to_string()).collect(),
+        );
+        harness.start_listener(config).expect("listener with bootstrap");
+
+        let request = ParityRequestSpec {
+            method: "GET",
+            authority: "localhost",
+            path: "/auth",
+            headers: &[],
+            body: None,
+            user_agent: "spooky-bootstrap-quic-parity-test",
+            selected_response_headers: &["www-authenticate", "x-auth-reason", "location"],
+            capture_metrics_delta: false,
+        };
+        let pair = harness.run_parity_pair(request).unwrap_or_else(|err| {
+            panic!("external auth parity case `{}` failed: {err}", case.name)
+        });
+
+        assert_eq!(
+            pair.quic.response.status, case.expected_status,
+            "quic external auth status mismatch for case `{}`",
+            case.name
+        );
+        assert_eq!(
+            pair.bootstrap.response.status, case.expected_status,
+            "bootstrap external auth status mismatch for case `{}`",
+            case.name
+        );
+        assert_eq!(
+            pair.quic.response.body,
+            case.expected_body,
+            "quic external auth body mismatch for case `{}`",
+            case.name
+        );
+        assert_eq!(
+            pair.bootstrap.response.body,
+            case.expected_body,
+            "bootstrap external auth body mismatch for case `{}`",
+            case.name
+        );
+        assert_eq!(
+            pair.quic.response.selected_headers,
+            expected_selected_headers(case.expected_headers),
+            "quic external auth headers mismatch for case `{}`",
+            case.name
+        );
+        assert_eq!(
+            pair.bootstrap.response.selected_headers,
+            pair.quic.response.selected_headers,
+            "bootstrap and quic external auth headers should match for case `{}`",
+            case.name
+        );
+    }
+}
+
 fn routed_upstream(
     host: Option<&str>,
     path_prefix: &str,
@@ -234,4 +526,80 @@ fn routed_upstream(
         method: method.map(str::to_string),
     };
     upstream
+}
+
+fn auth_protected_upstream(
+    path_prefix: &str,
+    backends: Vec<spooky_config::config::Backend>,
+    auth: RouteAuth,
+) -> Upstream {
+    let mut upstream = make_upstream(path_prefix, backends, None, "round-robin");
+    upstream.auth = auth;
+    upstream
+}
+
+fn configure_http_external_auth(
+    harness: &BootstrapQuicParityHarness,
+    backend_address: String,
+    auth_endpoint: String,
+    timeout_ms: u64,
+    failure_mode: ExternalAuthFailureMode,
+    response_header_allowlist: Vec<String>,
+) -> spooky_config::config::Config {
+    let mut upstream = make_upstream(
+        "/auth",
+        vec![make_backend("auth-backend", backend_address)],
+        None,
+        "round-robin",
+    );
+    upstream.auth.external_auth = Some(ExternalAuth::Http {
+        endpoint: auth_endpoint,
+        request_headers: vec![ExternalAuthRequestHeader {
+            name: "x-auth-static".to_string(),
+            value: "1".to_string(),
+        }],
+        response_header_allowlist,
+        timeout_ms,
+        failure_mode,
+    });
+
+    let mut upstreams = HashMap::new();
+    upstreams.insert("api".to_string(), upstream);
+    harness.make_config(upstreams)
+}
+
+fn encode_test_hs256_jwt(secret: &str, claims: serde_json::Value) -> String {
+    use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+
+    let header = URL_SAFE_NO_PAD.encode(
+        serde_json::to_vec(&serde_json::json!({ "alg": "HS256", "typ": "JWT" }))
+            .expect("serialize header"),
+    );
+    let payload = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&claims).expect("serialize claims"));
+    let signing_input = format!("{header}.{payload}");
+    let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).expect("mac");
+    mac.update(signing_input.as_bytes());
+    let signature = URL_SAFE_NO_PAD.encode(mac.finalize().into_bytes());
+    format!("{signing_input}.{signature}")
+}
+
+fn expected_selected_headers(headers: &[(&str, &str)]) -> Vec<(String, String)> {
+    headers
+        .iter()
+        .map(|(name, value)| (name.to_string(), value.to_string()))
+        .collect()
+}
+
+#[derive(Clone, Copy)]
+struct ExternalAuthParityCase<'a> {
+    name: &'a str,
+    auth_status: u16,
+    auth_headers: &'a [(&'a str, &'a str)],
+    auth_body: &'a [u8],
+    allowlist: &'a [&'a str],
+    expected_status: u16,
+    expected_body: &'a [u8],
+    expected_headers: &'a [(&'a str, &'a str)],
 }

--- a/crates/edge/tests/bootstrap_quic_parity.rs
+++ b/crates/edge/tests/bootstrap_quic_parity.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, convert::Infallible};
 use bytes::Bytes;
 use http_body_util::Full;
 use hyper::{Request, Response, body::Incoming};
+use spooky_config::config::{LoadBalancing, RouteMatch, Upstream};
 
 mod support;
 
@@ -59,4 +60,178 @@ fn bootstrap_and_quic_parity_harness_collects_canonical_response_shape() {
     );
     assert!(pair.quic.metrics_delta.is_some());
     assert!(pair.bootstrap.metrics_delta.is_some());
+}
+
+#[test]
+fn bootstrap_and_quic_route_resolution_choose_the_same_route_and_backend_result() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = BootstrapQuicParityHarness::new();
+    let payments_get = harness.start_h1_backend(|_req: Request<Incoming>| async move {
+        Ok::<_, Infallible>(
+            Response::builder()
+                .status(200)
+                .header("x-backend", "payments-get")
+                .body(Full::new(Bytes::from_static(b"payments get\n")))
+                .expect("response"),
+        )
+    });
+    let payments_post = harness.start_h1_backend(|_req: Request<Incoming>| async move {
+        Ok::<_, Infallible>(
+            Response::builder()
+                .status(200)
+                .header("x-backend", "payments-post")
+                .body(Full::new(Bytes::from_static(b"payments post\n")))
+                .expect("response"),
+        )
+    });
+    let admin_get = harness.start_h1_backend(|_req: Request<Incoming>| async move {
+        Ok::<_, Infallible>(
+            Response::builder()
+                .status(200)
+                .header("x-backend", "admin-get")
+                .body(Full::new(Bytes::from_static(b"admin get\n")))
+                .expect("response"),
+        )
+    });
+
+    let upstreams = HashMap::from([
+        (
+            "payments-get".to_string(),
+            routed_upstream(
+                Some("api.example.com"),
+                "/payments",
+                Some("GET"),
+                "round-robin",
+                vec![make_backend("payments-get-a", payments_get.to_string())],
+            ),
+        ),
+        (
+            "payments-post".to_string(),
+            routed_upstream(
+                Some("api.example.com"),
+                "/payments",
+                Some("POST"),
+                "round-robin",
+                vec![make_backend("payments-post-a", payments_post.to_string())],
+            ),
+        ),
+        (
+            "admin-get".to_string(),
+            routed_upstream(
+                Some("admin.example.com"),
+                "/admin",
+                Some("GET"),
+                "round-robin",
+                vec![make_backend("admin-get-a", admin_get.to_string())],
+            ),
+        ),
+    ]);
+
+    let config = harness.make_config(upstreams);
+    harness.start_listener(config).expect("listener with bootstrap");
+
+    let cases = [
+        ("GET", "api.example.com", "/payments/charge", "payments get\n", "payments-get"),
+        ("POST", "api.example.com", "/payments/charge", "payments post\n", "payments-post"),
+        ("GET", "admin.example.com", "/admin/audit", "admin get\n", "admin-get"),
+    ];
+
+    for (method, authority, path, expected_body, expected_backend) in cases {
+        let request = ParityRequestSpec {
+            method,
+            authority,
+            path,
+            headers: &[],
+            body: None,
+            user_agent: "spooky-bootstrap-quic-parity-test",
+            selected_response_headers: &["x-backend"],
+            capture_metrics_delta: false,
+        };
+
+        let pair = harness.run_parity_pair(request).expect("parity pair");
+
+        assert_eq!(
+            pair.quic.response.status, 200,
+            "quic route resolution should succeed for {method} {authority}{path}"
+        );
+        assert_eq!(
+            pair.bootstrap.response.status, 200,
+            "bootstrap route resolution should succeed for {method} {authority}{path}"
+        );
+        assert_eq!(
+            pair.quic.response.body,
+            expected_body.as_bytes(),
+            "quic should hit the expected upstream-visible backend result for {method} {authority}{path}"
+        );
+        assert_eq!(
+            pair.bootstrap.response.body,
+            expected_body.as_bytes(),
+            "bootstrap should hit the expected upstream-visible backend result for {method} {authority}{path}"
+        );
+        assert_eq!(
+            pair.quic.response.selected_headers,
+            vec![(String::from("x-backend"), expected_backend.to_string())],
+            "quic should surface the selected backend marker for {method} {authority}{path}"
+        );
+        assert_eq!(
+            pair.bootstrap.response.selected_headers,
+            pair.quic.response.selected_headers,
+            "bootstrap and quic should expose the same backend-selection result for {method} {authority}{path}"
+        );
+    }
+}
+
+#[test]
+fn bootstrap_and_quic_route_resolution_share_observable_unrouted_behavior() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = BootstrapQuicParityHarness::new();
+    let backend_addr = harness.start_h1_static_backend(b"matched route\n");
+
+    let upstreams = HashMap::from([(
+        "api".to_string(),
+        routed_upstream(
+            Some("api.example.com"),
+            "/payments",
+            Some("GET"),
+            "round-robin",
+            vec![make_backend("backend-a", backend_addr.to_string())],
+        ),
+    )]);
+
+    let config = harness.make_config(upstreams);
+    harness.start_listener(config).expect("listener with bootstrap");
+
+    let request = ParityRequestSpec::get("unknown.example.com", "/missing");
+    let pair = harness.run_parity_pair(request).expect("unrouted parity pair");
+
+    assert_eq!(pair.quic.response.status, 502);
+    assert_eq!(pair.bootstrap.response.status, 502);
+    assert_eq!(pair.quic.response.body, b"no route\n");
+    assert_eq!(pair.bootstrap.response.body, pair.quic.response.body);
+}
+
+fn routed_upstream(
+    host: Option<&str>,
+    path_prefix: &str,
+    method: Option<&str>,
+    lb_type: &str,
+    backends: Vec<spooky_config::config::Backend>,
+) -> Upstream {
+    let mut upstream = make_upstream(path_prefix, backends, None, lb_type);
+    upstream.load_balancing = LoadBalancing {
+        lb_type: lb_type.to_string(),
+        key: None,
+    };
+    upstream.route = RouteMatch {
+        host: host.map(str::to_string),
+        path_prefix: Some(path_prefix.to_string()),
+        method: method.map(str::to_string),
+    };
+    upstream
 }

--- a/crates/edge/tests/bootstrap_quic_parity.rs
+++ b/crates/edge/tests/bootstrap_quic_parity.rs
@@ -24,7 +24,10 @@ mod support;
 use support::{
     net::local_listener_bind_available,
     parity::{BootstrapQuicParityHarness, ParityRequestSpec, make_backend, make_upstream},
-    request_path::{BootstrapRequestSpec, H3RequestSpec, run_bootstrap_request_to, run_request_to},
+    request_path::{
+        BootstrapRequestSpec, H3RequestSpec, run_bootstrap_request_to, run_request_to,
+        run_two_chunk_bootstrap_post_to, run_two_chunk_post_to,
+    },
 };
 
 #[test]
@@ -637,6 +640,191 @@ fn bootstrap_and_quic_malformed_upstream_responses_share_observable_bucket() {
         String::from_utf8_lossy(&pair.quic.response.body).contains("upstream error"),
         "expected canonical malformed-response body"
     );
+}
+
+#[test]
+#[serial]
+fn bootstrap_and_quic_request_body_too_large_guardrail_contract_matches() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = BootstrapQuicParityHarness::new();
+    let backend_addr = harness.start_h1_static_backend(b"backend upload");
+
+    let mut config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        make_upstream(
+            "/upload",
+            vec![make_backend("backend-a", backend_addr.to_string())],
+            None,
+            "round-robin",
+        ),
+    )]));
+    config.performance.max_request_body_bytes = 1024;
+    let listen_addr = harness.start_listener(config).expect("listener with bootstrap");
+
+    let (quic_response, got_reset) = run_two_chunk_post_to(
+        listen_addr,
+        "localhost",
+        "/upload",
+        vec![0u8; 600],
+        vec![0u8; 600],
+        Duration::ZERO,
+    )
+    .expect("quic oversized request should complete");
+    let bootstrap_response = run_two_chunk_bootstrap_post_to(
+        listen_addr,
+        harness.cert_path(),
+        "localhost",
+        "/upload",
+        vec![0u8; 600],
+        vec![0u8; 600],
+        Duration::ZERO,
+    )
+    .expect("bootstrap oversized request should complete");
+
+    assert_eq!(quic_response.status, 413);
+    assert_eq!(bootstrap_response.status, 413);
+    assert_eq!(bootstrap_response.body, quic_response.body);
+    assert!(
+        quic_response.body_text().contains("request body too large"),
+        "expected canonical request body cap rejection body"
+    );
+    assert!(
+        !got_reset,
+        "quic oversized request should terminate with an HTTP response"
+    );
+}
+
+#[test]
+#[serial]
+#[ignore = "bootstrap path does not yet share request-body idle-timeout guardrail semantics"]
+fn bootstrap_and_quic_request_body_idle_timeout_guardrail_contract_matches() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = BootstrapQuicParityHarness::new();
+    let backend_addr = harness.start_h1_static_backend(b"unexpected backend call");
+
+    let mut config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        make_upstream(
+            "/upload-idle",
+            vec![make_backend("backend-a", backend_addr.to_string())],
+            None,
+            "round-robin",
+        ),
+    )]));
+    config.performance.client_body_idle_timeout_ms = 120;
+    config.performance.backend_body_total_timeout_ms = 10_000;
+    config.performance.backend_total_request_timeout_ms = 10_000;
+    let listen_addr = harness.start_listener(config).expect("listener with bootstrap");
+
+    let (quic_response, got_reset) = run_two_chunk_post_to(
+        listen_addr,
+        "localhost",
+        "/upload-idle",
+        vec![0u8; 512],
+        vec![0u8; 512],
+        Duration::from_millis(250),
+    )
+    .expect("quic idle-timeout request should complete");
+    let bootstrap_response = run_two_chunk_bootstrap_post_to(
+        listen_addr,
+        harness.cert_path(),
+        "localhost",
+        "/upload-idle",
+        vec![0u8; 512],
+        vec![0u8; 512],
+        Duration::from_millis(250),
+    )
+    .expect("bootstrap idle-timeout request should complete");
+
+    assert_eq!(quic_response.status, 408);
+    assert_eq!(bootstrap_response.status, 408);
+    assert_eq!(bootstrap_response.body, quic_response.body);
+    assert!(
+        quic_response.body_text().contains("request body idle timeout"),
+        "expected canonical request body idle-timeout body"
+    );
+    assert!(
+        !got_reset,
+        "quic request body idle timeout should return an HTTP response"
+    );
+}
+
+#[test]
+#[serial]
+#[ignore = "bootstrap path does not yet share unknown-length response prebuffer guardrail semantics"]
+fn bootstrap_and_quic_unknown_length_response_prebuffer_guardrail_contract_matches() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = BootstrapQuicParityHarness::new();
+    let backend_addr = harness.start_h1_chunked_backend(vec![b"chunk-1", b"chunk-2"]);
+
+    let mut config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        make_upstream(
+            "/long-stream",
+            vec![make_backend("backend-a", backend_addr.to_string())],
+            None,
+            "round-robin",
+        ),
+    )]));
+    config.performance.max_response_body_bytes = 64 * 1024;
+    config.performance.unknown_length_response_prebuffer_bytes = 8;
+    harness.start_listener(config).expect("listener with bootstrap");
+
+    let pair = harness
+        .run_parity_pair(ParityRequestSpec::get("localhost", "/long-stream"))
+        .expect("unknown-length response cap parity pair");
+
+    assert_eq!(pair.quic.response.status, 503);
+    assert_eq!(pair.bootstrap.response.status, 503);
+    assert_eq!(pair.bootstrap.response.body, pair.quic.response.body);
+    assert_eq!(pair.quic.response.body, b"upstream response body too large\n");
+}
+
+#[test]
+#[serial]
+#[ignore = "bootstrap path does not yet share slow response-body timeout guardrail semantics"]
+fn bootstrap_and_quic_slow_response_body_timeout_guardrail_contract_matches() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = BootstrapQuicParityHarness::new();
+    let backend_addr = harness.start_h1_delayed_chunked_backend(vec![
+        (b"chunk-1".to_vec(), Duration::from_millis(250)),
+        (b"chunk-2".to_vec(), Duration::ZERO),
+    ]);
+
+    let mut config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        make_upstream(
+            "/slow-stream",
+            vec![make_backend("backend-a", backend_addr.to_string())],
+            None,
+            "round-robin",
+        ),
+    )]));
+    config.performance.backend_timeout_ms = 100;
+    config.performance.backend_connect_timeout_ms = 100;
+    config.performance.backend_body_total_timeout_ms = 5_000;
+    config.performance.backend_body_idle_timeout_ms = 120;
+    harness.start_listener(config).expect("listener with bootstrap");
+
+    let pair = harness
+        .run_parity_pair(ParityRequestSpec::get("localhost", "/slow-stream"))
+        .expect("slow response-body timeout parity pair");
+
+    assert_timeout_bucket(&pair.quic.response);
+    assert_timeout_bucket(&pair.bootstrap.response);
+    assert_eq!(pair.bootstrap.response.body, pair.quic.response.body);
 }
 
 #[test]

--- a/crates/edge/tests/bootstrap_quic_parity.rs
+++ b/crates/edge/tests/bootstrap_quic_parity.rs
@@ -26,7 +26,8 @@ use support::{
     parity::{BootstrapQuicParityHarness, ParityRequestSpec, make_backend, make_upstream},
     request_path::{
         BootstrapRequestSpec, H3RequestSpec, run_bootstrap_request_to, run_request_to,
-        run_two_chunk_bootstrap_post_to, run_two_chunk_post_to,
+        run_bootstrap_h1_websocket_handshake_to, run_two_chunk_bootstrap_post_to,
+        run_two_chunk_post_to,
     },
 };
 
@@ -1122,6 +1123,82 @@ fn bootstrap_and_quic_admission_overload_shed_contracts_match() {
     assert_eq!(
         bootstrap.upstream_calls, 1,
         "bootstrap overload shedding should stop the second request before backend dispatch"
+    );
+}
+
+#[test]
+#[serial]
+fn bootstrap_websocket_upgrade_is_an_explicit_quic_parity_boundary() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = BootstrapQuicParityHarness::new();
+    let backend_addr = harness.start_h1_websocket_upgrade_backend();
+
+    let config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        make_upstream(
+            "/ws",
+            vec![make_backend("backend-a", backend_addr.to_string())],
+            None,
+            "round-robin",
+        ),
+    )]));
+    let listen_addr = harness.start_listener(config).expect("listener with bootstrap");
+
+    let bootstrap = run_bootstrap_h1_websocket_handshake_to(
+        listen_addr,
+        harness.cert_path(),
+        "localhost",
+        "/ws",
+    )
+    .expect("bootstrap websocket handshake");
+    let quic = run_request_to(
+        listen_addr,
+        H3RequestSpec {
+            method: "GET",
+            authority: "localhost",
+            path: "/ws",
+            headers: &[
+                ("connection", "Upgrade"),
+                ("upgrade", "websocket"),
+                ("sec-websocket-version", "13"),
+            ],
+            body: None,
+            user_agent: "spooky-bootstrap-quic-parity-test",
+        },
+    )
+    .expect("quic websocket request");
+
+    assert_eq!(
+        bootstrap.status, 101,
+        "bootstrap keeps HTTP/1.1 upgrade mechanics as a compatibility ingress contract"
+    );
+    assert!(bootstrap.body.is_empty());
+    assert_eq!(bootstrap.header("connection"), Some("upgrade"));
+    assert_eq!(bootstrap.header("upgrade"), Some("websocket"));
+    assert_eq!(bootstrap.header("sec-websocket-accept"), Some("test-accept"));
+
+    assert_eq!(
+        quic.status, 200,
+        "quic should not pretend to share bootstrap-only HTTP/1.1 switching-protocols mechanics"
+    );
+    assert!(quic.body.is_empty());
+    assert_eq!(quic.header("sec-websocket-accept"), Some("test-accept"));
+    assert_eq!(
+        quic.header("connection"),
+        None,
+        "HTTP/3 websocket tunneling should not expose bootstrap's upgrade header contract"
+    );
+    assert_eq!(
+        quic.header("upgrade"),
+        None,
+        "HTTP/3 websocket tunneling should not expose bootstrap's upgrade header contract"
+    );
+    assert_ne!(
+        bootstrap.status, quic.status,
+        "the parity suite should document websocket/upgrade as an intentional ingress boundary, not a shared contract"
     );
 }
 

--- a/crates/edge/tests/bootstrap_quic_parity.rs
+++ b/crates/edge/tests/bootstrap_quic_parity.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
     convert::Infallible,
+    net::TcpListener,
     sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
@@ -520,6 +521,125 @@ fn bootstrap_and_quic_external_auth_decisions_match() {
 }
 
 #[test]
+#[serial]
+fn bootstrap_and_quic_upstream_timeout_failures_share_observable_bucket() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = BootstrapQuicParityHarness::new();
+    let backend_calls = Arc::new(AtomicUsize::new(0));
+    let backend_observed = Arc::clone(&backend_calls);
+    let backend_addr = harness.start_h1_backend(move |_req: Request<Incoming>| {
+        let backend_observed = Arc::clone(&backend_observed);
+        async move {
+            backend_observed.fetch_add(1, Ordering::Relaxed);
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            Ok::<_, Infallible>(Response::new(Full::new(Bytes::from_static(
+                b"too late",
+            ))))
+        }
+    });
+
+    let mut config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        make_upstream(
+            "/timeout",
+            vec![make_backend("backend-a", backend_addr.to_string())],
+            None,
+            "round-robin",
+        ),
+    )]));
+    config.performance.backend_timeout_ms = 150;
+    config.performance.backend_connect_timeout_ms = 150;
+    harness.start_listener(config).expect("listener with bootstrap");
+
+    let request = ParityRequestSpec::get("localhost", "/timeout");
+    let pair = harness.run_parity_pair(request).expect("timeout parity pair");
+
+    assert_timeout_bucket(&pair.quic.response);
+    assert_timeout_bucket(&pair.bootstrap.response);
+    assert_eq!(pair.bootstrap.response.body, pair.quic.response.body);
+    assert_eq!(backend_calls.load(Ordering::Relaxed), 2);
+}
+
+#[test]
+#[serial]
+fn bootstrap_and_quic_connect_failures_share_observable_bucket() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = BootstrapQuicParityHarness::new();
+    let unused_listener = TcpListener::bind("127.0.0.1:0").expect("bind unused backend port");
+    let unused_addr = unused_listener.local_addr().expect("unused backend addr");
+    drop(unused_listener);
+
+    let mut config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        make_upstream(
+            "/connect-fail",
+            vec![make_backend("backend-a", format!("http://{unused_addr}"))],
+            None,
+            "round-robin",
+        ),
+    )]));
+    config.performance.backend_timeout_ms = 150;
+    config.performance.backend_connect_timeout_ms = 150;
+    harness.start_listener(config).expect("listener with bootstrap");
+
+    let request = ParityRequestSpec::get("localhost", "/connect-fail");
+    let pair = harness
+        .run_parity_pair(request)
+        .expect("connect failure parity pair");
+
+    assert_eq!(pair.quic.response.status, 502);
+    assert_eq!(pair.bootstrap.response.status, 502);
+    assert_eq!(pair.bootstrap.response.body, pair.quic.response.body);
+    assert!(
+        String::from_utf8_lossy(&pair.quic.response.body).contains("upstream error"),
+        "expected canonical transport failure body"
+    );
+}
+
+#[test]
+#[serial]
+fn bootstrap_and_quic_malformed_upstream_responses_share_observable_bucket() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = BootstrapQuicParityHarness::new();
+    let backend_addr = harness.start_h1_raw_response_backend(b"NOT_HTTP\r\n\r\n".to_vec());
+
+    let mut config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        make_upstream(
+            "/malformed",
+            vec![make_backend("backend-a", backend_addr.to_string())],
+            None,
+            "round-robin",
+        ),
+    )]));
+    config.performance.backend_timeout_ms = 150;
+    config.performance.backend_connect_timeout_ms = 150;
+    harness.start_listener(config).expect("listener with bootstrap");
+
+    let request = ParityRequestSpec::get("localhost", "/malformed");
+    let pair = harness
+        .run_parity_pair(request)
+        .expect("malformed upstream parity pair");
+
+    assert_eq!(pair.quic.response.status, 502);
+    assert_eq!(pair.bootstrap.response.status, 502);
+    assert_eq!(pair.bootstrap.response.body, pair.quic.response.body);
+    assert!(
+        String::from_utf8_lossy(&pair.quic.response.body).contains("upstream error"),
+        "expected canonical malformed-response body"
+    );
+}
+
+#[test]
 fn bootstrap_and_quic_response_normalization_strip_same_hop_headers() {
     if !local_listener_bind_available() {
         return;
@@ -910,6 +1030,19 @@ fn selected_header_value<'a>(
         .iter()
         .find(|(header_name, _)| header_name.eq_ignore_ascii_case(name))
         .map(|(_, value)| value.as_str())
+}
+
+fn assert_timeout_bucket(response: &support::parity::ParityResponseSnapshot) {
+    assert!(
+        matches!(response.status, 503 | 504),
+        "expected timeout bucket status, got {}",
+        response.status
+    );
+    assert!(
+        String::from_utf8_lossy(&response.body).contains("upstream timeout"),
+        "expected canonical timeout body, got `{}`",
+        String::from_utf8_lossy(&response.body)
+    );
 }
 
 #[derive(Clone, Copy)]

--- a/crates/edge/tests/bootstrap_quic_parity.rs
+++ b/crates/edge/tests/bootstrap_quic_parity.rs
@@ -31,6 +31,8 @@ use support::{
     },
 };
 
+// Routing parity
+
 #[test]
 fn bootstrap_and_quic_parity_harness_collects_canonical_response_shape() {
     if !local_listener_bind_available() {
@@ -234,6 +236,8 @@ fn bootstrap_and_quic_route_resolution_share_observable_unrouted_behavior() {
     assert_eq!(pair.quic.response.body, b"no route\n");
     assert_eq!(pair.bootstrap.response.body, pair.quic.response.body);
 }
+
+// Authentication and admission parity
 
 #[test]
 fn bootstrap_and_quic_local_api_key_auth_decisions_match() {
@@ -523,6 +527,285 @@ fn bootstrap_and_quic_external_auth_decisions_match() {
         );
     }
 }
+
+#[test]
+#[serial]
+fn bootstrap_and_quic_admission_rate_limit_rejections_match() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let quic = run_scoped_rate_limit_scenario(IngressKind::Quic);
+    let bootstrap = run_scoped_rate_limit_scenario(IngressKind::Bootstrap);
+
+    assert_eq!(quic.status, 429);
+    assert_eq!(bootstrap.status, 429);
+    assert_eq!(bootstrap.status, quic.status);
+    assert_eq!(bootstrap.body, quic.body);
+    assert!(
+        quic.body.contains("request rate limited"),
+        "expected canonical rate-limit rejection body, got `{}`",
+        quic.body
+    );
+    assert_eq!(bootstrap.headers, quic.headers);
+    assert_eq!(
+        quic.headers,
+        vec![(String::from("retry-after"), String::from("1"))]
+    );
+    assert_eq!(
+        quic.upstream_calls, 1,
+        "quic rate-limit path should reject before the second upstream dispatch"
+    );
+    assert_eq!(
+        bootstrap.upstream_calls, 1,
+        "bootstrap rate-limit path should reject before the second upstream dispatch"
+    );
+}
+
+#[test]
+#[serial]
+#[ignore = "bootstrap path does not yet share post-auth admission overload semantics"]
+fn bootstrap_and_quic_admission_overload_shed_contracts_match() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let quic = run_overload_shed_scenario(IngressKind::Quic);
+    let bootstrap = run_overload_shed_scenario(IngressKind::Bootstrap);
+
+    assert_eq!(quic.status, 503);
+    assert_eq!(bootstrap.status, 503);
+    assert_eq!(bootstrap.body, quic.body);
+    assert!(
+        quic.body.contains("route queue cap exceeded"),
+        "expected canonical overload body, got `{}`",
+        quic.body
+    );
+    assert_eq!(bootstrap.headers, quic.headers);
+    assert_eq!(
+        quic.headers,
+        vec![(String::from("retry-after"), String::from("1"))]
+    );
+    assert_eq!(
+        quic.upstream_calls, 1,
+        "quic overload shedding should stop the second request before backend dispatch"
+    );
+    assert_eq!(
+        bootstrap.upstream_calls, 1,
+        "bootstrap overload shedding should stop the second request before backend dispatch"
+    );
+}
+
+// Response normalization parity
+
+#[test]
+fn bootstrap_and_quic_response_normalization_strip_same_hop_headers() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = BootstrapQuicParityHarness::new();
+    let backend_addr = harness.start_h1_backend(|_req: Request<Incoming>| async move {
+        Ok::<_, Infallible>(
+            Response::builder()
+                .status(200)
+                .header("connection", "x-hop-token")
+                .header("x-hop-token", "secret")
+                .header("content-length", "9")
+                .header("content-type", "text/plain")
+                .header("cache-control", "max-age=60")
+                .header("etag", "\"etag-1\"")
+                .body(Full::new(Bytes::from_static(b"strip hop")))
+                .expect("response"),
+        )
+    });
+
+    start_single_route_listener(
+        &mut harness,
+        "/normalize-hop",
+        backend_addr.to_string(),
+    );
+
+    let request = ParityRequestSpec {
+        method: "GET",
+        authority: "localhost",
+        path: "/normalize-hop",
+        headers: &[],
+        body: None,
+        user_agent: "spooky-bootstrap-quic-parity-test",
+        selected_response_headers: &[
+            "cache-control",
+            "connection",
+            "content-length",
+            "content-type",
+            "etag",
+            "x-hop-token",
+        ],
+        capture_metrics_delta: false,
+    };
+    let pair = harness
+        .run_parity_pair(request)
+        .expect("response normalization parity pair");
+
+    assert_eq!(pair.quic.response.status, 200);
+    assert_eq!(pair.bootstrap.response.status, 200);
+    assert_eq!(pair.quic.response.body, b"strip hop");
+    assert_eq!(pair.bootstrap.response.body, pair.quic.response.body);
+    assert_eq!(
+        selected_header_value(&pair.quic.response, "cache-control"),
+        Some("max-age=60")
+    );
+    assert_eq!(
+        selected_header_value(&pair.bootstrap.response, "cache-control"),
+        Some("max-age=60")
+    );
+    assert_eq!(
+        selected_header_value(&pair.quic.response, "etag"),
+        Some("\"etag-1\"")
+    );
+    assert_eq!(
+        selected_header_value(&pair.bootstrap.response, "etag"),
+        Some("\"etag-1\"")
+    );
+    for stripped in ["connection", "x-hop-token"] {
+        assert_eq!(
+            selected_header_value(&pair.quic.response, stripped),
+            None,
+            "quic should strip hop header `{stripped}`"
+        );
+        assert_eq!(
+            selected_header_value(&pair.bootstrap.response, stripped),
+            None,
+            "bootstrap should strip hop header `{stripped}`"
+        );
+    }
+    assert_eq!(
+        selected_header_value(&pair.quic.response, "content-type"),
+        Some("text/plain")
+    );
+    assert_eq!(
+        selected_header_value(&pair.bootstrap.response, "content-type"),
+        Some("text/plain")
+    );
+    assert_eq!(
+        selected_header_value(&pair.quic.response, "content-length"),
+        None,
+        "quic should omit downstream content-length under HTTP/3 framing"
+    );
+    assert_eq!(
+        selected_header_value(&pair.bootstrap.response, "content-length"),
+        Some("9"),
+        "bootstrap should preserve explicit content-length under HTTP compatibility ingress"
+    );
+}
+
+#[test]
+fn bootstrap_and_quic_response_normalization_head_bodyless_contract_matches() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = BootstrapQuicParityHarness::new();
+    let backend_addr = harness.start_h1_backend(|_req: Request<Incoming>| async move {
+        Ok::<_, Infallible>(
+            Response::builder()
+                .status(200)
+                .body(Full::new(Bytes::from_static(b"hidden head body")))
+                .expect("response"),
+        )
+    });
+
+    start_single_route_listener(&mut harness, "/head", backend_addr.to_string());
+
+    let request = ParityRequestSpec {
+        method: "HEAD",
+        authority: "localhost",
+        path: "/head",
+        headers: &[],
+        body: None,
+        user_agent: "spooky-bootstrap-quic-parity-test",
+        selected_response_headers: &["content-length", "content-type"],
+        capture_metrics_delta: false,
+    };
+    let pair = harness.run_parity_pair(request).expect("head parity pair");
+
+    assert_eq!(pair.quic.response.status, 200);
+    assert_eq!(pair.bootstrap.response.status, 200);
+    assert!(pair.quic.response.body.is_empty());
+    assert!(pair.bootstrap.response.body.is_empty());
+    assert_eq!(
+        selected_header_value(&pair.quic.response, "content-type"),
+        None
+    );
+    assert_eq!(
+        selected_header_value(&pair.bootstrap.response, "content-type"),
+        None
+    );
+    assert_eq!(
+        selected_header_value(&pair.quic.response, "content-length"),
+        None
+    );
+    assert_eq!(
+        selected_header_value(&pair.bootstrap.response, "content-length"),
+        Some("16")
+    );
+}
+
+#[test]
+fn bootstrap_and_quic_response_normalization_no_content_contract_matches() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = BootstrapQuicParityHarness::new();
+    let backend_addr = harness.start_h1_backend(|_req: Request<Incoming>| async move {
+        Ok::<_, Infallible>(
+            Response::builder()
+                .status(204)
+                .body(Full::new(Bytes::new()))
+                .expect("response"),
+        )
+    });
+
+    start_single_route_listener(&mut harness, "/no-content", backend_addr.to_string());
+
+    let request = ParityRequestSpec {
+        method: "GET",
+        authority: "localhost",
+        path: "/no-content",
+        headers: &[],
+        body: None,
+        user_agent: "spooky-bootstrap-quic-parity-test",
+        selected_response_headers: &["content-length", "content-type"],
+        capture_metrics_delta: false,
+    };
+    let pair = harness
+        .run_parity_pair(request)
+        .expect("no content parity pair");
+
+    assert_eq!(pair.quic.response.status, 204);
+    assert_eq!(pair.bootstrap.response.status, 204);
+    assert!(pair.quic.response.body.is_empty());
+    assert!(pair.bootstrap.response.body.is_empty());
+    assert_eq!(
+        selected_header_value(&pair.quic.response, "content-type"),
+        None
+    );
+    assert_eq!(
+        selected_header_value(&pair.bootstrap.response, "content-type"),
+        None
+    );
+    assert_eq!(
+        selected_header_value(&pair.quic.response, "content-length"),
+        None
+    );
+    assert_eq!(
+        selected_header_value(&pair.bootstrap.response, "content-length"),
+        None
+    );
+}
+
+// Failure and guardrail parity
 
 #[test]
 #[serial]
@@ -829,380 +1112,6 @@ fn bootstrap_and_quic_slow_response_body_timeout_guardrail_contract_matches() {
 }
 
 #[test]
-fn bootstrap_and_quic_response_normalization_strip_same_hop_headers() {
-    if !local_listener_bind_available() {
-        return;
-    }
-
-    let mut harness = BootstrapQuicParityHarness::new();
-    let backend_addr = harness.start_h1_backend(|_req: Request<Incoming>| async move {
-        Ok::<_, Infallible>(
-            Response::builder()
-                .status(200)
-                .header("connection", "x-hop-token")
-                .header("x-hop-token", "secret")
-                .header("content-length", "9")
-                .header("content-type", "text/plain")
-                .header("cache-control", "max-age=60")
-                .header("etag", "\"etag-1\"")
-                .body(Full::new(Bytes::from_static(b"strip hop")))
-                .expect("response"),
-        )
-    });
-
-    let config = harness.make_config(HashMap::from([(
-        "api".to_string(),
-        make_upstream(
-            "/normalize-hop",
-            vec![make_backend("backend-a", backend_addr.to_string())],
-            None,
-            "round-robin",
-        ),
-    )]));
-    harness.start_listener(config).expect("listener with bootstrap");
-
-    let request = ParityRequestSpec {
-        method: "GET",
-        authority: "localhost",
-        path: "/normalize-hop",
-        headers: &[],
-        body: None,
-        user_agent: "spooky-bootstrap-quic-parity-test",
-        selected_response_headers: &[
-            "cache-control",
-            "connection",
-            "content-length",
-            "content-type",
-            "etag",
-            "x-hop-token",
-        ],
-        capture_metrics_delta: false,
-    };
-    let pair = harness
-        .run_parity_pair(request)
-        .expect("response normalization parity pair");
-
-    assert_eq!(pair.quic.response.status, 200);
-    assert_eq!(pair.bootstrap.response.status, 200);
-    assert_eq!(pair.quic.response.body, b"strip hop");
-    assert_eq!(pair.bootstrap.response.body, pair.quic.response.body);
-    assert_eq!(
-        selected_header_value(&pair.quic.response, "cache-control"),
-        Some("max-age=60")
-    );
-    assert_eq!(
-        selected_header_value(&pair.bootstrap.response, "cache-control"),
-        Some("max-age=60")
-    );
-    assert_eq!(
-        selected_header_value(&pair.quic.response, "etag"),
-        Some("\"etag-1\"")
-    );
-    assert_eq!(
-        selected_header_value(&pair.bootstrap.response, "etag"),
-        Some("\"etag-1\"")
-    );
-    for stripped in ["connection", "x-hop-token"] {
-        assert_eq!(
-            selected_header_value(&pair.quic.response, stripped),
-            None,
-            "quic should strip hop header `{stripped}`"
-        );
-        assert_eq!(
-            selected_header_value(&pair.bootstrap.response, stripped),
-            None,
-            "bootstrap should strip hop header `{stripped}`"
-        );
-    }
-    assert_eq!(
-        selected_header_value(&pair.quic.response, "content-type"),
-        Some("text/plain")
-    );
-    assert_eq!(
-        selected_header_value(&pair.bootstrap.response, "content-type"),
-        Some("text/plain")
-    );
-    assert_eq!(
-        selected_header_value(&pair.quic.response, "content-length"),
-        None,
-        "quic should omit downstream content-length under HTTP/3 framing"
-    );
-    assert_eq!(
-        selected_header_value(&pair.bootstrap.response, "content-length"),
-        Some("9"),
-        "bootstrap should preserve explicit content-length under HTTP compatibility ingress"
-    );
-}
-
-#[test]
-fn bootstrap_and_quic_response_normalization_head_bodyless_contract_matches() {
-    if !local_listener_bind_available() {
-        return;
-    }
-
-    let mut harness = BootstrapQuicParityHarness::new();
-    let backend_addr = harness.start_h1_backend(|_req: Request<Incoming>| async move {
-        Ok::<_, Infallible>(
-            Response::builder()
-                .status(200)
-                .body(Full::new(Bytes::from_static(b"hidden head body")))
-                .expect("response"),
-        )
-    });
-
-    let config = harness.make_config(HashMap::from([(
-        "api".to_string(),
-        make_upstream(
-            "/head",
-            vec![make_backend("backend-a", backend_addr.to_string())],
-            None,
-            "round-robin",
-        ),
-    )]));
-    harness.start_listener(config).expect("listener with bootstrap");
-
-    let request = ParityRequestSpec {
-        method: "HEAD",
-        authority: "localhost",
-        path: "/head",
-        headers: &[],
-        body: None,
-        user_agent: "spooky-bootstrap-quic-parity-test",
-        selected_response_headers: &["content-length", "content-type"],
-        capture_metrics_delta: false,
-    };
-    let pair = harness.run_parity_pair(request).expect("head parity pair");
-
-    assert_eq!(pair.quic.response.status, 200);
-    assert_eq!(pair.bootstrap.response.status, 200);
-    assert!(pair.quic.response.body.is_empty());
-    assert!(pair.bootstrap.response.body.is_empty());
-    assert_eq!(
-        selected_header_value(&pair.quic.response, "content-type"),
-        None
-    );
-    assert_eq!(
-        selected_header_value(&pair.bootstrap.response, "content-type"),
-        None
-    );
-    assert_eq!(
-        selected_header_value(&pair.quic.response, "content-length"),
-        None
-    );
-    assert_eq!(
-        selected_header_value(&pair.bootstrap.response, "content-length"),
-        Some("16")
-    );
-}
-
-#[test]
-fn bootstrap_and_quic_response_normalization_no_content_contract_matches() {
-    if !local_listener_bind_available() {
-        return;
-    }
-
-    let mut harness = BootstrapQuicParityHarness::new();
-    let backend_addr = harness.start_h1_backend(|_req: Request<Incoming>| async move {
-        Ok::<_, Infallible>(
-            Response::builder()
-                .status(204)
-                .body(Full::new(Bytes::new()))
-                .expect("response"),
-        )
-    });
-
-    let config = harness.make_config(HashMap::from([(
-        "api".to_string(),
-        make_upstream(
-            "/no-content",
-            vec![make_backend("backend-a", backend_addr.to_string())],
-            None,
-            "round-robin",
-        ),
-    )]));
-    harness.start_listener(config).expect("listener with bootstrap");
-
-    let request = ParityRequestSpec {
-        method: "GET",
-        authority: "localhost",
-        path: "/no-content",
-        headers: &[],
-        body: None,
-        user_agent: "spooky-bootstrap-quic-parity-test",
-        selected_response_headers: &["content-length", "content-type"],
-        capture_metrics_delta: false,
-    };
-    let pair = harness
-        .run_parity_pair(request)
-        .expect("no content parity pair");
-
-    assert_eq!(pair.quic.response.status, 204);
-    assert_eq!(pair.bootstrap.response.status, 204);
-    assert!(pair.quic.response.body.is_empty());
-    assert!(pair.bootstrap.response.body.is_empty());
-    assert_eq!(
-        selected_header_value(&pair.quic.response, "content-type"),
-        None
-    );
-    assert_eq!(
-        selected_header_value(&pair.bootstrap.response, "content-type"),
-        None
-    );
-    assert_eq!(
-        selected_header_value(&pair.quic.response, "content-length"),
-        None
-    );
-    assert_eq!(
-        selected_header_value(&pair.bootstrap.response, "content-length"),
-        None
-    );
-}
-
-#[test]
-#[serial]
-fn bootstrap_and_quic_admission_rate_limit_rejections_match() {
-    if !local_listener_bind_available() {
-        return;
-    }
-
-    let quic = run_scoped_rate_limit_scenario(IngressKind::Quic);
-    let bootstrap = run_scoped_rate_limit_scenario(IngressKind::Bootstrap);
-
-    assert_eq!(quic.status, 429);
-    assert_eq!(bootstrap.status, 429);
-    assert_eq!(bootstrap.status, quic.status);
-    assert_eq!(bootstrap.body, quic.body);
-    assert!(
-        quic.body.contains("request rate limited"),
-        "expected canonical rate-limit rejection body, got `{}`",
-        quic.body
-    );
-    assert_eq!(bootstrap.headers, quic.headers);
-    assert_eq!(
-        quic.headers,
-        vec![(String::from("retry-after"), String::from("1"))]
-    );
-    assert_eq!(
-        quic.upstream_calls, 1,
-        "quic rate-limit path should reject before the second upstream dispatch"
-    );
-    assert_eq!(
-        bootstrap.upstream_calls, 1,
-        "bootstrap rate-limit path should reject before the second upstream dispatch"
-    );
-}
-
-#[test]
-#[serial]
-#[ignore = "bootstrap path does not yet share post-auth admission overload semantics"]
-fn bootstrap_and_quic_admission_overload_shed_contracts_match() {
-    if !local_listener_bind_available() {
-        return;
-    }
-
-    let quic = run_overload_shed_scenario(IngressKind::Quic);
-    let bootstrap = run_overload_shed_scenario(IngressKind::Bootstrap);
-
-    assert_eq!(quic.status, 503);
-    assert_eq!(bootstrap.status, 503);
-    assert_eq!(bootstrap.body, quic.body);
-    assert!(
-        quic.body.contains("route queue cap exceeded"),
-        "expected canonical overload body, got `{}`",
-        quic.body
-    );
-    assert_eq!(bootstrap.headers, quic.headers);
-    assert_eq!(
-        quic.headers,
-        vec![(String::from("retry-after"), String::from("1"))]
-    );
-    assert_eq!(
-        quic.upstream_calls, 1,
-        "quic overload shedding should stop the second request before backend dispatch"
-    );
-    assert_eq!(
-        bootstrap.upstream_calls, 1,
-        "bootstrap overload shedding should stop the second request before backend dispatch"
-    );
-}
-
-#[test]
-#[serial]
-fn bootstrap_websocket_upgrade_is_an_explicit_quic_parity_boundary() {
-    if !local_listener_bind_available() {
-        return;
-    }
-
-    let mut harness = BootstrapQuicParityHarness::new();
-    let backend_addr = harness.start_h1_websocket_upgrade_backend();
-
-    let config = harness.make_config(HashMap::from([(
-        "api".to_string(),
-        make_upstream(
-            "/ws",
-            vec![make_backend("backend-a", backend_addr.to_string())],
-            None,
-            "round-robin",
-        ),
-    )]));
-    let listen_addr = harness.start_listener(config).expect("listener with bootstrap");
-
-    let bootstrap = run_bootstrap_h1_websocket_handshake_to(
-        listen_addr,
-        harness.cert_path(),
-        "localhost",
-        "/ws",
-    )
-    .expect("bootstrap websocket handshake");
-    let quic = run_request_to(
-        listen_addr,
-        H3RequestSpec {
-            method: "GET",
-            authority: "localhost",
-            path: "/ws",
-            headers: &[
-                ("connection", "Upgrade"),
-                ("upgrade", "websocket"),
-                ("sec-websocket-version", "13"),
-            ],
-            body: None,
-            user_agent: "spooky-bootstrap-quic-parity-test",
-        },
-    )
-    .expect("quic websocket request");
-
-    assert_eq!(
-        bootstrap.status, 101,
-        "bootstrap keeps HTTP/1.1 upgrade mechanics as a compatibility ingress contract"
-    );
-    assert!(bootstrap.body.is_empty());
-    assert_eq!(bootstrap.header("connection"), Some("upgrade"));
-    assert_eq!(bootstrap.header("upgrade"), Some("websocket"));
-    assert_eq!(bootstrap.header("sec-websocket-accept"), Some("test-accept"));
-
-    assert_eq!(
-        quic.status, 200,
-        "quic should not pretend to share bootstrap-only HTTP/1.1 switching-protocols mechanics"
-    );
-    assert!(quic.body.is_empty());
-    assert_eq!(quic.header("sec-websocket-accept"), Some("test-accept"));
-    assert_eq!(
-        quic.header("connection"),
-        None,
-        "HTTP/3 websocket tunneling should not expose bootstrap's upgrade header contract"
-    );
-    assert_eq!(
-        quic.header("upgrade"),
-        None,
-        "HTTP/3 websocket tunneling should not expose bootstrap's upgrade header contract"
-    );
-    assert_ne!(
-        bootstrap.status, quic.status,
-        "the parity suite should document websocket/upgrade as an intentional ingress boundary, not a shared contract"
-    );
-}
-
-#[test]
 #[serial]
 fn bootstrap_and_quic_outcome_recording_success_bucket_matches() {
     if !local_listener_bind_available() {
@@ -1211,17 +1120,7 @@ fn bootstrap_and_quic_outcome_recording_success_bucket_matches() {
 
     let mut harness = BootstrapQuicParityHarness::new();
     let backend_addr = harness.start_h1_static_backend(b"metrics success");
-
-    let config = harness.make_config(HashMap::from([(
-        "api".to_string(),
-        make_upstream(
-            "/metrics-success",
-            vec![make_backend("backend-a", backend_addr.to_string())],
-            None,
-            "round-robin",
-        ),
-    )]));
-    harness.start_listener(config).expect("listener with bootstrap");
+    start_single_route_listener(&mut harness, "/metrics-success", backend_addr.to_string());
 
     let request = ParityRequestSpec {
         method: "GET",
@@ -1452,6 +1351,23 @@ fn auth_protected_upstream(
     let mut upstream = make_upstream(path_prefix, backends, None, "round-robin");
     upstream.auth = auth;
     upstream
+}
+
+fn start_single_route_listener(
+    harness: &mut BootstrapQuicParityHarness,
+    path_prefix: &str,
+    backend_address: String,
+) {
+    let config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        make_upstream(
+            path_prefix,
+            vec![make_backend("backend-a", backend_address)],
+            None,
+            "round-robin",
+        ),
+    )]));
+    harness.start_listener(config).expect("listener with bootstrap");
 }
 
 fn configure_http_external_auth(
@@ -1827,6 +1743,77 @@ fn run_overload_shed_scenario(ingress: IngressKind) -> RejectionObservation {
         upstream_calls: upstream_calls.load(Ordering::Relaxed),
     }
 }
+
+// Upgrade-exception parity boundaries
+
+#[test]
+#[serial]
+fn bootstrap_websocket_upgrade_is_an_explicit_quic_parity_boundary() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = BootstrapQuicParityHarness::new();
+    let backend_addr = harness.start_h1_websocket_upgrade_backend();
+    start_single_route_listener(&mut harness, "/ws", backend_addr.to_string());
+    let listen_addr = harness.listen_addr();
+
+    let bootstrap = run_bootstrap_h1_websocket_handshake_to(
+        listen_addr,
+        harness.cert_path(),
+        "localhost",
+        "/ws",
+    )
+    .expect("bootstrap websocket handshake");
+    let quic = run_request_to(
+        listen_addr,
+        H3RequestSpec {
+            method: "GET",
+            authority: "localhost",
+            path: "/ws",
+            headers: &[
+                ("connection", "Upgrade"),
+                ("upgrade", "websocket"),
+                ("sec-websocket-version", "13"),
+            ],
+            body: None,
+            user_agent: "spooky-bootstrap-quic-parity-test",
+        },
+    )
+    .expect("quic websocket request");
+
+    assert_eq!(
+        bootstrap.status, 101,
+        "bootstrap keeps HTTP/1.1 upgrade mechanics as a compatibility ingress contract"
+    );
+    assert!(bootstrap.body.is_empty());
+    assert_eq!(bootstrap.header("connection"), Some("upgrade"));
+    assert_eq!(bootstrap.header("upgrade"), Some("websocket"));
+    assert_eq!(bootstrap.header("sec-websocket-accept"), Some("test-accept"));
+
+    assert_eq!(
+        quic.status, 200,
+        "quic should not pretend to share bootstrap-only HTTP/1.1 switching-protocols mechanics"
+    );
+    assert!(quic.body.is_empty());
+    assert_eq!(quic.header("sec-websocket-accept"), Some("test-accept"));
+    assert_eq!(
+        quic.header("connection"),
+        None,
+        "HTTP/3 websocket tunneling should not expose bootstrap's upgrade header contract"
+    );
+    assert_eq!(
+        quic.header("upgrade"),
+        None,
+        "HTTP/3 websocket tunneling should not expose bootstrap's upgrade header contract"
+    );
+    assert_ne!(
+        bootstrap.status, quic.status,
+        "the parity suite should document websocket/upgrade as an intentional ingress boundary, not a shared contract"
+    );
+}
+
+// Observability parity
 
 fn run_rate_limit_outcome_recording_scenario(ingress: IngressKind) -> OutcomeRecordingObservation {
     let mut harness = BootstrapQuicParityHarness::new();

--- a/crates/edge/tests/support/mod.rs
+++ b/crates/edge/tests/support/mod.rs
@@ -1,2 +1,3 @@
 pub mod net;
+pub mod parity;
 pub mod request_path;

--- a/crates/edge/tests/support/parity.rs
+++ b/crates/edge/tests/support/parity.rs
@@ -96,6 +96,10 @@ impl BootstrapQuicParityHarness {
         self.inner.start_h1_static_backend(body)
     }
 
+    pub fn start_h1_raw_response_backend(&mut self, response_bytes: Vec<u8>) -> SocketAddr {
+        self.inner.start_h1_raw_response_backend(response_bytes)
+    }
+
     pub fn start_h2_backend<F, Fut>(&mut self, handler: F) -> SocketAddr
     where
         F: Fn(Request<Incoming>) -> Fut + Send + Sync + 'static,

--- a/crates/edge/tests/support/parity.rs
+++ b/crates/edge/tests/support/parity.rs
@@ -1,0 +1,225 @@
+#![allow(dead_code)]
+
+use std::{collections::HashMap, convert::Infallible, net::SocketAddr};
+
+use bytes::Bytes;
+use http_body_util::Full;
+use hyper::{Request, Response, body::Incoming};
+
+use super::request_path::{
+    BootstrapRequestSpec, BootstrapResponse, H3RequestSpec, H3Response, QuicRequestPathHarness,
+};
+use spooky_config::config::{Backend, Config, Upstream, UpstreamTls};
+
+#[derive(Clone, Copy)]
+pub struct ParityRequestSpec<'a> {
+    pub method: &'a str,
+    pub authority: &'a str,
+    pub path: &'a str,
+    pub headers: &'a [(&'a str, &'a str)],
+    pub body: Option<&'a [u8]>,
+    pub user_agent: &'a str,
+    pub selected_response_headers: &'a [&'a str],
+    pub capture_metrics_delta: bool,
+}
+
+impl<'a> ParityRequestSpec<'a> {
+    pub fn get(authority: &'a str, path: &'a str) -> Self {
+        Self {
+            method: "GET",
+            authority,
+            path,
+            headers: &[],
+            body: None,
+            user_agent: "spooky-bootstrap-quic-parity-test",
+            selected_response_headers: &[],
+            capture_metrics_delta: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MetricsDeltaSnapshot {
+    pub before: String,
+    pub after: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParityResponseSnapshot {
+    pub status: u16,
+    pub body: Vec<u8>,
+    pub selected_headers: Vec<(String, String)>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParityObservation {
+    pub response: ParityResponseSnapshot,
+    pub metrics_delta: Option<MetricsDeltaSnapshot>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IngressParityPair {
+    pub quic: ParityObservation,
+    pub bootstrap: ParityObservation,
+}
+
+pub struct BootstrapQuicParityHarness {
+    inner: QuicRequestPathHarness,
+}
+
+impl BootstrapQuicParityHarness {
+    pub fn new() -> Self {
+        Self {
+            inner: QuicRequestPathHarness::new(),
+        }
+    }
+
+    pub fn make_config(&self, upstreams: HashMap<String, Upstream>) -> Config {
+        self.inner.make_config(upstreams)
+    }
+
+    pub fn start_listener(&mut self, config: Config) -> Result<SocketAddr, String> {
+        self.inner.start_listener_with_bootstrap(config)
+    }
+
+    pub fn start_h1_backend<F, Fut>(&mut self, handler: F) -> SocketAddr
+    where
+        F: Fn(Request<Incoming>) -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = Result<Response<Full<Bytes>>, Infallible>>
+            + Send
+            + 'static,
+    {
+        self.inner.start_h1_backend(handler)
+    }
+
+    pub fn start_h1_static_backend(&mut self, body: &'static [u8]) -> SocketAddr {
+        self.inner.start_h1_static_backend(body)
+    }
+
+    pub fn start_h2_backend<F, Fut>(&mut self, handler: F) -> SocketAddr
+    where
+        F: Fn(Request<Incoming>) -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = Result<Response<Full<Bytes>>, Infallible>>
+            + Send
+            + 'static,
+    {
+        self.inner.start_h2_backend(handler)
+    }
+
+    pub fn start_h2_static_backend(&mut self, body: &'static [u8]) -> SocketAddr {
+        self.inner.start_h2_static_backend(body)
+    }
+
+    pub fn run_quic(&self, request: ParityRequestSpec<'_>) -> Result<ParityObservation, String> {
+        let before = self.capture_metrics(request.capture_metrics_delta);
+        let response = self.inner.run_request(H3RequestSpec {
+            method: request.method,
+            authority: request.authority,
+            path: request.path,
+            headers: request.headers,
+            body: request.body,
+            user_agent: request.user_agent,
+        })?;
+        let after = self.capture_metrics(request.capture_metrics_delta);
+        Ok(ParityObservation {
+            response: snapshot_h3_response(response, request.selected_response_headers),
+            metrics_delta: join_metrics_delta(before, after),
+        })
+    }
+
+    pub fn run_bootstrap(
+        &self,
+        request: ParityRequestSpec<'_>,
+    ) -> Result<ParityObservation, String> {
+        let before = self.capture_metrics(request.capture_metrics_delta);
+        let response = self.inner.run_bootstrap_h2_request(BootstrapRequestSpec {
+            method: request.method,
+            authority: request.authority,
+            path: request.path,
+            headers: request.headers,
+            body: request.body,
+            user_agent: request.user_agent,
+        })?;
+        let after = self.capture_metrics(request.capture_metrics_delta);
+        Ok(ParityObservation {
+            response: snapshot_bootstrap_response(response, request.selected_response_headers),
+            metrics_delta: join_metrics_delta(before, after),
+        })
+    }
+
+    pub fn run_parity_pair(
+        &self,
+        request: ParityRequestSpec<'_>,
+    ) -> Result<IngressParityPair, String> {
+        Ok(IngressParityPair {
+            quic: self.run_quic(request)?,
+            bootstrap: self.run_bootstrap(request)?,
+        })
+    }
+
+    fn capture_metrics(&self, enabled: bool) -> Option<String> {
+        enabled.then(|| self.inner.metrics_text()).flatten()
+    }
+}
+
+impl Default for BootstrapQuicParityHarness {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn snapshot_h3_response(
+    response: H3Response,
+    selected_response_headers: &[&str],
+) -> ParityResponseSnapshot {
+    ParityResponseSnapshot {
+        status: response.status,
+        body: response.body,
+        selected_headers: select_headers(response.headers, selected_response_headers),
+    }
+}
+
+fn snapshot_bootstrap_response(
+    response: BootstrapResponse,
+    selected_response_headers: &[&str],
+) -> ParityResponseSnapshot {
+    ParityResponseSnapshot {
+        status: response.status,
+        body: response.body,
+        selected_headers: select_headers(response.headers, selected_response_headers),
+    }
+}
+
+fn select_headers(
+    headers: Vec<(String, String)>,
+    selected_response_headers: &[&str],
+) -> Vec<(String, String)> {
+    headers
+        .into_iter()
+        .filter(|(name, _)| {
+            selected_response_headers
+                .iter()
+                .any(|selected| name.eq_ignore_ascii_case(selected))
+        })
+        .collect()
+}
+
+fn join_metrics_delta(before: Option<String>, after: Option<String>) -> Option<MetricsDeltaSnapshot> {
+    match (before, after) {
+        (Some(before), Some(after)) => Some(MetricsDeltaSnapshot { before, after }),
+        _ => None,
+    }
+}
+
+pub fn make_upstream(
+    path_prefix: &str,
+    backends: Vec<Backend>,
+    tls: Option<UpstreamTls>,
+    lb_type: &str,
+) -> Upstream {
+    super::request_path::make_upstream(path_prefix, backends, tls, lb_type)
+}
+
+pub fn make_backend(id: &str, address: impl Into<String>) -> Backend {
+    super::request_path::make_backend(id, address)
+}

--- a/crates/edge/tests/support/parity.rs
+++ b/crates/edge/tests/support/parity.rs
@@ -96,6 +96,10 @@ impl BootstrapQuicParityHarness {
         self.inner.start_h1_static_backend(body)
     }
 
+    pub fn start_h1_websocket_upgrade_backend(&mut self) -> SocketAddr {
+        self.inner.start_h1_websocket_upgrade_backend()
+    }
+
     pub fn start_h1_chunked_backend(&mut self, chunks: Vec<&'static [u8]>) -> SocketAddr {
         self.inner.start_h1_chunked_backend(chunks)
     }

--- a/crates/edge/tests/support/parity.rs
+++ b/crates/edge/tests/support/parity.rs
@@ -96,6 +96,17 @@ impl BootstrapQuicParityHarness {
         self.inner.start_h1_static_backend(body)
     }
 
+    pub fn start_h1_chunked_backend(&mut self, chunks: Vec<&'static [u8]>) -> SocketAddr {
+        self.inner.start_h1_chunked_backend(chunks)
+    }
+
+    pub fn start_h1_delayed_chunked_backend(
+        &mut self,
+        chunks: Vec<(Vec<u8>, std::time::Duration)>,
+    ) -> SocketAddr {
+        self.inner.start_h1_delayed_chunked_backend(chunks)
+    }
+
     pub fn start_h1_raw_response_backend(&mut self, response_bytes: Vec<u8>) -> SocketAddr {
         self.inner.start_h1_raw_response_backend(response_bytes)
     }

--- a/crates/edge/tests/support/parity.rs
+++ b/crates/edge/tests/support/parity.rs
@@ -157,6 +157,14 @@ impl BootstrapQuicParityHarness {
         })
     }
 
+    pub fn listen_addr(&self) -> SocketAddr {
+        self.inner.listen_addr.expect("listener address")
+    }
+
+    pub fn cert_path(&self) -> &str {
+        &self.inner.tls.cert_path
+    }
+
     fn capture_metrics(&self, enabled: bool) -> Option<String> {
         enabled.then(|| self.inner.metrics_text()).flatten()
     }

--- a/crates/edge/tests/support/parity.rs
+++ b/crates/edge/tests/support/parity.rs
@@ -194,14 +194,21 @@ fn select_headers(
     headers: Vec<(String, String)>,
     selected_response_headers: &[&str],
 ) -> Vec<(String, String)> {
-    headers
+    let mut selected = headers
         .into_iter()
         .filter(|(name, _)| {
             selected_response_headers
                 .iter()
                 .any(|selected| name.eq_ignore_ascii_case(selected))
         })
-        .collect()
+        .collect::<Vec<_>>();
+    selected.sort_by(|left, right| {
+        left.0
+            .to_ascii_lowercase()
+            .cmp(&right.0.to_ascii_lowercase())
+            .then_with(|| left.1.cmp(&right.1))
+    });
+    selected
 }
 
 fn join_metrics_delta(before: Option<String>, after: Option<String>) -> Option<MetricsDeltaSnapshot> {

--- a/crates/edge/tests/support/parity.rs
+++ b/crates/edge/tests/support/parity.rs
@@ -5,11 +5,11 @@ use std::{collections::HashMap, convert::Infallible, net::SocketAddr};
 use bytes::Bytes;
 use http_body_util::Full;
 use hyper::{Request, Response, body::Incoming};
+use spooky_config::config::{Backend, Config, Upstream, UpstreamTls};
 
 use super::request_path::{
     BootstrapRequestSpec, BootstrapResponse, H3RequestSpec, H3Response, QuicRequestPathHarness,
 };
-use spooky_config::config::{Backend, Config, Upstream, UpstreamTls};
 
 #[derive(Clone, Copy)]
 pub struct ParityRequestSpec<'a> {
@@ -242,7 +242,10 @@ fn select_headers(
     selected
 }
 
-fn join_metrics_delta(before: Option<String>, after: Option<String>) -> Option<MetricsDeltaSnapshot> {
+fn join_metrics_delta(
+    before: Option<String>,
+    after: Option<String>,
+) -> Option<MetricsDeltaSnapshot> {
     match (before, after) {
         (Some(before), Some(after)) => Some(MetricsDeltaSnapshot { before, after }),
         _ => None,

--- a/crates/edge/tests/support/parity.rs
+++ b/crates/edge/tests/support/parity.rs
@@ -180,6 +180,10 @@ impl BootstrapQuicParityHarness {
         &self.inner.tls.cert_path
     }
 
+    pub fn metrics_text(&self) -> Option<String> {
+        self.inner.metrics_text()
+    }
+
     fn capture_metrics(&self, enabled: bool) -> Option<String> {
         enabled.then(|| self.inner.metrics_text()).flatten()
     }

--- a/crates/edge/tests/support/request_path.rs
+++ b/crates/edge/tests/support/request_path.rs
@@ -17,7 +17,7 @@ use http_body_util::{BodyExt, Full, combinators::BoxBody};
 use hyper::{
     Request, Response,
     body::{Body, Frame, Incoming},
-    client::conn::http2,
+    client::conn::{http1, http2},
     service::service_fn,
 };
 use hyper_util::rt::{TokioExecutor, TokioIo};
@@ -239,6 +239,13 @@ impl QuicRequestPathHarness {
         self.start_h1_backend(move |_req| async move {
             Ok::<_, Infallible>(Response::new(Full::new(Bytes::from_static(body))))
         })
+    }
+
+    pub fn start_h1_websocket_upgrade_backend(&mut self) -> SocketAddr {
+        let fixture = self.rt.block_on(start_h1_websocket_upgrade_backend());
+        let addr = fixture.addr;
+        self.backends.push(fixture);
+        addr
     }
 
     pub fn start_h1_chunked_backend(&mut self, chunks: Vec<&'static [u8]>) -> SocketAddr {
@@ -493,6 +500,19 @@ pub fn run_bootstrap_request_to(
         .block_on(run_bootstrap_h2_request(addr, cert_path, request))
 }
 
+pub fn run_bootstrap_h1_websocket_handshake_to(
+    addr: SocketAddr,
+    cert_path: &str,
+    authority: &str,
+    path: &str,
+) -> Result<BootstrapResponse, String> {
+    tokio::runtime::Runtime::new()
+        .expect("runtime")
+        .block_on(run_bootstrap_h1_websocket_handshake(
+            addr, cert_path, authority, path,
+        ))
+}
+
 pub fn run_two_chunk_bootstrap_post_to(
     addr: SocketAddr,
     cert_path: &str,
@@ -549,6 +569,92 @@ async fn run_bootstrap_h2_request(
         .await
         .map_err(|err| format!("send request: {err}"))?;
     read_bootstrap_h2_response(response).await
+}
+
+async fn run_bootstrap_h1_websocket_handshake(
+    addr: SocketAddr,
+    cert_path: &str,
+    authority: &str,
+    path: &str,
+) -> Result<BootstrapResponse, String> {
+    let roots = read_test_root_store(cert_path)?;
+    let tls_config = ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    let connector = TlsConnector::from(Arc::new(tls_config));
+
+    let server_name = ServerName::try_from(authority)
+        .map_err(|err| format!("server name: {err}"))?
+        .to_owned();
+    let deadline = Instant::now() + Duration::from_secs(5);
+
+    loop {
+        match TcpStream::connect(addr).await {
+            Ok(stream) => {
+                let tls_stream = connector
+                    .connect(server_name.clone(), stream)
+                    .await
+                    .map_err(|err| format!("tls connect: {err}"))?;
+                let (mut sender, conn) = http1::handshake(TokioIo::new(tls_stream))
+                    .await
+                    .map_err(|err| format!("h1 handshake: {err}"))?;
+                tokio::spawn(async move {
+                    let _ = conn.with_upgrades().await;
+                });
+                sender
+                    .ready()
+                    .await
+                    .map_err(|err| format!("sender ready: {err}"))?;
+
+                let request = Request::builder()
+                    .method("GET")
+                    .uri(
+                        http::Uri::builder()
+                            .path_and_query(path)
+                            .build()
+                            .map_err(|err| format!("uri build: {err}"))?,
+                    )
+                    .header("host", authority)
+                    .header(http::header::CONNECTION, "Upgrade")
+                    .header(http::header::UPGRADE, "websocket")
+                    .header("sec-websocket-key", "dGVzdC1rZXktMTIzNDU2Nzg5MA==")
+                    .header("sec-websocket-version", "13")
+                    .body(http_body_util::Empty::<Bytes>::new())
+                    .map_err(|err| format!("request build: {err}"))?;
+
+                let response = sender
+                    .send_request(request)
+                    .await
+                    .map_err(|err| format!("send request: {err}"))?;
+
+                return Ok(BootstrapResponse {
+                    status: response.status().as_u16(),
+                    headers: response
+                        .headers()
+                        .iter()
+                        .map(|(name, value)| {
+                            (
+                                name.as_str().to_string(),
+                                value.to_str().unwrap_or_default().to_string(),
+                            )
+                        })
+                        .collect(),
+                    body: response
+                        .into_body()
+                        .collect()
+                        .await
+                        .map_err(|err| format!("collect response body: {err}"))?
+                        .to_bytes()
+                        .to_vec(),
+                });
+            }
+            Err(err) if Instant::now() < deadline => {
+                let _ = err;
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+            Err(err) => return Err(format!("tcp connect: {err}")),
+        }
+    }
 }
 
 async fn run_two_chunk_bootstrap_h2_post_to(
@@ -970,6 +1076,77 @@ where
 
                 let _ = hyper::server::conn::http1::Builder::new()
                     .serve_connection(TokioIo::new(stream), service)
+                    .await;
+            });
+        }
+    });
+
+    BackendFixture {
+        addr,
+        stop,
+        accept_task,
+    }
+}
+
+pub async fn start_h1_websocket_upgrade_backend() -> BackendFixture {
+    let listener = bind_tcp_listener();
+    let addr = listener.local_addr().expect("h1 websocket local addr");
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_flag = Arc::clone(&stop);
+
+    let accept_task = tokio::spawn(async move {
+        while !stop_flag.load(Ordering::Relaxed) {
+            let (stream, _) = match listener.accept().await {
+                Ok(value) => value,
+                Err(_) => break,
+            };
+            tokio::spawn(async move {
+                let service = service_fn(|mut req: Request<Incoming>| async move {
+                    let is_upgrade = req
+                        .headers()
+                        .get(http::header::UPGRADE)
+                        .and_then(|value| value.to_str().ok())
+                        .map(|value| value.eq_ignore_ascii_case("websocket"))
+                        .unwrap_or(false)
+                        && req
+                            .headers()
+                            .get(http::header::CONNECTION)
+                            .and_then(|value| value.to_str().ok())
+                            .map(|value| {
+                                value
+                                    .split(',')
+                                    .any(|part| part.trim().eq_ignore_ascii_case("upgrade"))
+                            })
+                            .unwrap_or(false);
+
+                    if !is_upgrade {
+                        return Ok::<_, hyper::Error>(
+                            Response::builder()
+                                .status(http::StatusCode::BAD_REQUEST)
+                                .body(Full::new(Bytes::from_static(b"missing upgrade\n")))
+                                .expect("websocket bad request"),
+                        );
+                    }
+
+                    let on_upgrade = hyper::upgrade::on(&mut req);
+                    tokio::spawn(async move {
+                        let _ = on_upgrade.await;
+                    });
+
+                    Ok::<_, hyper::Error>(
+                        Response::builder()
+                            .status(http::StatusCode::SWITCHING_PROTOCOLS)
+                            .header(http::header::CONNECTION, "upgrade")
+                            .header(http::header::UPGRADE, "websocket")
+                            .header("sec-websocket-accept", "test-accept")
+                            .body(Full::new(Bytes::new()))
+                            .expect("websocket upgrade response"),
+                    )
+                });
+
+                let _ = hyper::server::conn::http1::Builder::new()
+                    .serve_connection(TokioIo::new(stream), service)
+                    .with_upgrades()
                     .await;
             });
         }

--- a/crates/edge/tests/support/request_path.rs
+++ b/crates/edge/tests/support/request_path.rs
@@ -13,10 +13,11 @@ use std::{
 };
 
 use bytes::Bytes;
-use http_body_util::Full;
+use http_body_util::{BodyExt, Full};
 use hyper::{
     Request, Response,
     body::{Body, Frame, Incoming},
+    client::conn::http2,
     service::service_fn,
 };
 use hyper_util::rt::{TokioExecutor, TokioIo};
@@ -29,6 +30,7 @@ use spooky_config::{
         Backend, ClientAuth, Config, Listen, LoadBalancing, Log, LogFormat, RouteMatch, Security,
         Tls, Upstream, UpstreamTls,
     },
+    runtime::RuntimeConfig,
     validator::validate,
 };
 use spooky_edge::{
@@ -40,9 +42,12 @@ use spooky_edge::{
 use tempfile::{TempDir, tempdir};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
-    net::TcpListener,
+    net::{TcpListener, TcpStream},
 };
-use tokio_rustls::{TlsAcceptor, rustls::ServerConfig};
+use tokio_rustls::{
+    TlsConnector, TlsAcceptor,
+    rustls::{ClientConfig, RootCertStore, ServerConfig, pki_types::ServerName},
+};
 
 pub struct TestTlsMaterial {
     _dir: TempDir,
@@ -143,7 +148,7 @@ impl QuicRequestPathHarness {
             version: 1,
             listen: Listen {
                 protocol: "http3".to_string(),
-                port: reserve_unused_udp_port(),
+                port: reserve_unused_listener_port(),
                 address: "127.0.0.1".to_string(),
                 tls: Tls {
                     cert: self.tls.cert_path.clone(),
@@ -174,6 +179,41 @@ impl QuicRequestPathHarness {
     pub fn start_listener(&mut self, config: Config) -> Result<SocketAddr, String> {
         validate(&config).map_err(|err| format!("config validation failed: {err}"))?;
         let listener = QUICListener::new(config).map_err(|err| format!("listener: {err}"))?;
+        self.metrics = Some(Arc::clone(&listener.metrics));
+        let listen_addr = listener
+            .socket
+            .local_addr()
+            .map_err(|err| format!("listen addr: {err}"))?;
+        self.listener_task = Some(ListenerTaskGuard::spawn(&self.rt, listener));
+        self.listen_addr = Some(listen_addr);
+        Ok(listen_addr)
+    }
+
+    pub fn start_listener_with_bootstrap(&mut self, config: Config) -> Result<SocketAddr, String> {
+        validate(&config).map_err(|err| format!("config validation failed: {err}"))?;
+        let runtime_config =
+            RuntimeConfig::from_config(&config).map_err(|err| format!("runtime config: {err}"))?;
+        let listener_config = runtime_config
+            .listener_runtime_configs()
+            .into_iter()
+            .next()
+            .ok_or_else(|| "missing listener runtime config".to_string())?;
+        let shared_state = Arc::new(
+            QUICListener::build_shared_state(&runtime_config)
+                .map_err(|err| format!("shared runtime state: {err}"))?,
+        );
+        QUICListener::spawn_control_plane_tasks(&runtime_config, &shared_state, 1)
+            .map_err(|err| format!("control plane tasks: {err}"))?;
+        QUICListener::spawn_bootstrap_tls_listener(&listener_config, &shared_state, None, None)
+            .map_err(|err| format!("bootstrap listener: {err}"))?;
+        let socket = QUICListener::bind_socket(&listener_config, false)
+            .map_err(|err| format!("bind socket: {err}"))?;
+        let listener = QUICListener::new_with_socket_and_shared_state(
+            listener_config,
+            socket,
+            shared_state,
+        )
+        .map_err(|err| format!("listener with shared state: {err}"))?;
         self.metrics = Some(Arc::clone(&listener.metrics));
         let listen_addr = listener
             .socket
@@ -270,6 +310,17 @@ impl QuicRequestPathHarness {
         self.metrics
             .as_ref()
             .map(|metrics| metrics.render_prometheus())
+    }
+
+    pub fn run_bootstrap_h2_request(
+        &self,
+        request: BootstrapRequestSpec<'_>,
+    ) -> Result<BootstrapResponse, String> {
+        let listen_addr = self
+            .listen_addr
+            .ok_or_else(|| "listener not started".to_string())?;
+        self.rt
+            .block_on(run_bootstrap_h2_request(listen_addr, &self.tls.cert_path, request))
     }
 }
 
@@ -385,8 +436,163 @@ impl H3Response {
     }
 }
 
+#[derive(Clone, Copy)]
+pub struct BootstrapRequestSpec<'a> {
+    pub method: &'a str,
+    pub authority: &'a str,
+    pub path: &'a str,
+    pub headers: &'a [(&'a str, &'a str)],
+    pub body: Option<&'a [u8]>,
+    pub user_agent: &'a str,
+}
+
+impl<'a> BootstrapRequestSpec<'a> {
+    pub fn get(authority: &'a str, path: &'a str) -> Self {
+        Self {
+            method: "GET",
+            authority,
+            path,
+            headers: &[],
+            body: None,
+            user_agent: "spooky-request-path-test",
+        }
+    }
+}
+
+pub struct BootstrapResponse {
+    pub status: u16,
+    pub headers: Vec<(String, String)>,
+    pub body: Vec<u8>,
+}
+
 pub fn run_request_to(addr: SocketAddr, request: H3RequestSpec<'_>) -> Result<H3Response, String> {
     run_h3_request(addr, request)
+}
+
+async fn run_bootstrap_h2_request(
+    addr: SocketAddr,
+    cert_path: &str,
+    request: BootstrapRequestSpec<'_>,
+) -> Result<BootstrapResponse, String> {
+    let (mut sender, _conn_task) = connect_bootstrap_h2(addr, cert_path).await?;
+    sender
+        .ready()
+        .await
+        .map_err(|err| format!("sender ready: {err}"))?;
+
+    let mut builder = Request::builder()
+        .method(request.method)
+        .uri(
+            http::Uri::builder()
+                .path_and_query(request.path)
+                .build()
+                .map_err(|err| format!("uri build: {err}"))?,
+        )
+        .header("host", request.authority)
+        .header("user-agent", request.user_agent);
+    for (name, value) in request.headers {
+        builder = builder.header(*name, *value);
+    }
+
+    let body = request.body.unwrap_or_default().to_vec();
+    let req = builder
+        .body(Full::new(Bytes::from(body)))
+        .map_err(|err| format!("request build: {err}"))?;
+    let mut response = sender
+        .send_request(req)
+        .await
+        .map_err(|err| format!("send request: {err}"))?;
+    let status = response.status().as_u16();
+    let headers = response
+        .headers()
+        .iter()
+        .map(|(name, value)| {
+            Ok::<_, String>((
+                name.as_str().to_string(),
+                value
+                    .to_str()
+                    .map_err(|err| format!("header utf8: {err}"))?
+                    .to_string(),
+            ))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut body = Vec::new();
+
+    while let Some(frame) = response.body_mut().frame().await {
+        let frame = frame.map_err(|err| format!("read frame: {err}"))?;
+        if let Ok(data) = frame.into_data() {
+            body.extend_from_slice(&data);
+        }
+    }
+
+    Ok(BootstrapResponse {
+        status,
+        headers,
+        body,
+    })
+}
+
+async fn connect_bootstrap_h2(
+    addr: SocketAddr,
+    cert_path: &str,
+) -> Result<
+    (
+        hyper::client::conn::http2::SendRequest<Full<Bytes>>,
+        tokio::task::JoinHandle<()>,
+    ),
+    String,
+> {
+    let roots = read_test_root_store(cert_path)?;
+    let mut tls_config = ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    tls_config.alpn_protocols = vec![b"h2".to_vec()];
+    let connector = TlsConnector::from(Arc::new(tls_config));
+
+    let server_name = ServerName::try_from("localhost")
+        .map_err(|err| format!("server name: {err}"))?
+        .to_owned();
+    let deadline = Instant::now() + Duration::from_secs(5);
+
+    loop {
+        match TcpStream::connect(addr).await {
+            Ok(stream) => {
+                let tls_stream = connector
+                    .connect(server_name.clone(), stream)
+                    .await
+                    .map_err(|err| format!("tls connect: {err}"))?;
+                let (sender, conn) =
+                    http2::handshake(TokioExecutor::new(), TokioIo::new(tls_stream))
+                        .await
+                        .map_err(|err| format!("h2 handshake: {err}"))?;
+                let conn_task = tokio::spawn(async move {
+                    let _ = conn.await;
+                });
+                return Ok((sender, conn_task));
+            }
+            Err(err) if Instant::now() < deadline => {
+                let _ = err;
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+            Err(err) => return Err(format!("tcp connect: {err}")),
+        }
+    }
+}
+
+fn read_test_root_store(cert_path: &str) -> Result<RootCertStore, String> {
+    let mut roots = RootCertStore::empty();
+    let certs = CertificateDer::pem_file_iter(cert_path)
+        .map_err(|err| format!("open cert file: {err}"))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|err| format!("parse certs: {err}"))?;
+
+    for cert in certs {
+        roots
+            .add(cert)
+            .map_err(|err| format!("add root cert: {err}"))?;
+    }
+
+    Ok(roots)
 }
 
 pub fn run_two_chunk_post_to(
@@ -910,6 +1116,21 @@ pub fn reserve_unused_udp_port() -> u16 {
     let port = socket.local_addr().expect("udp local addr").port();
     drop(socket);
     port
+}
+
+fn reserve_unused_listener_port() -> u16 {
+    for _ in 0..32 {
+        let tcp = StdTcpListener::bind("127.0.0.1:0").expect("reserve listener tcp port");
+        let port = tcp.local_addr().expect("tcp local addr").port();
+        if let Ok(udp) = UdpSocket::bind(("127.0.0.1", port)) {
+            drop(udp);
+            drop(tcp);
+            return port;
+        }
+        drop(tcp);
+    }
+
+    reserve_unused_udp_port()
 }
 
 fn bind_tcp_listener() -> TcpListener {

--- a/crates/edge/tests/support/request_path.rs
+++ b/crates/edge/tests/support/request_path.rs
@@ -465,8 +465,32 @@ pub struct BootstrapResponse {
     pub body: Vec<u8>,
 }
 
+impl BootstrapResponse {
+    pub fn body_text(&self) -> String {
+        String::from_utf8_lossy(&self.body).into_owned()
+    }
+
+    pub fn header(&self, name: &str) -> Option<&str> {
+        self.headers.iter().find_map(|(header_name, value)| {
+            header_name
+                .eq_ignore_ascii_case(name)
+                .then_some(value.as_str())
+        })
+    }
+}
+
 pub fn run_request_to(addr: SocketAddr, request: H3RequestSpec<'_>) -> Result<H3Response, String> {
     run_h3_request(addr, request)
+}
+
+pub fn run_bootstrap_request_to(
+    addr: SocketAddr,
+    cert_path: &str,
+    request: BootstrapRequestSpec<'_>,
+) -> Result<BootstrapResponse, String> {
+    tokio::runtime::Runtime::new()
+        .expect("runtime")
+        .block_on(run_bootstrap_h2_request(addr, cert_path, request))
 }
 
 async fn run_bootstrap_h2_request(

--- a/crates/edge/tests/support/request_path.rs
+++ b/crates/edge/tests/support/request_path.rs
@@ -45,7 +45,7 @@ use tokio::{
     net::{TcpListener, TcpStream},
 };
 use tokio_rustls::{
-    TlsConnector, TlsAcceptor,
+    TlsAcceptor, TlsConnector,
     rustls::{ClientConfig, RootCertStore, ServerConfig, pki_types::ServerName},
 };
 
@@ -208,12 +208,9 @@ impl QuicRequestPathHarness {
             .map_err(|err| format!("bootstrap listener: {err}"))?;
         let socket = QUICListener::bind_socket(&listener_config, false)
             .map_err(|err| format!("bind socket: {err}"))?;
-        let listener = QUICListener::new_with_socket_and_shared_state(
-            listener_config,
-            socket,
-            shared_state,
-        )
-        .map_err(|err| format!("listener with shared state: {err}"))?;
+        let listener =
+            QUICListener::new_with_socket_and_shared_state(listener_config, socket, shared_state)
+                .map_err(|err| format!("listener with shared state: {err}"))?;
         self.metrics = Some(Arc::clone(&listener.metrics));
         let listen_addr = listener
             .socket
@@ -326,8 +323,11 @@ impl QuicRequestPathHarness {
         let listen_addr = self
             .listen_addr
             .ok_or_else(|| "listener not started".to_string())?;
-        self.rt
-            .block_on(run_bootstrap_h2_request(listen_addr, &self.tls.cert_path, request))
+        self.rt.block_on(run_bootstrap_h2_request(
+            listen_addr,
+            &self.tls.cert_path,
+            request,
+        ))
     }
 }
 
@@ -562,7 +562,11 @@ async fn run_bootstrap_h2_request(
 
     let body = request.body.unwrap_or_default().to_vec();
     let req = builder
-        .body(Full::new(Bytes::from(body)).map_err(|never| match never {}).boxed())
+        .body(
+            Full::new(Bytes::from(body))
+                .map_err(|never| match never {})
+                .boxed(),
+        )
         .map_err(|err| format!("request build: {err}"))?;
     let response = sender
         .send_request(req)

--- a/crates/edge/tests/support/request_path.rs
+++ b/crates/edge/tests/support/request_path.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 use bytes::Bytes;
-use http_body_util::{BodyExt, Full};
+use http_body_util::{BodyExt, Full, combinators::BoxBody};
 use hyper::{
     Request, Response,
     body::{Body, Frame, Incoming},
@@ -493,6 +493,28 @@ pub fn run_bootstrap_request_to(
         .block_on(run_bootstrap_h2_request(addr, cert_path, request))
 }
 
+pub fn run_two_chunk_bootstrap_post_to(
+    addr: SocketAddr,
+    cert_path: &str,
+    authority: &str,
+    path: &str,
+    chunk1: Vec<u8>,
+    chunk2: Vec<u8>,
+    delay_between_chunks: Duration,
+) -> Result<BootstrapResponse, String> {
+    tokio::runtime::Runtime::new()
+        .expect("runtime")
+        .block_on(run_two_chunk_bootstrap_h2_post_to(
+            addr,
+            cert_path,
+            authority,
+            path,
+            chunk1,
+            chunk2,
+            delay_between_chunks,
+        ))
+}
+
 async fn run_bootstrap_h2_request(
     addr: SocketAddr,
     cert_path: &str,
@@ -520,12 +542,60 @@ async fn run_bootstrap_h2_request(
 
     let body = request.body.unwrap_or_default().to_vec();
     let req = builder
-        .body(Full::new(Bytes::from(body)))
+        .body(Full::new(Bytes::from(body)).map_err(|never| match never {}).boxed())
         .map_err(|err| format!("request build: {err}"))?;
-    let mut response = sender
+    let response = sender
         .send_request(req)
         .await
         .map_err(|err| format!("send request: {err}"))?;
+    read_bootstrap_h2_response(response).await
+}
+
+async fn run_two_chunk_bootstrap_h2_post_to(
+    addr: SocketAddr,
+    cert_path: &str,
+    authority: &str,
+    path: &str,
+    chunk1: Vec<u8>,
+    chunk2: Vec<u8>,
+    delay_between_chunks: Duration,
+) -> Result<BootstrapResponse, String> {
+    let (mut sender, _conn_task) = connect_bootstrap_h2(addr, cert_path).await?;
+    sender
+        .ready()
+        .await
+        .map_err(|err| format!("sender ready: {err}"))?;
+
+    let req = Request::builder()
+        .method("POST")
+        .uri(
+            http::Uri::builder()
+                .path_and_query(path)
+                .build()
+                .map_err(|err| format!("uri build: {err}"))?,
+        )
+        .header("host", authority)
+        .header("user-agent", "spooky-request-path-test")
+        .header("content-length", (chunk1.len() + chunk2.len()).to_string())
+        .body(
+            TwoChunkDelayedBody::new(
+                Bytes::from(chunk1),
+                Bytes::from(chunk2),
+                delay_between_chunks,
+            )
+            .boxed(),
+        )
+        .map_err(|err| format!("request build: {err}"))?;
+    let response = sender
+        .send_request(req)
+        .await
+        .map_err(|err| format!("send request: {err}"))?;
+    read_bootstrap_h2_response(response).await
+}
+
+async fn read_bootstrap_h2_response(
+    mut response: Response<Incoming>,
+) -> Result<BootstrapResponse, String> {
     let status = response.status().as_u16();
     let headers = response
         .headers()
@@ -561,7 +631,7 @@ async fn connect_bootstrap_h2(
     cert_path: &str,
 ) -> Result<
     (
-        hyper::client::conn::http2::SendRequest<Full<Bytes>>,
+        hyper::client::conn::http2::SendRequest<BoxBody<Bytes, Infallible>>,
         tokio::task::JoinHandle<()>,
     ),
     String,
@@ -600,6 +670,64 @@ async fn connect_bootstrap_h2(
             }
             Err(err) => return Err(format!("tcp connect: {err}")),
         }
+    }
+}
+
+struct TwoChunkDelayedBody {
+    first: Option<Bytes>,
+    second: Option<Bytes>,
+    delay_before_second: Duration,
+    second_delay: Option<std::pin::Pin<Box<tokio::time::Sleep>>>,
+}
+
+impl TwoChunkDelayedBody {
+    fn new(first: Bytes, second: Bytes, delay_before_second: Duration) -> Self {
+        Self {
+            first: Some(first),
+            second: Some(second),
+            delay_before_second,
+            second_delay: None,
+        }
+    }
+}
+
+impl Body for TwoChunkDelayedBody {
+    type Data = Bytes;
+    type Error = Infallible;
+
+    fn poll_frame(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        if let Some(first) = self.first.take() {
+            return std::task::Poll::Ready(Some(Ok(Frame::data(first))));
+        }
+
+        if self.second.is_none() {
+            return std::task::Poll::Ready(None);
+        }
+
+        if self.delay_before_second.is_zero() {
+            return std::task::Poll::Ready(self.second.take().map(|chunk| Ok(Frame::data(chunk))));
+        }
+
+        if self.second_delay.is_none() {
+            self.second_delay = Some(Box::pin(tokio::time::sleep(self.delay_before_second)));
+        }
+
+        if let Some(delay) = self.second_delay.as_mut() {
+            match delay.as_mut().poll(cx) {
+                std::task::Poll::Ready(()) => {
+                    self.second_delay = None;
+                    return std::task::Poll::Ready(
+                        self.second.take().map(|chunk| Ok(Frame::data(chunk))),
+                    );
+                }
+                std::task::Poll::Pending => return std::task::Poll::Pending,
+            }
+        }
+
+        std::task::Poll::Ready(None)
     }
 }
 


### PR DESCRIPTION
## Summary
This PR rounds out the bootstrap-vs-QUIC parity suite and turns it into the canonical cross-ingress policy spec.

It adds parity coverage for:
- coarse outcome-recording buckets
- explicit websocket/upgrade compatibility boundaries
- shared parity harness support for bootstrap H1 upgrade scenarios

It also cleans up the parity suite structure so it is grouped by behavior domain rather than growing as a flat list.

## What Changed
- Added outcome-recording parity coverage for:
  - success
  - failure
  - timeout
  - rate-limited
- Added an ignored overload outcome parity test to document the known bootstrap overload-semantics gap.
- Added explicit bootstrap websocket upgrade vs QUIC boundary coverage:
  - bootstrap HTTP/1.1 keeps `101 Switching Protocols`
  - QUIC/H3 keeps its tunnel-style contract instead
  - the difference is asserted as intentional
- Extended test support with:
  - bootstrap H1 websocket handshake helper
  - websocket-upgrade backend fixture
  - parity harness access to the new helper
- Cleaned up `bootstrap_quic_parity.rs` by:
  - removing duplicate scenario blocks
  - grouping tests into routing, auth/admission, normalization, failure/guardrails, upgrade exceptions, and observability
  - extracting small repeated single-route setup into a helper

## Why
Bootstrap is now a compatibility ingress, while QUIC is the main data-plane path. The parity suite should prove where both paths must behave the same and where they intentionally do not.

This PR makes those boundaries explicit:
- shared policy layers should match
- ingress-specific mechanics should be documented, not accidentally treated as regressions

## Known Gaps Documented by Ignored Tests
The suite still documents a few intentional or not-yet-closed parity gaps:
- post-auth overload shedding semantics
- request body idle-timeout parity
- unknown-length response prebuffer parity
- slow response-body timeout parity

These remain visible in the test suite as explicit follow-up work rather than silent drift.