### PR TITLE
test: add regression hardening coverage across edge runtime, bootstrap, and lb

### DIFF
--- a/crates/bridge/tests/regression/README.md
+++ b/crates/bridge/tests/regression/README.md
@@ -1,0 +1,23 @@
+## Bridge Regression Boundaries
+
+This directory owns request-shaping regressions for the canonical bridge surface.
+
+Keep tests here when the bug is about:
+- canonical request-builder inputs flowing into H1/H2 request shapes
+- host policy or forwarded-header policy application
+- WebSocket and upgrade request shaping
+- H1/H2 request parity for the same logical bridge input
+
+Representative regressions already covered here:
+- forwarded-header and spoofed-header stripping parity
+- canonical host rewrite versus preserve behavior
+- WebSocket upgrade request shaping staying stable across H1/H2 builder paths
+
+Do not force response-normalization regressions into this directory when the contract is clearer on
+the unit-test side of the bridge crate. Response normalization is owned by the canonical normalizer
+entrypoints and should stay near that implementation when the bug is not specifically about
+cross-protocol request shaping.
+
+Rule of thumb: request construction and ingress-to-upstream shaping regressions live here;
+response-normalization and lower-level helper regressions stay next to the owning bridge module if
+that gives a clearer contract.

--- a/crates/bridge/tests/regression/main.rs
+++ b/crates/bridge/tests/regression/main.rs
@@ -5,6 +5,10 @@
 //! hop-by-hop stripping, spoofed-header removal, WebSocket shaping, and H1/H2
 //! output parity. Shared fixtures live in `common`, while response-normalization
 //! contracts live under the bridge unit tests.
+//!
+//! See `tests/regression/README.md` for the boundary between request-shaping
+//! regressions kept here and response-normalization contracts kept beside the
+//! owning bridge entrypoints.
 
 mod common;
 

--- a/crates/config/tests/regression/README.md
+++ b/crates/config/tests/regression/README.md
@@ -1,0 +1,26 @@
+## Config Regression Boundaries
+
+This directory is the regression suite for raw-config to runtime-config lowering.
+
+Keep tests here when the bug is about:
+- listener precedence and listener normalization
+- timeout normalization and validation
+- transport, auth, admission, rate-limit, backend, TLS, or load-balancing runtime shaping
+- reloadable versus startup-owned config interpretation
+
+Representative regressions already covered here:
+- `listen` versus `listeners[]` precedence
+- timeout ordering and nonzero validation
+- backend health-check zero-value rejection
+- runtime shaping for auth, admission, rate limits, and alternate-backend policy
+
+These tests should stay on the canonical public lowering path:
+- `RuntimeConfig::from_config`
+
+Do not move crate-internal helper behavior here if the contract is clearer beside the owning
+runtime interpreter module. Internal shaping details that require private helpers should stay as
+unit tests under `crates/config/src/runtime/`.
+
+Rule of thumb: if the regression is visible in the runtime config produced from raw config, keep it
+here. If it only exists because of a private helper or intermediate normalization detail, test it
+next to the owning module.

--- a/crates/config/tests/regression/main.rs
+++ b/crates/config/tests/regression/main.rs
@@ -8,6 +8,10 @@
 //! module and the `#[cfg(test)] pub(crate)` `upstreams_as_config` /
 //! `upstream_policy_sets` helpers) remain as unit tests in
 //! `crates/config/src/runtime.rs`.
+//!
+//! See `tests/regression/README.md` for the split between runtime-lowering
+//! regressions kept here and interpreter-internal unit tests kept beside the
+//! owning modules.
 
 mod common;
 

--- a/crates/edge/src/quic_listener/bootstrap/response.rs
+++ b/crates/edge/src/quic_listener/bootstrap/response.rs
@@ -570,8 +570,14 @@ mod tests {
         assert_eq!(normalized.head.status, StatusCode::SWITCHING_PROTOCOLS);
         assert_eq!(normalized.emission.body, ResponseBodyPolicy::Suppress);
         assert!(normalized.emission.emit_end_stream_on_headers);
-        assert_eq!(header_value(&normalized.head.headers, "connection"), Some("upgrade, x-hop-token"));
-        assert_eq!(header_value(&normalized.head.headers, "upgrade"), Some("websocket"));
+        assert_eq!(
+            header_value(&normalized.head.headers, "connection"),
+            Some("upgrade, x-hop-token")
+        );
+        assert_eq!(
+            header_value(&normalized.head.headers, "upgrade"),
+            Some("websocket")
+        );
         assert_eq!(
             header_value(&normalized.head.headers, "sec-websocket-accept"),
             Some("test-accept")

--- a/crates/edge/src/quic_listener/bootstrap/response.rs
+++ b/crates/edge/src/quic_listener/bootstrap/response.rs
@@ -535,4 +535,51 @@ mod tests {
         assert_eq!(no_content.emission.body, ResponseBodyPolicy::Suppress);
         assert!(no_content.emission.emit_end_stream_on_headers);
     }
+
+    #[test]
+    fn bootstrap_websocket_upgrade_switching_protocols_response_survives_header_cleanup() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            http::header::CONNECTION,
+            HeaderValue::from_static("upgrade, x-hop-token"),
+        );
+        headers.insert(http::header::UPGRADE, HeaderValue::from_static("websocket"));
+        headers.insert(
+            http::HeaderName::from_static("sec-websocket-accept"),
+            HeaderValue::from_static("test-accept"),
+        );
+        headers.insert(
+            http::HeaderName::from_static("x-hop-token"),
+            HeaderValue::from_static("strip-me"),
+        );
+        headers.insert(
+            http::header::TRANSFER_ENCODING,
+            HeaderValue::from_static("chunked"),
+        );
+
+        let normalized = normalize_upstream_response(ResponseNormalizationInput {
+            upstream: spooky_bridge::response::UpstreamResponseView {
+                status: StatusCode::SWITCHING_PROTOCOLS,
+                headers: &headers,
+                trailers: None,
+            },
+            body_mode: ResponseBodyMode::Normal,
+            constraints: bootstrap_response_constraints(BootstrapResponseMode::WebsocketUpgrade),
+        });
+
+        assert_eq!(normalized.head.status, StatusCode::SWITCHING_PROTOCOLS);
+        assert_eq!(normalized.emission.body, ResponseBodyPolicy::Suppress);
+        assert!(normalized.emission.emit_end_stream_on_headers);
+        assert_eq!(header_value(&normalized.head.headers, "connection"), Some("upgrade, x-hop-token"));
+        assert_eq!(header_value(&normalized.head.headers, "upgrade"), Some("websocket"));
+        assert_eq!(
+            header_value(&normalized.head.headers, "sec-websocket-accept"),
+            Some("test-accept")
+        );
+        assert_eq!(header_value(&normalized.head.headers, "x-hop-token"), None);
+        assert_eq!(
+            header_value(&normalized.head.headers, "transfer-encoding"),
+            None
+        );
+    }
 }

--- a/crates/edge/src/quic_listener/control_api/tests.rs
+++ b/crates/edge/src/quic_listener/control_api/tests.rs
@@ -462,7 +462,8 @@ async fn control_api_runtime_snapshot_uses_live_primary_listener_label_after_bun
     let startup_bundle = runtime_bundle_from_config("startup.yaml", &startup);
     let (state, runtime_handle) = runtime_bundle_control_api_state(startup_bundle);
 
-    let startup_payload = json_body(QUICListener::render_control_api_runtime_snapshot(&state)).await;
+    let startup_payload =
+        json_body(QUICListener::render_control_api_runtime_snapshot(&state)).await;
     let startup_listeners = startup_payload["tls"]["listeners"]
         .as_object()
         .expect("startup listeners object");

--- a/crates/edge/src/quic_listener/control_api/tests.rs
+++ b/crates/edge/src/quic_listener/control_api/tests.rs
@@ -452,6 +452,69 @@ fn control_api_state_uses_live_primary_listener_label_after_runtime_swap() {
     );
 }
 
+#[tokio::test]
+async fn control_api_runtime_snapshot_uses_live_primary_listener_label_after_bundle_replace() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+    let mut startup = test_config(cert.clone(), key.clone());
+    startup.observability.control_api.enabled = true;
+
+    let startup_bundle = runtime_bundle_from_config("startup.yaml", &startup);
+    let (state, runtime_handle) = runtime_bundle_control_api_state(startup_bundle);
+
+    let startup_payload = json_body(QUICListener::render_control_api_runtime_snapshot(&state)).await;
+    let startup_listeners = startup_payload["tls"]["listeners"]
+        .as_object()
+        .expect("startup listeners object");
+    assert!(
+        startup_listeners.contains_key("127.0.0.1:9889"),
+        "startup snapshot should expose the startup primary listener label"
+    );
+
+    let mut reloaded = startup.clone();
+    reloaded.listeners = vec![
+        Listen {
+            protocol: "http3".to_string(),
+            port: 9890,
+            address: "127.0.0.1".to_string(),
+            tls: Tls {
+                cert: cert.clone(),
+                key: key.clone(),
+                certificates: vec![],
+                client_auth: ClientAuth::default(),
+            },
+        },
+        startup.listen.clone(),
+    ];
+
+    let mut reloaded_bundle = runtime_bundle_from_config("reloaded.yaml", &reloaded);
+    reloaded_bundle.generation = 1;
+    runtime_handle
+        .replace(reloaded_bundle)
+        .expect("replace runtime bundle");
+
+    assert_eq!(
+        state.current_primary_listener_label().as_deref(),
+        Some("127.0.0.1:9890"),
+        "control api state must prefer the live generation's primary listener label"
+    );
+
+    let live_payload = json_body(QUICListener::render_control_api_runtime_snapshot(&state)).await;
+    let live_listeners = live_payload["tls"]["listeners"]
+        .as_object()
+        .expect("live listeners object");
+
+    assert_eq!(live_payload["runtime"]["generation"], 1);
+    assert!(
+        live_listeners.contains_key("127.0.0.1:9890"),
+        "runtime snapshot must render the live generation's primary listener label after bundle replacement"
+    );
+    assert!(
+        live_listeners.contains_key("127.0.0.1:9889"),
+        "runtime snapshot should keep the remaining listener inventory from the live generation"
+    );
+}
+
 #[test]
 fn control_api_state_sees_the_active_runtime_generation_after_bundle_replace() {
     let dir = tempdir().expect("tempdir");
@@ -490,6 +553,55 @@ fn control_api_state_sees_the_active_runtime_generation_after_bundle_replace() {
         state.current_paths().runtime_path,
         "/runtime-reloaded".to_string()
     );
+}
+
+#[test]
+fn control_api_gating_uses_live_generation_paths_and_auth_after_bundle_replace() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+    let mut startup = test_config(cert.clone(), key.clone());
+    startup.observability.control_api.enabled = true;
+    startup.observability.control_api.runtime_path = "/runtime-startup".to_string();
+    startup.observability.control_api.auth_token = Some("startup-token".to_string());
+
+    let startup_bundle = runtime_bundle_from_config("startup.yaml", &startup);
+    let (state, runtime_handle) = runtime_bundle_control_api_state(startup_bundle);
+
+    let mut reloaded = startup.clone();
+    reloaded.observability.control_api.runtime_path = "/runtime-reloaded".to_string();
+    reloaded.observability.control_api.auth_token = Some("reloaded-token".to_string());
+    let mut reloaded_bundle = runtime_bundle_from_config("reloaded.yaml", &reloaded);
+    reloaded_bundle.generation = 1;
+    runtime_handle
+        .replace(reloaded_bundle)
+        .expect("replace runtime bundle");
+
+    let startup_path = control_api_request(
+        Method::GET,
+        "/runtime-startup",
+        Some("Bearer startup-token"),
+    );
+    let startup_err = QUICListener::gate_control_api_request_for(&startup_path, &state)
+        .expect_err("stale runtime path should be rejected after replacement");
+    assert_eq!(startup_err.status(), StatusCode::NOT_FOUND);
+
+    let stale_token = control_api_request(
+        Method::GET,
+        "/runtime-reloaded",
+        Some("Bearer startup-token"),
+    );
+    let stale_token_err = QUICListener::gate_control_api_request_for(&stale_token, &state)
+        .expect_err("stale token should be rejected after replacement");
+    assert_eq!(stale_token_err.status(), StatusCode::UNAUTHORIZED);
+
+    let live = control_api_request(
+        Method::GET,
+        "/runtime-reloaded",
+        Some("Bearer reloaded-token"),
+    );
+    let route = QUICListener::gate_control_api_request_for(&live, &state)
+        .expect("live control api path and auth should be accepted");
+    assert!(matches!(route, super::auth::ControlApiRoute::Runtime));
 }
 
 #[test]

--- a/crates/edge/src/quic_listener/health_check.rs
+++ b/crates/edge/src/quic_listener/health_check.rs
@@ -208,6 +208,70 @@ impl QUICListener {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::Ordering;
+
+    use spooky_errors::{PoolError, ProxyError};
+    use spooky_lb::health::HealthFailureReason;
+
+    use super::*;
+
+    #[test]
+    fn timeout_health_check_failures_remain_mapped_to_timeout_reason() {
+        let metrics = Metrics::default();
+
+        let evaluation = QUICListener::evaluate_failed_health_check(
+            "http://backend-a",
+            &metrics,
+            1_000,
+            0,
+            ProxyError::Timeout,
+            HealthFailureReason::Timeout,
+        );
+
+        assert_eq!(
+            evaluation.observation.outcome,
+            BackendHealthObservationOutcome::Failure
+        );
+        assert_eq!(
+            evaluation.observation.reason,
+            Some(HealthFailureReason::Timeout),
+            "timeout health checks must keep the canonical timeout failure mapping after lint cleanup"
+        );
+        assert_eq!(evaluation.next_consecutive_failures, 1);
+        assert_eq!(metrics.health_failure_timeout.load(Ordering::Relaxed), 1);
+        assert_eq!(metrics.health_failure_transport.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn unclassified_health_check_failures_fall_back_to_supplied_reason() {
+        let metrics = Metrics::default();
+
+        let evaluation = QUICListener::evaluate_failed_health_check(
+            "http://backend-a",
+            &metrics,
+            1_000,
+            2,
+            ProxyError::Pool(PoolError::UnknownBackend("backend-a".to_string())),
+            HealthFailureReason::Transport,
+        );
+
+        assert_eq!(
+            evaluation.observation.outcome,
+            BackendHealthObservationOutcome::Failure
+        );
+        assert_eq!(
+            evaluation.observation.reason,
+            Some(HealthFailureReason::Transport),
+            "health checks must still emit the fallback transport reason when proxy classification is unavailable"
+        );
+        assert_eq!(evaluation.next_consecutive_failures, 3);
+        assert_eq!(metrics.health_failure_transport.load(Ordering::Relaxed), 1);
+        assert_eq!(metrics.health_failure_timeout.load(Ordering::Relaxed), 0);
+    }
+}
+
 pub(super) fn classify_active_health_check_response(status: StatusCode) -> HealthClassification {
     outcome_from_status(status)
 }

--- a/crates/edge/src/quic_listener/health_check.rs
+++ b/crates/edge/src/quic_listener/health_check.rs
@@ -208,6 +208,48 @@ impl QUICListener {
     }
 }
 
+pub(super) fn classify_active_health_check_response(status: StatusCode) -> HealthClassification {
+    outcome_from_status(status)
+}
+
+impl QUICListener {
+    fn evaluate_failed_health_check(
+        backend_identity: &str,
+        metrics: &Metrics,
+        base_interval_ms: u64,
+        consecutive_failures: u32,
+        proxy_error: ProxyError,
+        fallback_reason: HealthFailureReason,
+    ) -> ActiveHealthCheckEvaluation {
+        let reason = if let Some(classified) = classify_upstream_proxy_error(&proxy_error) {
+            Self::log_classified_upstream_failure(
+                "health_check",
+                None,
+                None,
+                backend_identity,
+                &classified,
+            );
+            record_classified_backend_failure_metrics(
+                "health_check",
+                backend_identity,
+                metrics,
+                &classified,
+            )
+        } else {
+            metrics.inc_health_failure(fallback_reason);
+            Some(fallback_reason)
+        };
+
+        evaluate_active_health_check(
+            BackendIdentity::new(backend_identity.to_string()),
+            BackendHealthObservationOutcome::Failure,
+            reason,
+            base_interval_ms,
+            consecutive_failures,
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::Ordering;
@@ -269,47 +311,5 @@ mod tests {
         assert_eq!(evaluation.next_consecutive_failures, 3);
         assert_eq!(metrics.health_failure_transport.load(Ordering::Relaxed), 1);
         assert_eq!(metrics.health_failure_timeout.load(Ordering::Relaxed), 0);
-    }
-}
-
-pub(super) fn classify_active_health_check_response(status: StatusCode) -> HealthClassification {
-    outcome_from_status(status)
-}
-
-impl QUICListener {
-    fn evaluate_failed_health_check(
-        backend_identity: &str,
-        metrics: &Metrics,
-        base_interval_ms: u64,
-        consecutive_failures: u32,
-        proxy_error: ProxyError,
-        fallback_reason: HealthFailureReason,
-    ) -> ActiveHealthCheckEvaluation {
-        let reason = if let Some(classified) = classify_upstream_proxy_error(&proxy_error) {
-            Self::log_classified_upstream_failure(
-                "health_check",
-                None,
-                None,
-                backend_identity,
-                &classified,
-            );
-            record_classified_backend_failure_metrics(
-                "health_check",
-                backend_identity,
-                metrics,
-                &classified,
-            )
-        } else {
-            metrics.inc_health_failure(fallback_reason);
-            Some(fallback_reason)
-        };
-
-        evaluate_active_health_check(
-            BackendIdentity::new(backend_identity.to_string()),
-            BackendHealthObservationOutcome::Failure,
-            reason,
-            base_interval_ms,
-            consecutive_failures,
-        )
     }
 }

--- a/crates/edge/src/runtime/bundle.rs
+++ b/crates/edge/src/runtime/bundle.rs
@@ -524,6 +524,63 @@ mod tests {
         }
 
         #[test]
+        fn current_view_helpers_follow_the_live_generation_after_replacement() {
+            let dir = tempdir().expect("tempdir");
+            let (current_bundle, next_bundle) = runtime_bundle_pair(
+                dir.path(),
+                "startup.yaml",
+                "http://127.0.0.1:7001",
+                2,
+                "reloaded.yaml",
+                "http://127.0.0.1:7002",
+            );
+            let handle = RuntimeBundleHandle::new(current_bundle);
+
+            handle.replace(next_bundle).expect("replace");
+
+            let via_generation = handle.with_current_generation(|active| {
+                (
+                    active.generation(),
+                    active.startup().config_path.clone(),
+                    active
+                        .runtime_config()
+                        .upstreams
+                        .get("api")
+                        .expect("active upstream")
+                        .backends[0]
+                        .backend
+                        .address
+                        .clone(),
+                )
+            });
+            let via_view = handle.with_current_view(|view| {
+                (
+                    view.generation,
+                    view.startup.config_path.clone(),
+                    view.runtime_config
+                        .upstreams
+                        .get("api")
+                        .expect("active upstream")
+                        .backends[0]
+                        .backend
+                        .address
+                        .clone(),
+                )
+            });
+
+            assert_eq!(handle.current_generation(), 2);
+            assert_eq!(
+                via_generation,
+                (
+                    2,
+                    "reloaded.yaml".to_string(),
+                    "http://127.0.0.1:7002".to_string()
+                )
+            );
+            assert_eq!(via_generation, via_view);
+        }
+
+        #[test]
         fn stale_generation_views_keep_the_original_runtime_snapshot_after_replacement() {
             let dir = tempdir().expect("tempdir");
             let (current_bundle, next_bundle) = runtime_bundle_pair(

--- a/crates/edge/tests/regression/README.md
+++ b/crates/edge/tests/regression/README.md
@@ -1,0 +1,28 @@
+## Edge Regression Boundaries
+
+This directory is for stable edge behavior regressions that are easiest to express through the
+crate's public or externally visible contracts without booting the full listener runtime.
+
+Keep tests here when the bug is about:
+- stable hash or request-key derivation contracts
+- Prometheus exposition shape and metric rendering contracts
+- other edge-visible output that is best asserted without a live QUIC/bootstrap harness
+
+Representative regressions already pinned elsewhere in the edge test tree:
+- request-body guardrails returning `413` instead of accidentally surfacing `503`
+- long streamed responses surviving total-timeout semantics after forward progress
+- control-plane runtime-swap snapshots exposing the active listener label
+- backend failure and partial-outage availability behavior through lifecycle-aware integration suites
+
+Do not add tests here when the bug depends on runtime orchestration, live reload, backend health,
+bootstrap-vs-QUIC parity, or full request execution. Those belong in the dedicated integration
+files under `crates/edge/tests/`, where the runtime harness already exists:
+- `h3_bridge.rs`
+- `bootstrap_quic_parity.rs`
+- `runtime_swap.rs`
+- `backend_failure_and_recovery.rs`
+- related support-backed integration suites
+
+Rule of thumb: if the regression is about a live listener, backend lifecycle, or end-to-end request
+path, keep it in the integration suite that already owns that contract. If it is about a stable
+edge-facing output contract, keep it here.

--- a/crates/edge/tests/regression/main.rs
+++ b/crates/edge/tests/regression/main.rs
@@ -4,6 +4,10 @@
 //! (`Metrics::render_prometheus` output), and `hash` pins the stable-hash
 //! helpers used for load-balancing key derivation. Both use only the crate's
 //! public API.
+//!
+//! More runtime-heavy regressions stay in the dedicated integration suites
+//! under `crates/edge/tests/`; see `tests/regression/README.md` for the suite
+//! boundary.
 
 mod hash;
 mod metrics;

--- a/crates/edge/tests/request_path_harness.rs
+++ b/crates/edge/tests/request_path_harness.rs
@@ -24,7 +24,7 @@ use support::{
     net::local_listener_bind_available,
     request_path::{
         H3RequestSpec, QuicRequestPathHarness, make_backend, make_upstream, run_request_to,
-        run_two_chunk_post_to,
+        run_two_chunk_post_to, run_two_chunk_post_to_with_response_timeout,
     },
 };
 
@@ -44,6 +44,29 @@ fn metrics_counter(metrics: &str, prefix: &str) -> u64 {
 
 fn metrics_delta(before: &str, after: &str, prefix: &str) -> u64 {
     metrics_counter(after, prefix).saturating_sub(metrics_counter(before, prefix))
+}
+
+fn start_single_backend_listener(
+    harness: &mut QuicRequestPathHarness,
+    path: &str,
+    backend_id: &str,
+    backend_addr: String,
+    configure: impl FnOnce(&mut spooky_config::config::Config),
+) -> std::net::SocketAddr {
+    let mut upstreams = HashMap::new();
+    upstreams.insert(
+        "api".to_string(),
+        make_upstream(
+            path,
+            vec![make_backend(backend_id, backend_addr)],
+            None,
+            "round-robin",
+        ),
+    );
+
+    let mut config = harness.make_config(upstreams);
+    configure(&mut config);
+    harness.start_listener(config).expect("listener")
 }
 
 fn configure_http_external_auth(
@@ -1125,28 +1148,22 @@ fn quic_request_path_malformed_upstream_response_maps_to_upstream_error() {
 
 #[test]
 #[serial]
-fn quic_request_path_request_body_too_large_returns_413() {
+fn quic_request_path_request_body_cap_breach_returns_413_not_503() {
     if !local_listener_bind_available() {
         return;
     }
 
     let mut harness = QuicRequestPathHarness::new();
     let backend_addr = harness.start_h1_static_backend(b"backend upload");
-
-    let mut upstreams = HashMap::new();
-    upstreams.insert(
-        "api".to_string(),
-        make_upstream(
-            "/upload",
-            vec![make_backend("h1-upload", format!("http://{backend_addr}"))],
-            None,
-            "round-robin",
-        ),
+    let listen_addr = start_single_backend_listener(
+        &mut harness,
+        "/upload",
+        "h1-upload",
+        format!("http://{backend_addr}"),
+        |config| {
+            config.performance.max_request_body_bytes = 1024;
+        },
     );
-
-    let mut config = harness.make_config(upstreams);
-    config.performance.max_request_body_bytes = 1024;
-    let listen_addr = harness.start_listener(config).expect("listener");
 
     let (response, got_reset) = run_two_chunk_post_to(
         listen_addr,
@@ -1159,6 +1176,10 @@ fn quic_request_path_request_body_too_large_returns_413() {
     .expect("oversized request should complete");
 
     response.assert_status(413);
+    assert_ne!(
+        response.status, 503,
+        "request body cap breaches must stay on the bounded 413 path"
+    );
     assert!(
         response.body_text().contains("request body too large"),
         "expected canonical request-body-too-large response body"
@@ -1166,6 +1187,53 @@ fn quic_request_path_request_body_too_large_returns_413() {
     assert!(
         !got_reset,
         "oversized request should terminate with HTTP response"
+    );
+}
+
+#[test]
+#[serial]
+/// Regression: a slow over-cap producer previously escaped through a generic
+/// fallback path and surfaced as 503 instead of the bounded 413 contract.
+fn quic_request_path_slow_request_body_cap_breach_stays_on_413_path() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = QuicRequestPathHarness::new();
+    let backend_addr = harness.start_h2_static_backend(b"unexpected backend call");
+    let listen_addr = start_single_backend_listener(
+        &mut harness,
+        "/upload-slow-over-cap",
+        "h2-upload-slow-over-cap",
+        backend_addr.to_string(),
+        |config| {
+            config.performance.max_request_body_bytes = 1024;
+        },
+    );
+
+    let (response, got_reset) = run_two_chunk_post_to_with_response_timeout(
+        listen_addr,
+        "localhost",
+        "/upload-slow-over-cap",
+        vec![0u8; 600],
+        vec![0u8; 600],
+        Duration::from_millis(120),
+        Duration::from_secs(spooky_edge::REQUEST_TIMEOUT_SECS + 12),
+    )
+    .expect("slow over-cap request should complete");
+
+    response.assert_status(413);
+    assert_ne!(
+        response.status, 503,
+        "slow over-cap request bodies must not escape through a fallback 503 path"
+    );
+    assert!(
+        response.body_text().contains("request body too large"),
+        "expected canonical request-body-too-large response body"
+    );
+    assert!(
+        !got_reset,
+        "slow over-cap request should terminate with HTTP response, not reset"
     );
 }
 
@@ -1299,6 +1367,57 @@ fn quic_request_path_slow_response_body_before_first_chunk_returns_timeout() {
     assert!(
         response.body_text().contains("upstream timeout"),
         "expected canonical upstream timeout body for stalled response body stream"
+    );
+}
+
+#[test]
+#[serial]
+/// Regression: the total response-body timer must not kill streams that keep
+/// making forward progress before the idle timer expires.
+fn quic_request_path_progressing_long_stream_ignores_body_total_timeout() {
+    if !local_listener_bind_available() {
+        return;
+    }
+
+    let mut harness = QuicRequestPathHarness::new();
+    let backend_addr = harness.start_h1_delayed_chunked_backend(vec![
+        (b"part-1".to_vec(), Duration::from_millis(50)),
+        (b"part-2".to_vec(), Duration::from_millis(100)),
+        (b"part-3".to_vec(), Duration::from_millis(100)),
+        (b"part-4".to_vec(), Duration::from_millis(100)),
+    ]);
+
+    let mut upstreams = HashMap::new();
+    upstreams.insert(
+        "api".to_string(),
+        make_upstream(
+            "/long-stream",
+            vec![make_backend(
+                "h1-long-stream-progress",
+                format!("http://{backend_addr}"),
+            )],
+            None,
+            "round-robin",
+        ),
+    );
+
+    let mut config = harness.make_config(upstreams);
+    config.performance.backend_timeout_ms = 240;
+    config.performance.backend_connect_timeout_ms = 240;
+    config.performance.backend_body_total_timeout_ms = 250;
+    config.performance.backend_body_idle_timeout_ms = 240;
+    config.performance.backend_total_request_timeout_ms = 5_000;
+    harness.start_listener(config).expect("listener");
+
+    let response = harness
+        .run_request(H3RequestSpec::get("localhost", "/long-stream"))
+        .expect("long stream request should complete");
+
+    response.assert_status(200);
+    assert_eq!(
+        response.body_text(),
+        "part-1part-2part-3part-4",
+        "body-total timeout must not kill a response stream that keeps making progress"
     );
 }
 

--- a/crates/edge/tests/support/request_path.rs
+++ b/crates/edge/tests/support/request_path.rs
@@ -1009,9 +1009,7 @@ pub fn run_two_chunk_post_to_with_response_timeout(
                             chunk1_written += written;
                         }
                         Err(quiche::h3::Error::Done | quiche::h3::Error::StreamBlocked) => {}
-                        Err(quiche::h3::Error::TransportError(
-                            quiche::Error::StreamStopped(_),
-                        )) => {
+                        Err(quiche::h3::Error::TransportError(quiche::Error::StreamStopped(_))) => {
                             request_stream_stopped = true;
                             chunk1_written = chunk1.len();
                             chunk2_written = chunk2.len();

--- a/crates/edge/tests/support/request_path.rs
+++ b/crates/edge/tests/support/request_path.rs
@@ -865,6 +865,26 @@ pub fn run_two_chunk_post_to(
     chunk2: Vec<u8>,
     delay_between_chunks: Duration,
 ) -> Result<(H3Response, bool), String> {
+    run_two_chunk_post_to_with_response_timeout(
+        addr,
+        authority,
+        path,
+        chunk1,
+        chunk2,
+        delay_between_chunks,
+        Duration::from_secs(REQUEST_TIMEOUT_SECS + 4),
+    )
+}
+
+pub fn run_two_chunk_post_to_with_response_timeout(
+    addr: SocketAddr,
+    authority: &str,
+    path: &str,
+    chunk1: Vec<u8>,
+    chunk2: Vec<u8>,
+    delay_between_chunks: Duration,
+    response_timeout: Duration,
+) -> Result<(H3Response, bool), String> {
     let socket = UdpSocket::bind("0.0.0.0:0").map_err(|err| err.to_string())?;
     let local_addr = socket.local_addr().map_err(|err| err.to_string())?;
 
@@ -901,11 +921,12 @@ pub fn run_two_chunk_post_to(
     let mut stream_id: Option<u64> = None;
     let mut chunk1_written = 0usize;
     let mut chunk2_written = 0usize;
-    let mut chunk2_ready_at: Option<Instant> = None;
+    let mut delayed_once = false;
     let mut status = 0u16;
     let mut headers = Vec::new();
     let mut body = Vec::new();
     let mut got_reset = false;
+    let mut request_stream_stopped = false;
 
     let (write, send_info) = conn
         .send(&mut out)
@@ -975,24 +996,45 @@ pub fn run_two_chunk_post_to(
             }
 
             if let Some(sid) = stream_id {
-                if chunk1_written < chunk1.len() {
+                if request_stream_stopped {
+                    // Keep polling for the terminal response after the server
+                    // has stopped accepting request-body bytes.
+                } else if status != 0 {
+                    request_stream_stopped = true;
+                    chunk1_written = chunk1.len();
+                    chunk2_written = chunk2.len();
+                } else if chunk1_written < chunk1.len() {
                     match h3_conn.send_body(&mut conn, sid, &chunk1[chunk1_written..], false) {
                         Ok(written) => {
                             chunk1_written += written;
-                            if chunk1_written == chunk1.len() {
-                                chunk2_ready_at = Some(Instant::now() + delay_between_chunks);
-                            }
                         }
                         Err(quiche::h3::Error::Done | quiche::h3::Error::StreamBlocked) => {}
+                        Err(quiche::h3::Error::TransportError(
+                            quiche::Error::StreamStopped(_),
+                        )) => {
+                            request_stream_stopped = true;
+                            chunk1_written = chunk1.len();
+                            chunk2_written = chunk2.len();
+                        }
                         Err(err) => return Err(format!("send_body chunk1: {err:?}")),
                     }
-                } else if chunk2_written < chunk2.len()
-                    && chunk2_ready_at.is_some_and(|deadline| Instant::now() >= deadline)
-                {
-                    match h3_conn.send_body(&mut conn, sid, &chunk2[chunk2_written..], true) {
-                        Ok(written) => chunk2_written += written,
-                        Err(quiche::h3::Error::Done | quiche::h3::Error::StreamBlocked) => {}
-                        Err(err) => return Err(format!("send_body chunk2: {err:?}")),
+                } else {
+                    if !delayed_once && !delay_between_chunks.is_zero() {
+                        std::thread::sleep(delay_between_chunks);
+                        delayed_once = true;
+                    }
+                    if chunk2_written < chunk2.len() {
+                        match h3_conn.send_body(&mut conn, sid, &chunk2[chunk2_written..], true) {
+                            Ok(written) => chunk2_written += written,
+                            Err(quiche::h3::Error::Done | quiche::h3::Error::StreamBlocked) => {}
+                            Err(quiche::h3::Error::TransportError(
+                                quiche::Error::StreamStopped(_),
+                            )) => {
+                                request_stream_stopped = true;
+                                chunk2_written = chunk2.len();
+                            }
+                            Err(err) => return Err(format!("send_body chunk2: {err:?}")),
+                        }
                     }
                 }
             }
@@ -1045,7 +1087,7 @@ pub fn run_two_chunk_post_to(
             }
         }
 
-        if start.elapsed() > Duration::from_secs(REQUEST_TIMEOUT_SECS + 4) {
+        if start.elapsed() > response_timeout {
             return Err(format!(
                 "timeout waiting for response (status={status}, body_len={}, got_reset={got_reset})",
                 body.len()

--- a/crates/lb/tests/README.md
+++ b/crates/lb/tests/README.md
@@ -1,0 +1,24 @@
+## LB Test Boundaries
+
+The load-balancing crate keeps its regression and contract coverage as crate-local integration
+tests instead of a separate `tests/regression/` subtree.
+
+Keep tests in this directory when the bug is about:
+- strategy behavior such as round robin, random, consistent hash, least-connections, or
+  latency-aware selection
+- runtime-upstream to pool construction
+- healthy-only selection semantics
+- alternate-backend selection substrate behavior
+- canonical request-key extraction owned by the balancing layer
+
+Representative regressions already pinned here:
+- round-robin sequencing drifting back to the first backend
+- strategy normalization through the canonical runtime pool surface
+- healthy-membership filtering for strategy picks
+
+Do not add edge orchestration or backend lifecycle behavior here. If the regression requires live
+runtime health transitions, DNS refresh, request feedback, or listener behavior, it belongs in the
+edge lifecycle or request-path suites.
+
+Rule of thumb: if the bug is about balancing substrate behavior independent of edge orchestration,
+keep it here.

--- a/crates/lb/tests/strategy_behavior.rs
+++ b/crates/lb/tests/strategy_behavior.rs
@@ -107,12 +107,7 @@ fn round_robin_repeated_picks_keep_alternating_across_backends() {
     let mut pool = pool("round-robin", 2);
 
     let keys = [
-        "tenant-a",
-        "tenant-b",
-        "tenant-c",
-        "tenant-d",
-        "tenant-e",
-        "tenant-f",
+        "tenant-a", "tenant-b", "tenant-c", "tenant-d", "tenant-e", "tenant-f",
     ];
     let picks: Vec<_> = keys
         .into_iter()

--- a/crates/lb/tests/strategy_behavior.rs
+++ b/crates/lb/tests/strategy_behavior.rs
@@ -103,6 +103,33 @@ fn round_robin_sequences_across_healthy_backends() {
 }
 
 #[test]
+fn round_robin_repeated_picks_keep_alternating_across_backends() {
+    let mut pool = pool("round-robin", 2);
+
+    let keys = [
+        "tenant-a",
+        "tenant-b",
+        "tenant-c",
+        "tenant-d",
+        "tenant-e",
+        "tenant-f",
+    ];
+    let picks: Vec<_> = keys
+        .into_iter()
+        .map(|key| {
+            pool.pick_without_begin(key)
+                .expect("round-robin regression pick")
+        })
+        .collect();
+
+    assert_eq!(
+        picks,
+        vec![0, 1, 0, 1, 0, 1],
+        "round-robin must keep alternating across healthy backends even when caller keys vary"
+    );
+}
+
+#[test]
 fn random_selection_stays_within_healthy_membership() {
     let mut pool = pool("random", 3);
     let _ = pool.mark_backend_failure_from_active_check(0);

--- a/crates/transport/tests/README.md
+++ b/crates/transport/tests/README.md
@@ -1,0 +1,23 @@
+## Transport Test Boundaries
+
+The transport crate keeps protocol-hiding regressions as crate-local facade tests instead of a
+separate `tests/regression/` subtree.
+
+Keep tests in this directory when the bug is about:
+- canonical transport facade request execution
+- H1/H2 protocol hiding from callers
+- unified client rotation semantics
+- transport-boundary timeout ownership
+- stable transport-side error and overload mapping
+
+Representative regressions already pinned here:
+- caller-visible protocol branching leaking out of the transport facade
+- H1/H2 client rotation returning different observable contracts
+- unknown-backend, overload, and send-failure mapping drifting across protocol implementations
+
+Do not add edge request-path policy tests here. Admission, auth, retry, response normalization, and
+listener/runtime behavior belong in edge or bridge suites unless the regression is truly at the
+transport facade boundary.
+
+Rule of thumb: if the caller should be able to treat transport as one backend-execution surface,
+the regression belongs here.


### PR DESCRIPTION
## Summary
Adds focused regression coverage for bugs and behavior drifts already seen during the refactor work, with emphasis on keeping request-path, bootstrap compatibility, runtime swap, and LB behavior stable.

## What’s included
- Bootstrap websocket regression coverage
  - locks `101 Switching Protocols` behavior
  - verifies upgrade headers survive bootstrap response normalization

- QUIC request-path regression coverage
  - locks oversized request-body failures to `413` instead of falling through to `503`
  - covers slow over-cap request producers
  - locks long-lived response streams so total body timeout does not kill streams that continue making progress

- Load-balancing regression coverage
  - adds explicit round-robin alternation coverage
  - protects against unintended stickiness across repeated picks

- Runtime/control-plane regression coverage
  - locks control API runtime snapshot behavior after bundle replacement
  - verifies live-generation listener labels and auth/path gating stay correct after runtime swap
  - adds health-check regression coverage for timeout and fallback failure-reason mapping

## Why
These tests capture real regressions encountered during Phase 2 and the follow-on hardening work, so future cleanup, lint-driven changes, and boundary refactors do not silently reintroduce them.

## Validation
- targeted regression suites passed
- request-path hardening suite passed
- backend failure and recovery suite passed
- runtime swap suite passed
- LB strategy behavior suite passed