### PR TITLE
test(edge): cover runtime reload, drain, and watchdog restart behavior

### DIFF
--- a/crates/edge/src/quic_listener/tests.rs
+++ b/crates/edge/src/quic_listener/tests.rs
@@ -741,6 +741,80 @@ fn start_draining_is_idempotent_and_drain_completes_when_idle() {
 }
 
 #[test]
+fn watchdog_restart_transitions_listener_into_draining_and_counts_worker_drain_once() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+    let mut startup = tls_test_config(cert, key, Vec::new());
+    startup.listen.port = 0;
+    startup.performance.shutdown_drain_timeout_ms = 5_000;
+    startup.resilience.watchdog.enabled = true;
+
+    let startup_runtime = RuntimeConfig::from_config(&startup).expect("startup runtime");
+    let startup_bundle = super::QUICListener::build_runtime_bundle(
+        "startup.yaml".to_string(),
+        startup.log.clone(),
+        &startup_runtime,
+    )
+    .expect("startup bundle");
+    let runtime_handle = Arc::new(super::RuntimeBundleHandle::new(startup_bundle.clone()));
+    let listener_config = startup_bundle
+        .runtime_config
+        .primary_listener_runtime_config()
+        .expect("listener runtime config");
+    let socket = match super::QUICListener::bind_socket(&listener_config, false) {
+        Ok(socket) => socket,
+        Err(spooky_errors::ProxyError::Transport(message))
+            if message.contains("Operation not permitted") =>
+        {
+            return;
+        }
+        Err(err) => panic!("bind socket: {err:?}"),
+    };
+    let mut listener = super::QUICListener::new_with_socket_and_shared_state(
+        listener_config,
+        socket,
+        Arc::clone(&startup_bundle.shared_state),
+    )
+    .expect("listener")
+    .with_runtime_bundle(Arc::clone(&runtime_handle));
+
+    listener.watchdog.set_expected_workers(2);
+    assert!(
+        listener.watchdog.request_restart("unit-test-drain"),
+        "watchdog restart should be accepted when the runtime watchdog is enabled"
+    );
+    assert!(!listener.draining);
+    assert!(!listener.watchdog_worker_drained);
+    assert!(!listener.watchdog.workers_drained());
+
+    assert!(
+        !listener.poll_preamble(),
+        "an idle listener should finish its watchdog drain in the same preamble cycle"
+    );
+    assert!(
+        listener.draining,
+        "watchdog restart should transition the listener into draining mode"
+    );
+    assert!(
+        listener.watchdog_worker_drained,
+        "listener should mark its worker drain completion once the watchdog drain finishes"
+    );
+    assert!(
+        !listener.watchdog.workers_drained(),
+        "one drained listener must not satisfy a two-worker watchdog restart"
+    );
+
+    assert!(
+        !listener.poll_preamble(),
+        "re-entering the idle drain preamble should remain terminal for this listener"
+    );
+    assert!(
+        !listener.watchdog.workers_drained(),
+        "repeated drain completion must not double-count the same worker toward restart completion"
+    );
+}
+
+#[test]
 fn build_server_tls_acceptor_rejects_mismatched_sni_certificate_mapping() {
     let dir = tempdir().expect("tempdir");
     let (api_cert, api_key) = write_test_cert_for_name(dir.path(), "api", "api.example.com");

--- a/crates/edge/tests/runtime_swap.rs
+++ b/crates/edge/tests/runtime_swap.rs
@@ -1,11 +1,13 @@
 use std::collections::HashMap;
 
+use serial_test::serial;
 use spooky_config::config::{Backend, LoadBalancing, RouteMatch, Upstream};
 
 mod support;
 
 use support::{
     net::local_listener_bind_available,
+    request_path::H3RequestSpec,
     runtime_swap::RuntimeSwapHarness,
 };
 
@@ -33,6 +35,7 @@ fn single_backend_upstream(backend_addr: std::net::SocketAddr) -> Upstream {
 }
 
 #[test]
+#[serial]
 fn runtime_swap_harness_exposes_control_api_metrics_and_reload_surface() {
     if !local_listener_bind_available() {
         return;
@@ -80,5 +83,85 @@ fn runtime_swap_harness_exposes_control_api_metrics_and_reload_surface() {
     assert_eq!(
         reloaded_snapshot["runtime"]["config_path"],
         harness.config_path().to_string_lossy().to_string()
+    );
+}
+
+#[test]
+#[serial]
+fn runtime_reload_swaps_generation_owned_backend_targets_without_changing_listener_identity() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = RuntimeSwapHarness::new();
+    let old_backend = harness.start_h1_static_backend(b"backend-old");
+    let new_backend = harness.start_h1_static_backend(b"backend-new");
+    let config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        single_backend_upstream(old_backend),
+    )]));
+
+    harness
+        .start_listener(config)
+        .expect("start runtime swap listener");
+
+    let before = harness
+        .run_request(H3RequestSpec::get("localhost", "/"))
+        .expect("request before reload");
+    before.assert_status(200);
+    before.assert_body_bytes(b"backend-old");
+
+    let startup_snapshot = harness.runtime_snapshot().expect("startup runtime snapshot");
+    assert_eq!(startup_snapshot["runtime"]["generation"], 0);
+    let startup_tls = startup_snapshot["tls"]["listeners"]
+        .as_object()
+        .expect("startup tls listener object")
+        .clone();
+    assert!(
+        !startup_tls.is_empty(),
+        "startup runtime snapshot should expose listener TLS inventory"
+    );
+
+    harness
+        .rewrite_config(|config| {
+            let upstream = config
+                .upstream
+                .get_mut("api")
+                .expect("runtime swap test upstream");
+            upstream.backends[0].address = format!("http://{new_backend}");
+        })
+        .expect("rewrite backend target");
+
+    let reload = harness
+        .trigger_runtime_reload()
+        .expect("trigger runtime reload");
+    assert_eq!(reload["reloaded"], true);
+    assert_eq!(reload["generation"], 1);
+
+    let after = harness
+        .run_request(H3RequestSpec::get("localhost", "/"))
+        .expect("request after reload");
+    after.assert_status(200);
+    after.assert_body_bytes(b"backend-new");
+
+    let reloaded_snapshot = harness.runtime_snapshot().expect("reloaded runtime snapshot");
+    assert_eq!(reloaded_snapshot["runtime"]["generation"], 1);
+    assert_eq!(
+        startup_snapshot["runtime"]["generation"], 0,
+        "stale runtime snapshot values should remain stable after bundle replacement"
+    );
+    assert_eq!(
+        startup_snapshot["tls"]["listeners"]
+            .as_object()
+            .expect("stale startup tls listeners"),
+        &startup_tls,
+        "stale runtime snapshot should keep its original listener identity view"
+    );
+    assert_eq!(
+        reloaded_snapshot["tls"]["listeners"]
+            .as_object()
+            .expect("reloaded tls listener object"),
+        &startup_tls,
+        "startup-owned listener TLS identity should not change across generation-only reloads"
     );
 }

--- a/crates/edge/tests/runtime_swap.rs
+++ b/crates/edge/tests/runtime_swap.rs
@@ -504,6 +504,79 @@ fn watchdog_requested_drain_blocks_new_quic_connections() {
 
 #[test]
 #[serial]
+fn watchdog_restart_surfaces_drain_state_consistently_across_control_api_views() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = RuntimeSwapHarness::new();
+    let backend_addr = harness.start_h1_static_backend(b"watchdog-drain-state");
+    let mut config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        single_backend_upstream(backend_addr),
+    )]));
+    config.resilience.watchdog.enabled = true;
+
+    harness
+        .start_listener(config)
+        .expect("start runtime swap listener");
+
+    let ready_before = harness
+        .ready_snapshot_expect(http::StatusCode::OK)
+        .expect("ready snapshot before watchdog restart");
+    assert_eq!(ready_before["ready"], true);
+    assert_eq!(ready_before["restart_requested"], false);
+
+    let runtime_before = harness.runtime_snapshot().expect("runtime snapshot before restart");
+    assert_eq!(runtime_before["watchdog"]["restart_requested"], false);
+    assert_eq!(runtime_before["watchdog"]["restart_reason"], "");
+
+    assert!(
+        harness
+            .request_watchdog_restart("runtime-swap-drain-visible")
+            .expect("request watchdog restart"),
+        "watchdog restart request should be accepted"
+    );
+
+    let ready_after = harness
+        .ready_snapshot_expect(http::StatusCode::SERVICE_UNAVAILABLE)
+        .expect("ready snapshot after watchdog restart");
+    assert_eq!(ready_after["ready"], false);
+    assert_eq!(ready_after["restart_requested"], true);
+
+    let runtime_after = harness.runtime_snapshot().expect("runtime snapshot after restart");
+    assert_eq!(runtime_after["watchdog"]["restart_requested"], true);
+    assert_eq!(
+        runtime_after["watchdog"]["restart_reason"],
+        "runtime-swap-drain-visible"
+    );
+    assert!(
+        runtime_after["watchdog"]["restart_requested_at_ms"]
+            .as_u64()
+            .expect("watchdog restart timestamp")
+            > 0,
+        "runtime snapshot should expose the watchdog restart timestamp while drain is pending"
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let mut established = true;
+    while Instant::now() < deadline {
+        established = harness
+            .fresh_quic_connection_establishes_within(Duration::from_millis(250))
+            .expect("fresh quic connection attempt");
+        if !established {
+            break;
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+    assert!(
+        !established,
+        "watchdog restart should surface as both not-ready control-plane state and a draining listener that stops accepting fresh QUIC connections"
+    );
+}
+
+#[test]
+#[serial]
 fn in_flight_request_can_complete_while_listener_is_draining() {
     if !local_listener_bind_available() {
         return;

--- a/crates/edge/tests/runtime_swap.rs
+++ b/crates/edge/tests/runtime_swap.rs
@@ -165,3 +165,133 @@ fn runtime_reload_swaps_generation_owned_backend_targets_without_changing_listen
         "startup-owned listener TLS identity should not change across generation-only reloads"
     );
 }
+
+#[test]
+#[serial]
+fn runtime_reload_rejects_listener_bind_change_and_keeps_active_generation_live() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = RuntimeSwapHarness::new();
+    let backend_addr = harness.start_h1_static_backend(b"bind-stable");
+    let config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        single_backend_upstream(backend_addr),
+    )]));
+
+    harness
+        .start_listener(config)
+        .expect("start runtime swap listener");
+
+    let before = harness
+        .run_request(H3RequestSpec::get("localhost", "/"))
+        .expect("request before bind-change reload");
+    before.assert_status(200);
+    before.assert_body_bytes(b"bind-stable");
+
+    let startup_snapshot = harness.runtime_snapshot().expect("startup runtime snapshot");
+    assert_eq!(startup_snapshot["runtime"]["generation"], 0);
+
+    harness
+        .rewrite_config(|config| {
+            config.listen.port = config.listen.port.saturating_add(1);
+        })
+        .expect("rewrite listener bind");
+
+    let rejection = harness
+        .trigger_runtime_reload_expect(http::StatusCode::CONFLICT)
+        .expect("reload rejection");
+    assert_eq!(rejection["reloaded"], false);
+    let error = rejection["error"]
+        .as_str()
+        .expect("reload rejection error string");
+    assert!(
+        error.contains("restart required"),
+        "listener bind change should be restart-required, got: {error}"
+    );
+    assert!(
+        error.contains("listener"),
+        "listener bind rejection should mention the listener, got: {error}"
+    );
+
+    let after_snapshot = harness.runtime_snapshot().expect("post-rejection runtime snapshot");
+    assert_eq!(
+        after_snapshot["runtime"]["generation"], 0,
+        "startup-owned rejection must leave the active generation unchanged"
+    );
+    assert_eq!(
+        after_snapshot["runtime"]["config_path"],
+        startup_snapshot["runtime"]["config_path"],
+        "config path should remain the same for a rejected same-path reload attempt"
+    );
+
+    let after = harness
+        .run_request(H3RequestSpec::get("localhost", "/"))
+        .expect("request after bind-change rejection");
+    after.assert_status(200);
+    after.assert_body_bytes(b"bind-stable");
+}
+
+#[test]
+#[serial]
+fn runtime_reload_rejects_startup_owned_log_sink_change_and_keeps_request_behavior() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = RuntimeSwapHarness::new();
+    let backend_addr = harness.start_h1_static_backend(b"log-sink-stable");
+    let config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        single_backend_upstream(backend_addr),
+    )]));
+
+    harness
+        .start_listener(config)
+        .expect("start runtime swap listener");
+
+    let before = harness
+        .run_request(H3RequestSpec::get("localhost", "/"))
+        .expect("request before log-sink reload");
+    before.assert_status(200);
+    before.assert_body_bytes(b"log-sink-stable");
+
+    let startup_snapshot = harness.runtime_snapshot().expect("startup runtime snapshot");
+    assert_eq!(startup_snapshot["runtime"]["generation"], 0);
+
+    harness
+        .rewrite_config(|config| {
+            config.log.file.enabled = true;
+            config.log.file.path = "/tmp/spooky-runtime-swap.log".to_string();
+        })
+        .expect("rewrite log sink shape");
+
+    let rejection = harness
+        .trigger_runtime_reload_expect(http::StatusCode::CONFLICT)
+        .expect("reload rejection");
+    assert_eq!(rejection["reloaded"], false);
+    let error = rejection["error"]
+        .as_str()
+        .expect("reload rejection error string");
+    assert!(
+        error.contains("restart required"),
+        "log sink shape change should be restart-required, got: {error}"
+    );
+    assert!(
+        error.contains("log.file.enabled") || error.contains("log.file.path"),
+        "log sink rejection should point at startup-owned log file fields, got: {error}"
+    );
+
+    let after_snapshot = harness.runtime_snapshot().expect("post-rejection runtime snapshot");
+    assert_eq!(
+        after_snapshot["runtime"]["generation"], 0,
+        "startup-owned log sink rejection must keep the active generation unchanged"
+    );
+
+    let after = harness
+        .run_request(H3RequestSpec::get("localhost", "/"))
+        .expect("request after log-sink rejection");
+    after.assert_status(200);
+    after.assert_body_bytes(b"log-sink-stable");
+}

--- a/crates/edge/tests/runtime_swap.rs
+++ b/crates/edge/tests/runtime_swap.rs
@@ -34,6 +34,20 @@ fn single_backend_upstream(backend_addr: std::net::SocketAddr) -> Upstream {
     }
 }
 
+fn lifecycle_backend_addresses(snapshot: &serde_json::Value) -> Vec<String> {
+    snapshot["backends"]["lifecycle"]
+        .as_array()
+        .expect("backend lifecycle array")
+        .iter()
+        .map(|backend| {
+            backend["backend"]
+                .as_str()
+                .expect("backend lifecycle address")
+                .to_string()
+        })
+        .collect()
+}
+
 #[test]
 #[serial]
 fn runtime_swap_harness_exposes_control_api_metrics_and_reload_surface() {
@@ -294,4 +308,83 @@ fn runtime_reload_rejects_startup_owned_log_sink_change_and_keeps_request_behavi
         .expect("request after log-sink rejection");
     after.assert_status(200);
     after.assert_body_bytes(b"log-sink-stable");
+}
+
+#[test]
+#[serial]
+fn control_api_runtime_snapshot_tracks_active_generation_listener_labels_and_backend_inventory() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = RuntimeSwapHarness::new();
+    let old_backend = harness.start_h1_static_backend(b"snapshot-old");
+    let new_backend = harness.start_h1_static_backend(b"snapshot-new");
+    let config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        single_backend_upstream(old_backend),
+    )]));
+    let listener_label = format!("127.0.0.1:{}", config.listen.port);
+
+    harness
+        .start_listener(config)
+        .expect("start runtime swap listener");
+
+    let startup_snapshot = harness.runtime_snapshot().expect("startup runtime snapshot");
+    assert_eq!(startup_snapshot["runtime"]["generation"], 0);
+    let startup_listeners = startup_snapshot["tls"]["listeners"]
+        .as_object()
+        .expect("startup tls listeners");
+    assert!(
+        startup_listeners.contains_key(&listener_label),
+        "runtime snapshot should render the current active listener label"
+    );
+    assert_eq!(
+        lifecycle_backend_addresses(&startup_snapshot),
+        vec![format!("http://{old_backend}")],
+        "startup runtime snapshot should expose only the active generation backend inventory"
+    );
+
+    harness
+        .rewrite_config(|config| {
+            let upstream = config
+                .upstream
+                .get_mut("api")
+                .expect("runtime swap test upstream");
+            upstream.backends[0].address = format!("http://{new_backend}");
+            config.observability.control_api.runtime_path = "/runtime-live".to_string();
+        })
+        .expect("rewrite active generation fields");
+
+    let reload = harness
+        .trigger_runtime_reload()
+        .expect("trigger runtime reload");
+    assert_eq!(reload["reloaded"], true);
+    assert_eq!(reload["generation"], 1);
+
+    let live_snapshot = harness.runtime_snapshot().expect("live runtime snapshot");
+    assert_eq!(live_snapshot["runtime"]["generation"], 1);
+    let live_listeners = live_snapshot["tls"]["listeners"]
+        .as_object()
+        .expect("live tls listeners");
+    assert!(
+        live_listeners.contains_key(&listener_label),
+        "runtime snapshot should keep rendering the current live listener label after swap"
+    );
+    assert_eq!(
+        live_listeners.len(),
+        1,
+        "runtime snapshot should render only the active generation listener inventory"
+    );
+
+    let live_backends = lifecycle_backend_addresses(&live_snapshot);
+    assert_eq!(
+        live_backends,
+        vec![format!("http://{new_backend}")],
+        "runtime snapshot should expose backend lifecycle inventory from the active generation only"
+    );
+    assert!(
+        !live_backends.iter().any(|backend| backend == &format!("http://{old_backend}")),
+        "runtime snapshot must not leak stale-generation backend inventory"
+    );
 }

--- a/crates/edge/tests/runtime_swap.rs
+++ b/crates/edge/tests/runtime_swap.rs
@@ -1,0 +1,84 @@
+use std::collections::HashMap;
+
+use spooky_config::config::{Backend, LoadBalancing, RouteMatch, Upstream};
+
+mod support;
+
+use support::{
+    net::local_listener_bind_available,
+    runtime_swap::RuntimeSwapHarness,
+};
+
+fn single_backend_upstream(backend_addr: std::net::SocketAddr) -> Upstream {
+    Upstream {
+        load_balancing: LoadBalancing {
+            lb_type: "round-robin".to_string(),
+            key: None,
+        },
+        auth: Default::default(),
+        host_policy: Default::default(),
+        forwarded_headers: Default::default(),
+        tls: None,
+        route: RouteMatch {
+            path_prefix: Some("/".to_string()),
+            ..Default::default()
+        },
+        backends: vec![Backend {
+            id: "backend-a".to_string(),
+            address: format!("http://{backend_addr}"),
+            weight: 1,
+            health_check: None,
+        }],
+    }
+}
+
+#[test]
+fn runtime_swap_harness_exposes_control_api_metrics_and_reload_surface() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = RuntimeSwapHarness::new();
+    let backend_addr = harness.start_h1_static_backend(b"ok");
+    let config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        single_backend_upstream(backend_addr),
+    )]));
+
+    harness
+        .start_listener(config)
+        .expect("start runtime swap listener");
+
+    let startup_snapshot = harness.runtime_snapshot().expect("runtime snapshot");
+    assert_eq!(startup_snapshot["runtime"]["generation"], 0);
+    assert_eq!(
+        startup_snapshot["runtime"]["config_path"],
+        harness.config_path().to_string_lossy().to_string()
+    );
+
+    let metrics = harness.metrics_text().expect("metrics text");
+    assert!(
+        metrics.contains("# HELP spooky_requests_total Total requests seen by spooky.\n"),
+        "metrics endpoint should expose prometheus request totals"
+    );
+
+    harness
+        .rewrite_config(|config| {
+            config.log.level = "debug".to_string();
+            config.performance.new_connections_burst = 2;
+        })
+        .expect("rewrite config");
+
+    let reload = harness
+        .trigger_runtime_reload()
+        .expect("trigger runtime reload");
+    assert_eq!(reload["reloaded"], true);
+    assert_eq!(reload["generation"], 1);
+
+    let reloaded_snapshot = harness.runtime_snapshot().expect("reloaded runtime snapshot");
+    assert_eq!(reloaded_snapshot["runtime"]["generation"], 1);
+    assert_eq!(
+        reloaded_snapshot["runtime"]["config_path"],
+        harness.config_path().to_string_lossy().to_string()
+    );
+}

--- a/crates/edge/tests/runtime_swap.rs
+++ b/crates/edge/tests/runtime_swap.rs
@@ -1,13 +1,24 @@
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread,
+    time::{Duration, Instant},
+};
 
+use bytes::Bytes;
+use http_body_util::Full;
 use serial_test::serial;
 use spooky_config::config::{Backend, LoadBalancing, RouteMatch, Upstream};
+use spooky_edge::runtime::policy::{LifecycleTransitionResult, RuntimeLifecyclePhase};
 
 mod support;
 
 use support::{
     net::local_listener_bind_available,
-    request_path::H3RequestSpec,
+    request_path::{H3RequestSpec, run_request_to},
     runtime_swap::RuntimeSwapHarness,
 };
 
@@ -445,5 +456,164 @@ fn metrics_endpoint_tracks_active_generation_path_and_metric_surface_after_reloa
         old_path_status,
         http::StatusCode::NOT_FOUND,
         "old metrics path should no longer be treated as the active metrics endpoint after reload"
+    );
+}
+
+#[test]
+#[serial]
+fn watchdog_requested_drain_blocks_new_quic_connections() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = RuntimeSwapHarness::new();
+    let backend_addr = harness.start_h1_static_backend(b"drain-blocked");
+    let mut config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        single_backend_upstream(backend_addr),
+    )]));
+    config.resilience.watchdog.enabled = true;
+
+    harness
+        .start_listener(config)
+        .expect("start runtime swap listener");
+
+    assert!(
+        harness
+            .request_watchdog_restart("runtime-swap-drain-block")
+            .expect("request watchdog restart"),
+        "watchdog restart request should be accepted"
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let mut established = true;
+    while Instant::now() < deadline {
+        established = harness
+            .fresh_quic_connection_establishes_within(Duration::from_millis(250))
+            .expect("fresh quic connection attempt");
+        if !established {
+            break;
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+    assert!(
+        !established,
+        "fresh QUIC connections must stop establishing once the live listener enters draining"
+    );
+}
+
+#[test]
+#[serial]
+fn in_flight_request_can_complete_while_listener_is_draining() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = RuntimeSwapHarness::new();
+    let request_started = Arc::new(AtomicBool::new(false));
+    let started = Arc::clone(&request_started);
+    let backend_addr = harness.start_h1_backend(move |_req| {
+        let started = Arc::clone(&started);
+        async move {
+            started.store(true, Ordering::Relaxed);
+            tokio::time::sleep(Duration::from_millis(80)).await;
+            Ok::<_, std::convert::Infallible>(hyper::Response::new(Full::new(
+                Bytes::from_static(b"drain-complete"),
+            )))
+        }
+    });
+    let mut config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        single_backend_upstream(backend_addr),
+    )]));
+    config.resilience.watchdog.enabled = true;
+    config.performance.shutdown_drain_timeout_ms = 500;
+
+    let listen_addr = harness
+        .start_listener(config)
+        .expect("start runtime swap listener");
+
+    let client = thread::spawn(move || run_request_to(listen_addr, H3RequestSpec::get("localhost", "/")));
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while Instant::now() < deadline && !request_started.load(Ordering::Relaxed) {
+        thread::sleep(Duration::from_millis(10));
+    }
+    assert!(
+        request_started.load(Ordering::Relaxed),
+        "backend should observe the in-flight request before drain begins"
+    );
+
+    assert!(
+        harness
+            .request_watchdog_restart("runtime-swap-drain-inflight")
+            .expect("request watchdog restart"),
+        "watchdog restart request should be accepted"
+    );
+
+    let response = client.join().expect("client thread join").expect("in-flight response");
+    response.assert_status(200);
+    response.assert_body_bytes(b"drain-complete");
+}
+
+#[test]
+#[serial]
+fn runtime_reload_is_rejected_once_lifecycle_leaves_running() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = RuntimeSwapHarness::new();
+    let backend_addr = harness.start_h1_static_backend(b"lifecycle-running");
+    let config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        single_backend_upstream(backend_addr),
+    )]));
+
+    harness
+        .start_listener(config)
+        .expect("start runtime swap listener");
+
+    assert_eq!(
+        harness.lifecycle_phase().expect("runtime lifecycle phase"),
+        RuntimeLifecyclePhase::Running
+    );
+    assert!(matches!(
+        harness.begin_lifecycle_drain().expect("begin lifecycle drain"),
+        LifecycleTransitionResult::Applied {
+            to: RuntimeLifecyclePhase::Draining,
+            ..
+        }
+        | LifecycleTransitionResult::NoOp {
+            phase: RuntimeLifecyclePhase::Draining
+        }
+    ));
+    assert_eq!(
+        harness.lifecycle_phase().expect("draining lifecycle phase"),
+        RuntimeLifecyclePhase::Draining
+    );
+
+    let generation_before = harness.current_generation().expect("generation before");
+    harness
+        .rewrite_config(|config| {
+            config.log.level = "debug".to_string();
+        })
+        .expect("rewrite live-reloadable config");
+
+    let rejection = harness
+        .trigger_runtime_reload_expect(http::StatusCode::INTERNAL_SERVER_ERROR)
+        .expect("reload rejection after drain");
+    assert_eq!(rejection["reloaded"], false);
+    let error = rejection["error"]
+        .as_str()
+        .expect("reload rejection error string");
+    assert!(
+        error.contains("illegal_transition") || error.contains("Draining") || error.contains("ReloadCommit"),
+        "reload rejection should reflect the non-running lifecycle gate, got: {error}"
+    );
+    assert_eq!(
+        harness.current_generation().expect("generation after rejection"),
+        generation_before,
+        "reload rejection after drain must keep the active generation unchanged"
     );
 }

--- a/crates/edge/tests/runtime_swap.rs
+++ b/crates/edge/tests/runtime_swap.rs
@@ -388,3 +388,62 @@ fn control_api_runtime_snapshot_tracks_active_generation_listener_labels_and_bac
         "runtime snapshot must not leak stale-generation backend inventory"
     );
 }
+
+#[test]
+#[serial]
+fn metrics_endpoint_tracks_active_generation_path_and_metric_surface_after_reload() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = RuntimeSwapHarness::new();
+    let backend_addr = harness.start_h1_static_backend(b"metrics-live");
+    let config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        single_backend_upstream(backend_addr),
+    )]));
+
+    harness
+        .start_listener(config)
+        .expect("start runtime swap listener");
+
+    let startup_metrics = harness.metrics_text().expect("startup metrics text");
+    assert!(
+        startup_metrics.contains("spooky_route_requests_total{route=\"api\"} 0\n"),
+        "startup metrics should render the startup generation route label"
+    );
+    let old_path = "/metrics".to_string();
+
+    harness
+        .rewrite_config(|config| {
+            let upstream = config.upstream.remove("api").expect("startup upstream");
+            config.upstream.insert("api-reloaded".to_string(), upstream);
+            config.observability.metrics.path = "/metrics-live".to_string();
+        })
+        .expect("rewrite metrics path and route labels");
+
+    let reload = harness
+        .trigger_runtime_reload()
+        .expect("trigger runtime reload");
+    assert_eq!(reload["reloaded"], true);
+    assert_eq!(reload["generation"], 1);
+
+    let live_metrics = harness.metrics_text().expect("live metrics text");
+    assert!(
+        live_metrics.contains("spooky_route_requests_total{route=\"api-reloaded\"} 0\n"),
+        "reloaded metrics should render the active generation route label"
+    );
+    assert!(
+        !live_metrics.contains("spooky_route_requests_total{route=\"api\"}"),
+        "reloaded metrics must not fall back to the startup metrics surface after reload"
+    );
+
+    let old_path_status = harness
+        .metrics_status_at(&old_path)
+        .expect("old metrics path status");
+    assert_eq!(
+        old_path_status,
+        http::StatusCode::NOT_FOUND,
+        "old metrics path should no longer be treated as the active metrics endpoint after reload"
+    );
+}

--- a/crates/edge/tests/runtime_swap.rs
+++ b/crates/edge/tests/runtime_swap.rs
@@ -11,7 +11,7 @@ use std::{
 use bytes::Bytes;
 use http_body_util::Full;
 use serial_test::serial;
-use spooky_config::config::{Backend, LoadBalancing, RouteMatch, Upstream};
+use spooky_config::config::{Backend, Config, LoadBalancing, RouteMatch, Upstream};
 use spooky_edge::runtime::policy::{LifecycleTransitionResult, RuntimeLifecyclePhase};
 
 mod support;
@@ -59,23 +59,63 @@ fn lifecycle_backend_addresses(snapshot: &serde_json::Value) -> Vec<String> {
         .collect()
 }
 
-#[test]
-#[serial]
-fn runtime_swap_harness_exposes_control_api_metrics_and_reload_surface() {
+fn start_static_runtime_swap_listener(
+    body: &'static [u8],
+    configure: impl FnOnce(&mut Config),
+) -> Option<RuntimeSwapHarness> {
     if !local_listener_bind_available() {
-        return;
+        return None;
     }
 
     let mut harness = RuntimeSwapHarness::new();
-    let backend_addr = harness.start_h1_static_backend(b"ok");
-    let config = harness.make_config(HashMap::from([(
+    let backend_addr = harness.start_h1_static_backend(body);
+    let mut config = harness.make_config(HashMap::from([(
         "api".to_string(),
         single_backend_upstream(backend_addr),
     )]));
+    configure(&mut config);
 
     harness
         .start_listener(config)
         .expect("start runtime swap listener");
+    Some(harness)
+}
+
+fn assert_listener_stops_accepting_fresh_quic_connections(harness: &RuntimeSwapHarness) {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let mut established = true;
+    while Instant::now() < deadline {
+        established = harness
+            .fresh_quic_connection_establishes_within(Duration::from_millis(250))
+            .expect("fresh quic connection attempt");
+        if !established {
+            break;
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+    assert!(
+        !established,
+        "fresh QUIC connections must stop establishing once the live listener enters draining"
+    );
+}
+
+fn assert_watchdog_restart_drains_listener(harness: &RuntimeSwapHarness, reason: &str) {
+    assert!(
+        harness
+            .request_watchdog_restart(reason)
+            .expect("request watchdog restart"),
+        "watchdog restart request should be accepted"
+    );
+    assert_listener_stops_accepting_fresh_quic_connections(harness);
+}
+
+// Domain: reload swap.
+#[test]
+#[serial]
+fn runtime_swap_harness_exposes_reload_control_plane_and_metrics_surfaces() {
+    let Some(mut harness) = start_static_runtime_swap_listener(b"ok", |_| {}) else {
+        return;
+    };
 
     let startup_snapshot = harness.runtime_snapshot().expect("runtime snapshot");
     assert_eq!(startup_snapshot["runtime"]["generation"], 0);
@@ -103,7 +143,9 @@ fn runtime_swap_harness_exposes_control_api_metrics_and_reload_surface() {
     assert_eq!(reload["reloaded"], true);
     assert_eq!(reload["generation"], 1);
 
-    let reloaded_snapshot = harness.runtime_snapshot().expect("reloaded runtime snapshot");
+    let reloaded_snapshot = harness
+        .runtime_snapshot()
+        .expect("reloaded runtime snapshot");
     assert_eq!(reloaded_snapshot["runtime"]["generation"], 1);
     assert_eq!(
         reloaded_snapshot["runtime"]["config_path"],
@@ -113,7 +155,7 @@ fn runtime_swap_harness_exposes_control_api_metrics_and_reload_surface() {
 
 #[test]
 #[serial]
-fn runtime_reload_swaps_generation_owned_backend_targets_without_changing_listener_identity() {
+fn generation_owned_reload_swaps_backend_targets_without_changing_listener_identity() {
     if !local_listener_bind_available() {
         return;
     }
@@ -136,7 +178,9 @@ fn runtime_reload_swaps_generation_owned_backend_targets_without_changing_listen
     before.assert_status(200);
     before.assert_body_bytes(b"backend-old");
 
-    let startup_snapshot = harness.runtime_snapshot().expect("startup runtime snapshot");
+    let startup_snapshot = harness
+        .runtime_snapshot()
+        .expect("startup runtime snapshot");
     assert_eq!(startup_snapshot["runtime"]["generation"], 0);
     let startup_tls = startup_snapshot["tls"]["listeners"]
         .as_object()
@@ -169,7 +213,9 @@ fn runtime_reload_swaps_generation_owned_backend_targets_without_changing_listen
     after.assert_status(200);
     after.assert_body_bytes(b"backend-new");
 
-    let reloaded_snapshot = harness.runtime_snapshot().expect("reloaded runtime snapshot");
+    let reloaded_snapshot = harness
+        .runtime_snapshot()
+        .expect("reloaded runtime snapshot");
     assert_eq!(reloaded_snapshot["runtime"]["generation"], 1);
     assert_eq!(
         startup_snapshot["runtime"]["generation"], 0,
@@ -191,23 +237,13 @@ fn runtime_reload_swaps_generation_owned_backend_targets_without_changing_listen
     );
 }
 
+// Domain: reload rejection.
 #[test]
 #[serial]
-fn runtime_reload_rejects_listener_bind_change_and_keeps_active_generation_live() {
-    if !local_listener_bind_available() {
+fn startup_owned_listener_bind_change_is_rejected_and_keeps_active_generation_live() {
+    let Some(mut harness) = start_static_runtime_swap_listener(b"bind-stable", |_| {}) else {
         return;
-    }
-
-    let mut harness = RuntimeSwapHarness::new();
-    let backend_addr = harness.start_h1_static_backend(b"bind-stable");
-    let config = harness.make_config(HashMap::from([(
-        "api".to_string(),
-        single_backend_upstream(backend_addr),
-    )]));
-
-    harness
-        .start_listener(config)
-        .expect("start runtime swap listener");
+    };
 
     let before = harness
         .run_request(H3RequestSpec::get("localhost", "/"))
@@ -215,7 +251,9 @@ fn runtime_reload_rejects_listener_bind_change_and_keeps_active_generation_live(
     before.assert_status(200);
     before.assert_body_bytes(b"bind-stable");
 
-    let startup_snapshot = harness.runtime_snapshot().expect("startup runtime snapshot");
+    let startup_snapshot = harness
+        .runtime_snapshot()
+        .expect("startup runtime snapshot");
     assert_eq!(startup_snapshot["runtime"]["generation"], 0);
 
     harness
@@ -240,14 +278,15 @@ fn runtime_reload_rejects_listener_bind_change_and_keeps_active_generation_live(
         "listener bind rejection should mention the listener, got: {error}"
     );
 
-    let after_snapshot = harness.runtime_snapshot().expect("post-rejection runtime snapshot");
+    let after_snapshot = harness
+        .runtime_snapshot()
+        .expect("post-rejection runtime snapshot");
     assert_eq!(
         after_snapshot["runtime"]["generation"], 0,
         "startup-owned rejection must leave the active generation unchanged"
     );
     assert_eq!(
-        after_snapshot["runtime"]["config_path"],
-        startup_snapshot["runtime"]["config_path"],
+        after_snapshot["runtime"]["config_path"], startup_snapshot["runtime"]["config_path"],
         "config path should remain the same for a rejected same-path reload attempt"
     );
 
@@ -260,21 +299,10 @@ fn runtime_reload_rejects_listener_bind_change_and_keeps_active_generation_live(
 
 #[test]
 #[serial]
-fn runtime_reload_rejects_startup_owned_log_sink_change_and_keeps_request_behavior() {
-    if !local_listener_bind_available() {
+fn startup_owned_log_sink_change_is_rejected_and_keeps_request_behavior() {
+    let Some(mut harness) = start_static_runtime_swap_listener(b"log-sink-stable", |_| {}) else {
         return;
-    }
-
-    let mut harness = RuntimeSwapHarness::new();
-    let backend_addr = harness.start_h1_static_backend(b"log-sink-stable");
-    let config = harness.make_config(HashMap::from([(
-        "api".to_string(),
-        single_backend_upstream(backend_addr),
-    )]));
-
-    harness
-        .start_listener(config)
-        .expect("start runtime swap listener");
+    };
 
     let before = harness
         .run_request(H3RequestSpec::get("localhost", "/"))
@@ -282,7 +310,9 @@ fn runtime_reload_rejects_startup_owned_log_sink_change_and_keeps_request_behavi
     before.assert_status(200);
     before.assert_body_bytes(b"log-sink-stable");
 
-    let startup_snapshot = harness.runtime_snapshot().expect("startup runtime snapshot");
+    let startup_snapshot = harness
+        .runtime_snapshot()
+        .expect("startup runtime snapshot");
     assert_eq!(startup_snapshot["runtime"]["generation"], 0);
 
     harness
@@ -308,7 +338,9 @@ fn runtime_reload_rejects_startup_owned_log_sink_change_and_keeps_request_behavi
         "log sink rejection should point at startup-owned log file fields, got: {error}"
     );
 
-    let after_snapshot = harness.runtime_snapshot().expect("post-rejection runtime snapshot");
+    let after_snapshot = harness
+        .runtime_snapshot()
+        .expect("post-rejection runtime snapshot");
     assert_eq!(
         after_snapshot["runtime"]["generation"], 0,
         "startup-owned log sink rejection must keep the active generation unchanged"
@@ -323,7 +355,64 @@ fn runtime_reload_rejects_startup_owned_log_sink_change_and_keeps_request_behavi
 
 #[test]
 #[serial]
-fn control_api_runtime_snapshot_tracks_active_generation_listener_labels_and_backend_inventory() {
+fn runtime_reload_is_rejected_after_listener_lifecycle_leaves_running() {
+    let Some(mut harness) = start_static_runtime_swap_listener(b"lifecycle-running", |_| {}) else {
+        return;
+    };
+
+    assert_eq!(
+        harness.lifecycle_phase().expect("runtime lifecycle phase"),
+        RuntimeLifecyclePhase::Running
+    );
+    assert!(matches!(
+        harness
+            .begin_lifecycle_drain()
+            .expect("begin lifecycle drain"),
+        LifecycleTransitionResult::Applied {
+            to: RuntimeLifecyclePhase::Draining,
+            ..
+        } | LifecycleTransitionResult::NoOp {
+            phase: RuntimeLifecyclePhase::Draining
+        }
+    ));
+    assert_eq!(
+        harness.lifecycle_phase().expect("draining lifecycle phase"),
+        RuntimeLifecyclePhase::Draining
+    );
+
+    let generation_before = harness.current_generation().expect("generation before");
+    harness
+        .rewrite_config(|config| {
+            config.log.level = "debug".to_string();
+        })
+        .expect("rewrite live-reloadable config");
+
+    let rejection = harness
+        .trigger_runtime_reload_expect(http::StatusCode::INTERNAL_SERVER_ERROR)
+        .expect("reload rejection after drain");
+    assert_eq!(rejection["reloaded"], false);
+    let error = rejection["error"]
+        .as_str()
+        .expect("reload rejection error string");
+    assert!(
+        error.contains("illegal_transition")
+            || error.contains("Draining")
+            || error.contains("ReloadCommit"),
+        "reload rejection should reflect the non-running lifecycle gate, got: {error}"
+    );
+    assert_eq!(
+        harness
+            .current_generation()
+            .expect("generation after rejection"),
+        generation_before,
+        "reload rejection after drain must keep the active generation unchanged"
+    );
+}
+
+// Domain: control-plane visibility.
+#[test]
+#[serial]
+fn control_api_runtime_snapshot_tracks_active_generation_listener_and_backend_inventory() {
     if !local_listener_bind_available() {
         return;
     }
@@ -341,7 +430,9 @@ fn control_api_runtime_snapshot_tracks_active_generation_listener_labels_and_bac
         .start_listener(config)
         .expect("start runtime swap listener");
 
-    let startup_snapshot = harness.runtime_snapshot().expect("startup runtime snapshot");
+    let startup_snapshot = harness
+        .runtime_snapshot()
+        .expect("startup runtime snapshot");
     assert_eq!(startup_snapshot["runtime"]["generation"], 0);
     let startup_listeners = startup_snapshot["tls"]["listeners"]
         .as_object()
@@ -395,28 +486,73 @@ fn control_api_runtime_snapshot_tracks_active_generation_listener_labels_and_bac
         "runtime snapshot should expose backend lifecycle inventory from the active generation only"
     );
     assert!(
-        !live_backends.iter().any(|backend| backend == &format!("http://{old_backend}")),
+        !live_backends
+            .iter()
+            .any(|backend| backend == &format!("http://{old_backend}")),
         "runtime snapshot must not leak stale-generation backend inventory"
     );
 }
 
 #[test]
 #[serial]
-fn metrics_endpoint_tracks_active_generation_path_and_metric_surface_after_reload() {
-    if !local_listener_bind_available() {
+fn watchdog_restart_surfaces_not_ready_and_restart_pending_control_plane_state() {
+    let Some(harness) = start_static_runtime_swap_listener(b"watchdog-drain-state", |config| {
+        config.resilience.watchdog.enabled = true;
+    }) else {
         return;
-    }
+    };
 
-    let mut harness = RuntimeSwapHarness::new();
-    let backend_addr = harness.start_h1_static_backend(b"metrics-live");
-    let config = harness.make_config(HashMap::from([(
-        "api".to_string(),
-        single_backend_upstream(backend_addr),
-    )]));
+    let ready_before = harness
+        .ready_snapshot_expect(http::StatusCode::OK)
+        .expect("ready snapshot before watchdog restart");
+    assert_eq!(ready_before["ready"], true);
+    assert_eq!(ready_before["restart_requested"], false);
 
-    harness
-        .start_listener(config)
-        .expect("start runtime swap listener");
+    let runtime_before = harness
+        .runtime_snapshot()
+        .expect("runtime snapshot before restart");
+    assert_eq!(runtime_before["watchdog"]["restart_requested"], false);
+    assert_eq!(runtime_before["watchdog"]["restart_reason"], "");
+
+    assert!(
+        harness
+            .request_watchdog_restart("runtime-swap-drain-visible")
+            .expect("request watchdog restart"),
+        "watchdog restart request should be accepted"
+    );
+
+    let ready_after = harness
+        .ready_snapshot_expect(http::StatusCode::SERVICE_UNAVAILABLE)
+        .expect("ready snapshot after watchdog restart");
+    assert_eq!(ready_after["ready"], false);
+    assert_eq!(ready_after["restart_requested"], true);
+
+    let runtime_after = harness
+        .runtime_snapshot()
+        .expect("runtime snapshot after restart");
+    assert_eq!(runtime_after["watchdog"]["restart_requested"], true);
+    assert_eq!(
+        runtime_after["watchdog"]["restart_reason"],
+        "runtime-swap-drain-visible"
+    );
+    assert!(
+        runtime_after["watchdog"]["restart_requested_at_ms"]
+            .as_u64()
+            .expect("watchdog restart timestamp")
+            > 0,
+        "runtime snapshot should expose the watchdog restart timestamp while drain is pending"
+    );
+
+    assert_listener_stops_accepting_fresh_quic_connections(&harness);
+}
+
+// Domain: metrics visibility.
+#[test]
+#[serial]
+fn metrics_endpoint_tracks_active_generation_route_label_and_path_after_reload() {
+    let Some(mut harness) = start_static_runtime_swap_listener(b"metrics-live", |_| {}) else {
+        return;
+    };
 
     let startup_metrics = harness.metrics_text().expect("startup metrics text");
     assert!(
@@ -459,125 +595,10 @@ fn metrics_endpoint_tracks_active_generation_path_and_metric_surface_after_reloa
     );
 }
 
+// Domain: drain behavior.
 #[test]
 #[serial]
-fn watchdog_requested_drain_blocks_new_quic_connections() {
-    if !local_listener_bind_available() {
-        return;
-    }
-
-    let mut harness = RuntimeSwapHarness::new();
-    let backend_addr = harness.start_h1_static_backend(b"drain-blocked");
-    let mut config = harness.make_config(HashMap::from([(
-        "api".to_string(),
-        single_backend_upstream(backend_addr),
-    )]));
-    config.resilience.watchdog.enabled = true;
-
-    harness
-        .start_listener(config)
-        .expect("start runtime swap listener");
-
-    assert!(
-        harness
-            .request_watchdog_restart("runtime-swap-drain-block")
-            .expect("request watchdog restart"),
-        "watchdog restart request should be accepted"
-    );
-
-    let deadline = Instant::now() + Duration::from_secs(2);
-    let mut established = true;
-    while Instant::now() < deadline {
-        established = harness
-            .fresh_quic_connection_establishes_within(Duration::from_millis(250))
-            .expect("fresh quic connection attempt");
-        if !established {
-            break;
-        }
-        thread::sleep(Duration::from_millis(25));
-    }
-    assert!(
-        !established,
-        "fresh QUIC connections must stop establishing once the live listener enters draining"
-    );
-}
-
-#[test]
-#[serial]
-fn watchdog_restart_surfaces_drain_state_consistently_across_control_api_views() {
-    if !local_listener_bind_available() {
-        return;
-    }
-
-    let mut harness = RuntimeSwapHarness::new();
-    let backend_addr = harness.start_h1_static_backend(b"watchdog-drain-state");
-    let mut config = harness.make_config(HashMap::from([(
-        "api".to_string(),
-        single_backend_upstream(backend_addr),
-    )]));
-    config.resilience.watchdog.enabled = true;
-
-    harness
-        .start_listener(config)
-        .expect("start runtime swap listener");
-
-    let ready_before = harness
-        .ready_snapshot_expect(http::StatusCode::OK)
-        .expect("ready snapshot before watchdog restart");
-    assert_eq!(ready_before["ready"], true);
-    assert_eq!(ready_before["restart_requested"], false);
-
-    let runtime_before = harness.runtime_snapshot().expect("runtime snapshot before restart");
-    assert_eq!(runtime_before["watchdog"]["restart_requested"], false);
-    assert_eq!(runtime_before["watchdog"]["restart_reason"], "");
-
-    assert!(
-        harness
-            .request_watchdog_restart("runtime-swap-drain-visible")
-            .expect("request watchdog restart"),
-        "watchdog restart request should be accepted"
-    );
-
-    let ready_after = harness
-        .ready_snapshot_expect(http::StatusCode::SERVICE_UNAVAILABLE)
-        .expect("ready snapshot after watchdog restart");
-    assert_eq!(ready_after["ready"], false);
-    assert_eq!(ready_after["restart_requested"], true);
-
-    let runtime_after = harness.runtime_snapshot().expect("runtime snapshot after restart");
-    assert_eq!(runtime_after["watchdog"]["restart_requested"], true);
-    assert_eq!(
-        runtime_after["watchdog"]["restart_reason"],
-        "runtime-swap-drain-visible"
-    );
-    assert!(
-        runtime_after["watchdog"]["restart_requested_at_ms"]
-            .as_u64()
-            .expect("watchdog restart timestamp")
-            > 0,
-        "runtime snapshot should expose the watchdog restart timestamp while drain is pending"
-    );
-
-    let deadline = Instant::now() + Duration::from_secs(2);
-    let mut established = true;
-    while Instant::now() < deadline {
-        established = harness
-            .fresh_quic_connection_establishes_within(Duration::from_millis(250))
-            .expect("fresh quic connection attempt");
-        if !established {
-            break;
-        }
-        thread::sleep(Duration::from_millis(25));
-    }
-    assert!(
-        !established,
-        "watchdog restart should surface as both not-ready control-plane state and a draining listener that stops accepting fresh QUIC connections"
-    );
-}
-
-#[test]
-#[serial]
-fn in_flight_request_can_complete_while_listener_is_draining() {
+fn in_flight_request_completes_while_watchdog_restart_drains_listener() {
     if !local_listener_bind_available() {
         return;
     }
@@ -590,9 +611,9 @@ fn in_flight_request_can_complete_while_listener_is_draining() {
         async move {
             started.store(true, Ordering::Relaxed);
             tokio::time::sleep(Duration::from_millis(80)).await;
-            Ok::<_, std::convert::Infallible>(hyper::Response::new(Full::new(
-                Bytes::from_static(b"drain-complete"),
-            )))
+            Ok::<_, std::convert::Infallible>(hyper::Response::new(Full::new(Bytes::from_static(
+                b"drain-complete",
+            ))))
         }
     });
     let mut config = harness.make_config(HashMap::from([(
@@ -606,7 +627,8 @@ fn in_flight_request_can_complete_while_listener_is_draining() {
         .start_listener(config)
         .expect("start runtime swap listener");
 
-    let client = thread::spawn(move || run_request_to(listen_addr, H3RequestSpec::get("localhost", "/")));
+    let client =
+        thread::spawn(move || run_request_to(listen_addr, H3RequestSpec::get("localhost", "/")));
 
     let deadline = Instant::now() + Duration::from_secs(2);
     while Instant::now() < deadline && !request_started.load(Ordering::Relaxed) {
@@ -624,69 +646,23 @@ fn in_flight_request_can_complete_while_listener_is_draining() {
         "watchdog restart request should be accepted"
     );
 
-    let response = client.join().expect("client thread join").expect("in-flight response");
+    let response = client
+        .join()
+        .expect("client thread join")
+        .expect("in-flight response");
     response.assert_status(200);
     response.assert_body_bytes(b"drain-complete");
 }
 
+// Domain: watchdog restart path.
 #[test]
 #[serial]
-fn runtime_reload_is_rejected_once_lifecycle_leaves_running() {
-    if !local_listener_bind_available() {
+fn watchdog_restart_blocks_new_quic_connections_once_listener_starts_draining() {
+    let Some(harness) = start_static_runtime_swap_listener(b"drain-blocked", |config| {
+        config.resilience.watchdog.enabled = true;
+    }) else {
         return;
-    }
+    };
 
-    let mut harness = RuntimeSwapHarness::new();
-    let backend_addr = harness.start_h1_static_backend(b"lifecycle-running");
-    let config = harness.make_config(HashMap::from([(
-        "api".to_string(),
-        single_backend_upstream(backend_addr),
-    )]));
-
-    harness
-        .start_listener(config)
-        .expect("start runtime swap listener");
-
-    assert_eq!(
-        harness.lifecycle_phase().expect("runtime lifecycle phase"),
-        RuntimeLifecyclePhase::Running
-    );
-    assert!(matches!(
-        harness.begin_lifecycle_drain().expect("begin lifecycle drain"),
-        LifecycleTransitionResult::Applied {
-            to: RuntimeLifecyclePhase::Draining,
-            ..
-        }
-        | LifecycleTransitionResult::NoOp {
-            phase: RuntimeLifecyclePhase::Draining
-        }
-    ));
-    assert_eq!(
-        harness.lifecycle_phase().expect("draining lifecycle phase"),
-        RuntimeLifecyclePhase::Draining
-    );
-
-    let generation_before = harness.current_generation().expect("generation before");
-    harness
-        .rewrite_config(|config| {
-            config.log.level = "debug".to_string();
-        })
-        .expect("rewrite live-reloadable config");
-
-    let rejection = harness
-        .trigger_runtime_reload_expect(http::StatusCode::INTERNAL_SERVER_ERROR)
-        .expect("reload rejection after drain");
-    assert_eq!(rejection["reloaded"], false);
-    let error = rejection["error"]
-        .as_str()
-        .expect("reload rejection error string");
-    assert!(
-        error.contains("illegal_transition") || error.contains("Draining") || error.contains("ReloadCommit"),
-        "reload rejection should reflect the non-running lifecycle gate, got: {error}"
-    );
-    assert_eq!(
-        harness.current_generation().expect("generation after rejection"),
-        generation_before,
-        "reload rejection after drain must keep the active generation unchanged"
-    );
+    assert_watchdog_restart_drains_listener(&harness, "runtime-swap-drain-block");
 }

--- a/crates/edge/tests/support/mod.rs
+++ b/crates/edge/tests/support/mod.rs
@@ -1,3 +1,4 @@
 pub mod net;
 pub mod parity;
 pub mod request_path;
+pub mod runtime_swap;

--- a/crates/edge/tests/support/runtime_swap.rs
+++ b/crates/edge/tests/support/runtime_swap.rs
@@ -1,0 +1,688 @@
+#![allow(dead_code)]
+
+use std::{
+    collections::HashMap,
+    convert::Infallible,
+    fmt::Write as _,
+    future::Future,
+    net::{SocketAddr, TcpListener as StdTcpListener, UdpSocket as StdUdpSocket},
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use bytes::Bytes;
+use http::{Method, StatusCode};
+use http_body_util::{BodyExt, Empty, Full};
+use hyper::{
+    Request, Response,
+    body::Incoming,
+    client::conn::http1,
+};
+use hyper_util::rt::TokioIo;
+use rustls_pki_types::{CertificateDer, pem::PemObject};
+use serde_json::Value as JsonValue;
+use spooky_config::{
+    config::{
+        ClientAuth, Config, ControlApi, Listen, LoadBalancing, Log, LogFormat, MetricsEndpoint,
+        Observability, Security, Tls, Upstream, UpstreamTls,
+    },
+    runtime::RuntimeConfig,
+    validator::validate,
+};
+use spooky_edge::runtime::{bundle::RuntimeBundleHandle, listener::QUICListener as RuntimeListener};
+use tempfile::{TempDir, tempdir};
+use tokio::net::TcpStream;
+use tokio_rustls::{
+    TlsConnector,
+    rustls::{ClientConfig, RootCertStore, pki_types::ServerName},
+};
+
+use super::request_path::{BackendFixture, ListenerTaskGuard, TestTlsMaterial, start_h1_backend};
+
+pub struct RuntimeSwapHarness {
+    backends: Vec<BackendFixture>,
+    listener_task: Option<ListenerTaskGuard>,
+    rt: tokio::runtime::Runtime,
+    tls: TestTlsMaterial,
+    config_dir: TempDir,
+    config_path: PathBuf,
+    listen_port: u16,
+    metrics_port: u16,
+    control_api_port: u16,
+    current_config: Option<Config>,
+    runtime_bundle: Option<Arc<RuntimeBundleHandle>>,
+    listen_addr: Option<SocketAddr>,
+}
+
+impl RuntimeSwapHarness {
+    pub fn new() -> Self {
+        let config_dir = tempdir().expect("runtime swap tempdir");
+        Self {
+            backends: Vec::new(),
+            listener_task: None,
+            rt: tokio::runtime::Runtime::new().expect("runtime"),
+            tls: TestTlsMaterial::localhost(),
+            config_path: config_dir.path().join("spooky-runtime-swap.yaml"),
+            config_dir,
+            listen_port: reserve_udp_port(),
+            metrics_port: reserve_tcp_port(),
+            control_api_port: reserve_tcp_port(),
+            current_config: None,
+            runtime_bundle: None,
+            listen_addr: None,
+        }
+    }
+
+    pub fn config_path(&self) -> &Path {
+        &self.config_path
+    }
+
+    pub fn make_config(&self, upstreams: HashMap<String, Upstream>) -> Config {
+        Config {
+            version: 1,
+            listen: Listen {
+                protocol: "http3".to_string(),
+                port: self.listen_port,
+                address: "127.0.0.1".to_string(),
+                tls: Tls {
+                    cert: self.tls.cert_path.clone(),
+                    key: self.tls.key_path.clone(),
+                    certificates: Vec::new(),
+                    client_auth: ClientAuth::default(),
+                },
+            },
+            listeners: Vec::new(),
+            upstream: upstreams,
+            load_balancing: Some(LoadBalancing {
+                lb_type: "round-robin".to_string(),
+                key: None,
+            }),
+            upstream_tls: UpstreamTls::default(),
+            log: Log {
+                level: "info".to_string(),
+                file: Default::default(),
+                format: LogFormat::Plain,
+            },
+            performance: spooky_config::config::Performance::default(),
+            observability: Observability {
+                metrics: MetricsEndpoint {
+                    enabled: true,
+                    required: true,
+                    address: "127.0.0.1".to_string(),
+                    port: self.metrics_port,
+                    path: "/metrics".to_string(),
+                    max_connections: 32,
+                    connection_timeout_ms: 5_000,
+                },
+                control_api: ControlApi {
+                    enabled: true,
+                    required: true,
+                    address: "127.0.0.1".to_string(),
+                    port: self.control_api_port,
+                    health_path: "/health".to_string(),
+                    ready_path: "/ready".to_string(),
+                    runtime_path: "/runtime".to_string(),
+                    restart_path: "/restart".to_string(),
+                    reload_path: "/reload".to_string(),
+                    reload_certs_path: "/reload-certs".to_string(),
+                    auth_token: Some("runtime-swap-token".to_string()),
+                    max_connections: 32,
+                    connection_timeout_ms: 5_000,
+                },
+                ..Observability::default()
+            },
+            resilience: spooky_config::config::Resilience::default(),
+            security: Security::default(),
+        }
+    }
+
+    pub fn start_h1_backend<F, Fut>(&mut self, handler: F) -> SocketAddr
+    where
+        F: Fn(Request<Incoming>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<Response<Full<Bytes>>, Infallible>> + Send + 'static,
+    {
+        let fixture = self.rt.block_on(start_h1_backend(handler));
+        let addr = fixture.addr;
+        self.backends.push(fixture);
+        addr
+    }
+
+    pub fn start_h1_static_backend(&mut self, body: &'static [u8]) -> SocketAddr {
+        self.start_h1_backend(move |_req| async move {
+            Ok::<_, Infallible>(Response::new(Full::new(Bytes::from_static(body))))
+        })
+    }
+
+    pub fn start_listener(&mut self, config: Config) -> Result<SocketAddr, String> {
+        validate(&config).map_err(|err| format!("config validation failed: {err}"))?;
+        self.write_config_file(&config)?;
+
+        let runtime_config =
+            RuntimeConfig::from_config(&config).map_err(|err| format!("runtime config: {err}"))?;
+        let runtime_bundle = RuntimeListener::build_runtime_bundle(
+            self.config_path.to_string_lossy().to_string(),
+            config.log.clone(),
+            &runtime_config,
+        )
+        .map_err(|err| format!("runtime bundle: {err}"))?;
+        let runtime_bundle_handle = Arc::new(RuntimeBundleHandle::new(runtime_bundle.clone()));
+        let listener_config = runtime_bundle
+            .runtime_config
+            .primary_listener_runtime_config()
+            .ok_or_else(|| "missing primary listener runtime config".to_string())?;
+        let socket = RuntimeListener::bind_socket(&listener_config, false)
+            .map_err(|err| format!("bind socket: {err}"))?;
+
+        {
+            let _enter = self.rt.enter();
+            RuntimeListener::spawn_control_plane_tasks_with_runtime_bundle(
+                &runtime_bundle.runtime_config,
+                runtime_bundle.shared_state.as_ref(),
+                Arc::clone(&runtime_bundle_handle),
+                1,
+            )
+            .map_err(|err| format!("control plane tasks: {err}"))?;
+        }
+
+        let listener = RuntimeListener::new_with_socket_and_shared_state(
+            listener_config,
+            socket,
+            Arc::clone(&runtime_bundle.shared_state),
+        )
+        .map_err(|err| format!("listener: {err}"))?
+        .with_runtime_bundle(Arc::clone(&runtime_bundle_handle));
+
+        let listen_addr = listener
+            .socket
+            .local_addr()
+            .map_err(|err| format!("listen addr: {err}"))?;
+
+        self.listener_task = Some(ListenerTaskGuard::spawn(&self.rt, listener));
+        self.listen_addr = Some(listen_addr);
+        self.current_config = Some(config);
+        self.runtime_bundle = Some(runtime_bundle_handle);
+        Ok(listen_addr)
+    }
+
+    pub fn rewrite_config<F>(&mut self, edit: F) -> Result<(), String>
+    where
+        F: FnOnce(&mut Config),
+    {
+        let mut config = self
+            .current_config
+            .clone()
+            .ok_or_else(|| "listener not started".to_string())?;
+        edit(&mut config);
+        validate(&config).map_err(|err| format!("config validation failed: {err}"))?;
+        self.write_config_file(&config)?;
+        self.current_config = Some(config);
+        Ok(())
+    }
+
+    pub fn runtime_snapshot(&self) -> Result<JsonValue, String> {
+        let path = self
+            .current_config
+            .as_ref()
+            .ok_or_else(|| "listener not started".to_string())?
+            .observability
+            .control_api
+            .runtime_path
+            .clone();
+        let token = self.control_api_token()?;
+        self.rt.block_on(self.poll_control_api_json(
+            Method::GET,
+            path,
+            token,
+            StatusCode::OK,
+            Duration::from_secs(5),
+        ))
+    }
+
+    pub fn trigger_runtime_reload(&self) -> Result<JsonValue, String> {
+        let path = self
+            .current_config
+            .as_ref()
+            .ok_or_else(|| "listener not started".to_string())?
+            .observability
+            .control_api
+            .reload_path
+            .clone();
+        let token = self.control_api_token()?;
+        self.rt.block_on(self.poll_control_api_json(
+            Method::POST,
+            path,
+            token,
+            StatusCode::ACCEPTED,
+            Duration::from_secs(5),
+        ))
+    }
+
+    pub fn metrics_text(&self) -> Result<String, String> {
+        let path = self
+            .current_config
+            .as_ref()
+            .ok_or_else(|| "listener not started".to_string())?
+            .observability
+            .metrics
+            .path
+            .clone();
+        self.rt
+            .block_on(self.poll_metrics_text(path, Duration::from_secs(5)))
+    }
+
+    fn control_api_token(&self) -> Result<String, String> {
+        self.current_config
+            .as_ref()
+            .and_then(|config| config.observability.control_api.auth_token.clone())
+            .ok_or_else(|| "missing control api auth token".to_string())
+    }
+
+    fn write_config_file(&self, config: &Config) -> Result<(), String> {
+        let rendered = render_runtime_swap_config(config)?;
+        std::fs::write(&self.config_path, rendered)
+            .map_err(|err| format!("write config file '{}': {err}", self.config_path.display()))
+    }
+
+    async fn poll_metrics_text(
+        &self,
+        path: String,
+        timeout: Duration,
+    ) -> Result<String, String> {
+        let addr = SocketAddr::from(([127, 0, 0, 1], self.metrics_port));
+        let deadline = Instant::now() + timeout;
+        let mut last_error = String::new();
+
+        while Instant::now() < deadline {
+            match metrics_request_once(addr, &path).await {
+                Ok((status, body)) if status == StatusCode::OK && !body.is_empty() => {
+                    return Ok(body);
+                }
+                Ok((status, body)) => {
+                    last_error = format!("unexpected metrics response {status} body={body:?}");
+                }
+                Err(err) => {
+                    last_error = err;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        Err(format!(
+            "metrics endpoint not reachable within {:?} ({})",
+            timeout, last_error
+        ))
+    }
+
+    async fn poll_control_api_json(
+        &self,
+        method: Method,
+        path: String,
+        token: String,
+        expected_status: StatusCode,
+        timeout: Duration,
+    ) -> Result<JsonValue, String> {
+        let addr = SocketAddr::from(([127, 0, 0, 1], self.control_api_port));
+        let deadline = Instant::now() + timeout;
+        let mut last_error = String::new();
+
+        while Instant::now() < deadline {
+            match control_api_request_once(
+                addr,
+                &self.tls.cert_path,
+                method.clone(),
+                &path,
+                &token,
+            )
+            .await
+            {
+                Ok((status, body)) if status == expected_status => return Ok(body),
+                Ok((status, body)) => {
+                    last_error = format!("unexpected control api response {status} body={body}");
+                }
+                Err(err) => {
+                    last_error = err;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        Err(format!(
+            "control api '{}' not reachable within {:?} ({})",
+            path, timeout, last_error
+        ))
+    }
+}
+
+fn reserve_tcp_port() -> u16 {
+    StdTcpListener::bind(("127.0.0.1", 0))
+        .expect("reserve tcp port")
+        .local_addr()
+        .expect("tcp local addr")
+        .port()
+}
+
+fn reserve_udp_port() -> u16 {
+    StdUdpSocket::bind(("127.0.0.1", 0))
+        .expect("reserve udp port")
+        .local_addr()
+        .expect("udp local addr")
+        .port()
+}
+
+fn read_test_root_store(cert_path: &str) -> Result<RootCertStore, String> {
+    let mut roots = RootCertStore::empty();
+    let certs = CertificateDer::pem_file_iter(cert_path)
+        .map_err(|err| format!("open cert file: {err}"))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|err| format!("parse certs: {err}"))?;
+
+    for cert in certs {
+        roots
+            .add(cert)
+            .map_err(|err| format!("add root cert: {err}"))?;
+    }
+
+    Ok(roots)
+}
+
+async fn metrics_request_once(addr: SocketAddr, path: &str) -> Result<(StatusCode, String), String> {
+    let stream = TcpStream::connect(addr)
+        .await
+        .map_err(|err| format!("metrics connect: {err}"))?;
+    let (mut sender, conn) = http1::handshake(TokioIo::new(stream))
+        .await
+        .map_err(|err| format!("metrics handshake: {err}"))?;
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri(path)
+        .header("host", "127.0.0.1")
+        .body(Empty::<Bytes>::new())
+        .map_err(|err| format!("metrics request build: {err}"))?;
+    let response = sender
+        .send_request(request)
+        .await
+        .map_err(|err| format!("metrics request: {err}"))?;
+    let status = response.status();
+    let body = response
+        .into_body()
+        .collect()
+        .await
+        .map_err(|err| format!("metrics read body: {err}"))?
+        .to_bytes();
+    let body = String::from_utf8(body.to_vec()).map_err(|err| format!("metrics utf8: {err}"))?;
+    Ok((status, body))
+}
+
+async fn control_api_request_once(
+    addr: SocketAddr,
+    cert_path: &str,
+    method: Method,
+    path: &str,
+    token: &str,
+) -> Result<(StatusCode, JsonValue), String> {
+    let roots = read_test_root_store(cert_path)?;
+    let tls_config = ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    let connector = TlsConnector::from(Arc::new(tls_config));
+    let server_name = ServerName::try_from("localhost")
+        .map_err(|err| format!("server name: {err}"))?
+        .to_owned();
+
+    let stream = TcpStream::connect(addr)
+        .await
+        .map_err(|err| format!("control api connect: {err}"))?;
+    let tls_stream = connector
+        .connect(server_name, stream)
+        .await
+        .map_err(|err| format!("control api tls connect: {err}"))?;
+    let (mut sender, conn) = http1::handshake(TokioIo::new(tls_stream))
+        .await
+        .map_err(|err| format!("control api handshake: {err}"))?;
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+
+    let request = Request::builder()
+        .method(method)
+        .uri(path)
+        .header("host", "localhost")
+        .header("authorization", format!("Bearer {token}"))
+        .body(Empty::<Bytes>::new())
+        .map_err(|err| format!("control api request build: {err}"))?;
+    let response = sender
+        .send_request(request)
+        .await
+        .map_err(|err| format!("control api request: {err}"))?;
+    let status = response.status();
+    let body = response
+        .into_body()
+        .collect()
+        .await
+        .map_err(|err| format!("control api read body: {err}"))?
+        .to_bytes();
+    let json = serde_json::from_slice(&body).map_err(|err| {
+        format!(
+            "control api json parse: {err}; payload={}",
+            String::from_utf8_lossy(&body)
+        )
+    })?;
+    Ok((status, json))
+}
+
+fn render_runtime_swap_config(config: &Config) -> Result<String, String> {
+    let mut yaml = String::new();
+    writeln!(&mut yaml, "version: {}", config.version).map_err(|err| err.to_string())?;
+    writeln!(&mut yaml, "listen:").map_err(|err| err.to_string())?;
+    writeln!(&mut yaml, "  protocol: {}", config.listen.protocol).map_err(|err| err.to_string())?;
+    writeln!(&mut yaml, "  address: \"{}\"", config.listen.address).map_err(|err| err.to_string())?;
+    writeln!(&mut yaml, "  port: {}", config.listen.port).map_err(|err| err.to_string())?;
+    writeln!(&mut yaml, "  tls:").map_err(|err| err.to_string())?;
+    writeln!(&mut yaml, "    cert: \"{}\"", config.listen.tls.cert).map_err(|err| err.to_string())?;
+    writeln!(&mut yaml, "    key: \"{}\"", config.listen.tls.key).map_err(|err| err.to_string())?;
+
+    if let Some(load_balancing) = &config.load_balancing {
+        writeln!(&mut yaml, "load_balancing:").map_err(|err| err.to_string())?;
+        writeln!(&mut yaml, "  type: {}", load_balancing.lb_type).map_err(|err| err.to_string())?;
+    }
+
+    writeln!(&mut yaml, "upstream:").map_err(|err| err.to_string())?;
+    for (name, upstream) in &config.upstream {
+        writeln!(&mut yaml, "  {}:", yaml_scalar(name)).map_err(|err| err.to_string())?;
+        writeln!(&mut yaml, "    load_balancing:").map_err(|err| err.to_string())?;
+        writeln!(
+            &mut yaml,
+            "      type: {}",
+            upstream.load_balancing.lb_type
+        )
+        .map_err(|err| err.to_string())?;
+        writeln!(&mut yaml, "    route:").map_err(|err| err.to_string())?;
+        if let Some(path_prefix) = upstream.route.path_prefix.as_deref() {
+            writeln!(
+                &mut yaml,
+                "      path_prefix: \"{}\"",
+                path_prefix
+            )
+            .map_err(|err| err.to_string())?;
+        }
+        writeln!(&mut yaml, "    backends:").map_err(|err| err.to_string())?;
+        for backend in &upstream.backends {
+            writeln!(&mut yaml, "      - id: {}", yaml_scalar(&backend.id))
+                .map_err(|err| err.to_string())?;
+            writeln!(
+                &mut yaml,
+                "        address: \"{}\"",
+                backend.address
+            )
+            .map_err(|err| err.to_string())?;
+            writeln!(&mut yaml, "        weight: {}", backend.weight)
+                .map_err(|err| err.to_string())?;
+        }
+    }
+
+    writeln!(&mut yaml, "log:").map_err(|err| err.to_string())?;
+    writeln!(&mut yaml, "  level: {}", yaml_scalar(&config.log.level)).map_err(|err| err.to_string())?;
+    writeln!(
+        &mut yaml,
+        "  format: {}",
+        match config.log.format {
+            LogFormat::Plain => "plain",
+            LogFormat::Json => "json",
+        }
+    )
+    .map_err(|err| err.to_string())?;
+
+    writeln!(&mut yaml, "performance:").map_err(|err| err.to_string())?;
+    writeln!(
+        &mut yaml,
+        "  new_connections_burst: {}",
+        config.performance.new_connections_burst
+    )
+    .map_err(|err| err.to_string())?;
+    writeln!(
+        &mut yaml,
+        "  new_connections_per_sec: {}",
+        config.performance.new_connections_per_sec
+    )
+    .map_err(|err| err.to_string())?;
+
+    writeln!(&mut yaml, "observability:").map_err(|err| err.to_string())?;
+    writeln!(&mut yaml, "  metrics:").map_err(|err| err.to_string())?;
+    writeln!(
+        &mut yaml,
+        "    enabled: {}",
+        config.observability.metrics.enabled
+    )
+    .map_err(|err| err.to_string())?;
+    writeln!(
+        &mut yaml,
+        "    required: {}",
+        config.observability.metrics.required
+    )
+    .map_err(|err| err.to_string())?;
+    writeln!(
+        &mut yaml,
+        "    address: \"{}\"",
+        config.observability.metrics.address
+    )
+    .map_err(|err| err.to_string())?;
+    writeln!(
+        &mut yaml,
+        "    port: {}",
+        config.observability.metrics.port
+    )
+    .map_err(|err| err.to_string())?;
+    writeln!(
+        &mut yaml,
+        "    path: \"{}\"",
+        config.observability.metrics.path
+    )
+    .map_err(|err| err.to_string())?;
+    writeln!(
+        &mut yaml,
+        "    max_connections: {}",
+        config.observability.metrics.max_connections
+    )
+    .map_err(|err| err.to_string())?;
+    writeln!(
+        &mut yaml,
+        "    connection_timeout_ms: {}",
+        config.observability.metrics.connection_timeout_ms
+    )
+    .map_err(|err| err.to_string())?;
+
+    writeln!(&mut yaml, "  control_api:").map_err(|err| err.to_string())?;
+    writeln!(
+        &mut yaml,
+        "    enabled: {}",
+        config.observability.control_api.enabled
+    )
+    .map_err(|err| err.to_string())?;
+    writeln!(
+        &mut yaml,
+        "    required: {}",
+        config.observability.control_api.required
+    )
+    .map_err(|err| err.to_string())?;
+    writeln!(
+        &mut yaml,
+        "    address: \"{}\"",
+        config.observability.control_api.address
+    )
+    .map_err(|err| err.to_string())?;
+    writeln!(
+        &mut yaml,
+        "    port: {}",
+        config.observability.control_api.port
+    )
+    .map_err(|err| err.to_string())?;
+    writeln!(
+        &mut yaml,
+        "    health_path: \"{}\"",
+        config.observability.control_api.health_path
+    )
+    .map_err(|err| err.to_string())?;
+    writeln!(
+        &mut yaml,
+        "    ready_path: \"{}\"",
+        config.observability.control_api.ready_path
+    )
+    .map_err(|err| err.to_string())?;
+    writeln!(
+        &mut yaml,
+        "    runtime_path: \"{}\"",
+        config.observability.control_api.runtime_path
+    )
+    .map_err(|err| err.to_string())?;
+    writeln!(
+        &mut yaml,
+        "    restart_path: \"{}\"",
+        config.observability.control_api.restart_path
+    )
+    .map_err(|err| err.to_string())?;
+    writeln!(
+        &mut yaml,
+        "    reload_path: \"{}\"",
+        config.observability.control_api.reload_path
+    )
+    .map_err(|err| err.to_string())?;
+    writeln!(
+        &mut yaml,
+        "    reload_certs_path: \"{}\"",
+        config.observability.control_api.reload_certs_path
+    )
+    .map_err(|err| err.to_string())?;
+    if let Some(token) = config.observability.control_api.auth_token.as_deref() {
+        writeln!(&mut yaml, "    auth_token: \"{}\"", token).map_err(|err| err.to_string())?;
+    }
+    writeln!(
+        &mut yaml,
+        "    max_connections: {}",
+        config.observability.control_api.max_connections
+    )
+    .map_err(|err| err.to_string())?;
+    writeln!(
+        &mut yaml,
+        "    connection_timeout_ms: {}",
+        config.observability.control_api.connection_timeout_ms
+    )
+    .map_err(|err| err.to_string())?;
+
+    Ok(yaml)
+}
+
+fn yaml_scalar(value: &str) -> String {
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+    {
+        value.to_string()
+    } else {
+        format!("{value:?}")
+    }
+}

--- a/crates/edge/tests/support/runtime_swap.rs
+++ b/crates/edge/tests/support/runtime_swap.rs
@@ -243,6 +243,13 @@ impl RuntimeSwapHarness {
     }
 
     pub fn trigger_runtime_reload(&self) -> Result<JsonValue, String> {
+        self.trigger_runtime_reload_expect(StatusCode::ACCEPTED)
+    }
+
+    pub fn trigger_runtime_reload_expect(
+        &self,
+        expected_status: StatusCode,
+    ) -> Result<JsonValue, String> {
         let path = self
             .current_config
             .as_ref()
@@ -256,7 +263,7 @@ impl RuntimeSwapHarness {
             Method::POST,
             path,
             token,
-            StatusCode::ACCEPTED,
+            expected_status,
             Duration::from_secs(5),
         ))
     }
@@ -537,6 +544,19 @@ fn render_runtime_swap_config(config: &Config) -> Result<String, String> {
 
     writeln!(&mut yaml, "log:").map_err(|err| err.to_string())?;
     writeln!(&mut yaml, "  level: {}", yaml_scalar(&config.log.level)).map_err(|err| err.to_string())?;
+    writeln!(&mut yaml, "  file:").map_err(|err| err.to_string())?;
+    writeln!(
+        &mut yaml,
+        "    enabled: {}",
+        config.log.file.enabled
+    )
+    .map_err(|err| err.to_string())?;
+    writeln!(
+        &mut yaml,
+        "    path: \"{}\"",
+        config.log.file.path
+    )
+    .map_err(|err| err.to_string())?;
     writeln!(
         &mut yaml,
         "  format: {}",

--- a/crates/edge/tests/support/runtime_swap.rs
+++ b/crates/edge/tests/support/runtime_swap.rs
@@ -38,7 +38,10 @@ use tokio_rustls::{
     rustls::{ClientConfig, RootCertStore, pki_types::ServerName},
 };
 
-use super::request_path::{BackendFixture, ListenerTaskGuard, TestTlsMaterial, start_h1_backend};
+use super::request_path::{
+    BackendFixture, H3RequestSpec, H3Response, ListenerTaskGuard, TestTlsMaterial,
+    run_request_to, start_h1_backend,
+};
 
 pub struct RuntimeSwapHarness {
     backends: Vec<BackendFixture>,
@@ -269,6 +272,13 @@ impl RuntimeSwapHarness {
             .clone();
         self.rt
             .block_on(self.poll_metrics_text(path, Duration::from_secs(5)))
+    }
+
+    pub fn run_request(&self, request: H3RequestSpec<'_>) -> Result<H3Response, String> {
+        let listen_addr = self
+            .listen_addr
+            .ok_or_else(|| "listener not started".to_string())?;
+        run_request_to(listen_addr, request)
     }
 
     fn control_api_token(&self) -> Result<String, String> {

--- a/crates/edge/tests/support/runtime_swap.rs
+++ b/crates/edge/tests/support/runtime_swap.rs
@@ -30,7 +30,15 @@ use spooky_config::{
     runtime::RuntimeConfig,
     validator::validate,
 };
-use spooky_edge::runtime::{bundle::RuntimeBundleHandle, listener::QUICListener as RuntimeListener};
+use spooky_edge::{
+    MAX_DATAGRAM_SIZE_BYTES, MAX_UDP_PAYLOAD_BYTES, QUIC_IDLE_TIMEOUT_MS, QUIC_INITIAL_MAX_DATA,
+    QUIC_INITIAL_MAX_STREAMS_BIDI, QUIC_INITIAL_MAX_STREAMS_UNI, QUIC_INITIAL_STREAM_DATA,
+    runtime::{
+        bundle::RuntimeBundleHandle,
+        listener::QUICListener as RuntimeListener,
+        policy::{LifecycleTransitionResult, RuntimeLifecyclePhase},
+    },
+};
 use tempfile::{TempDir, tempdir};
 use tokio::net::TcpStream;
 use tokio_rustls::{
@@ -300,6 +308,56 @@ impl RuntimeSwapHarness {
         run_request_to(listen_addr, request)
     }
 
+    pub fn listen_addr(&self) -> Result<SocketAddr, String> {
+        self.listen_addr
+            .ok_or_else(|| "listener not started".to_string())
+    }
+
+    pub fn current_generation(&self) -> Result<u64, String> {
+        Ok(self
+            .runtime_bundle
+            .as_ref()
+            .ok_or_else(|| "runtime bundle unavailable".to_string())?
+            .current_generation())
+    }
+
+    pub fn lifecycle_phase(&self) -> Result<RuntimeLifecyclePhase, String> {
+        Ok(self
+            .runtime_bundle
+            .as_ref()
+            .ok_or_else(|| "runtime bundle unavailable".to_string())?
+            .lifecycle()
+            .phase())
+    }
+
+    pub fn begin_lifecycle_drain(&self) -> Result<LifecycleTransitionResult, String> {
+        Ok(self
+            .runtime_bundle
+            .as_ref()
+            .ok_or_else(|| "runtime bundle unavailable".to_string())?
+            .lifecycle()
+            .begin_drain())
+    }
+
+    pub fn request_watchdog_restart(&self, reason: &str) -> Result<bool, String> {
+        Ok(self
+            .runtime_bundle
+            .as_ref()
+            .ok_or_else(|| "runtime bundle unavailable".to_string())?
+            .current_view()
+            .shared_services()
+            .watchdog
+            .request_restart(reason))
+    }
+
+    pub fn fresh_quic_connection_establishes_within(
+        &self,
+        timeout: Duration,
+    ) -> Result<bool, String> {
+        let listen_addr = self.listen_addr()?;
+        quic_connection_establishes_within(listen_addr, timeout)
+    }
+
     fn control_api_token(&self) -> Result<String, String> {
         self.current_config
             .as_ref()
@@ -526,6 +584,86 @@ async fn control_api_request_once(
         )
     })?;
     Ok((status, json))
+}
+
+fn quic_connection_establishes_within(addr: SocketAddr, timeout: Duration) -> Result<bool, String> {
+    let socket = StdUdpSocket::bind("0.0.0.0:0").map_err(|err| format!("udp bind: {err}"))?;
+    let local_addr = socket
+        .local_addr()
+        .map_err(|err| format!("udp local addr: {err}"))?;
+
+    let mut config =
+        quiche::Config::new(quiche::PROTOCOL_VERSION).map_err(|err| format!("config: {err:?}"))?;
+    config.verify_peer(false);
+    config
+        .set_application_protos(quiche::h3::APPLICATION_PROTOCOL)
+        .map_err(|err| format!("alpn: {err:?}"))?;
+    config.set_max_idle_timeout(QUIC_IDLE_TIMEOUT_MS);
+    config.set_max_recv_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    config.set_max_send_udp_payload_size(MAX_UDP_PAYLOAD_BYTES);
+    config.set_initial_max_data(QUIC_INITIAL_MAX_DATA);
+    config.set_initial_max_stream_data_bidi_local(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_stream_data_bidi_remote(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_stream_data_uni(QUIC_INITIAL_STREAM_DATA);
+    config.set_initial_max_streams_bidi(QUIC_INITIAL_MAX_STREAMS_BIDI);
+    config.set_initial_max_streams_uni(QUIC_INITIAL_MAX_STREAMS_UNI);
+    config.set_disable_active_migration(true);
+
+    let scid_bytes = [7u8; quiche::MAX_CONN_ID_LEN];
+    let scid = quiche::ConnectionId::from_ref(&scid_bytes);
+    let mut conn = quiche::connect(Some("localhost"), &scid, local_addr, addr, &mut config)
+        .map_err(|err| format!("connect: {err:?}"))?;
+
+    let mut out = [0u8; MAX_UDP_PAYLOAD_BYTES];
+    let mut buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
+
+    let (written, send_info) = conn.send(&mut out).map_err(|err| format!("send: {err:?}"))?;
+    socket
+        .send_to(&out[..written], send_info.to)
+        .map_err(|err| format!("send_to: {err}"))?;
+
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        socket
+            .set_read_timeout(Some(remaining.min(Duration::from_millis(50))))
+            .map_err(|err| format!("read timeout: {err}"))?;
+
+        match socket.recv_from(&mut buf) {
+            Ok((len, from)) => {
+                let _ = conn.recv(
+                    &mut buf[..len],
+                    quiche::RecvInfo {
+                        from,
+                        to: local_addr,
+                    },
+                );
+            }
+            Err(ref err)
+                if err.kind() == std::io::ErrorKind::WouldBlock
+                    || err.kind() == std::io::ErrorKind::TimedOut =>
+            {
+                conn.on_timeout();
+            }
+            Err(err) => return Err(format!("recv_from: {err}")),
+        }
+
+        loop {
+            match conn.send(&mut out) {
+                Ok((written, send_info)) => {
+                    let _ = socket.send_to(&out[..written], send_info.to);
+                }
+                Err(quiche::Error::Done) => break,
+                Err(err) => return Err(format!("send loop: {err:?}")),
+            }
+        }
+
+        if conn.is_established() {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
 }
 
 fn render_runtime_swap_config(config: &Config) -> Result<String, String> {

--- a/crates/edge/tests/support/runtime_swap.rs
+++ b/crates/edge/tests/support/runtime_swap.rs
@@ -277,8 +277,20 @@ impl RuntimeSwapHarness {
             .metrics
             .path
             .clone();
-        self.rt
-            .block_on(self.poll_metrics_text(path, Duration::from_secs(5)))
+        self.metrics_text_at(&path)
+    }
+
+    pub fn metrics_text_at(&self, path: &str) -> Result<String, String> {
+        self.rt.block_on(
+            self.poll_metrics_text(path.to_string(), StatusCode::OK, Duration::from_secs(5)),
+        )
+    }
+
+    pub fn metrics_status_at(&self, path: &str) -> Result<StatusCode, String> {
+        self.rt.block_on(self.poll_metrics_status(
+            path.to_string(),
+            Duration::from_secs(5),
+        ))
     }
 
     pub fn run_request(&self, request: H3RequestSpec<'_>) -> Result<H3Response, String> {
@@ -304,6 +316,7 @@ impl RuntimeSwapHarness {
     async fn poll_metrics_text(
         &self,
         path: String,
+        expected_status: StatusCode,
         timeout: Duration,
     ) -> Result<String, String> {
         let addr = SocketAddr::from(([127, 0, 0, 1], self.metrics_port));
@@ -312,7 +325,7 @@ impl RuntimeSwapHarness {
 
         while Instant::now() < deadline {
             match metrics_request_once(addr, &path).await {
-                Ok((status, body)) if status == StatusCode::OK && !body.is_empty() => {
+                Ok((status, body)) if status == expected_status && !body.is_empty() => {
                     return Ok(body);
                 }
                 Ok((status, body)) => {
@@ -327,6 +340,29 @@ impl RuntimeSwapHarness {
 
         Err(format!(
             "metrics endpoint not reachable within {:?} ({})",
+            timeout, last_error
+        ))
+    }
+
+    async fn poll_metrics_status(
+        &self,
+        path: String,
+        timeout: Duration,
+    ) -> Result<StatusCode, String> {
+        let addr = SocketAddr::from(([127, 0, 0, 1], self.metrics_port));
+        let deadline = Instant::now() + timeout;
+        let mut last_error = String::new();
+
+        while Instant::now() < deadline {
+            match metrics_request_once(addr, &path).await {
+                Ok((status, _body)) => return Ok(status),
+                Err(err) => last_error = err,
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        Err(format!(
+            "metrics endpoint status not reachable within {:?} ({})",
             timeout, last_error
         ))
     }

--- a/crates/edge/tests/support/runtime_swap.rs
+++ b/crates/edge/tests/support/runtime_swap.rs
@@ -250,6 +250,25 @@ impl RuntimeSwapHarness {
         ))
     }
 
+    pub fn ready_snapshot_expect(&self, expected_status: StatusCode) -> Result<JsonValue, String> {
+        let path = self
+            .current_config
+            .as_ref()
+            .ok_or_else(|| "listener not started".to_string())?
+            .observability
+            .control_api
+            .ready_path
+            .clone();
+        let token = self.control_api_token()?;
+        self.rt.block_on(self.poll_control_api_json(
+            Method::GET,
+            path,
+            token,
+            expected_status,
+            Duration::from_secs(5),
+        ))
+    }
+
     pub fn trigger_runtime_reload(&self) -> Result<JsonValue, String> {
         self.trigger_runtime_reload_expect(StatusCode::ACCEPTED)
     }

--- a/crates/edge/tests/support/runtime_swap.rs
+++ b/crates/edge/tests/support/runtime_swap.rs
@@ -14,11 +14,7 @@ use std::{
 use bytes::Bytes;
 use http::{Method, StatusCode};
 use http_body_util::{BodyExt, Empty, Full};
-use hyper::{
-    Request, Response,
-    body::Incoming,
-    client::conn::http1,
-};
+use hyper::{Request, Response, body::Incoming, client::conn::http1};
 use hyper_util::rt::TokioIo;
 use rustls_pki_types::{CertificateDer, pem::PemObject};
 use serde_json::Value as JsonValue;
@@ -47,8 +43,8 @@ use tokio_rustls::{
 };
 
 use super::request_path::{
-    BackendFixture, H3RequestSpec, H3Response, ListenerTaskGuard, TestTlsMaterial,
-    run_request_to, start_h1_backend,
+    BackendFixture, H3RequestSpec, H3Response, ListenerTaskGuard, TestTlsMaterial, run_request_to,
+    start_h1_backend,
 };
 
 pub struct RuntimeSwapHarness {
@@ -308,16 +304,16 @@ impl RuntimeSwapHarness {
     }
 
     pub fn metrics_text_at(&self, path: &str) -> Result<String, String> {
-        self.rt.block_on(
-            self.poll_metrics_text(path.to_string(), StatusCode::OK, Duration::from_secs(5)),
-        )
+        self.rt.block_on(self.poll_metrics_text(
+            path.to_string(),
+            StatusCode::OK,
+            Duration::from_secs(5),
+        ))
     }
 
     pub fn metrics_status_at(&self, path: &str) -> Result<StatusCode, String> {
-        self.rt.block_on(self.poll_metrics_status(
-            path.to_string(),
-            Duration::from_secs(5),
-        ))
+        self.rt
+            .block_on(self.poll_metrics_status(path.to_string(), Duration::from_secs(5)))
     }
 
     pub fn run_request(&self, request: H3RequestSpec<'_>) -> Result<H3Response, String> {
@@ -457,14 +453,8 @@ impl RuntimeSwapHarness {
         let mut last_error = String::new();
 
         while Instant::now() < deadline {
-            match control_api_request_once(
-                addr,
-                &self.tls.cert_path,
-                method.clone(),
-                &path,
-                &token,
-            )
-            .await
+            match control_api_request_once(addr, &self.tls.cert_path, method.clone(), &path, &token)
+                .await
             {
                 Ok((status, body)) if status == expected_status => return Ok(body),
                 Ok((status, body)) => {
@@ -516,7 +506,10 @@ fn read_test_root_store(cert_path: &str) -> Result<RootCertStore, String> {
     Ok(roots)
 }
 
-async fn metrics_request_once(addr: SocketAddr, path: &str) -> Result<(StatusCode, String), String> {
+async fn metrics_request_once(
+    addr: SocketAddr,
+    path: &str,
+) -> Result<(StatusCode, String), String> {
     let stream = TcpStream::connect(addr)
         .await
         .map_err(|err| format!("metrics connect: {err}"))?;
@@ -636,7 +629,9 @@ fn quic_connection_establishes_within(addr: SocketAddr, timeout: Duration) -> Re
     let mut out = [0u8; MAX_UDP_PAYLOAD_BYTES];
     let mut buf = [0u8; MAX_DATAGRAM_SIZE_BYTES];
 
-    let (written, send_info) = conn.send(&mut out).map_err(|err| format!("send: {err:?}"))?;
+    let (written, send_info) = conn
+        .send(&mut out)
+        .map_err(|err| format!("send: {err:?}"))?;
     socket
         .send_to(&out[..written], send_info.to)
         .map_err(|err| format!("send_to: {err}"))?;
@@ -690,10 +685,12 @@ fn render_runtime_swap_config(config: &Config) -> Result<String, String> {
     writeln!(&mut yaml, "version: {}", config.version).map_err(|err| err.to_string())?;
     writeln!(&mut yaml, "listen:").map_err(|err| err.to_string())?;
     writeln!(&mut yaml, "  protocol: {}", config.listen.protocol).map_err(|err| err.to_string())?;
-    writeln!(&mut yaml, "  address: \"{}\"", config.listen.address).map_err(|err| err.to_string())?;
+    writeln!(&mut yaml, "  address: \"{}\"", config.listen.address)
+        .map_err(|err| err.to_string())?;
     writeln!(&mut yaml, "  port: {}", config.listen.port).map_err(|err| err.to_string())?;
     writeln!(&mut yaml, "  tls:").map_err(|err| err.to_string())?;
-    writeln!(&mut yaml, "    cert: \"{}\"", config.listen.tls.cert).map_err(|err| err.to_string())?;
+    writeln!(&mut yaml, "    cert: \"{}\"", config.listen.tls.cert)
+        .map_err(|err| err.to_string())?;
     writeln!(&mut yaml, "    key: \"{}\"", config.listen.tls.key).map_err(|err| err.to_string())?;
 
     if let Some(load_balancing) = &config.load_balancing {
@@ -705,51 +702,31 @@ fn render_runtime_swap_config(config: &Config) -> Result<String, String> {
     for (name, upstream) in &config.upstream {
         writeln!(&mut yaml, "  {}:", yaml_scalar(name)).map_err(|err| err.to_string())?;
         writeln!(&mut yaml, "    load_balancing:").map_err(|err| err.to_string())?;
-        writeln!(
-            &mut yaml,
-            "      type: {}",
-            upstream.load_balancing.lb_type
-        )
-        .map_err(|err| err.to_string())?;
+        writeln!(&mut yaml, "      type: {}", upstream.load_balancing.lb_type)
+            .map_err(|err| err.to_string())?;
         writeln!(&mut yaml, "    route:").map_err(|err| err.to_string())?;
         if let Some(path_prefix) = upstream.route.path_prefix.as_deref() {
-            writeln!(
-                &mut yaml,
-                "      path_prefix: \"{}\"",
-                path_prefix
-            )
-            .map_err(|err| err.to_string())?;
+            writeln!(&mut yaml, "      path_prefix: \"{}\"", path_prefix)
+                .map_err(|err| err.to_string())?;
         }
         writeln!(&mut yaml, "    backends:").map_err(|err| err.to_string())?;
         for backend in &upstream.backends {
             writeln!(&mut yaml, "      - id: {}", yaml_scalar(&backend.id))
                 .map_err(|err| err.to_string())?;
-            writeln!(
-                &mut yaml,
-                "        address: \"{}\"",
-                backend.address
-            )
-            .map_err(|err| err.to_string())?;
+            writeln!(&mut yaml, "        address: \"{}\"", backend.address)
+                .map_err(|err| err.to_string())?;
             writeln!(&mut yaml, "        weight: {}", backend.weight)
                 .map_err(|err| err.to_string())?;
         }
     }
 
     writeln!(&mut yaml, "log:").map_err(|err| err.to_string())?;
-    writeln!(&mut yaml, "  level: {}", yaml_scalar(&config.log.level)).map_err(|err| err.to_string())?;
+    writeln!(&mut yaml, "  level: {}", yaml_scalar(&config.log.level))
+        .map_err(|err| err.to_string())?;
     writeln!(&mut yaml, "  file:").map_err(|err| err.to_string())?;
-    writeln!(
-        &mut yaml,
-        "    enabled: {}",
-        config.log.file.enabled
-    )
-    .map_err(|err| err.to_string())?;
-    writeln!(
-        &mut yaml,
-        "    path: \"{}\"",
-        config.log.file.path
-    )
-    .map_err(|err| err.to_string())?;
+    writeln!(&mut yaml, "    enabled: {}", config.log.file.enabled)
+        .map_err(|err| err.to_string())?;
+    writeln!(&mut yaml, "    path: \"{}\"", config.log.file.path).map_err(|err| err.to_string())?;
     writeln!(
         &mut yaml,
         "  format: {}",
@@ -794,12 +771,8 @@ fn render_runtime_swap_config(config: &Config) -> Result<String, String> {
         config.observability.metrics.address
     )
     .map_err(|err| err.to_string())?;
-    writeln!(
-        &mut yaml,
-        "    port: {}",
-        config.observability.metrics.port
-    )
-    .map_err(|err| err.to_string())?;
+    writeln!(&mut yaml, "    port: {}", config.observability.metrics.port)
+        .map_err(|err| err.to_string())?;
     writeln!(
         &mut yaml,
         "    path: \"{}\"",


### PR DESCRIPTION
## Summary
This PR strengthens edge runtime lifecycle coverage around live reload, drain, and watchdog-driven restart behavior.

## What’s included
- adds runtime-swap integration coverage for:
  - generation-owned reload swaps
  - startup-owned reload rejection
  - control-plane runtime snapshot visibility
  - metrics endpoint visibility after reload
  - drain behavior during in-flight requests
  - watchdog-triggered restart and drain behavior
- adds unit coverage for listener-side watchdog drain accounting
- cleans up the runtime-swap suite structure so tests are grouped by contract domain instead of implementation order
- reduces duplicated harness/setup code in runtime lifecycle tests

## Why
The runtime generation model, drain flow, and watchdog restart path are now core lifecycle contracts. This PR locks those behaviors down so future refactors do not drift in:
- reload boundaries
- control-plane state visibility
- drain semantics
- watchdog restart orchestration
