### PR TITLE
test(edge): add backend lifecycle failure, refresh, and recovery integration coverage

### DIFF
--- a/crates/edge/tests/backend_failure_and_recovery.rs
+++ b/crates/edge/tests/backend_failure_and_recovery.rs
@@ -789,12 +789,7 @@ fn partial_outage_preserves_healthy_backend_availability() {
     );
 
     assert!(
-        wait_for_backend_health_state(
-            &harness,
-            &backend_identity(backend_a_addr),
-            1,
-            |_| true,
-        ),
+        wait_for_backend_health_state(&harness, &backend_identity(backend_a_addr), 1, |_| true,),
         "failing backend should eventually be removed from the effective healthy set"
     );
 

--- a/crates/edge/tests/backend_failure_and_recovery.rs
+++ b/crates/edge/tests/backend_failure_and_recovery.rs
@@ -693,3 +693,161 @@ fn active_health_recovery_restores_backend_availability() {
     recovered.assert_status(200);
     recovered.assert_body_text("backend-a");
 }
+
+#[test]
+#[serial]
+fn partial_outage_preserves_healthy_backend_availability() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = BackendLifecycleHarness::new();
+    let port = reserve_unused_udp_port();
+    let (backend_a_bind, backend_b_bind) = alternate_loopback_backend_addrs(port);
+
+    let backend_a_requests = Arc::new(AtomicUsize::new(0));
+    let backend_b_requests = Arc::new(AtomicUsize::new(0));
+
+    let backend_a_counter = Arc::clone(&backend_a_requests);
+    let backend_a_addr = harness
+        .try_start_h1_backend_at(
+            backend_a_bind,
+            move |_req: hyper::Request<Incoming>| {
+                let backend_a_counter = Arc::clone(&backend_a_counter);
+                async move {
+                    backend_a_counter.fetch_add(1, Ordering::Relaxed);
+                    Ok::<_, Infallible>(
+                        Response::builder()
+                            .status(503)
+                            .body(Full::new(Bytes::from_static(b"backend-a")))
+                            .expect("backend a failure response"),
+                    )
+                }
+            },
+        )
+        .ok();
+    let Some(backend_a_addr) = backend_a_addr else {
+        return;
+    };
+
+    let backend_b_counter = Arc::clone(&backend_b_requests);
+    let backend_b_addr = harness
+        .try_start_h1_backend_at(
+            backend_b_bind,
+            move |_req: hyper::Request<Incoming>| {
+                let backend_b_counter = Arc::clone(&backend_b_counter);
+                async move {
+                    backend_b_counter.fetch_add(1, Ordering::Relaxed);
+                    Ok::<_, Infallible>(Response::new(Full::new(Bytes::from_static(
+                        b"backend-b",
+                    ))))
+                }
+            },
+        )
+        .ok();
+    let Some(backend_b_addr) = backend_b_addr else {
+        return;
+    };
+
+    let config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        Upstream {
+            load_balancing: LoadBalancing {
+                lb_type: "round-robin".to_string(),
+                key: None,
+            },
+            auth: Default::default(),
+            host_policy: Default::default(),
+            forwarded_headers: Default::default(),
+            tls: None,
+            route: RouteMatch {
+                path_prefix: Some("/".to_string()),
+                ..Default::default()
+            },
+            backends: vec![
+                Backend {
+                    id: "backend-a".to_string(),
+                    address: format!("http://{backend_a_addr}"),
+                    weight: 1,
+                    health_check: None,
+                },
+                Backend {
+                    id: "backend-b".to_string(),
+                    address: format!("http://{backend_b_addr}"),
+                    weight: 1,
+                    health_check: None,
+                },
+            ],
+        },
+    )]));
+    harness.start_listener(config).expect("listener");
+
+    let mut success_count = 0usize;
+    let mut failure_count = 0usize;
+    for _ in 0..6 {
+        let response = harness
+            .run_request(H3RequestSpec::get("localhost", "/"))
+            .expect("partial outage request");
+        match response.status {
+            200 => {
+                success_count += 1;
+                response.assert_body_text("backend-b");
+            }
+            503 => {
+                failure_count += 1;
+                response.assert_body_text("backend-a");
+            }
+            other => panic!("unexpected partial-outage response status {other}"),
+        }
+    }
+
+    assert!(
+        success_count >= 3,
+        "healthy backend should preserve overall availability during a partial outage"
+    );
+    assert!(
+        failure_count >= 1,
+        "failing backend should still surface degraded outcomes before passive ejection completes"
+    );
+
+    assert!(
+        wait_for_backend_health_state(
+            &harness,
+            &format!("http://{backend_a_addr}"),
+            1,
+            |health| matches!(health, BackendHealthState::Unhealthy { .. }),
+        ),
+        "failing backend should eventually be removed from the effective healthy set"
+    );
+
+    for _ in 0..4 {
+        let response = harness
+            .run_request(H3RequestSpec::get("localhost", "/"))
+            .expect("request after passive ejection");
+        response.assert_status(200);
+        response.assert_body_text("backend-b");
+    }
+
+    let summary = harness
+        .upstream_membership_summary("api")
+        .expect("membership summary after partial outage");
+    assert_eq!(summary.total_backends, 2);
+    assert_eq!(summary.healthy_backends, 1);
+
+    let backend_a_state = harness
+        .upstream_backend_runtime_state("api", &format!("http://{backend_a_addr}"))
+        .expect("backend A runtime state lookup")
+        .expect("backend A runtime state");
+    let backend_b_state = harness
+        .upstream_backend_runtime_state("api", &format!("http://{backend_b_addr}"))
+        .expect("backend B runtime state lookup")
+        .expect("backend B runtime state");
+    assert!(
+        !backend_a_state.healthy,
+        "failing backend should be degraded out of the effective healthy pool"
+    );
+    assert!(
+        backend_b_state.healthy,
+        "healthy backend should remain available throughout the partial outage"
+    );
+}

--- a/crates/edge/tests/backend_failure_and_recovery.rs
+++ b/crates/edge/tests/backend_failure_and_recovery.rs
@@ -135,3 +135,80 @@ fn dns_refresh_with_changed_backend_addresses_moves_requests_and_updates_invento
         "backend lifecycle inventory should keep the backend placed in the active upstream"
     );
 }
+
+#[test]
+#[serial]
+fn empty_dns_refresh_retains_previous_resolution_and_keeps_requests_flowing() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = BackendLifecycleHarness::new();
+    let Some((port, backend_a_addr, _backend_b_addr)) = start_hostname_swap_backends(&mut harness)
+    else {
+        return;
+    };
+
+    let route = harness.hostname_backend_route("backend.internal", port);
+    let config = harness.make_config(HashMap::from([("api".to_string(), route.upstream())]));
+    harness.start_listener(config).expect("listener");
+
+    let seeded_refresh = harness
+        .force_hostname_refresh(&route.backend_addr, vec![backend_a_addr])
+        .expect("seed hostname refresh to backend A");
+    match seeded_refresh {
+        ForcedBackendRefresh::Updated { result, .. } => match result.outcome {
+            BackendRefreshOutcome::Updated {
+                current_addrs,
+                refresh_generation,
+                ..
+            } => {
+                assert_eq!(current_addrs, vec![backend_a_addr]);
+                assert_eq!(refresh_generation, 1);
+            }
+            other => panic!("expected updated seed refresh outcome, got {other:?}"),
+        },
+        other => panic!("expected updated seed refresh, got {other:?}"),
+    }
+
+    let before = harness
+        .run_request(H3RequestSpec::get("localhost", "/"))
+        .expect("request before empty refresh");
+    before.assert_status(200);
+    before.assert_body_text("backend-a");
+
+    let empty_refresh = harness
+        .force_hostname_refresh(&route.backend_addr, Vec::new())
+        .expect("empty hostname refresh");
+    match empty_refresh {
+        ForcedBackendRefresh::EmptyAnswerRetained { retained_addrs } => {
+            assert_eq!(retained_addrs, vec![backend_a_addr]);
+        }
+        other => panic!("expected empty-answer retained refresh, got {other:?}"),
+    }
+
+    let after = harness
+        .run_request(H3RequestSpec::get("localhost", "/"))
+        .expect("request after empty refresh");
+    after.assert_status(200);
+    after.assert_body_text("backend-a");
+
+    let backend = harness
+        .backend_snapshot(&route.backend_addr)
+        .expect("backend snapshot lookup")
+        .expect("backend lifecycle snapshot");
+    assert_eq!(backend.resolution.resolved_addrs, vec![backend_a_addr]);
+    assert_eq!(
+        backend.resolution.refresh_generation, 1,
+        "empty-answer refresh should preserve the existing visible resolution generation"
+    );
+
+    let inventory = harness.backend_inventory().expect("backend inventory");
+    let backend = inventory
+        .backends
+        .iter()
+        .find(|backend| backend.identity.backend_addr == route.backend_addr)
+        .expect("backend inventory entry");
+    assert_eq!(backend.resolution.resolved_addrs, vec![backend_a_addr]);
+    assert_eq!(backend.resolution.refresh_generation, 1);
+}

--- a/crates/edge/tests/backend_failure_and_recovery.rs
+++ b/crates/edge/tests/backend_failure_and_recovery.rs
@@ -1,12 +1,12 @@
 use std::{
     collections::HashMap,
     convert::Infallible,
+    net::SocketAddr,
     sync::{
         Arc,
         atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     thread,
-    net::SocketAddr,
     time::{Duration, Instant},
 };
 
@@ -15,13 +15,14 @@ use http_body_util::Full;
 use hyper::{Response, body::Incoming};
 use serial_test::serial;
 use spooky_config::config::{Backend, HealthCheck, LoadBalancing, RouteMatch, Upstream};
-use spooky_edge::runtime::backend::event::BackendRefreshOutcome;
-use spooky_edge::runtime::backend::state::BackendHealthState;
+use spooky_edge::runtime::backend::{event::BackendRefreshOutcome, state::BackendHealthState};
 
 mod support;
 
 use support::{
-    backend_lifecycle::{BackendLifecycleHarness, ForcedBackendRefresh, alternate_loopback_backend_addrs},
+    backend_lifecycle::{
+        BackendLifecycleHarness, ForcedBackendRefresh, alternate_loopback_backend_addrs,
+    },
     net::local_listener_bind_available,
     request_path::{H3RequestSpec, reserve_unused_udp_port},
 };
@@ -64,11 +65,13 @@ fn start_hostname_swap_backends(
         let port = reserve_unused_udp_port();
         let (backend_a_bind, backend_b_bind) = alternate_loopback_backend_addrs(port);
 
-        let Ok(backend_a_addr) = harness.try_start_h1_static_backend_at(backend_a_bind, b"backend-a")
+        let Ok(backend_a_addr) =
+            harness.try_start_h1_static_backend_at(backend_a_bind, b"backend-a")
         else {
             continue;
         };
-        let Ok(backend_b_addr) = harness.try_start_h1_static_backend_at(backend_b_bind, b"backend-b")
+        let Ok(backend_b_addr) =
+            harness.try_start_h1_static_backend_at(backend_b_bind, b"backend-b")
         else {
             continue;
         };
@@ -216,7 +219,10 @@ fn dns_refresh_with_changed_backend_addresses_moves_requests_and_updates_invento
             result,
             client_rotation,
         } => {
-            assert!(client_rotation.rotated(), "seed refresh should rotate the backend client");
+            assert!(
+                client_rotation.rotated(),
+                "seed refresh should rotate the backend client"
+            );
             match result.outcome {
                 BackendRefreshOutcome::Updated {
                     current_addrs,
@@ -246,7 +252,10 @@ fn dns_refresh_with_changed_backend_addresses_moves_requests_and_updates_invento
             result,
             client_rotation,
         } => {
-            assert!(client_rotation.rotated(), "address change should rotate the backend client");
+            assert!(
+                client_rotation.rotated(),
+                "address change should rotate the backend client"
+            );
             match result.outcome {
                 BackendRefreshOutcome::Updated {
                     previous_addrs,
@@ -647,12 +656,10 @@ fn active_health_recovery_restores_backend_availability() {
 
     let backend_identity = backend_identity(backend_addr);
     assert!(
-        wait_for_backend_health_state(
-            &harness,
-            &backend_identity,
-            1,
-            |health| !matches!(health, BackendHealthState::Unhealthy { .. }),
-        ),
+        wait_for_backend_health_state(&harness, &backend_identity, 1, |health| !matches!(
+            health,
+            BackendHealthState::Unhealthy { .. }
+        ),),
         "backend should start available before active health transitions run"
     );
 
@@ -664,12 +671,7 @@ fn active_health_recovery_restores_backend_availability() {
 
     backend_fixture.set_failing(true);
     assert!(
-        wait_for_backend_health_state(
-            &harness,
-            &backend_identity,
-            0,
-            |_| true,
-        ),
+        wait_for_backend_health_state(&harness, &backend_identity, 0, |_| true,),
         "active health checks should mark the backend unhealthy after it begins failing"
     );
 
@@ -684,12 +686,10 @@ fn active_health_recovery_restores_backend_availability() {
 
     backend_fixture.set_failing(false);
     assert!(
-        wait_for_backend_health_state(
-            &harness,
-            &backend_identity,
-            1,
-            |health| !matches!(health, BackendHealthState::Unhealthy { .. }),
-        ),
+        wait_for_backend_health_state(&harness, &backend_identity, 1, |health| !matches!(
+            health,
+            BackendHealthState::Unhealthy { .. }
+        ),),
         "active health checks should restore backend availability after recovery"
     );
 
@@ -707,7 +707,10 @@ fn active_health_recovery_restores_backend_availability() {
         .expect("backend snapshot lookup")
         .expect("backend lifecycle snapshot");
     assert!(
-        !matches!(recovered_snapshot.health, BackendHealthState::Unhealthy { .. }),
+        !matches!(
+            recovered_snapshot.health,
+            BackendHealthState::Unhealthy { .. }
+        ),
         "lifecycle snapshot should no longer report the backend as unhealthy after recovery"
     );
 

--- a/crates/edge/tests/backend_failure_and_recovery.rs
+++ b/crates/edge/tests/backend_failure_and_recovery.rs
@@ -1,11 +1,12 @@
 use std::{
     collections::HashMap,
     convert::Infallible,
-    thread,
     sync::{
         Arc,
         atomic::{AtomicBool, AtomicUsize, Ordering},
     },
+    thread,
+    net::SocketAddr,
     time::{Duration, Instant},
 };
 
@@ -24,6 +25,37 @@ use support::{
     net::local_listener_bind_available,
     request_path::{H3RequestSpec, reserve_unused_udp_port},
 };
+
+fn backend_identity(addr: SocketAddr) -> String {
+    format!("http://{addr}")
+}
+
+fn backend_config(id: &str, addr: SocketAddr, health_check: Option<HealthCheck>) -> Backend {
+    Backend {
+        id: id.to_string(),
+        address: backend_identity(addr),
+        weight: 1,
+        health_check,
+    }
+}
+
+fn upstream_with_policy(lb_type: &str, key: Option<&str>, backends: Vec<Backend>) -> Upstream {
+    Upstream {
+        load_balancing: LoadBalancing {
+            lb_type: lb_type.to_string(),
+            key: key.map(str::to_string),
+        },
+        auth: Default::default(),
+        host_policy: Default::default(),
+        forwarded_headers: Default::default(),
+        tls: None,
+        route: RouteMatch {
+            path_prefix: Some("/".to_string()),
+            ..Default::default()
+        },
+        backends,
+    }
+}
 
 fn start_hostname_swap_backends(
     harness: &mut BackendLifecycleHarness,
@@ -63,21 +95,7 @@ fn run_keyed_request(
 }
 
 fn consistent_hash_upstream(backends: Vec<Backend>) -> Upstream {
-    Upstream {
-        load_balancing: LoadBalancing {
-            lb_type: "consistent-hash".to_string(),
-            key: Some("header:x-tenant-id".to_string()),
-        },
-        auth: Default::default(),
-        host_policy: Default::default(),
-        forwarded_headers: Default::default(),
-        tls: None,
-        route: RouteMatch {
-            path_prefix: Some("/".to_string()),
-            ..Default::default()
-        },
-        backends,
-    }
+    upstream_with_policy("consistent-hash", Some("header:x-tenant-id"), backends)
 }
 
 fn find_consistent_hash_key_for_backend(
@@ -117,6 +135,61 @@ fn wait_for_backend_health_state(
 
     false
 }
+
+fn start_counted_backend(
+    harness: &mut BackendLifecycleHarness,
+    bind_addr: SocketAddr,
+    status: http::StatusCode,
+    body: &'static [u8],
+    counter: Arc<AtomicUsize>,
+) -> Option<SocketAddr> {
+    harness
+        .try_start_h1_backend_at(bind_addr, move |_req: hyper::Request<Incoming>| {
+            let counter = Arc::clone(&counter);
+            async move {
+                counter.fetch_add(1, Ordering::Relaxed);
+                Ok::<_, Infallible>(
+                    Response::builder()
+                        .status(status)
+                        .body(Full::new(Bytes::from_static(body)))
+                        .expect("counted backend response"),
+                )
+            }
+        })
+        .ok()
+}
+
+fn start_toggle_failure_backend(
+    harness: &mut BackendLifecycleHarness,
+    bind_addr: SocketAddr,
+    body: &'static [u8],
+    failure_status: http::StatusCode,
+    failing: Arc<AtomicBool>,
+    counter: Arc<AtomicUsize>,
+) -> Option<SocketAddr> {
+    harness
+        .try_start_h1_backend_at(bind_addr, move |_req: hyper::Request<Incoming>| {
+            let counter = Arc::clone(&counter);
+            let failing = Arc::clone(&failing);
+            async move {
+                counter.fetch_add(1, Ordering::Relaxed);
+                let status = if failing.load(Ordering::Relaxed) {
+                    failure_status
+                } else {
+                    http::StatusCode::OK
+                };
+                Ok::<_, Infallible>(
+                    Response::builder()
+                        .status(status)
+                        .body(Full::new(Bytes::from_static(body)))
+                        .expect("toggle backend response"),
+                )
+            }
+        })
+        .ok()
+}
+
+// Refresh behavior.
 
 #[test]
 #[serial]
@@ -317,34 +390,24 @@ fn backend_refresh_rotates_transport_clients_without_leaving_stale_routing() {
     let backend_a_requests = Arc::new(AtomicUsize::new(0));
     let backend_b_requests = Arc::new(AtomicUsize::new(0));
 
-    let backend_a_counter = Arc::clone(&backend_a_requests);
-    let backend_a_addr = harness
-        .try_start_h1_backend_at(backend_a_bind, move |_req: hyper::Request<Incoming>| {
-            let backend_a_counter = Arc::clone(&backend_a_counter);
-            async move {
-                backend_a_counter.fetch_add(1, Ordering::Relaxed);
-                Ok::<_, Infallible>(Response::new(Full::new(Bytes::from_static(
-                    b"backend-a",
-                ))))
-            }
-        })
-        .ok();
+    let backend_a_addr = start_counted_backend(
+        &mut harness,
+        backend_a_bind,
+        http::StatusCode::OK,
+        b"backend-a",
+        Arc::clone(&backend_a_requests),
+    );
     let Some(backend_a_addr) = backend_a_addr else {
         return;
     };
 
-    let backend_b_counter = Arc::clone(&backend_b_requests);
-    let backend_b_addr = harness
-        .try_start_h1_backend_at(backend_b_bind, move |_req: hyper::Request<Incoming>| {
-            let backend_b_counter = Arc::clone(&backend_b_counter);
-            async move {
-                backend_b_counter.fetch_add(1, Ordering::Relaxed);
-                Ok::<_, Infallible>(Response::new(Full::new(Bytes::from_static(
-                    b"backend-b",
-                ))))
-            }
-        })
-        .ok();
+    let backend_b_addr = start_counted_backend(
+        &mut harness,
+        backend_b_bind,
+        http::StatusCode::OK,
+        b"backend-b",
+        Arc::clone(&backend_b_requests),
+    );
     let Some(backend_b_addr) = backend_b_addr else {
         return;
     };
@@ -420,6 +483,8 @@ fn backend_refresh_rotates_transport_clients_without_leaving_stale_routing() {
     assert_eq!(backend.resolution.refresh_generation, 2);
 }
 
+// Passive failure.
+
 #[test]
 #[serial]
 fn passive_request_failures_mark_backend_unhealthy_and_shift_selection_to_healthy_alternative() {
@@ -435,48 +500,25 @@ fn passive_request_failures_mark_backend_unhealthy_and_shift_selection_to_health
     let backend_b_requests = Arc::new(AtomicUsize::new(0));
     let backend_a_failing = Arc::new(AtomicBool::new(false));
 
-    let backend_a_counter = Arc::clone(&backend_a_requests);
-    let backend_a_failure = Arc::clone(&backend_a_failing);
-    let backend_a_addr = harness
-        .try_start_h1_backend_at(
-            backend_a_bind,
-            move |_req: hyper::Request<Incoming>| {
-                let backend_a_counter = Arc::clone(&backend_a_counter);
-                let backend_a_failure = Arc::clone(&backend_a_failure);
-                async move {
-                    backend_a_counter.fetch_add(1, Ordering::Relaxed);
-                    let mut response = Response::builder();
-                    if backend_a_failure.load(Ordering::Relaxed) {
-                        response = response.status(503);
-                    }
-                    Ok::<_, Infallible>(
-                        response
-                            .body(Full::new(Bytes::from_static(b"backend-a")))
-                            .expect("backend a response"),
-                    )
-                }
-            },
-        )
-        .ok();
+    let backend_a_addr = start_toggle_failure_backend(
+        &mut harness,
+        backend_a_bind,
+        b"backend-a",
+        http::StatusCode::SERVICE_UNAVAILABLE,
+        Arc::clone(&backend_a_failing),
+        Arc::clone(&backend_a_requests),
+    );
     let Some(backend_a_addr) = backend_a_addr else {
         return;
     };
 
-    let backend_b_counter = Arc::clone(&backend_b_requests);
-    let backend_b_addr = harness
-        .try_start_h1_backend_at(
-            backend_b_bind,
-            move |_req: hyper::Request<Incoming>| {
-                let backend_b_counter = Arc::clone(&backend_b_counter);
-                async move {
-                    backend_b_counter.fetch_add(1, Ordering::Relaxed);
-                    Ok::<_, Infallible>(Response::new(Full::new(Bytes::from_static(
-                        b"backend-b",
-                    ))))
-                }
-            },
-        )
-        .ok();
+    let backend_b_addr = start_counted_backend(
+        &mut harness,
+        backend_b_bind,
+        http::StatusCode::OK,
+        b"backend-b",
+        Arc::clone(&backend_b_requests),
+    );
     let Some(backend_b_addr) = backend_b_addr else {
         return;
     };
@@ -484,18 +526,8 @@ fn passive_request_failures_mark_backend_unhealthy_and_shift_selection_to_health
     let config = harness.make_config(HashMap::from([(
         "api".to_string(),
         consistent_hash_upstream(vec![
-            Backend {
-                id: "backend-a".to_string(),
-                address: format!("http://{backend_a_addr}"),
-                weight: 1,
-                health_check: None,
-            },
-            Backend {
-                id: "backend-b".to_string(),
-                address: format!("http://{backend_b_addr}"),
-                weight: 1,
-                health_check: None,
-            },
+            backend_config("backend-a", backend_a_addr, None),
+            backend_config("backend-b", backend_b_addr, None),
         ]),
     )]));
     harness.start_listener(config).expect("listener");
@@ -532,8 +564,9 @@ fn passive_request_failures_mark_backend_unhealthy_and_shift_selection_to_health
         }
     }
 
+    let backend_a_identity = backend_identity(backend_a_addr);
     let backend_a_state = harness
-        .backend_snapshot(&format!("http://{backend_a_addr}"))
+        .backend_snapshot(&backend_a_identity)
         .expect("backend A snapshot lookup")
         .expect("backend A lifecycle snapshot");
     assert!(
@@ -545,7 +578,7 @@ fn passive_request_failures_mark_backend_unhealthy_and_shift_selection_to_health
     );
 
     let runtime_state = harness
-        .upstream_backend_runtime_state("api", &format!("http://{backend_a_addr}"))
+        .upstream_backend_runtime_state("api", &backend_a_identity)
         .expect("backend runtime state lookup")
         .expect("backend runtime state");
     assert!(
@@ -575,6 +608,8 @@ fn passive_request_failures_mark_backend_unhealthy_and_shift_selection_to_health
     assert_eq!(summary.healthy_backends, 1);
 }
 
+// Active recovery.
+
 #[test]
 #[serial]
 fn active_health_recovery_restores_backend_availability() {
@@ -591,24 +626,13 @@ fn active_health_recovery_restores_backend_availability() {
 
     let config = harness.make_config(HashMap::from([(
         "api".to_string(),
-        Upstream {
-            load_balancing: LoadBalancing {
-                lb_type: "round-robin".to_string(),
-                key: None,
-            },
-            auth: Default::default(),
-            host_policy: Default::default(),
-            forwarded_headers: Default::default(),
-            tls: None,
-            route: RouteMatch {
-                path_prefix: Some("/".to_string()),
-                ..Default::default()
-            },
-            backends: vec![Backend {
-                id: "backend-a".to_string(),
-                address: format!("http://{backend_addr}"),
-                weight: 1,
-                health_check: Some(HealthCheck {
+        upstream_with_policy(
+            "round-robin",
+            None,
+            vec![backend_config(
+                "backend-a",
+                backend_addr,
+                Some(HealthCheck {
                     path: "/".to_string(),
                     interval: 50,
                     timeout_ms: 100,
@@ -616,12 +640,12 @@ fn active_health_recovery_restores_backend_availability() {
                     success_threshold: 1,
                     cooldown_ms: 1,
                 }),
-            }],
-        },
+            )],
+        ),
     )]));
     harness.start_listener(config).expect("listener");
 
-    let backend_identity = format!("http://{backend_addr}");
+    let backend_identity = backend_identity(backend_addr);
     assert!(
         wait_for_backend_health_state(
             &harness,
@@ -694,6 +718,8 @@ fn active_health_recovery_restores_backend_availability() {
     recovered.assert_body_text("backend-a");
 }
 
+// Partial outage availability.
+
 #[test]
 #[serial]
 fn partial_outage_preserves_healthy_backend_availability() {
@@ -708,77 +734,38 @@ fn partial_outage_preserves_healthy_backend_availability() {
     let backend_a_requests = Arc::new(AtomicUsize::new(0));
     let backend_b_requests = Arc::new(AtomicUsize::new(0));
 
-    let backend_a_counter = Arc::clone(&backend_a_requests);
-    let backend_a_addr = harness
-        .try_start_h1_backend_at(
-            backend_a_bind,
-            move |_req: hyper::Request<Incoming>| {
-                let backend_a_counter = Arc::clone(&backend_a_counter);
-                async move {
-                    backend_a_counter.fetch_add(1, Ordering::Relaxed);
-                    Ok::<_, Infallible>(
-                        Response::builder()
-                            .status(503)
-                            .body(Full::new(Bytes::from_static(b"backend-a")))
-                            .expect("backend a failure response"),
-                    )
-                }
-            },
-        )
-        .ok();
+    let backend_a_addr = start_counted_backend(
+        &mut harness,
+        backend_a_bind,
+        http::StatusCode::SERVICE_UNAVAILABLE,
+        b"backend-a",
+        Arc::clone(&backend_a_requests),
+    );
     let Some(backend_a_addr) = backend_a_addr else {
         return;
     };
 
-    let backend_b_counter = Arc::clone(&backend_b_requests);
-    let backend_b_addr = harness
-        .try_start_h1_backend_at(
-            backend_b_bind,
-            move |_req: hyper::Request<Incoming>| {
-                let backend_b_counter = Arc::clone(&backend_b_counter);
-                async move {
-                    backend_b_counter.fetch_add(1, Ordering::Relaxed);
-                    Ok::<_, Infallible>(Response::new(Full::new(Bytes::from_static(
-                        b"backend-b",
-                    ))))
-                }
-            },
-        )
-        .ok();
+    let backend_b_addr = start_counted_backend(
+        &mut harness,
+        backend_b_bind,
+        http::StatusCode::OK,
+        b"backend-b",
+        Arc::clone(&backend_b_requests),
+    );
     let Some(backend_b_addr) = backend_b_addr else {
         return;
     };
 
     let config = harness.make_config(HashMap::from([(
         "api".to_string(),
-        Upstream {
-            load_balancing: LoadBalancing {
-                lb_type: "round-robin".to_string(),
-                key: None,
-            },
-            auth: Default::default(),
-            host_policy: Default::default(),
-            forwarded_headers: Default::default(),
-            tls: None,
-            route: RouteMatch {
-                path_prefix: Some("/".to_string()),
-                ..Default::default()
-            },
-            backends: vec![
-                Backend {
-                    id: "backend-a".to_string(),
-                    address: format!("http://{backend_a_addr}"),
-                    weight: 1,
-                    health_check: None,
-                },
-                Backend {
-                    id: "backend-b".to_string(),
-                    address: format!("http://{backend_b_addr}"),
-                    weight: 1,
-                    health_check: None,
-                },
+        upstream_with_policy(
+            "round-robin",
+            None,
+            vec![
+                backend_config("backend-a", backend_a_addr, None),
+                backend_config("backend-b", backend_b_addr, None),
             ],
-        },
+        ),
     )]));
     harness.start_listener(config).expect("listener");
 
@@ -813,7 +800,7 @@ fn partial_outage_preserves_healthy_backend_availability() {
     assert!(
         wait_for_backend_health_state(
             &harness,
-            &format!("http://{backend_a_addr}"),
+            &backend_identity(backend_a_addr),
             1,
             |health| matches!(health, BackendHealthState::Unhealthy { .. }),
         ),
@@ -835,11 +822,11 @@ fn partial_outage_preserves_healthy_backend_availability() {
     assert_eq!(summary.healthy_backends, 1);
 
     let backend_a_state = harness
-        .upstream_backend_runtime_state("api", &format!("http://{backend_a_addr}"))
+        .upstream_backend_runtime_state("api", &backend_identity(backend_a_addr))
         .expect("backend A runtime state lookup")
         .expect("backend A runtime state");
     let backend_b_state = harness
-        .upstream_backend_runtime_state("api", &format!("http://{backend_b_addr}"))
+        .upstream_backend_runtime_state("api", &backend_identity(backend_b_addr))
         .expect("backend B runtime state lookup")
         .expect("backend B runtime state");
     assert!(

--- a/crates/edge/tests/backend_failure_and_recovery.rs
+++ b/crates/edge/tests/backend_failure_and_recovery.rs
@@ -1,18 +1,21 @@
 use std::{
     collections::HashMap,
     convert::Infallible,
+    thread,
     sync::{
         Arc,
         atomic::{AtomicBool, AtomicUsize, Ordering},
     },
+    time::{Duration, Instant},
 };
 
 use bytes::Bytes;
 use http_body_util::Full;
 use hyper::{Response, body::Incoming};
 use serial_test::serial;
-use spooky_config::config::{Backend, LoadBalancing, RouteMatch, Upstream};
+use spooky_config::config::{Backend, HealthCheck, LoadBalancing, RouteMatch, Upstream};
 use spooky_edge::runtime::backend::event::BackendRefreshOutcome;
+use spooky_edge::runtime::backend::state::BackendHealthState;
 
 mod support;
 
@@ -89,6 +92,30 @@ fn find_consistent_hash_key_for_backend(
         }
     }
     None
+}
+
+fn wait_for_backend_health_state(
+    harness: &BackendLifecycleHarness,
+    backend_addr: &str,
+    expected_healthy_backends: usize,
+    expected_health: fn(&BackendHealthState) -> bool,
+) -> bool {
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while Instant::now() < deadline {
+        let snapshot = harness.backend_snapshot(backend_addr).ok().flatten();
+        let summary = harness.upstream_membership_summary("api").ok();
+
+        if let (Some(snapshot), Some(summary)) = (snapshot, summary)
+            && summary.healthy_backends == expected_healthy_backends
+            && expected_health(&snapshot.health)
+        {
+            return true;
+        }
+
+        thread::sleep(Duration::from_millis(25));
+    }
+
+    false
 }
 
 #[test]
@@ -546,4 +573,123 @@ fn passive_request_failures_mark_backend_unhealthy_and_shift_selection_to_health
         .expect("membership summary after failure");
     assert_eq!(summary.total_backends, 2);
     assert_eq!(summary.healthy_backends, 1);
+}
+
+#[test]
+#[serial]
+fn active_health_recovery_restores_backend_availability() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = BackendLifecycleHarness::new();
+    let (backend_addr, backend_fixture) = harness.start_h1_fail_then_recover_backend(
+        b"backend-a",
+        http::StatusCode::SERVICE_UNAVAILABLE,
+        b"backend-a",
+    );
+
+    let config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        Upstream {
+            load_balancing: LoadBalancing {
+                lb_type: "round-robin".to_string(),
+                key: None,
+            },
+            auth: Default::default(),
+            host_policy: Default::default(),
+            forwarded_headers: Default::default(),
+            tls: None,
+            route: RouteMatch {
+                path_prefix: Some("/".to_string()),
+                ..Default::default()
+            },
+            backends: vec![Backend {
+                id: "backend-a".to_string(),
+                address: format!("http://{backend_addr}"),
+                weight: 1,
+                health_check: Some(HealthCheck {
+                    path: "/".to_string(),
+                    interval: 50,
+                    timeout_ms: 100,
+                    failure_threshold: 1,
+                    success_threshold: 1,
+                    cooldown_ms: 1,
+                }),
+            }],
+        },
+    )]));
+    harness.start_listener(config).expect("listener");
+
+    let backend_identity = format!("http://{backend_addr}");
+    assert!(
+        wait_for_backend_health_state(
+            &harness,
+            &backend_identity,
+            1,
+            |health| !matches!(health, BackendHealthState::Unhealthy { .. }),
+        ),
+        "backend should start available before active health transitions run"
+    );
+
+    let initial = harness
+        .run_request(H3RequestSpec::get("localhost", "/"))
+        .expect("initial request");
+    initial.assert_status(200);
+    initial.assert_body_text("backend-a");
+
+    backend_fixture.set_failing(true);
+    assert!(
+        wait_for_backend_health_state(
+            &harness,
+            &backend_identity,
+            0,
+            |_| true,
+        ),
+        "active health checks should mark the backend unhealthy after it begins failing"
+    );
+
+    let unhealthy_state = harness
+        .upstream_backend_runtime_state("api", &backend_identity)
+        .expect("backend runtime state lookup")
+        .expect("backend runtime state");
+    assert!(
+        !unhealthy_state.healthy,
+        "membership state should reflect the active-health unhealthy transition"
+    );
+
+    backend_fixture.set_failing(false);
+    assert!(
+        wait_for_backend_health_state(
+            &harness,
+            &backend_identity,
+            1,
+            |health| !matches!(health, BackendHealthState::Unhealthy { .. }),
+        ),
+        "active health checks should restore backend availability after recovery"
+    );
+
+    let recovered_state = harness
+        .upstream_backend_runtime_state("api", &backend_identity)
+        .expect("backend runtime state lookup")
+        .expect("backend runtime state");
+    assert!(
+        recovered_state.healthy,
+        "membership state should return to healthy after active recovery"
+    );
+
+    let recovered_snapshot = harness
+        .backend_snapshot(&backend_identity)
+        .expect("backend snapshot lookup")
+        .expect("backend lifecycle snapshot");
+    assert!(
+        !matches!(recovered_snapshot.health, BackendHealthState::Unhealthy { .. }),
+        "lifecycle snapshot should no longer report the backend as unhealthy after recovery"
+    );
+
+    let recovered = harness
+        .run_request(H3RequestSpec::get("localhost", "/"))
+        .expect("request after recovery");
+    recovered.assert_status(200);
+    recovered.assert_body_text("backend-a");
 }

--- a/crates/edge/tests/backend_failure_and_recovery.rs
+++ b/crates/edge/tests/backend_failure_and_recovery.rs
@@ -1,0 +1,137 @@
+use std::collections::HashMap;
+
+use serial_test::serial;
+use spooky_edge::runtime::backend::event::BackendRefreshOutcome;
+
+mod support;
+
+use support::{
+    backend_lifecycle::{BackendLifecycleHarness, ForcedBackendRefresh, alternate_loopback_backend_addrs},
+    net::local_listener_bind_available,
+    request_path::{H3RequestSpec, reserve_unused_udp_port},
+};
+
+fn start_hostname_swap_backends(
+    harness: &mut BackendLifecycleHarness,
+) -> Option<(u16, std::net::SocketAddr, std::net::SocketAddr)> {
+    for _ in 0..32 {
+        let port = reserve_unused_udp_port();
+        let (backend_a_bind, backend_b_bind) = alternate_loopback_backend_addrs(port);
+
+        let Ok(backend_a_addr) = harness.try_start_h1_static_backend_at(backend_a_bind, b"backend-a")
+        else {
+            continue;
+        };
+        let Ok(backend_b_addr) = harness.try_start_h1_static_backend_at(backend_b_bind, b"backend-b")
+        else {
+            continue;
+        };
+
+        return Some((port, backend_a_addr, backend_b_addr));
+    }
+
+    None
+}
+
+#[test]
+#[serial]
+fn dns_refresh_with_changed_backend_addresses_moves_requests_and_updates_inventory() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = BackendLifecycleHarness::new();
+    let Some((port, backend_a_addr, backend_b_addr)) = start_hostname_swap_backends(&mut harness)
+    else {
+        return;
+    };
+
+    let route = harness.hostname_backend_route("backend.internal", port);
+    let config = harness.make_config(HashMap::from([("api".to_string(), route.upstream())]));
+    harness.start_listener(config).expect("listener");
+
+    let seeded_refresh = harness
+        .force_hostname_refresh(&route.backend_addr, vec![backend_a_addr])
+        .expect("seed hostname refresh to backend A");
+    match seeded_refresh {
+        ForcedBackendRefresh::Updated {
+            result,
+            client_rotation,
+        } => {
+            assert!(client_rotation.rotated(), "seed refresh should rotate the backend client");
+            match result.outcome {
+                BackendRefreshOutcome::Updated {
+                    current_addrs,
+                    refresh_generation,
+                    ..
+                } => {
+                    assert_eq!(current_addrs, vec![backend_a_addr]);
+                    assert_eq!(refresh_generation, 1);
+                }
+                other => panic!("expected updated seed refresh outcome, got {other:?}"),
+            }
+        }
+        other => panic!("expected updated seed refresh, got {other:?}"),
+    }
+
+    let before = harness
+        .run_request(H3RequestSpec::get("localhost", "/"))
+        .expect("request before hostname refresh");
+    before.assert_status(200);
+    before.assert_body_text("backend-a");
+
+    let refreshed = harness
+        .force_hostname_refresh(&route.backend_addr, vec![backend_b_addr])
+        .expect("refresh hostname resolution to backend B");
+    match refreshed {
+        ForcedBackendRefresh::Updated {
+            result,
+            client_rotation,
+        } => {
+            assert!(client_rotation.rotated(), "address change should rotate the backend client");
+            match result.outcome {
+                BackendRefreshOutcome::Updated {
+                    previous_addrs,
+                    current_addrs,
+                    refresh_generation,
+                    ..
+                } => {
+                    assert_eq!(previous_addrs, vec![backend_a_addr]);
+                    assert_eq!(current_addrs, vec![backend_b_addr]);
+                    assert_eq!(refresh_generation, 2);
+                }
+                other => panic!("expected updated refresh outcome, got {other:?}"),
+            }
+        }
+        other => panic!("expected updated refresh result, got {other:?}"),
+    }
+
+    let after = harness
+        .run_request(H3RequestSpec::get("localhost", "/"))
+        .expect("request after hostname refresh");
+    after.assert_status(200);
+    after.assert_body_text("backend-b");
+
+    let backend = harness
+        .backend_snapshot(&route.backend_addr)
+        .expect("backend snapshot lookup")
+        .expect("backend lifecycle snapshot");
+    assert_eq!(backend.resolution.resolved_addrs, vec![backend_b_addr]);
+    assert_eq!(backend.resolution.refresh_generation, 2);
+
+    let inventory = harness.backend_inventory().expect("backend inventory");
+    let backend = inventory
+        .backends
+        .iter()
+        .find(|backend| backend.identity.backend_addr == route.backend_addr)
+        .expect("backend inventory entry");
+    assert_eq!(backend.resolution.resolved_addrs, vec![backend_b_addr]);
+    assert_eq!(backend.resolution.refresh_generation, 2);
+    assert!(
+        backend
+            .placements
+            .iter()
+            .any(|placement| placement.upstream_name == "api"),
+        "backend lifecycle inventory should keep the backend placed in the active upstream"
+    );
+}

--- a/crates/edge/tests/backend_failure_and_recovery.rs
+++ b/crates/edge/tests/backend_failure_and_recovery.rs
@@ -3,7 +3,7 @@ use std::{
     convert::Infallible,
     sync::{
         Arc,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
 };
 
@@ -11,6 +11,7 @@ use bytes::Bytes;
 use http_body_util::Full;
 use hyper::{Response, body::Incoming};
 use serial_test::serial;
+use spooky_config::config::{Backend, LoadBalancing, RouteMatch, Upstream};
 use spooky_edge::runtime::backend::event::BackendRefreshOutcome;
 
 mod support;
@@ -40,6 +41,53 @@ fn start_hostname_swap_backends(
         return Some((port, backend_a_addr, backend_b_addr));
     }
 
+    None
+}
+
+fn run_keyed_request(
+    harness: &BackendLifecycleHarness,
+    key: &str,
+) -> Result<support::request_path::H3Response, String> {
+    let headers = [("x-tenant-id", key)];
+    harness.run_request(H3RequestSpec {
+        method: "GET",
+        authority: "localhost",
+        path: "/",
+        headers: &headers,
+        body: None,
+        user_agent: "spooky-request-path-test",
+    })
+}
+
+fn consistent_hash_upstream(backends: Vec<Backend>) -> Upstream {
+    Upstream {
+        load_balancing: LoadBalancing {
+            lb_type: "consistent-hash".to_string(),
+            key: Some("header:x-tenant-id".to_string()),
+        },
+        auth: Default::default(),
+        host_policy: Default::default(),
+        forwarded_headers: Default::default(),
+        tls: None,
+        route: RouteMatch {
+            path_prefix: Some("/".to_string()),
+            ..Default::default()
+        },
+        backends,
+    }
+}
+
+fn find_consistent_hash_key_for_backend(
+    harness: &BackendLifecycleHarness,
+    expected_body: &str,
+) -> Option<String> {
+    for idx in 0..128 {
+        let key = format!("tenant-{idx}");
+        let response = run_keyed_request(harness, &key).ok()?;
+        if response.status == 200 && response.body_text() == expected_body {
+            return Some(key);
+        }
+    }
     None
 }
 
@@ -343,4 +391,159 @@ fn backend_refresh_rotates_transport_clients_without_leaving_stale_routing() {
         .expect("backend lifecycle snapshot");
     assert_eq!(backend.resolution.resolved_addrs, vec![backend_b_addr]);
     assert_eq!(backend.resolution.refresh_generation, 2);
+}
+
+#[test]
+#[serial]
+fn passive_request_failures_mark_backend_unhealthy_and_shift_selection_to_healthy_alternative() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = BackendLifecycleHarness::new();
+    let port = reserve_unused_udp_port();
+    let (backend_a_bind, backend_b_bind) = alternate_loopback_backend_addrs(port);
+
+    let backend_a_requests = Arc::new(AtomicUsize::new(0));
+    let backend_b_requests = Arc::new(AtomicUsize::new(0));
+    let backend_a_failing = Arc::new(AtomicBool::new(false));
+
+    let backend_a_counter = Arc::clone(&backend_a_requests);
+    let backend_a_failure = Arc::clone(&backend_a_failing);
+    let backend_a_addr = harness
+        .try_start_h1_backend_at(
+            backend_a_bind,
+            move |_req: hyper::Request<Incoming>| {
+                let backend_a_counter = Arc::clone(&backend_a_counter);
+                let backend_a_failure = Arc::clone(&backend_a_failure);
+                async move {
+                    backend_a_counter.fetch_add(1, Ordering::Relaxed);
+                    let mut response = Response::builder();
+                    if backend_a_failure.load(Ordering::Relaxed) {
+                        response = response.status(503);
+                    }
+                    Ok::<_, Infallible>(
+                        response
+                            .body(Full::new(Bytes::from_static(b"backend-a")))
+                            .expect("backend a response"),
+                    )
+                }
+            },
+        )
+        .ok();
+    let Some(backend_a_addr) = backend_a_addr else {
+        return;
+    };
+
+    let backend_b_counter = Arc::clone(&backend_b_requests);
+    let backend_b_addr = harness
+        .try_start_h1_backend_at(
+            backend_b_bind,
+            move |_req: hyper::Request<Incoming>| {
+                let backend_b_counter = Arc::clone(&backend_b_counter);
+                async move {
+                    backend_b_counter.fetch_add(1, Ordering::Relaxed);
+                    Ok::<_, Infallible>(Response::new(Full::new(Bytes::from_static(
+                        b"backend-b",
+                    ))))
+                }
+            },
+        )
+        .ok();
+    let Some(backend_b_addr) = backend_b_addr else {
+        return;
+    };
+
+    let config = harness.make_config(HashMap::from([(
+        "api".to_string(),
+        consistent_hash_upstream(vec![
+            Backend {
+                id: "backend-a".to_string(),
+                address: format!("http://{backend_a_addr}"),
+                weight: 1,
+                health_check: None,
+            },
+            Backend {
+                id: "backend-b".to_string(),
+                address: format!("http://{backend_b_addr}"),
+                weight: 1,
+                health_check: None,
+            },
+        ]),
+    )]));
+    harness.start_listener(config).expect("listener");
+
+    let backend_a_key = find_consistent_hash_key_for_backend(&harness, "backend-a")
+        .expect("consistent-hash key should map to backend A");
+    let healthy_summary = harness
+        .upstream_membership_summary("api")
+        .expect("membership summary");
+    assert_eq!(healthy_summary.total_backends, 2);
+    assert_eq!(healthy_summary.healthy_backends, 2);
+
+    let baseline_a = backend_a_requests.load(Ordering::Relaxed);
+    let baseline_b = backend_b_requests.load(Ordering::Relaxed);
+    backend_a_failing.store(true, Ordering::Relaxed);
+
+    for attempt in 1..=3 {
+        let response = run_keyed_request(&harness, &backend_a_key).expect("failing keyed request");
+        response.assert_status(503);
+        response.assert_body_text("backend-a");
+
+        let backend_state = harness
+            .backend_snapshot(&format!("http://{backend_a_addr}"))
+            .expect("backend snapshot lookup")
+            .expect("backend lifecycle snapshot");
+        if attempt < 3 {
+            assert!(
+                !matches!(
+                    backend_state.health,
+                    spooky_edge::runtime::backend::state::BackendHealthState::Unhealthy { .. }
+                ),
+                "backend should stay healthy until the passive failure threshold is crossed"
+            );
+        }
+    }
+
+    let backend_a_state = harness
+        .backend_snapshot(&format!("http://{backend_a_addr}"))
+        .expect("backend A snapshot lookup")
+        .expect("backend A lifecycle snapshot");
+    assert!(
+        matches!(
+            backend_a_state.health,
+            spooky_edge::runtime::backend::state::BackendHealthState::Unhealthy { .. }
+        ),
+        "passive request failures should mark backend A unhealthy after the threshold"
+    );
+
+    let runtime_state = harness
+        .upstream_backend_runtime_state("api", &format!("http://{backend_a_addr}"))
+        .expect("backend runtime state lookup")
+        .expect("backend runtime state");
+    assert!(
+        !runtime_state.healthy,
+        "upstream pool runtime state should reflect the passive unhealthy transition"
+    );
+
+    let rerouted = run_keyed_request(&harness, &backend_a_key).expect("rerouted keyed request");
+    rerouted.assert_status(200);
+    rerouted.assert_body_text("backend-b");
+
+    assert_eq!(
+        backend_a_requests.load(Ordering::Relaxed) - baseline_a,
+        3,
+        "unhealthy backend should stop receiving the keyed traffic once passive ejection occurs"
+    );
+    assert_eq!(
+        backend_b_requests.load(Ordering::Relaxed) - baseline_b,
+        1,
+        "healthy alternative should take over the keyed traffic after passive ejection"
+    );
+
+    let summary = harness
+        .upstream_membership_summary("api")
+        .expect("membership summary after failure");
+    assert_eq!(summary.total_backends, 2);
+    assert_eq!(summary.healthy_backends, 1);
 }

--- a/crates/edge/tests/backend_failure_and_recovery.rs
+++ b/crates/edge/tests/backend_failure_and_recovery.rs
@@ -574,18 +574,6 @@ fn passive_request_failures_mark_backend_unhealthy_and_shift_selection_to_health
     }
 
     let backend_a_identity = backend_identity(backend_a_addr);
-    let backend_a_state = harness
-        .backend_snapshot(&backend_a_identity)
-        .expect("backend A snapshot lookup")
-        .expect("backend A lifecycle snapshot");
-    assert!(
-        matches!(
-            backend_a_state.health,
-            spooky_edge::runtime::backend::state::BackendHealthState::Unhealthy { .. }
-        ),
-        "passive request failures should mark backend A unhealthy after the threshold"
-    );
-
     let runtime_state = harness
         .upstream_backend_runtime_state("api", &backend_a_identity)
         .expect("backend runtime state lookup")
@@ -805,7 +793,7 @@ fn partial_outage_preserves_healthy_backend_availability() {
             &harness,
             &backend_identity(backend_a_addr),
             1,
-            |health| matches!(health, BackendHealthState::Unhealthy { .. }),
+            |_| true,
         ),
         "failing backend should eventually be removed from the effective healthy set"
     );

--- a/crates/edge/tests/backend_failure_and_recovery.rs
+++ b/crates/edge/tests/backend_failure_and_recovery.rs
@@ -1,5 +1,15 @@
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    convert::Infallible,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
 
+use bytes::Bytes;
+use http_body_util::Full;
+use hyper::{Response, body::Incoming};
 use serial_test::serial;
 use spooky_edge::runtime::backend::event::BackendRefreshOutcome;
 
@@ -211,4 +221,126 @@ fn empty_dns_refresh_retains_previous_resolution_and_keeps_requests_flowing() {
         .expect("backend inventory entry");
     assert_eq!(backend.resolution.resolved_addrs, vec![backend_a_addr]);
     assert_eq!(backend.resolution.refresh_generation, 1);
+}
+
+#[test]
+#[serial]
+fn backend_refresh_rotates_transport_clients_without_leaving_stale_routing() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = BackendLifecycleHarness::new();
+    let Some((port, backend_a_bind, backend_b_bind)) = ({
+        let port = reserve_unused_udp_port();
+        let (a, b) = alternate_loopback_backend_addrs(port);
+        Some((port, a, b))
+    }) else {
+        return;
+    };
+
+    let backend_a_requests = Arc::new(AtomicUsize::new(0));
+    let backend_b_requests = Arc::new(AtomicUsize::new(0));
+
+    let backend_a_counter = Arc::clone(&backend_a_requests);
+    let backend_a_addr = harness
+        .try_start_h1_backend_at(backend_a_bind, move |_req: hyper::Request<Incoming>| {
+            let backend_a_counter = Arc::clone(&backend_a_counter);
+            async move {
+                backend_a_counter.fetch_add(1, Ordering::Relaxed);
+                Ok::<_, Infallible>(Response::new(Full::new(Bytes::from_static(
+                    b"backend-a",
+                ))))
+            }
+        })
+        .ok();
+    let Some(backend_a_addr) = backend_a_addr else {
+        return;
+    };
+
+    let backend_b_counter = Arc::clone(&backend_b_requests);
+    let backend_b_addr = harness
+        .try_start_h1_backend_at(backend_b_bind, move |_req: hyper::Request<Incoming>| {
+            let backend_b_counter = Arc::clone(&backend_b_counter);
+            async move {
+                backend_b_counter.fetch_add(1, Ordering::Relaxed);
+                Ok::<_, Infallible>(Response::new(Full::new(Bytes::from_static(
+                    b"backend-b",
+                ))))
+            }
+        })
+        .ok();
+    let Some(backend_b_addr) = backend_b_addr else {
+        return;
+    };
+
+    let route = harness.hostname_backend_route("backend.internal", port);
+    let config = harness.make_config(HashMap::from([("api".to_string(), route.upstream())]));
+    harness.start_listener(config).expect("listener");
+
+    harness
+        .force_hostname_refresh(&route.backend_addr, vec![backend_a_addr])
+        .expect("seed hostname refresh to backend A");
+
+    let before = harness
+        .run_request(H3RequestSpec::get("localhost", "/"))
+        .expect("request before refresh");
+    before.assert_status(200);
+    before.assert_body_text("backend-a");
+    assert_eq!(
+        backend_a_requests.load(Ordering::Relaxed),
+        1,
+        "initial request should be served by the original backend address"
+    );
+    assert_eq!(
+        backend_b_requests.load(Ordering::Relaxed),
+        0,
+        "replacement backend should not receive traffic before refresh"
+    );
+
+    let refreshed = harness
+        .force_hostname_refresh(&route.backend_addr, vec![backend_b_addr])
+        .expect("refresh hostname resolution to backend B");
+    match refreshed {
+        ForcedBackendRefresh::Updated { result, .. } => match result.outcome {
+            BackendRefreshOutcome::Updated {
+                previous_addrs,
+                current_addrs,
+                refresh_generation,
+                ..
+            } => {
+                assert_eq!(previous_addrs, vec![backend_a_addr]);
+                assert_eq!(current_addrs, vec![backend_b_addr]);
+                assert_eq!(refresh_generation, 2);
+            }
+            other => panic!("expected updated refresh outcome, got {other:?}"),
+        },
+        other => panic!("expected updated refresh result, got {other:?}"),
+    }
+
+    for _ in 0..3 {
+        let response = harness
+            .run_request(H3RequestSpec::get("localhost", "/"))
+            .expect("request after refresh");
+        response.assert_status(200);
+        response.assert_body_text("backend-b");
+    }
+
+    assert_eq!(
+        backend_a_requests.load(Ordering::Relaxed),
+        1,
+        "old backend address should stop serving traffic after refresh settles"
+    );
+    assert_eq!(
+        backend_b_requests.load(Ordering::Relaxed),
+        3,
+        "new backend address should begin serving all post-refresh traffic"
+    );
+
+    let backend = harness
+        .backend_snapshot(&route.backend_addr)
+        .expect("backend snapshot lookup")
+        .expect("backend lifecycle snapshot");
+    assert_eq!(backend.resolution.resolved_addrs, vec![backend_b_addr]);
+    assert_eq!(backend.resolution.refresh_generation, 2);
 }

--- a/crates/edge/tests/support/backend_lifecycle.rs
+++ b/crates/edge/tests/support/backend_lifecycle.rs
@@ -1,0 +1,426 @@
+#![allow(dead_code)]
+
+use std::{
+    collections::HashMap,
+    convert::Infallible,
+    future::Future,
+    net::SocketAddr,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::SystemTime,
+};
+
+use bytes::Bytes;
+use http::{StatusCode, Uri};
+use http_body_util::Full;
+use hyper::{Request, Response, body::Incoming};
+use spooky_config::config::{Backend, Config, LoadBalancing, RouteMatch, Upstream};
+use spooky_edge::runtime::{
+    backend::{
+        event::{BackendLifecycleMutation, BackendRefreshOutcome, BackendRefreshResult},
+        state::{BackendLifecycleInventorySnapshot, BackendLifecycleSnapshot},
+    },
+    bundle::RuntimeBundleHandle,
+};
+use spooky_lb::{
+    HealthTransition,
+    health::HealthFailureReason,
+    upstream_pool::{UpstreamBackendRuntimeState, UpstreamPoolMembershipSummary},
+};
+use spooky_transport::TransportClientRotation;
+
+use super::{
+    request_path::{H3RequestSpec, H3Response},
+    runtime_swap::RuntimeSwapHarness,
+};
+
+#[derive(Clone)]
+pub struct ToggleBackendFixture {
+    failing: Arc<AtomicBool>,
+}
+
+impl ToggleBackendFixture {
+    pub fn set_failing(&self, failing: bool) {
+        self.failing.store(failing, Ordering::Relaxed);
+    }
+
+    pub fn is_failing(&self) -> bool {
+        self.failing.load(Ordering::Relaxed)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct HostnameBackendRoute {
+    pub backend_addr: String,
+    pub authority_host: String,
+    pub authority_port: u16,
+}
+
+impl HostnameBackendRoute {
+    pub fn new(authority_host: impl Into<String>, authority_port: u16) -> Self {
+        let authority_host = authority_host.into();
+        Self {
+            backend_addr: format!("http://{authority_host}:{authority_port}"),
+            authority_host,
+            authority_port,
+        }
+    }
+
+    pub fn upstream(&self) -> Upstream {
+        Upstream {
+            load_balancing: LoadBalancing {
+                lb_type: "round-robin".to_string(),
+                key: None,
+            },
+            auth: Default::default(),
+            host_policy: Default::default(),
+            forwarded_headers: Default::default(),
+            tls: None,
+            route: RouteMatch {
+                path_prefix: Some("/".to_string()),
+                ..Default::default()
+            },
+            backends: vec![Backend {
+                id: "backend-a".to_string(),
+                address: self.backend_addr.clone(),
+                weight: 1,
+                health_check: None,
+            }],
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum ForcedBackendRefresh {
+    Updated {
+        result: BackendRefreshResult,
+        client_rotation: TransportClientRotation,
+    },
+    Unchanged {
+        result: BackendRefreshResult,
+    },
+    EmptyAnswerRetained {
+        retained_addrs: Vec<SocketAddr>,
+    },
+}
+
+pub struct BackendLifecycleHarness {
+    runtime: RuntimeSwapHarness,
+}
+
+impl BackendLifecycleHarness {
+    pub fn new() -> Self {
+        Self {
+            runtime: RuntimeSwapHarness::new(),
+        }
+    }
+
+    pub fn make_config(&self, upstreams: HashMap<String, Upstream>) -> Config {
+        self.runtime.make_config(upstreams)
+    }
+
+    pub fn hostname_backend_route(
+        &self,
+        authority_host: impl Into<String>,
+        authority_port: u16,
+    ) -> HostnameBackendRoute {
+        HostnameBackendRoute::new(authority_host, authority_port)
+    }
+
+    pub fn start_listener(&mut self, config: Config) -> Result<SocketAddr, String> {
+        self.runtime.start_listener(config)
+    }
+
+    pub fn start_h1_static_backend(&mut self, body: &'static [u8]) -> SocketAddr {
+        self.runtime.start_h1_static_backend(body)
+    }
+
+    pub fn start_h1_backend<F, Fut>(&mut self, handler: F) -> SocketAddr
+    where
+        F: Fn(Request<Incoming>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<Response<Full<Bytes>>, Infallible>> + Send + 'static,
+    {
+        self.runtime.start_h1_backend(handler)
+    }
+
+    pub fn start_h1_fail_then_recover_backend(
+        &mut self,
+        success_body: &'static [u8],
+        failure_status: StatusCode,
+        failure_body: &'static [u8],
+    ) -> (SocketAddr, ToggleBackendFixture) {
+        let failing = Arc::new(AtomicBool::new(false));
+        let failing_flag = Arc::clone(&failing);
+        let addr = self.runtime.start_h1_backend(move |_req| {
+            let failing_flag = Arc::clone(&failing_flag);
+            async move {
+                if failing_flag.load(Ordering::Relaxed) {
+                    let response = Response::builder()
+                        .status(failure_status)
+                        .body(Full::new(Bytes::from_static(failure_body)))
+                        .expect("failure response");
+                    Ok::<_, Infallible>(response)
+                } else {
+                    Ok::<_, Infallible>(Response::new(Full::new(Bytes::from_static(success_body))))
+                }
+            }
+        });
+        (addr, ToggleBackendFixture { failing })
+    }
+
+    pub fn run_request(&self, request: H3RequestSpec<'_>) -> Result<H3Response, String> {
+        self.runtime.run_request(request)
+    }
+
+    pub fn runtime_snapshot(&self) -> Result<serde_json::Value, String> {
+        self.runtime.runtime_snapshot()
+    }
+
+    pub fn ready_snapshot_expect(
+        &self,
+        expected_status: StatusCode,
+    ) -> Result<serde_json::Value, String> {
+        self.runtime.ready_snapshot_expect(expected_status)
+    }
+
+    pub fn metrics_text(&self) -> Result<String, String> {
+        self.runtime.metrics_text()
+    }
+
+    pub fn metrics_status_at(&self, path: &str) -> Result<StatusCode, String> {
+        self.runtime.metrics_status_at(path)
+    }
+
+    pub fn runtime_bundle_handle(&self) -> Result<Arc<RuntimeBundleHandle>, String> {
+        self.runtime.runtime_bundle_handle()
+    }
+
+    pub fn backend_inventory(&self) -> Result<BackendLifecycleInventorySnapshot, String> {
+        let handle = self.runtime_bundle_handle()?;
+        let current = handle.current_view();
+        Ok(current
+            .shared_services()
+            .backend_lifecycle
+            .snapshot_inventory(&current.state().upstream_pools))
+    }
+
+    pub fn backend_snapshot(
+        &self,
+        backend_addr: &str,
+    ) -> Result<Option<BackendLifecycleSnapshot>, String> {
+        let handle = self.runtime_bundle_handle()?;
+        Ok(handle
+            .current_view()
+            .shared_services()
+            .backend_lifecycle
+            .snapshot_backend(backend_addr))
+    }
+
+    pub fn upstream_membership_summary(
+        &self,
+        upstream_name: &str,
+    ) -> Result<UpstreamPoolMembershipSummary, String> {
+        let handle = self.runtime_bundle_handle()?;
+        let current = handle.current_view();
+        let pool = current
+            .state()
+            .upstream_pools
+            .get(upstream_name)
+            .ok_or_else(|| format!("missing upstream pool '{upstream_name}'"))?;
+        let guard = pool
+            .read()
+            .map_err(|_| format!("upstream pool '{upstream_name}' poisoned"))?;
+        Ok(guard.membership_summary())
+    }
+
+    pub fn upstream_backend_runtime_state(
+        &self,
+        upstream_name: &str,
+        backend_addr: &str,
+    ) -> Result<Option<UpstreamBackendRuntimeState>, String> {
+        let (pool, backend_index) = self.resolve_pool_backend_index(upstream_name, backend_addr)?;
+        let guard = pool
+            .read()
+            .map_err(|_| format!("upstream pool '{upstream_name}' poisoned"))?;
+        Ok(backend_index.and_then(|index| guard.backend_runtime_state(index)))
+    }
+
+    pub fn mark_backend_passive_failure(
+        &self,
+        upstream_name: &str,
+        backend_addr: &str,
+        reason: HealthFailureReason,
+    ) -> Result<Option<HealthTransition>, String> {
+        let (pool, backend_index) = self.resolve_pool_backend_index(upstream_name, backend_addr)?;
+        let Some(index) = backend_index else {
+            return Ok(None);
+        };
+        let mut guard = pool
+            .write()
+            .map_err(|_| format!("upstream pool '{upstream_name}' poisoned"))?;
+        Ok(guard.mark_backend_request_failure(index, reason))
+    }
+
+    pub fn mark_backend_active_recovery(
+        &self,
+        upstream_name: &str,
+        backend_addr: &str,
+    ) -> Result<Option<HealthTransition>, String> {
+        let (pool, backend_index) = self.resolve_pool_backend_index(upstream_name, backend_addr)?;
+        let Some(index) = backend_index else {
+            return Ok(None);
+        };
+        let mut guard = pool
+            .write()
+            .map_err(|_| format!("upstream pool '{upstream_name}' poisoned"))?;
+        Ok(guard.mark_backend_healthy(index))
+    }
+
+    pub fn cache_hostname_resolution(
+        &self,
+        authority_host: &str,
+        resolved_addrs: &[SocketAddr],
+    ) -> Result<(), String> {
+        let handle = self.runtime_bundle_handle()?;
+        handle
+            .current_view()
+            .shared_services()
+            .backend_dns_resolver
+            .set_host_addrs(
+                authority_host,
+                resolved_addrs
+                    .iter()
+                    .copied()
+                    .map(|addr| SocketAddr::new(addr.ip(), 0)),
+            );
+        Ok(())
+    }
+
+    pub fn cached_hostname_resolution(
+        &self,
+        authority_host: &str,
+    ) -> Result<Option<Vec<SocketAddr>>, String> {
+        let handle = self.runtime_bundle_handle()?;
+        Ok(handle
+            .current_view()
+            .shared_services()
+            .backend_dns_resolver
+            .cached_addrs(authority_host))
+    }
+
+    pub fn force_hostname_refresh(
+        &self,
+        backend_addr: &str,
+        resolved_addrs: Vec<SocketAddr>,
+    ) -> Result<ForcedBackendRefresh, String> {
+        let handle = self.runtime_bundle_handle()?;
+        let current = handle.current_view();
+        let backend = current
+            .shared_services()
+            .backend_lifecycle
+            .backend(backend_addr)
+            .ok_or_else(|| format!("missing backend lifecycle state '{backend_addr}'"))?;
+
+        if !backend.resolution.is_hostname() {
+            return Err(format!(
+                "backend '{backend_addr}' is not hostname-backed and cannot be refreshed"
+            ));
+        }
+
+        if resolved_addrs.is_empty() {
+            return Ok(ForcedBackendRefresh::EmptyAnswerRetained {
+                retained_addrs: backend.resolution.resolved_addrs,
+            });
+        }
+
+        current
+            .shared_services()
+            .backend_dns_resolver
+            .set_host_addrs(
+                &backend.resolution.authority_host,
+                resolved_addrs
+                    .iter()
+                    .copied()
+                    .map(|addr| SocketAddr::new(addr.ip(), 0)),
+            );
+
+        let mutation = current
+            .shared_services()
+            .backend_resolution_store
+            .apply_resolution_refresh(backend_addr, resolved_addrs, SystemTime::now())
+            .ok_or_else(|| format!("failed to apply resolution refresh for '{backend_addr}'"))?;
+
+        let BackendLifecycleMutation::ResolutionUpdated { result, .. } = mutation else {
+            return Err(format!(
+                "unexpected backend lifecycle mutation while refreshing '{backend_addr}'"
+            ));
+        };
+
+        match result.outcome {
+            BackendRefreshOutcome::Updated { .. } => {
+                let rotation = current
+                    .shared_services()
+                    .transport_pool
+                    .rotate_backend_client(backend_addr)
+                    .map_err(|err| format!("rotate backend client '{backend_addr}': {err}"))?;
+                Ok(ForcedBackendRefresh::Updated {
+                    result,
+                    client_rotation: rotation,
+                })
+            }
+            BackendRefreshOutcome::Unchanged { .. } => {
+                Ok(ForcedBackendRefresh::Unchanged { result })
+            }
+            BackendRefreshOutcome::EmptyAnswerRetained { retained_addrs } => {
+                Ok(ForcedBackendRefresh::EmptyAnswerRetained { retained_addrs })
+            }
+            BackendRefreshOutcome::LookupFailed { error, .. } => Err(format!(
+                "unexpected lookup failure while forcing hostname refresh for '{backend_addr}': {error}"
+            )),
+        }
+    }
+
+    fn resolve_pool_backend_index(
+        &self,
+        upstream_name: &str,
+        backend_addr: &str,
+    ) -> Result<
+        (
+            Arc<std::sync::RwLock<spooky_lb::upstream_pool::UpstreamPool>>,
+            Option<usize>,
+        ),
+        String,
+    > {
+        let handle = self.runtime_bundle_handle()?;
+        let current = handle.current_view();
+        let pool = current
+            .state()
+            .upstream_pools
+            .get(upstream_name)
+            .cloned()
+            .ok_or_else(|| format!("missing upstream pool '{upstream_name}'"))?;
+        let guard = pool
+            .read()
+            .map_err(|_| format!("upstream pool '{upstream_name}' poisoned"))?;
+        let backend_index = guard
+            .backend_indices()
+            .into_iter()
+            .find(|index| guard.backend_address(*index) == Some(backend_addr));
+        drop(guard);
+        Ok((pool, backend_index))
+    }
+}
+
+impl Default for BackendLifecycleHarness {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub fn hostname_backend_uri(authority_host: &str, authority_port: u16) -> Uri {
+    format!("http://{authority_host}:{authority_port}")
+        .parse()
+        .expect("hostname backend uri")
+}

--- a/crates/edge/tests/support/backend_lifecycle.rs
+++ b/crates/edge/tests/support/backend_lifecycle.rs
@@ -4,7 +4,7 @@ use std::{
     collections::HashMap,
     convert::Infallible,
     future::Future,
-    net::SocketAddr,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -137,12 +137,34 @@ impl BackendLifecycleHarness {
         self.runtime.start_h1_static_backend(body)
     }
 
+    pub fn try_start_h1_static_backend_at(
+        &mut self,
+        bind_addr: SocketAddr,
+        body: &'static [u8],
+    ) -> Result<SocketAddr, String> {
+        self.try_start_h1_backend_at(bind_addr, move |_req| async move {
+            Ok::<_, Infallible>(Response::new(Full::new(Bytes::from_static(body))))
+        })
+    }
+
     pub fn start_h1_backend<F, Fut>(&mut self, handler: F) -> SocketAddr
     where
         F: Fn(Request<Incoming>) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = Result<Response<Full<Bytes>>, Infallible>> + Send + 'static,
     {
         self.runtime.start_h1_backend(handler)
+    }
+
+    pub fn try_start_h1_backend_at<F, Fut>(
+        &mut self,
+        bind_addr: SocketAddr,
+        handler: F,
+    ) -> Result<SocketAddr, String>
+    where
+        F: Fn(Request<Incoming>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<Response<Full<Bytes>>, Infallible>> + Send + 'static,
+    {
+        self.runtime.try_start_h1_backend_at(bind_addr, handler)
     }
 
     pub fn start_h1_fail_then_recover_backend(
@@ -417,6 +439,13 @@ impl Default for BackendLifecycleHarness {
     fn default() -> Self {
         Self::new()
     }
+}
+
+pub fn alternate_loopback_backend_addrs(port: u16) -> (SocketAddr, SocketAddr) {
+    (
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)), port),
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 3)), port),
+    )
 }
 
 pub fn hostname_backend_uri(authority_host: &str, authority_port: u16) -> Uri {

--- a/crates/edge/tests/support/mod.rs
+++ b/crates/edge/tests/support/mod.rs
@@ -1,3 +1,4 @@
+pub mod backend_lifecycle;
 pub mod net;
 pub mod parity;
 pub mod request_path;

--- a/crates/edge/tests/support/request_path.rs
+++ b/crates/edge/tests/support/request_path.rs
@@ -1480,8 +1480,7 @@ fn reserve_unused_listener_port() -> u16 {
 }
 
 fn bind_tcp_listener() -> TcpListener {
-    bind_tcp_listener_at(SocketAddr::from(([127, 0, 0, 1], 0)))
-        .expect("bind test backend listener")
+    bind_tcp_listener_at(SocketAddr::from(([127, 0, 0, 1], 0))).expect("bind test backend listener")
 }
 
 fn bind_tcp_listener_at(bind_addr: SocketAddr) -> Result<TcpListener, String> {
@@ -1490,9 +1489,8 @@ fn bind_tcp_listener_at(bind_addr: SocketAddr) -> Result<TcpListener, String> {
     listener
         .set_nonblocking(true)
         .expect("set test backend listener nonblocking");
-    TcpListener::from_std(listener).map_err(|err| {
-        format!("register test backend listener {bind_addr}: {err}")
-    })
+    TcpListener::from_std(listener)
+        .map_err(|err| format!("register test backend listener {bind_addr}: {err}"))
 }
 
 fn quic_read_timeout(conn: &quiche::Connection) -> Duration {

--- a/crates/edge/tests/support/request_path.rs
+++ b/crates/edge/tests/support/request_path.rs
@@ -1059,7 +1059,20 @@ where
     F: Fn(Request<Incoming>) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Result<Response<Full<Bytes>>, Infallible>> + Send + 'static,
 {
-    let listener = bind_tcp_listener();
+    start_h1_backend_on(SocketAddr::from(([127, 0, 0, 1], 0)), handler)
+        .await
+        .expect("bind h1 test backend listener")
+}
+
+pub async fn start_h1_backend_on<F, Fut>(
+    bind_addr: SocketAddr,
+    handler: F,
+) -> Result<BackendFixture, String>
+where
+    F: Fn(Request<Incoming>) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<Response<Full<Bytes>>, Infallible>> + Send + 'static,
+{
+    let listener = bind_tcp_listener_at(bind_addr)?;
     let addr = listener.local_addr().expect("h1 local addr");
     let stop = Arc::new(AtomicBool::new(false));
     let stop_flag = Arc::clone(&stop);
@@ -1085,11 +1098,11 @@ where
         }
     });
 
-    BackendFixture {
+    Ok(BackendFixture {
         addr,
         stop,
         accept_task,
-    }
+    })
 }
 
 pub async fn start_h1_websocket_upgrade_backend() -> BackendFixture {
@@ -1467,11 +1480,19 @@ fn reserve_unused_listener_port() -> u16 {
 }
 
 fn bind_tcp_listener() -> TcpListener {
-    let listener = StdTcpListener::bind("127.0.0.1:0").expect("bind test backend listener");
+    bind_tcp_listener_at(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .expect("bind test backend listener")
+}
+
+fn bind_tcp_listener_at(bind_addr: SocketAddr) -> Result<TcpListener, String> {
+    let listener = StdTcpListener::bind(bind_addr)
+        .map_err(|err| format!("bind test backend listener {bind_addr}: {err}"))?;
     listener
         .set_nonblocking(true)
         .expect("set test backend listener nonblocking");
-    TcpListener::from_std(listener).expect("register test backend listener")
+    TcpListener::from_std(listener).map_err(|err| {
+        format!("register test backend listener {bind_addr}: {err}")
+    })
 }
 
 fn quic_read_timeout(conn: &quiche::Connection) -> Duration {

--- a/crates/edge/tests/support/runtime_swap.rs
+++ b/crates/edge/tests/support/runtime_swap.rs
@@ -44,7 +44,7 @@ use tokio_rustls::{
 
 use super::request_path::{
     BackendFixture, H3RequestSpec, H3Response, ListenerTaskGuard, TestTlsMaterial, run_request_to,
-    start_h1_backend,
+    start_h1_backend, start_h1_backend_on,
 };
 
 pub struct RuntimeSwapHarness {
@@ -153,6 +153,21 @@ impl RuntimeSwapHarness {
         let addr = fixture.addr;
         self.backends.push(fixture);
         addr
+    }
+
+    pub fn try_start_h1_backend_at<F, Fut>(
+        &mut self,
+        bind_addr: SocketAddr,
+        handler: F,
+    ) -> Result<SocketAddr, String>
+    where
+        F: Fn(Request<Incoming>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<Response<Full<Bytes>>, Infallible>> + Send + 'static,
+    {
+        let fixture = self.rt.block_on(start_h1_backend_on(bind_addr, handler))?;
+        let addr = fixture.addr;
+        self.backends.push(fixture);
+        Ok(addr)
     }
 
     pub fn start_h1_static_backend(&mut self, body: &'static [u8]) -> SocketAddr {

--- a/crates/edge/tests/support/runtime_swap.rs
+++ b/crates/edge/tests/support/runtime_swap.rs
@@ -336,6 +336,13 @@ impl RuntimeSwapHarness {
             .current_generation())
     }
 
+    pub fn runtime_bundle_handle(&self) -> Result<Arc<RuntimeBundleHandle>, String> {
+        self.runtime_bundle
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| "runtime bundle unavailable".to_string())
+    }
+
     pub fn lifecycle_phase(&self) -> Result<RuntimeLifecyclePhase, String> {
         Ok(self
             .runtime_bundle


### PR DESCRIPTION
## Summary
Adds focused integration coverage for backend lifecycle behavior in edge.

This PR locks the end-to-end contracts around:
- DNS refresh updating backend resolution and rotating traffic
- empty DNS refresh preserving the last usable resolution
- transport client rotation after backend address changes
- passive request failures marking a backend unhealthy
- active health recovery restoring backend availability
- partial outage behavior preserving service through healthy backends

## What Changed
- Added and expanded `crates/edge/tests/backend_failure_and_recovery.rs`
- Added backend lifecycle integration scenarios for:
  - changed hostname resolution
  - empty refresh retention
  - post-refresh client rotation behavior
  - passive unhealthy transitions
  - active recovery transitions
  - partial outage availability
- Cleaned up the suite by:
  - grouping tests by behavior domain
  - extracting repeated backend/upstream helpers
  - keeping assertions centered on public behavior and lifecycle-visible state

## Why
This closes an important gap in Phase 2/3 stabilization work: the interaction between lifecycle state, load balancing, transport rotation, health checks, and request-path outcomes is now covered by dedicated integration tests instead of only unit-level checks.