### PR TITLE
feat(edge): add staged runtime activation, rollback, and history controls

### DIFF
--- a/crates/edge/src/metrics/mod.rs
+++ b/crates/edge/src/metrics/mod.rs
@@ -9,12 +9,12 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
+use crate::runtime::activation::{RuntimeOperationOutcomeReason, RuntimeRejectionReason};
 use spooky_errors::{
     HedgeOutcomeTelemetryReason, HedgeTriggerTelemetryReason, RetryAttemptTelemetryReason,
     RetryPolicyDenialReason,
 };
 use spooky_lb::health::HealthFailureReason;
-use crate::runtime::activation::{RuntimeOperationOutcomeReason, RuntimeRejectionReason};
 
 pub struct Metrics {
     pub requests_total: AtomicU64,
@@ -1295,9 +1295,9 @@ impl Metrics {
 
     pub fn runtime_rejection_reason_count(&self, reason: RuntimeRejectionReason) -> u64 {
         match reason {
-            RuntimeRejectionReason::InvalidConfig => {
-                self.runtime_rejection_invalid_config.load(Ordering::Relaxed)
-            }
+            RuntimeRejectionReason::InvalidConfig => self
+                .runtime_rejection_invalid_config
+                .load(Ordering::Relaxed),
             RuntimeRejectionReason::StartupOwnedChange => self
                 .runtime_rejection_startup_owned_change
                 .load(Ordering::Relaxed),

--- a/crates/edge/src/metrics/mod.rs
+++ b/crates/edge/src/metrics/mod.rs
@@ -14,6 +14,7 @@ use spooky_errors::{
     RetryPolicyDenialReason,
 };
 use spooky_lb::health::HealthFailureReason;
+use crate::runtime::activation::RuntimeRejectionReason;
 
 pub struct Metrics {
     pub requests_total: AtomicU64,
@@ -75,6 +76,13 @@ pub struct Metrics {
     pub watchdog_restart_hooks: AtomicU64,
     pub watchdog_degraded_windows: AtomicU64,
     pub runtime_panics: AtomicU64,
+    pub runtime_rejection_invalid_config: AtomicU64,
+    pub runtime_rejection_startup_owned_change: AtomicU64,
+    pub runtime_rejection_bind_conflict: AtomicU64,
+    pub runtime_rejection_resource_prepare_failed: AtomicU64,
+    pub runtime_rejection_incompatible_reload: AtomicU64,
+    pub runtime_rejection_unknown_generation: AtomicU64,
+    pub runtime_rejection_rollback_not_allowed: AtomicU64,
     pub retries_total: AtomicU64,
     pub retry_denied_budget: AtomicU64,
     pub retry_denied_no_bodyless: AtomicU64,
@@ -504,6 +512,13 @@ impl Metrics {
             watchdog_restart_hooks: AtomicU64::new(0),
             watchdog_degraded_windows: AtomicU64::new(0),
             runtime_panics: AtomicU64::new(0),
+            runtime_rejection_invalid_config: AtomicU64::new(0),
+            runtime_rejection_startup_owned_change: AtomicU64::new(0),
+            runtime_rejection_bind_conflict: AtomicU64::new(0),
+            runtime_rejection_resource_prepare_failed: AtomicU64::new(0),
+            runtime_rejection_incompatible_reload: AtomicU64::new(0),
+            runtime_rejection_unknown_generation: AtomicU64::new(0),
+            runtime_rejection_rollback_not_allowed: AtomicU64::new(0),
             retries_total: AtomicU64::new(0),
             retry_denied_budget: AtomicU64::new(0),
             retry_denied_no_bodyless: AtomicU64::new(0),
@@ -1213,6 +1228,65 @@ impl Metrics {
     pub fn inc_control_api_connection_limit_drop(&self) {
         self.control_api_connection_limit_drops
             .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_runtime_rejection_reason(&self, reason: RuntimeRejectionReason) {
+        match reason {
+            RuntimeRejectionReason::InvalidConfig => {
+                self.runtime_rejection_invalid_config
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            RuntimeRejectionReason::StartupOwnedChange => {
+                self.runtime_rejection_startup_owned_change
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            RuntimeRejectionReason::BindConflict => {
+                self.runtime_rejection_bind_conflict
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            RuntimeRejectionReason::ResourcePrepareFailed => {
+                self.runtime_rejection_resource_prepare_failed
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            RuntimeRejectionReason::IncompatibleReload => {
+                self.runtime_rejection_incompatible_reload
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            RuntimeRejectionReason::UnknownGeneration => {
+                self.runtime_rejection_unknown_generation
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            RuntimeRejectionReason::RollbackNotAllowed => {
+                self.runtime_rejection_rollback_not_allowed
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+
+    pub fn runtime_rejection_reason_count(&self, reason: RuntimeRejectionReason) -> u64 {
+        match reason {
+            RuntimeRejectionReason::InvalidConfig => {
+                self.runtime_rejection_invalid_config.load(Ordering::Relaxed)
+            }
+            RuntimeRejectionReason::StartupOwnedChange => self
+                .runtime_rejection_startup_owned_change
+                .load(Ordering::Relaxed),
+            RuntimeRejectionReason::BindConflict => {
+                self.runtime_rejection_bind_conflict.load(Ordering::Relaxed)
+            }
+            RuntimeRejectionReason::ResourcePrepareFailed => self
+                .runtime_rejection_resource_prepare_failed
+                .load(Ordering::Relaxed),
+            RuntimeRejectionReason::IncompatibleReload => self
+                .runtime_rejection_incompatible_reload
+                .load(Ordering::Relaxed),
+            RuntimeRejectionReason::UnknownGeneration => self
+                .runtime_rejection_unknown_generation
+                .load(Ordering::Relaxed),
+            RuntimeRejectionReason::RollbackNotAllowed => self
+                .runtime_rejection_rollback_not_allowed
+                .load(Ordering::Relaxed),
+        }
     }
 
     pub fn inc_watchdog_restart_request(&self) {

--- a/crates/edge/src/metrics/mod.rs
+++ b/crates/edge/src/metrics/mod.rs
@@ -14,7 +14,7 @@ use spooky_errors::{
     RetryPolicyDenialReason,
 };
 use spooky_lb::health::HealthFailureReason;
-use crate::runtime::activation::RuntimeRejectionReason;
+use crate::runtime::activation::{RuntimeOperationOutcomeReason, RuntimeRejectionReason};
 
 pub struct Metrics {
     pub requests_total: AtomicU64,
@@ -83,6 +83,12 @@ pub struct Metrics {
     pub runtime_rejection_incompatible_reload: AtomicU64,
     pub runtime_rejection_unknown_generation: AtomicU64,
     pub runtime_rejection_rollback_not_allowed: AtomicU64,
+    pub runtime_validation_attempts: AtomicU64,
+    pub runtime_preview_attempts: AtomicU64,
+    pub runtime_active_generation: AtomicU64,
+    pub runtime_history_depth: AtomicU64,
+    runtime_activation_outcomes: [AtomicU64; RuntimeOperationOutcomeReason::COUNT],
+    runtime_rollback_outcomes: [AtomicU64; RuntimeOperationOutcomeReason::COUNT],
     pub retries_total: AtomicU64,
     pub retry_denied_budget: AtomicU64,
     pub retry_denied_no_bodyless: AtomicU64,
@@ -519,6 +525,12 @@ impl Metrics {
             runtime_rejection_incompatible_reload: AtomicU64::new(0),
             runtime_rejection_unknown_generation: AtomicU64::new(0),
             runtime_rejection_rollback_not_allowed: AtomicU64::new(0),
+            runtime_validation_attempts: AtomicU64::new(0),
+            runtime_preview_attempts: AtomicU64::new(0),
+            runtime_active_generation: AtomicU64::new(0),
+            runtime_history_depth: AtomicU64::new(0),
+            runtime_activation_outcomes: std::array::from_fn(|_| AtomicU64::new(0)),
+            runtime_rollback_outcomes: std::array::from_fn(|_| AtomicU64::new(0)),
             retries_total: AtomicU64::new(0),
             retry_denied_budget: AtomicU64::new(0),
             retry_denied_no_bodyless: AtomicU64::new(0),
@@ -1263,6 +1275,24 @@ impl Metrics {
         }
     }
 
+    pub fn inc_runtime_validation_attempt(&self) {
+        self.runtime_validation_attempts
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_runtime_preview_attempt(&self) {
+        self.runtime_preview_attempts
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_runtime_activation_outcome(&self, reason: RuntimeOperationOutcomeReason) {
+        self.runtime_activation_outcomes[reason.index()].fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_runtime_rollback_outcome(&self, reason: RuntimeOperationOutcomeReason) {
+        self.runtime_rollback_outcomes[reason.index()].fetch_add(1, Ordering::Relaxed);
+    }
+
     pub fn runtime_rejection_reason_count(&self, reason: RuntimeRejectionReason) -> u64 {
         match reason {
             RuntimeRejectionReason::InvalidConfig => {
@@ -1287,6 +1317,24 @@ impl Metrics {
                 .runtime_rejection_rollback_not_allowed
                 .load(Ordering::Relaxed),
         }
+    }
+
+    pub fn runtime_activation_outcome_count(&self, reason: RuntimeOperationOutcomeReason) -> u64 {
+        self.runtime_activation_outcomes[reason.index()].load(Ordering::Relaxed)
+    }
+
+    pub fn runtime_rollback_outcome_count(&self, reason: RuntimeOperationOutcomeReason) -> u64 {
+        self.runtime_rollback_outcomes[reason.index()].load(Ordering::Relaxed)
+    }
+
+    pub fn set_runtime_active_generation(&self, generation: u64) {
+        self.runtime_active_generation
+            .store(generation, Ordering::Relaxed);
+    }
+
+    pub fn set_runtime_history_depth(&self, depth: usize) {
+        let depth = u64::try_from(depth).unwrap_or(u64::MAX);
+        self.runtime_history_depth.store(depth, Ordering::Relaxed);
     }
 
     pub fn inc_watchdog_restart_request(&self) {

--- a/crates/edge/src/metrics/mod.rs
+++ b/crates/edge/src/metrics/mod.rs
@@ -9,12 +9,13 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use crate::runtime::activation::{RuntimeOperationOutcomeReason, RuntimeRejectionReason};
 use spooky_errors::{
     HedgeOutcomeTelemetryReason, HedgeTriggerTelemetryReason, RetryAttemptTelemetryReason,
     RetryPolicyDenialReason,
 };
 use spooky_lb::health::HealthFailureReason;
+
+use crate::runtime::activation::{RuntimeOperationOutcomeReason, RuntimeRejectionReason};
 
 pub struct Metrics {
     pub requests_total: AtomicU64,

--- a/crates/edge/src/metrics/prometheus.rs
+++ b/crates/edge/src/metrics/prometheus.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::runtime::activation::RuntimeRejectionReason;
+use crate::runtime::activation::{RuntimeOperationOutcomeReason, RuntimeRejectionReason};
 
 impl Metrics {
     pub fn render_prometheus(&self) -> String {
@@ -247,6 +247,68 @@ impl Metrics {
                 self.runtime_rejection_reason_count(reason)
             ));
         }
+
+        out.push_str(
+            "# HELP spooky_runtime_validation_attempts_total Total staged runtime validation requests accepted by the control plane.\n",
+        );
+        out.push_str("# TYPE spooky_runtime_validation_attempts_total counter\n");
+        out.push_str(&format!(
+            "spooky_runtime_validation_attempts_total {}\n",
+            self.runtime_validation_attempts.load(Ordering::Relaxed)
+        ));
+
+        out.push_str(
+            "# HELP spooky_runtime_preview_attempts_total Total staged runtime preview requests accepted by the control plane.\n",
+        );
+        out.push_str("# TYPE spooky_runtime_preview_attempts_total counter\n");
+        out.push_str(&format!(
+            "spooky_runtime_preview_attempts_total {}\n",
+            self.runtime_preview_attempts.load(Ordering::Relaxed)
+        ));
+
+        out.push_str(
+            "# HELP spooky_runtime_activation_total Total runtime activation outcomes grouped by result and canonical reason.\n",
+        );
+        out.push_str("# TYPE spooky_runtime_activation_total counter\n");
+        for reason in RuntimeOperationOutcomeReason::ALL {
+            out.push_str(&format!(
+                "spooky_runtime_activation_total{{result=\"{}\",reason=\"{}\"}} {}\n",
+                reason.result_label(),
+                reason.slug(),
+                self.runtime_activation_outcome_count(reason)
+            ));
+        }
+
+        out.push_str(
+            "# HELP spooky_runtime_rollback_total Total runtime rollback outcomes grouped by result and canonical reason.\n",
+        );
+        out.push_str("# TYPE spooky_runtime_rollback_total counter\n");
+        for reason in RuntimeOperationOutcomeReason::ALL {
+            out.push_str(&format!(
+                "spooky_runtime_rollback_total{{result=\"{}\",reason=\"{}\"}} {}\n",
+                reason.result_label(),
+                reason.slug(),
+                self.runtime_rollback_outcome_count(reason)
+            ));
+        }
+
+        out.push_str(
+            "# HELP spooky_runtime_active_generation Current active runtime generation identifier.\n",
+        );
+        out.push_str("# TYPE spooky_runtime_active_generation gauge\n");
+        out.push_str(&format!(
+            "spooky_runtime_active_generation {}\n",
+            self.runtime_active_generation.load(Ordering::Relaxed)
+        ));
+
+        out.push_str(
+            "# HELP spooky_runtime_history_depth Number of retained runtime history entries visible to the active generation.\n",
+        );
+        out.push_str("# TYPE spooky_runtime_history_depth gauge\n");
+        out.push_str(&format!(
+            "spooky_runtime_history_depth {}\n",
+            self.runtime_history_depth.load(Ordering::Relaxed)
+        ));
 
         out.push_str(
             "# HELP spooky_connection_cap_rejects Total new-connection attempts rejected by max_active_connections cap.\n",

--- a/crates/edge/src/metrics/prometheus.rs
+++ b/crates/edge/src/metrics/prometheus.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::runtime::activation::RuntimeRejectionReason;
 
 impl Metrics {
     pub fn render_prometheus(&self) -> String {
@@ -226,6 +227,26 @@ impl Metrics {
             "spooky_active_connections {}\n",
             self.active_connections.load(Ordering::Relaxed)
         ));
+
+        out.push_str(
+            "# HELP spooky_runtime_rejections_total Total runtime activation or rollback rejections grouped by canonical operator reason.\n",
+        );
+        out.push_str("# TYPE spooky_runtime_rejections_total counter\n");
+        for reason in [
+            RuntimeRejectionReason::InvalidConfig,
+            RuntimeRejectionReason::StartupOwnedChange,
+            RuntimeRejectionReason::BindConflict,
+            RuntimeRejectionReason::ResourcePrepareFailed,
+            RuntimeRejectionReason::IncompatibleReload,
+            RuntimeRejectionReason::UnknownGeneration,
+            RuntimeRejectionReason::RollbackNotAllowed,
+        ] {
+            out.push_str(&format!(
+                "spooky_runtime_rejections_total{{reason=\"{}\"}} {}\n",
+                reason.slug(),
+                self.runtime_rejection_reason_count(reason)
+            ));
+        }
 
         out.push_str(
             "# HELP spooky_connection_cap_rejects Total new-connection attempts rejected by max_active_connections cap.\n",

--- a/crates/edge/src/quic_listener/control_api/auth.rs
+++ b/crates/edge/src/quic_listener/control_api/auth.rs
@@ -49,7 +49,9 @@ impl QUICListener {
             Method::GET if path == paths.health_path.as_str() => Some(ControlApiRoute::Health),
             Method::GET if path == paths.ready_path.as_str() => Some(ControlApiRoute::Ready),
             Method::GET if path == paths.runtime_path.as_str() => Some(ControlApiRoute::Runtime),
-            Method::GET if path == runtime_history_path.as_str() => Some(ControlApiRoute::RuntimeHistory),
+            Method::GET if path == runtime_history_path.as_str() => {
+                Some(ControlApiRoute::RuntimeHistory)
+            }
             Method::GET if path.starts_with(runtime_history_entry_prefix.as_str()) => path
                 .strip_prefix(runtime_history_entry_prefix.as_str())
                 .and_then(|raw_generation| raw_generation.parse::<u64>().ok())

--- a/crates/edge/src/quic_listener/control_api/auth.rs
+++ b/crates/edge/src/quic_listener/control_api/auth.rs
@@ -15,6 +15,12 @@ pub(super) enum ControlApiRoute {
     Health,
     Ready,
     Runtime,
+    RuntimeValidate,
+    RuntimePreview,
+    RuntimeActivate,
+    RuntimeRollback,
+    RuntimeHistory,
+    RuntimeHistoryGeneration(u64),
     ReloadCerts,
     ReloadRuntime,
     Restart,
@@ -32,13 +38,36 @@ impl QUICListener {
         paths: &ControlApiPaths,
     ) -> Option<ControlApiRoute> {
         let path = req.uri().path();
+        let runtime_validate_path = paths.runtime_validate_path();
+        let runtime_preview_path = paths.runtime_preview_path();
+        let runtime_activate_path = paths.runtime_activate_path();
+        let runtime_rollback_path = paths.runtime_rollback_path();
+        let runtime_history_path = paths.runtime_history_path();
+        let runtime_history_entry_prefix = paths.runtime_history_entry_prefix();
 
         match *req.method() {
             Method::GET if path == paths.health_path.as_str() => Some(ControlApiRoute::Health),
             Method::GET if path == paths.ready_path.as_str() => Some(ControlApiRoute::Ready),
             Method::GET if path == paths.runtime_path.as_str() => Some(ControlApiRoute::Runtime),
+            Method::GET if path == runtime_history_path.as_str() => Some(ControlApiRoute::RuntimeHistory),
+            Method::GET if path.starts_with(runtime_history_entry_prefix.as_str()) => path
+                .strip_prefix(runtime_history_entry_prefix.as_str())
+                .and_then(|raw_generation| raw_generation.parse::<u64>().ok())
+                .map(ControlApiRoute::RuntimeHistoryGeneration),
             Method::POST if path == paths.reload_certs_path.as_str() => {
                 Some(ControlApiRoute::ReloadCerts)
+            }
+            Method::POST if path == runtime_validate_path.as_str() => {
+                Some(ControlApiRoute::RuntimeValidate)
+            }
+            Method::POST if path == runtime_preview_path.as_str() => {
+                Some(ControlApiRoute::RuntimePreview)
+            }
+            Method::POST if path == runtime_activate_path.as_str() => {
+                Some(ControlApiRoute::RuntimeActivate)
+            }
+            Method::POST if path == runtime_rollback_path.as_str() => {
+                Some(ControlApiRoute::RuntimeRollback)
             }
             Method::POST if path == paths.reload_path.as_str() => {
                 Some(ControlApiRoute::ReloadRuntime)
@@ -94,7 +123,13 @@ impl QUICListener {
         }
 
         let response = match route {
-            ControlApiRoute::Runtime => json!({
+            ControlApiRoute::Runtime
+            | ControlApiRoute::RuntimeValidate
+            | ControlApiRoute::RuntimePreview
+            | ControlApiRoute::RuntimeActivate
+            | ControlApiRoute::RuntimeRollback
+            | ControlApiRoute::RuntimeHistory
+            | ControlApiRoute::RuntimeHistoryGeneration(_) => json!({
                 "error": "unauthorized",
             }),
             ControlApiRoute::ReloadCerts | ControlApiRoute::ReloadRuntime => json!({

--- a/crates/edge/src/quic_listener/control_api/http.rs
+++ b/crates/edge/src/quic_listener/control_api/http.rs
@@ -21,8 +21,7 @@ impl QUICListener {
             super::auth::ControlApiRoute::RuntimePreview => {
                 Self::handle_control_api_runtime_preview(req, state).await
             }
-            super::auth::ControlApiRoute::RuntimeActivate
-             => {
+            super::auth::ControlApiRoute::RuntimeActivate => {
                 Self::handle_control_api_runtime_activate(req, state).await
             }
             super::auth::ControlApiRoute::ReloadRuntime => {

--- a/crates/edge/src/quic_listener/control_api/http.rs
+++ b/crates/edge/src/quic_listener/control_api/http.rs
@@ -1,7 +1,7 @@
 use super::{state::ControlApiState, *};
 
 impl QUICListener {
-    pub(super) fn handle_control_api_request(
+    pub(super) async fn handle_control_api_request(
         req: Request<Incoming>,
         state: &ControlApiState,
     ) -> Response<http_body_util::Full<bytes::Bytes>> {
@@ -15,11 +15,30 @@ impl QUICListener {
             super::auth::ControlApiRoute::Runtime => {
                 Self::render_control_api_runtime_snapshot(state)
             }
-            super::auth::ControlApiRoute::ReloadCerts => {
-                Self::handle_control_api_reload_certs(state)
+            super::auth::ControlApiRoute::RuntimeValidate => {
+                Self::handle_control_api_runtime_validate(req, state).await
+            }
+            super::auth::ControlApiRoute::RuntimePreview => {
+                Self::handle_control_api_runtime_preview(req, state).await
+            }
+            super::auth::ControlApiRoute::RuntimeActivate
+             => {
+                Self::handle_control_api_runtime_activate(req, state).await
             }
             super::auth::ControlApiRoute::ReloadRuntime => {
-                Self::handle_control_api_runtime_reload(&req, state)
+                Self::handle_control_api_runtime_reload(req, state).await
+            }
+            super::auth::ControlApiRoute::RuntimeRollback => {
+                Self::handle_control_api_runtime_rollback(req, state).await
+            }
+            super::auth::ControlApiRoute::RuntimeHistory => {
+                Self::render_control_api_runtime_history(state)
+            }
+            super::auth::ControlApiRoute::RuntimeHistoryGeneration(generation) => {
+                Self::render_control_api_runtime_history_generation(state, generation)
+            }
+            super::auth::ControlApiRoute::ReloadCerts => {
+                Self::handle_control_api_reload_certs(state)
             }
             super::auth::ControlApiRoute::Restart => Self::handle_control_api_restart(state),
         }

--- a/crates/edge/src/quic_listener/control_api/mod.rs
+++ b/crates/edge/src/quic_listener/control_api/mod.rs
@@ -1,8 +1,6 @@
 use hyper::{server::conn::http1, service::service_fn};
 use hyper_util::rt::TokioIo;
-use spooky_config::{
-    config::ControlApi as ControlApiConfig, loader::read_config, runtime::RuntimeConfig,
-};
+use spooky_config::config::ControlApi as ControlApiConfig;
 use tokio_rustls::TlsAcceptor;
 
 use super::*;

--- a/crates/edge/src/quic_listener/control_api/reload.rs
+++ b/crates/edge/src/quic_listener/control_api/reload.rs
@@ -6,7 +6,8 @@ use super::*;
 use crate::runtime::{
     activation::{
         ActivationRequest, ActivationResult, RejectedChangeKind, ReloadConfigInput,
-        RollbackRequest, RollbackResult, RuntimeActivationService, plan_runtime_reload,
+        ReloadPlan, RollbackRequest, RollbackResult, RuntimeActivationService,
+        RuntimeRejectionReason, plan_runtime_reload,
     },
     bundle::ActiveRuntimeGeneration,
     policy::{ReloadCompatibilityAuthority, TransitionRejection},
@@ -136,6 +137,7 @@ impl QUICListener {
             Self::control_api_activation_request(&plan_request, current.generation(), "runtime_validate"),
             Self::control_api_reload_config_input(&current, plan_request.config_path),
         );
+        Self::record_control_api_plan_rejection(state, "validate", &plan.plan);
         Self::json_response(StatusCode::OK, plan.plan)
     }
 
@@ -157,6 +159,7 @@ impl QUICListener {
             Self::control_api_activation_request(&plan_request, current.generation(), "runtime_preview"),
             Self::control_api_reload_config_input(&current, plan_request.config_path),
         );
+        Self::record_control_api_plan_rejection(state, "preview", &plan.plan);
         Self::json_response(StatusCode::OK, plan.plan)
     }
 
@@ -167,10 +170,13 @@ impl QUICListener {
         match Self::perform_control_api_runtime_activation(req, state, "runtime_activate").await {
             Ok(activation) => Self::json_response(StatusCode::ACCEPTED, activation),
             Err(ControlApiActivationError::Response(response)) => response,
-            Err(ControlApiActivationError::Activation(activation)) => Self::json_response(
-                activation_result_status(&activation),
-                activation_error_payload(&activation, activation_error(&activation)),
-            ),
+            Err(ControlApiActivationError::Activation(activation)) => {
+                Self::record_control_api_activation_rejection(state, &activation);
+                Self::json_response(
+                    activation_result_status(&activation),
+                    activation_error_payload(&activation, activation_error(&activation)),
+                )
+            }
         }
     }
 
@@ -189,10 +195,13 @@ impl QUICListener {
                 }),
             ),
             Err(ControlApiActivationError::Response(response)) => response,
-            Err(ControlApiActivationError::Activation(activation)) => Self::json_response(
-                legacy_reload_result_status(&activation),
-                legacy_reload_error_payload(&activation, activation_error(&activation)),
-            ),
+            Err(ControlApiActivationError::Activation(activation)) => {
+                Self::record_control_api_activation_rejection(state, &activation);
+                Self::json_response(
+                    legacy_reload_result_status(&activation),
+                    legacy_reload_error_payload(&activation, activation_error(&activation)),
+                )
+            }
         }
     }
 
@@ -232,13 +241,6 @@ impl QUICListener {
             Self::control_api_reload_config_input(&runtime, plan_request.config_path),
         );
         if !activation.succeeded() {
-            let error = activation_error(&activation);
-            // Phase 8: API response and logs communicate the same core reason.
-            warn!(
-                "runtime reload rejected at generation {}; active runtime unchanged: {}",
-                runtime.generation(),
-                error
-            );
             return Err(ControlApiActivationError::Activation(activation));
         }
         let generation = activation
@@ -283,15 +285,10 @@ impl QUICListener {
             },
         );
         if !rollback.succeeded() {
-            let error = rollback_error(&rollback);
-            warn!(
-                "runtime rollback rejected at generation {}; active runtime unchanged: {}",
-                rollback.active_generation,
-                error
-            );
+            Self::record_control_api_rollback_rejection(state, &rollback);
             return Self::json_response(
                 rollback_result_status(&rollback),
-                rollback_error_payload(&rollback, error),
+                rollback_error_payload(&rollback, rollback_error(&rollback)),
             );
         }
         Self::json_response(StatusCode::ACCEPTED, rollback)
@@ -633,6 +630,63 @@ impl QUICListener {
             requested_at_ms: crate::watchdog::time::now_millis(),
         }
     }
+
+    fn record_control_api_plan_rejection(
+        state: &crate::quic_listener::runtime_state::ControlApiServiceCtx,
+        operation: &str,
+        plan: &ReloadPlan,
+    ) {
+        if let Some(reason) = plan.primary_rejection_reason() {
+            state.current_service_state()
+                .metrics()
+                .inc_runtime_rejection_reason(reason);
+            warn!(
+                "runtime {} rejected generation={} reason={} summary={}",
+                operation,
+                plan.candidate_generation,
+                reason.slug(),
+                plan.rejection_summary
+                    .as_deref()
+                    .unwrap_or(plan.summary.as_str())
+            );
+        }
+    }
+
+    fn record_control_api_activation_rejection(
+        state: &crate::quic_listener::runtime_state::ControlApiServiceCtx,
+        activation: &ActivationResult,
+    ) {
+        if let Some(reason) = activation.primary_rejection_reason() {
+            state.current_service_state()
+                .metrics()
+                .inc_runtime_rejection_reason(reason);
+            warn!(
+                "runtime activation rejected active_generation={} candidate_generation={} reason={} error={}",
+                activation.active_generation,
+                activation.history_entry.generation,
+                reason.slug(),
+                activation_error(activation)
+            );
+        }
+    }
+
+    fn record_control_api_rollback_rejection(
+        state: &crate::quic_listener::runtime_state::ControlApiServiceCtx,
+        rollback: &RollbackResult,
+    ) {
+        if let Some(reason) = rollback.primary_rejection_reason() {
+            state.current_service_state()
+                .metrics()
+                .inc_runtime_rejection_reason(reason);
+            warn!(
+                "runtime rollback rejected active_generation={} target_generation={} reason={} error={}",
+                rollback.active_generation,
+                rollback.request.target_generation,
+                reason.slug(),
+                rollback_error(rollback)
+            );
+        }
+    }
 }
 
 fn activation_result_status(activation: &ActivationResult) -> StatusCode {
@@ -670,6 +724,7 @@ fn activation_error(activation: &ActivationResult) -> &str {
 fn activation_error_payload(activation: &ActivationResult, error: &str) -> serde_json::Value {
     json!({
         "error": error,
+        "rejection_reason": activation.primary_rejection_reason().map(RuntimeRejectionReason::slug),
         "active_generation": activation.active_generation,
         "candidate_generation": activation.history_entry.generation,
         "status": activation.status,
@@ -682,6 +737,7 @@ fn legacy_reload_error_payload(activation: &ActivationResult, error: &str) -> se
     json!({
         "reloaded": false,
         "error": error,
+        "rejection_reason": activation.primary_rejection_reason().map(RuntimeRejectionReason::slug),
         "generation": activation.active_generation,
         "candidate_generation": activation.history_entry.generation,
         "status": activation.status,
@@ -742,6 +798,7 @@ fn rollback_error(rollback: &RollbackResult) -> &str {
 fn rollback_error_payload(rollback: &RollbackResult, error: &str) -> serde_json::Value {
     json!({
         "error": error,
+        "rejection_reason": rollback.primary_rejection_reason().map(RuntimeRejectionReason::slug),
         "active_generation": rollback.active_generation,
         "target_generation": rollback.request.target_generation,
         "rolled_back_to": rollback.rolled_back_to,

--- a/crates/edge/src/quic_listener/control_api/reload.rs
+++ b/crates/edge/src/quic_listener/control_api/reload.rs
@@ -1,15 +1,37 @@
 use bytes::Bytes;
-use http_body_util::Full;
+use http_body_util::{BodyExt, Full};
+use serde::{Deserialize, de::DeserializeOwned};
 
 use super::*;
 use crate::runtime::{
     activation::{
         ActivationRequest, ActivationResult, RejectedChangeKind, ReloadConfigInput,
-        RuntimeActivationService,
+        RollbackRequest, RollbackResult, RuntimeActivationService, plan_runtime_reload,
     },
     bundle::ActiveRuntimeGeneration,
     policy::{ReloadCompatibilityAuthority, TransitionRejection},
 };
+
+#[derive(Default, Deserialize)]
+struct ControlApiRuntimePlanRequest {
+    config_path: Option<String>,
+    requested_by: Option<String>,
+    reason: Option<String>,
+    expected_generation: Option<u64>,
+}
+
+#[derive(Deserialize)]
+struct ControlApiRuntimeRollbackPayload {
+    target_generation: u64,
+    requested_by: Option<String>,
+    reason: Option<String>,
+    expected_active_generation: Option<u64>,
+}
+
+enum ControlApiActivationError {
+    Response(Response<Full<Bytes>>),
+    Activation(ActivationResult),
+}
 
 impl QUICListener {
     pub(super) fn apply_live_log_level_reload(
@@ -96,37 +118,118 @@ impl QUICListener {
         )
     }
 
-    pub(super) fn handle_control_api_runtime_reload(
-        req: &Request<Incoming>,
+    pub(super) async fn handle_control_api_runtime_validate(
+        req: Request<Incoming>,
         state: &crate::quic_listener::runtime_state::ControlApiServiceCtx,
     ) -> Response<Full<Bytes>> {
         let runtime_state = state.current_service_state();
         let Some(runtime_bundle_handle) = runtime_state.runtime_bundle_handle().cloned() else {
             return Self::control_api_not_found_response();
         };
+        let current = runtime_bundle_handle.current_view();
+        let plan_request = match Self::control_api_json_body_or_default::<ControlApiRuntimePlanRequest>(req).await {
+            Ok(payload) => payload,
+            Err(response) => return response,
+        };
+        let plan = plan_runtime_reload(
+            &current,
+            Self::control_api_activation_request(&plan_request, current.generation(), "runtime_validate"),
+            Self::control_api_reload_config_input(&current, plan_request.config_path),
+        );
+        Self::json_response(StatusCode::OK, plan.plan)
+    }
+
+    pub(super) async fn handle_control_api_runtime_preview(
+        req: Request<Incoming>,
+        state: &crate::quic_listener::runtime_state::ControlApiServiceCtx,
+    ) -> Response<Full<Bytes>> {
+        let runtime_state = state.current_service_state();
+        let Some(runtime_bundle_handle) = runtime_state.runtime_bundle_handle().cloned() else {
+            return Self::control_api_not_found_response();
+        };
+        let current = runtime_bundle_handle.current_view();
+        let plan_request = match Self::control_api_json_body_or_default::<ControlApiRuntimePlanRequest>(req).await {
+            Ok(payload) => payload,
+            Err(response) => return response,
+        };
+        let plan = plan_runtime_reload(
+            &current,
+            Self::control_api_activation_request(&plan_request, current.generation(), "runtime_preview"),
+            Self::control_api_reload_config_input(&current, plan_request.config_path),
+        );
+        Self::json_response(StatusCode::OK, plan.plan)
+    }
+
+    pub(super) async fn handle_control_api_runtime_activate(
+        req: Request<Incoming>,
+        state: &crate::quic_listener::runtime_state::ControlApiServiceCtx,
+    ) -> Response<Full<Bytes>> {
+        match Self::perform_control_api_runtime_activation(req, state, "runtime_activate").await {
+            Ok(activation) => Self::json_response(StatusCode::ACCEPTED, activation),
+            Err(ControlApiActivationError::Response(response)) => response,
+            Err(ControlApiActivationError::Activation(activation)) => Self::json_response(
+                activation_result_status(&activation),
+                activation_error_payload(&activation, activation_error(&activation)),
+            ),
+        }
+    }
+
+    pub(super) async fn handle_control_api_runtime_reload(
+        req: Request<Incoming>,
+        state: &crate::quic_listener::runtime_state::ControlApiServiceCtx,
+    ) -> Response<Full<Bytes>> {
+        match Self::perform_control_api_runtime_activation(req, state, "runtime_reload").await {
+            Ok(activation) => Self::json_response(
+                StatusCode::ACCEPTED,
+                json!({
+                    "reloaded": true,
+                    "generation": activation.activated_generation.expect("successful activation must set activated_generation"),
+                    "candidate_generation": activation.history_entry.generation,
+                    "status": activation.status,
+                }),
+            ),
+            Err(ControlApiActivationError::Response(response)) => response,
+            Err(ControlApiActivationError::Activation(activation)) => Self::json_response(
+                legacy_reload_result_status(&activation),
+                legacy_reload_error_payload(&activation, activation_error(&activation)),
+            ),
+        }
+    }
+
+    async fn perform_control_api_runtime_activation(
+        req: Request<Incoming>,
+        state: &crate::quic_listener::runtime_state::ControlApiServiceCtx,
+        default_reason: &str,
+    ) -> Result<ActivationResult, ControlApiActivationError> {
+        let runtime_state = state.current_service_state();
+        let Some(runtime_bundle_handle) = runtime_state.runtime_bundle_handle().cloned() else {
+            return Err(ControlApiActivationError::Response(
+                Self::control_api_not_found_response(),
+            ));
+        };
         let Some(runtime) = runtime_state.generation.clone() else {
-            return Self::json_response(
+            return Err(ControlApiActivationError::Response(Self::json_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 json!({
                     "reloaded": false,
                     "error": "runtime generation unavailable",
                 }),
-            );
+            )));
         };
 
+        let plan_request =
+            Self::control_api_json_body_or_default::<ControlApiRuntimePlanRequest>(req)
+                .await
+                .map_err(ControlApiActivationError::Response)?;
         let current_log_level = runtime.startup().log_config.level.clone();
         let activation = RuntimeActivationService::activate_reload(
             &runtime_bundle_handle,
-            ActivationRequest {
-                requested_by: Some("control_api".to_string()),
-                trigger_source: Some("control_api".to_string()),
-                reason: Some("runtime_reload".to_string()),
-                expected_generation: Some(runtime.generation()),
-                requested_at_ms: crate::watchdog::time::now_millis(),
-            },
-            ReloadConfigInput::Path {
-                path: runtime.startup().config_path.clone(),
-            },
+            Self::control_api_activation_request(
+                &plan_request,
+                runtime.generation(),
+                default_reason,
+            ),
+            Self::control_api_reload_config_input(&runtime, plan_request.config_path),
         );
         if !activation.succeeded() {
             let error = activation_error(&activation);
@@ -136,16 +239,7 @@ impl QUICListener {
                 runtime.generation(),
                 error
             );
-            return Self::json_response(
-                activation_result_status(&activation),
-                json!({
-                    "reloaded": false,
-                    "error": error,
-                    "generation": activation.active_generation,
-                    "candidate_generation": activation.history_entry.generation,
-                    "status": activation.status,
-                }),
-            );
+            return Err(ControlApiActivationError::Activation(activation));
         }
         let generation = activation
             .activated_generation
@@ -162,15 +256,45 @@ impl QUICListener {
                 generation, current_log_level, next_log_level, err
             );
         }
-        Self::json_response(
-            StatusCode::ACCEPTED,
-            json!({
-                "reloaded": true,
-                "generation": generation,
-                "candidate_generation": generation,
-                "path": req.uri().path(),
-            }),
-        )
+        Ok(activation)
+    }
+
+    pub(super) async fn handle_control_api_runtime_rollback(
+        req: Request<Incoming>,
+        state: &crate::quic_listener::runtime_state::ControlApiServiceCtx,
+    ) -> Response<Full<Bytes>> {
+        let runtime_state = state.current_service_state();
+        let Some(runtime_bundle_handle) = runtime_state.runtime_bundle_handle().cloned() else {
+            return Self::control_api_not_found_response();
+        };
+        let payload = match Self::control_api_json_body::<ControlApiRuntimeRollbackPayload>(req).await {
+            Ok(payload) => payload,
+            Err(response) => return response,
+        };
+        let rollback = RuntimeActivationService::rollback_generation(
+            &runtime_bundle_handle,
+            RollbackRequest {
+                target_generation: payload.target_generation,
+                requested_by: payload.requested_by.or_else(|| Some("control_api".to_string())),
+                trigger_source: Some("control_api".to_string()),
+                reason: payload.reason.or_else(|| Some("runtime_rollback".to_string())),
+                expected_active_generation: payload.expected_active_generation,
+                requested_at_ms: crate::watchdog::time::now_millis(),
+            },
+        );
+        if !rollback.succeeded() {
+            let error = rollback_error(&rollback);
+            warn!(
+                "runtime rollback rejected at generation {}; active runtime unchanged: {}",
+                rollback.active_generation,
+                error
+            );
+            return Self::json_response(
+                rollback_result_status(&rollback),
+                rollback_error_payload(&rollback, error),
+            );
+        }
+        Self::json_response(StatusCode::ACCEPTED, rollback)
     }
 
     pub(super) fn handle_control_api_restart(
@@ -427,6 +551,90 @@ impl QUICListener {
     }
 }
 
+impl QUICListener {
+    async fn control_api_json_body<T>(req: Request<Incoming>) -> Result<T, Response<Full<Bytes>>>
+    where
+        T: DeserializeOwned,
+    {
+        let body = match req.into_body().collect().await {
+            Ok(collected) => collected.to_bytes(),
+            Err(err) => {
+                return Err(Self::json_response(
+                    StatusCode::BAD_REQUEST,
+                    json!({ "error": format!("invalid request body: {err}") }),
+                ));
+            }
+        };
+        if body.is_empty() {
+            return Err(Self::json_response(
+                StatusCode::BAD_REQUEST,
+                json!({ "error": "request body is required" }),
+            ));
+        }
+        serde_json::from_slice(&body).map_err(|err| {
+            Self::json_response(
+                StatusCode::BAD_REQUEST,
+                json!({ "error": format!("invalid request body: {err}") }),
+            )
+        })
+    }
+
+    async fn control_api_json_body_or_default<T>(
+        req: Request<Incoming>,
+    ) -> Result<T, Response<Full<Bytes>>>
+    where
+        T: DeserializeOwned + Default,
+    {
+        let body = match req.into_body().collect().await {
+            Ok(collected) => collected.to_bytes(),
+            Err(err) => {
+                return Err(Self::json_response(
+                    StatusCode::BAD_REQUEST,
+                    json!({ "error": format!("invalid request body: {err}") }),
+                ));
+            }
+        };
+        if body.is_empty() {
+            return Ok(T::default());
+        }
+        serde_json::from_slice(&body).map_err(|err| {
+            Self::json_response(
+                StatusCode::BAD_REQUEST,
+                json!({ "error": format!("invalid request body: {err}") }),
+            )
+        })
+    }
+
+    fn control_api_reload_config_input(
+        current: &ActiveRuntimeGeneration,
+        config_path: Option<String>,
+    ) -> ReloadConfigInput {
+        ReloadConfigInput::Path {
+            path: config_path.unwrap_or_else(|| current.startup().config_path.clone()),
+        }
+    }
+
+    fn control_api_activation_request(
+        payload: &ControlApiRuntimePlanRequest,
+        current_generation: u64,
+        default_reason: &str,
+    ) -> ActivationRequest {
+        ActivationRequest {
+            requested_by: payload
+                .requested_by
+                .clone()
+                .or_else(|| Some("control_api".to_string())),
+            trigger_source: Some("control_api".to_string()),
+            reason: payload
+                .reason
+                .clone()
+                .or_else(|| Some(default_reason.to_string())),
+            expected_generation: payload.expected_generation.or(Some(current_generation)),
+            requested_at_ms: crate::watchdog::time::now_millis(),
+        }
+    }
+}
+
 fn activation_result_status(activation: &ActivationResult) -> StatusCode {
     if activation
         .rejected_changes
@@ -457,4 +665,88 @@ fn activation_error(activation: &ActivationResult) -> &str {
         .first()
         .map(|rejection| rejection.message.as_str())
         .unwrap_or(activation.history_entry.summary.as_str())
+}
+
+fn activation_error_payload(activation: &ActivationResult, error: &str) -> serde_json::Value {
+    json!({
+        "error": error,
+        "active_generation": activation.active_generation,
+        "candidate_generation": activation.history_entry.generation,
+        "status": activation.status,
+        "rejected_changes": activation.rejected_changes,
+        "history_entry": activation.history_entry,
+    })
+}
+
+fn legacy_reload_error_payload(activation: &ActivationResult, error: &str) -> serde_json::Value {
+    json!({
+        "reloaded": false,
+        "error": error,
+        "generation": activation.active_generation,
+        "candidate_generation": activation.history_entry.generation,
+        "status": activation.status,
+    })
+}
+
+fn legacy_reload_result_status(activation: &ActivationResult) -> StatusCode {
+    if activation
+        .rejected_changes
+        .iter()
+        .any(|rejection| matches!(rejection.kind, RejectedChangeKind::InvalidConfiguration))
+    {
+        StatusCode::BAD_REQUEST
+    } else if activation.rejected_changes.iter().any(|rejection| {
+        matches!(
+            rejection.kind,
+            RejectedChangeKind::ResourcePreparationFailed
+                | RejectedChangeKind::IllegalTransition
+                | RejectedChangeKind::RuntimeStateUnavailable
+        )
+    }) || matches!(activation.status, crate::runtime::activation::GenerationStatus::Failed)
+    {
+        StatusCode::INTERNAL_SERVER_ERROR
+    } else {
+        StatusCode::CONFLICT
+    }
+}
+
+fn rollback_result_status(rollback: &RollbackResult) -> StatusCode {
+    if rollback
+        .rejected_changes
+        .iter()
+        .any(|rejection| matches!(rejection.kind, RejectedChangeKind::InvalidConfiguration))
+    {
+        StatusCode::BAD_REQUEST
+    } else if rollback.rejected_changes.iter().any(|rejection| {
+        matches!(
+            rejection.kind,
+            RejectedChangeKind::ResourcePreparationFailed
+                | RejectedChangeKind::RuntimeStateUnavailable
+        )
+    }) || matches!(rollback.status, crate::runtime::activation::GenerationStatus::Failed)
+    {
+        StatusCode::INTERNAL_SERVER_ERROR
+    } else {
+        StatusCode::CONFLICT
+    }
+}
+
+fn rollback_error(rollback: &RollbackResult) -> &str {
+    rollback
+        .rejected_changes
+        .first()
+        .map(|rejection| rejection.message.as_str())
+        .unwrap_or(rollback.history_entry.summary.as_str())
+}
+
+fn rollback_error_payload(rollback: &RollbackResult, error: &str) -> serde_json::Value {
+    json!({
+        "error": error,
+        "active_generation": rollback.active_generation,
+        "target_generation": rollback.request.target_generation,
+        "rolled_back_to": rollback.rolled_back_to,
+        "status": rollback.status,
+        "rejected_changes": rollback.rejected_changes,
+        "history_entry": rollback.history_entry,
+    })
 }

--- a/crates/edge/src/quic_listener/control_api/reload.rs
+++ b/crates/edge/src/quic_listener/control_api/reload.rs
@@ -6,9 +6,8 @@ use std::sync::Arc;
 use super::*;
 use crate::runtime::{
     activation::{
-        ActivationRequest, ActivationResult, RejectedChangeKind, ReloadConfigInput,
-        ReloadPlan, RollbackRequest, RollbackResult, RuntimeActivationService,
-        RuntimeRejectionReason,
+        ActivationRequest, ActivationResult, RejectedChangeKind, ReloadConfigInput, ReloadPlan,
+        RollbackRequest, RollbackResult, RuntimeActivationService, RuntimeRejectionReason,
     },
     bundle::{ActiveRuntimeGeneration, RuntimeBundleHandle},
     policy::{ReloadCompatibilityAuthority, TransitionRejection},
@@ -129,10 +128,12 @@ impl QUICListener {
             return Self::control_api_not_found_response();
         };
         let current = runtime_bundle_handle.current_view();
-        let plan_request = match Self::control_api_json_body_or_default::<ControlApiRuntimePlanRequest>(req).await {
-            Ok(payload) => payload,
-            Err(response) => return response,
-        };
+        let plan_request =
+            match Self::control_api_json_body_or_default::<ControlApiRuntimePlanRequest>(req).await
+            {
+                Ok(payload) => payload,
+                Err(response) => return response,
+            };
         let activation_request = Self::control_api_activation_request(
             &plan_request,
             current.generation(),
@@ -164,10 +165,12 @@ impl QUICListener {
             return Self::control_api_not_found_response();
         };
         let current = runtime_bundle_handle.current_view();
-        let plan_request = match Self::control_api_json_body_or_default::<ControlApiRuntimePlanRequest>(req).await {
-            Ok(payload) => payload,
-            Err(response) => return response,
-        };
+        let plan_request =
+            match Self::control_api_json_body_or_default::<ControlApiRuntimePlanRequest>(req).await
+            {
+                Ok(payload) => payload,
+                Err(response) => return response,
+            };
         let activation_request = Self::control_api_activation_request(
             &plan_request,
             current.generation(),
@@ -299,17 +302,22 @@ impl QUICListener {
         let Some(runtime_bundle_handle) = runtime_state.runtime_bundle_handle().cloned() else {
             return Self::control_api_not_found_response();
         };
-        let payload = match Self::control_api_json_body::<ControlApiRuntimeRollbackPayload>(req).await {
-            Ok(payload) => payload,
-            Err(response) => return response,
-        };
+        let payload =
+            match Self::control_api_json_body::<ControlApiRuntimeRollbackPayload>(req).await {
+                Ok(payload) => payload,
+                Err(response) => return response,
+            };
         let rollback = RuntimeActivationService::rollback_generation(
             &runtime_bundle_handle,
             RollbackRequest {
                 target_generation: payload.target_generation,
-                requested_by: payload.requested_by.or_else(|| Some("control_api".to_string())),
+                requested_by: payload
+                    .requested_by
+                    .or_else(|| Some("control_api".to_string())),
                 trigger_source: Some("control_api".to_string()),
-                reason: payload.reason.or_else(|| Some("runtime_rollback".to_string())),
+                reason: payload
+                    .reason
+                    .or_else(|| Some("runtime_rollback".to_string())),
                 expected_active_generation: payload.expected_active_generation,
                 requested_at_ms: crate::watchdog::time::now_millis(),
             },
@@ -706,9 +714,7 @@ impl QUICListener {
         } else {
             info!(
                 "runtime {} accepted candidate_generation={} summary={}",
-                operation,
-                plan.candidate_generation,
-                plan.summary
+                operation, plan.candidate_generation, plan.summary
             );
         }
     }
@@ -796,12 +802,16 @@ fn activation_result_status(activation: &ActivationResult) -> StatusCode {
             rejection.kind,
             RejectedChangeKind::ResourcePreparationFailed
         )
-    }) || matches!(activation.status, crate::runtime::activation::GenerationStatus::Failed)
-    {
+    }) || matches!(
+        activation.status,
+        crate::runtime::activation::GenerationStatus::Failed
+    ) {
         StatusCode::INTERNAL_SERVER_ERROR
-    } else if activation.rejected_changes.iter().any(|rejection| {
-        matches!(rejection.kind, RejectedChangeKind::RuntimeStateUnavailable)
-    }) {
+    } else if activation
+        .rejected_changes
+        .iter()
+        .any(|rejection| matches!(rejection.kind, RejectedChangeKind::RuntimeStateUnavailable))
+    {
         StatusCode::INTERNAL_SERVER_ERROR
     } else {
         StatusCode::CONFLICT
@@ -853,8 +863,10 @@ fn legacy_reload_result_status(activation: &ActivationResult) -> StatusCode {
                 | RejectedChangeKind::IllegalTransition
                 | RejectedChangeKind::RuntimeStateUnavailable
         )
-    }) || matches!(activation.status, crate::runtime::activation::GenerationStatus::Failed)
-    {
+    }) || matches!(
+        activation.status,
+        crate::runtime::activation::GenerationStatus::Failed
+    ) {
         StatusCode::INTERNAL_SERVER_ERROR
     } else {
         StatusCode::CONFLICT
@@ -874,8 +886,10 @@ fn rollback_result_status(rollback: &RollbackResult) -> StatusCode {
             RejectedChangeKind::ResourcePreparationFailed
                 | RejectedChangeKind::RuntimeStateUnavailable
         )
-    }) || matches!(rollback.status, crate::runtime::activation::GenerationStatus::Failed)
-    {
+    }) || matches!(
+        rollback.status,
+        crate::runtime::activation::GenerationStatus::Failed
+    ) {
         StatusCode::INTERNAL_SERVER_ERROR
     } else {
         StatusCode::CONFLICT

--- a/crates/edge/src/quic_listener/control_api/reload.rs
+++ b/crates/edge/src/quic_listener/control_api/reload.rs
@@ -4,10 +4,10 @@ use http_body_util::Full;
 use super::*;
 use crate::runtime::{
     activation::{
-        ActivationRequest, RejectedChangeKind, ReloadConfigInput, ReloadPlan,
-        StagedRuntimeReloadPlan, plan_runtime_reload,
+        ActivationRequest, ActivationResult, RejectedChangeKind, ReloadConfigInput,
+        RuntimeActivationService,
     },
-    bundle::{ActiveRuntimeGeneration, RuntimeBundleHandle},
+    bundle::ActiveRuntimeGeneration,
     policy::{ReloadCompatibilityAuthority, TransitionRejection},
 };
 
@@ -114,8 +114,9 @@ impl QUICListener {
             );
         };
 
-        let plan = plan_runtime_reload(
-            &runtime,
+        let current_log_level = runtime.startup().log_config.level.clone();
+        let activation = RuntimeActivationService::activate_reload(
+            &runtime_bundle_handle,
             ActivationRequest {
                 requested_by: Some("control_api".to_string()),
                 reason: Some("runtime_reload".to_string()),
@@ -126,12 +127,8 @@ impl QUICListener {
                 path: runtime.startup().config_path.clone(),
             },
         );
-        if !plan.can_activate() {
-            let error = plan
-                .plan
-                .rejection_summary
-                .as_deref()
-                .unwrap_or("reload candidate rejected");
+        if !activation.succeeded() {
+            let error = activation_error(&activation);
             // Phase 8: API response and logs communicate the same core reason.
             warn!(
                 "runtime reload rejected at generation {}; active runtime unchanged: {}",
@@ -139,30 +136,25 @@ impl QUICListener {
                 error
             );
             return Self::json_response(
-                plan_rejection_status(&plan.plan),
+                activation_result_status(&activation),
                 json!({
                     "reloaded": false,
                     "error": error,
-                    "generation": plan.plan.current_generation,
-                    "candidate_generation": plan.plan.candidate_generation,
-                    "compatibility": plan.plan.compatibility,
+                    "generation": activation.active_generation,
+                    "candidate_generation": activation.history_entry.generation,
+                    "status": activation.status,
                 }),
             );
         }
-        let current_log_level = plan.current_log_level.clone();
-        let next_log_level = plan.next_log_level.clone().unwrap_or_default();
-        let generation = match Self::apply_runtime_reload_plan(&runtime_bundle_handle, plan) {
-            Ok(generation) => generation,
-            Err(err) => {
-                return Self::json_response(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    json!({
-                        "reloaded": false,
-                        "error": err.to_string(),
-                    }),
-                );
-            }
-        };
+        let generation = activation
+            .activated_generation
+            .expect("successful activation must set activated_generation");
+        let next_log_level = runtime_bundle_handle
+            .current_view()
+            .startup()
+            .log_config
+            .level
+            .clone();
         if let Err(err) = Self::apply_live_log_level_reload(&current_log_level, &next_log_level) {
             error!(
                 "Runtime reload applied generation={} but failed to update live log.level from '{}' to '{}': {}",
@@ -234,20 +226,6 @@ impl QUICListener {
             return Err(vec![rejection]);
         }
         Self::validate_startup_owned_reload_compatibility(current.bundle(), next)
-    }
-
-    pub(super) fn apply_runtime_reload_plan(
-        runtime_bundle_handle: &RuntimeBundleHandle,
-        plan: StagedRuntimeReloadPlan,
-    ) -> Result<u64, ProxyError> {
-        let next_runtime = plan.next_runtime.ok_or_else(|| {
-            ProxyError::Transport("staged reload plan missing next runtime".to_string())
-        })?;
-        QUICListener::spawn_generation_background_tasks_for_runtime(
-            &next_runtime.runtime_config,
-            next_runtime.shared_state.as_ref(),
-        );
-        runtime_bundle_handle.replace(next_runtime)
     }
 
     pub(super) fn validate_runtime_reload_compatibility(
@@ -448,21 +426,34 @@ impl QUICListener {
     }
 }
 
-fn plan_rejection_status(plan: &ReloadPlan) -> StatusCode {
-    if plan
+fn activation_result_status(activation: &ActivationResult) -> StatusCode {
+    if activation
         .rejected_changes
         .iter()
         .any(|rejection| matches!(rejection.kind, RejectedChangeKind::InvalidConfiguration))
     {
         StatusCode::BAD_REQUEST
-    } else if plan.rejected_changes.iter().any(|rejection| {
+    } else if activation.rejected_changes.iter().any(|rejection| {
         matches!(
             rejection.kind,
             RejectedChangeKind::ResourcePreparationFailed
         )
+    }) || matches!(activation.status, crate::runtime::activation::GenerationStatus::Failed)
+    {
+        StatusCode::INTERNAL_SERVER_ERROR
+    } else if activation.rejected_changes.iter().any(|rejection| {
+        matches!(rejection.kind, RejectedChangeKind::RuntimeStateUnavailable)
     }) {
         StatusCode::INTERNAL_SERVER_ERROR
     } else {
         StatusCode::CONFLICT
     }
+}
+
+fn activation_error(activation: &ActivationResult) -> &str {
+    activation
+        .rejected_changes
+        .first()
+        .map(|rejection| rejection.message.as_str())
+        .unwrap_or(activation.history_entry.summary.as_str())
 }

--- a/crates/edge/src/quic_listener/control_api/reload.rs
+++ b/crates/edge/src/quic_listener/control_api/reload.rs
@@ -3,15 +3,13 @@ use http_body_util::Full;
 
 use super::*;
 use crate::runtime::{
+    activation::{
+        ActivationRequest, RejectedChangeKind, ReloadConfigInput, ReloadPlan,
+        StagedRuntimeReloadPlan, plan_runtime_reload,
+    },
     bundle::{ActiveRuntimeGeneration, RuntimeBundleHandle},
     policy::{ReloadCompatibilityAuthority, TransitionRejection},
 };
-
-pub(super) struct RuntimeReloadPlan {
-    pub(super) next_runtime: RuntimeBundle,
-    pub(super) current_log_level: String,
-    pub(super) next_log_level: String,
-}
 
 impl QUICListener {
     pub(super) fn apply_live_log_level_reload(
@@ -116,42 +114,43 @@ impl QUICListener {
             );
         };
 
-        let plan = match Self::build_runtime_reload_plan(&runtime) {
-            Ok(plan) => plan,
-            Err(err) => {
-                let status = if err.starts_with("Configuration validation failed:")
-                    || err.starts_with("Runtime configuration normalization failed:")
-                {
-                    StatusCode::BAD_REQUEST
-                } else {
-                    StatusCode::INTERNAL_SERVER_ERROR
-                };
-                return Self::json_response(
-                    status,
-                    json!({
-                        "reloaded": false,
-                        "error": err,
-                    }),
-                );
-            }
-        };
-        if let Err(err) = Self::validate_runtime_reload_plan(&runtime, &plan.next_runtime) {
+        let plan = plan_runtime_reload(
+            &runtime,
+            ActivationRequest {
+                requested_by: Some("control_api".to_string()),
+                reason: Some("runtime_reload".to_string()),
+                expected_generation: Some(runtime.generation()),
+                requested_at_ms: crate::watchdog::time::now_millis(),
+            },
+            ReloadConfigInput::Path {
+                path: runtime.startup().config_path.clone(),
+            },
+        );
+        if !plan.can_activate() {
+            let error = plan
+                .plan
+                .rejection_summary
+                .as_deref()
+                .unwrap_or("reload candidate rejected");
             // Phase 8: API response and logs communicate the same core reason.
             warn!(
                 "runtime reload rejected at generation {}; active runtime unchanged: {}",
                 runtime.generation(),
-                err
+                error
             );
             return Self::json_response(
-                StatusCode::CONFLICT,
+                plan_rejection_status(&plan.plan),
                 json!({
                     "reloaded": false,
-                    "error": err,
+                    "error": error,
+                    "generation": plan.plan.current_generation,
+                    "candidate_generation": plan.plan.candidate_generation,
+                    "compatibility": plan.plan.compatibility,
                 }),
             );
         }
         let current_log_level = plan.current_log_level.clone();
-        let next_log_level = plan.next_log_level.clone();
+        let next_log_level = plan.next_log_level.clone().unwrap_or_default();
         let generation = match Self::apply_runtime_reload_plan(&runtime_bundle_handle, plan) {
             Ok(generation) => generation,
             Err(err) => {
@@ -175,6 +174,7 @@ impl QUICListener {
             json!({
                 "reloaded": true,
                 "generation": generation,
+                "candidate_generation": generation,
                 "path": req.uri().path(),
             }),
         )
@@ -209,43 +209,6 @@ impl QUICListener {
         )
     }
 
-    pub(super) fn build_runtime_reload_plan(
-        current: &ActiveRuntimeGeneration,
-    ) -> Result<RuntimeReloadPlan, String> {
-        let config_path = current.startup().config_path.clone();
-        let config = read_config(&config_path)?;
-        spooky_config::validator::validate(&config)
-            .map_err(|err| format!("Configuration validation failed: {err}"))?;
-        let runtime_config = RuntimeConfig::from_config(&config)
-            .map_err(|err| format!("Runtime configuration normalization failed: {err}"))?;
-        // Carry the process-scoped services (watchdog, DNS resolver) forward from
-        // the active generation so their runtime state survives the swap; all other
-        // config-derived services are rebuilt from the new config.
-        let carried = crate::runtime::generation::CarriedProcessSharedServices::from_active(
-            current.shared_services(),
-        );
-        let next_shared_state =
-            QUICListener::build_shared_state_with_carried(&runtime_config, Some(carried))
-                .map(Arc::new)
-                .map_err(|err| err.to_string())?;
-        let current_log_level = current.startup().log_config.level.clone();
-        let next_log_level = config.log.level.clone();
-
-        Ok(RuntimeReloadPlan {
-            next_runtime: RuntimeBundle {
-                generation: current.generation().saturating_add(1),
-                startup: crate::runtime::generation::StartupOwnedRuntimeState {
-                    config_path,
-                    log_config: config.log.clone(),
-                },
-                runtime_config,
-                shared_state: next_shared_state,
-            },
-            current_log_level,
-            next_log_level,
-        })
-    }
-
     /// Evaluate reload compatibility, returning typed rejections.
     ///
     /// The check order and short-circuit behavior are preserved from the pre-Phase-2
@@ -253,7 +216,7 @@ impl QUICListener {
     /// first rejection they find; only if all three are compatible are the
     /// startup-owned field changes collected together. The per-domain *rules* and
     /// *wording* now come from the central [`ReloadCompatibilityAuthority`].
-    pub(super) fn evaluate_runtime_reload_compatibility(
+    pub(crate) fn evaluate_runtime_reload_compatibility(
         current: &ActiveRuntimeGeneration,
         next: &RuntimeBundle,
     ) -> Result<(), Vec<TransitionRejection>> {
@@ -273,26 +236,18 @@ impl QUICListener {
         Self::validate_startup_owned_reload_compatibility(current.bundle(), next)
     }
 
-    /// String-rendering adapter over [`Self::evaluate_runtime_reload_compatibility`]
-    /// for the current handler boundary. The rendered wording is byte-identical to
-    /// the pre-Phase-2 behavior.
-    pub(super) fn validate_runtime_reload_plan(
-        current: &ActiveRuntimeGeneration,
-        next: &RuntimeBundle,
-    ) -> Result<(), String> {
-        Self::evaluate_runtime_reload_compatibility(current, next)
-            .map_err(|rejections| crate::runtime::policy::render_rejections(&rejections))
-    }
-
     pub(super) fn apply_runtime_reload_plan(
         runtime_bundle_handle: &RuntimeBundleHandle,
-        plan: RuntimeReloadPlan,
+        plan: StagedRuntimeReloadPlan,
     ) -> Result<u64, ProxyError> {
+        let next_runtime = plan.next_runtime.ok_or_else(|| {
+            ProxyError::Transport("staged reload plan missing next runtime".to_string())
+        })?;
         QUICListener::spawn_generation_background_tasks_for_runtime(
-            &plan.next_runtime.runtime_config,
-            plan.next_runtime.shared_state.as_ref(),
+            &next_runtime.runtime_config,
+            next_runtime.shared_state.as_ref(),
         );
-        runtime_bundle_handle.replace(plan.next_runtime)
+        runtime_bundle_handle.replace(next_runtime)
     }
 
     pub(super) fn validate_runtime_reload_compatibility(
@@ -490,5 +445,24 @@ impl QUICListener {
         );
 
         authority.into_result()
+    }
+}
+
+fn plan_rejection_status(plan: &ReloadPlan) -> StatusCode {
+    if plan
+        .rejected_changes
+        .iter()
+        .any(|rejection| matches!(rejection.kind, RejectedChangeKind::InvalidConfiguration))
+    {
+        StatusCode::BAD_REQUEST
+    } else if plan.rejected_changes.iter().any(|rejection| {
+        matches!(
+            rejection.kind,
+            RejectedChangeKind::ResourcePreparationFailed
+        )
+    }) {
+        StatusCode::INTERNAL_SERVER_ERROR
+    } else {
+        StatusCode::CONFLICT
     }
 }

--- a/crates/edge/src/quic_listener/control_api/reload.rs
+++ b/crates/edge/src/quic_listener/control_api/reload.rs
@@ -816,11 +816,7 @@ fn activation_result_status(activation: &ActivationResult) -> StatusCode {
     {
         StatusCode::BAD_REQUEST
     } else if activation.rejected_changes.iter().any(|rejection| {
-        matches!(
-            rejection.kind,
-            RejectedChangeKind::ResourcePreparationFailed
-                | RejectedChangeKind::RuntimeStateUnavailable
-        )
+        matches!(rejection.kind, RejectedChangeKind::ResourcePreparationFailed)
     }) || matches!(
         activation.status,
         crate::runtime::activation::GenerationStatus::Failed
@@ -873,7 +869,6 @@ fn legacy_reload_result_status(activation: &ActivationResult) -> StatusCode {
         matches!(
             rejection.kind,
             RejectedChangeKind::ResourcePreparationFailed
-                | RejectedChangeKind::IllegalTransition
                 | RejectedChangeKind::RuntimeStateUnavailable
         )
     }) || matches!(
@@ -894,16 +889,17 @@ fn rollback_result_status(rollback: &RollbackResult) -> StatusCode {
     {
         StatusCode::BAD_REQUEST
     } else if rollback.rejected_changes.iter().any(|rejection| {
-        matches!(
-            rejection.kind,
-            RejectedChangeKind::ResourcePreparationFailed
-                | RejectedChangeKind::RuntimeStateUnavailable
-        )
+        matches!(rejection.kind, RejectedChangeKind::ResourcePreparationFailed)
     }) || matches!(
         rollback.status,
         crate::runtime::activation::GenerationStatus::Failed
     ) {
         StatusCode::INTERNAL_SERVER_ERROR
+    } else if rollback.rejected_changes.iter().any(|rejection| {
+        rejection.kind == RejectedChangeKind::RuntimeStateUnavailable
+            && rejection.reason == RuntimeRejectionReason::UnknownGeneration
+    }) {
+        StatusCode::NOT_FOUND
     } else {
         StatusCode::CONFLICT
     }
@@ -928,4 +924,115 @@ fn rollback_error_payload(rollback: &RollbackResult, error: &str) -> serde_json:
         "rejected_changes": rollback.rejected_changes,
         "history_entry": rollback.history_entry,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::activation::{
+        ActivationRequest, GenerationHistoryEntry, GenerationOperation, GenerationStatus,
+        ReloadDiff, RejectedChange, RejectedChangeKind, RollbackRequest,
+    };
+
+    fn rejected_change(reason: RuntimeRejectionReason, kind: RejectedChangeKind) -> RejectedChange {
+        RejectedChange {
+            reason,
+            kind,
+            field_path: None,
+            current_value: None,
+            requested_value: None,
+            operator_action: "retry".to_string(),
+            active_generation_changed: false,
+            message: "rejected".to_string(),
+        }
+    }
+
+    fn history_entry(operation: GenerationOperation, status: GenerationStatus) -> GenerationHistoryEntry {
+        GenerationHistoryEntry {
+            generation: 2,
+            operation,
+            status,
+            config_source: "config.yaml".to_string(),
+            config_version: Some(1),
+            requested_by: Some("test".to_string()),
+            trigger_source: Some("unit_test".to_string()),
+            requested_at_ms: 1,
+            completed_at_ms: Some(2),
+            summary: "summary".to_string(),
+            diff: ReloadDiff::default(),
+            rejected_changes: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn activation_status_maps_stale_generation_conflicts_to_conflict() {
+        let activation = ActivationResult {
+            request: ActivationRequest {
+                requested_by: Some("test".to_string()),
+                trigger_source: Some("unit_test".to_string()),
+                reason: Some("runtime_activate".to_string()),
+                expected_generation: Some(1),
+                requested_at_ms: 1,
+            },
+            active_generation: 3,
+            activated_generation: None,
+            status: GenerationStatus::Rejected,
+            rejected_changes: vec![rejected_change(
+                RuntimeRejectionReason::UnknownGeneration,
+                RejectedChangeKind::IllegalTransition,
+            )],
+            history_entry: history_entry(GenerationOperation::Activate, GenerationStatus::Rejected),
+        };
+
+        assert_eq!(activation_result_status(&activation), StatusCode::CONFLICT);
+        assert_eq!(legacy_reload_result_status(&activation), StatusCode::CONFLICT);
+    }
+
+    #[test]
+    fn rollback_status_maps_missing_target_to_not_found() {
+        let rollback = RollbackResult {
+            request: RollbackRequest {
+                target_generation: 9,
+                requested_by: Some("test".to_string()),
+                trigger_source: Some("unit_test".to_string()),
+                reason: Some("runtime_rollback".to_string()),
+                expected_active_generation: Some(3),
+                requested_at_ms: 1,
+            },
+            active_generation: 3,
+            rolled_back_to: None,
+            status: GenerationStatus::Rejected,
+            rejected_changes: vec![rejected_change(
+                RuntimeRejectionReason::UnknownGeneration,
+                RejectedChangeKind::RuntimeStateUnavailable,
+            )],
+            history_entry: history_entry(GenerationOperation::Rollback, GenerationStatus::Rejected),
+        };
+
+        assert_eq!(rollback_result_status(&rollback), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn rollback_status_keeps_other_operator_conflicts_as_conflict() {
+        let rollback = RollbackResult {
+            request: RollbackRequest {
+                target_generation: 3,
+                requested_by: Some("test".to_string()),
+                trigger_source: Some("unit_test".to_string()),
+                reason: Some("runtime_rollback".to_string()),
+                expected_active_generation: Some(3),
+                requested_at_ms: 1,
+            },
+            active_generation: 3,
+            rolled_back_to: None,
+            status: GenerationStatus::Rejected,
+            rejected_changes: vec![rejected_change(
+                RuntimeRejectionReason::RollbackNotAllowed,
+                RejectedChangeKind::RuntimeStateUnavailable,
+            )],
+            history_entry: history_entry(GenerationOperation::Rollback, GenerationStatus::Rejected),
+        };
+
+        assert_eq!(rollback_result_status(&rollback), StatusCode::CONFLICT);
+    }
 }

--- a/crates/edge/src/quic_listener/control_api/reload.rs
+++ b/crates/edge/src/quic_listener/control_api/reload.rs
@@ -816,7 +816,10 @@ fn activation_result_status(activation: &ActivationResult) -> StatusCode {
     {
         StatusCode::BAD_REQUEST
     } else if activation.rejected_changes.iter().any(|rejection| {
-        matches!(rejection.kind, RejectedChangeKind::ResourcePreparationFailed)
+        matches!(
+            rejection.kind,
+            RejectedChangeKind::ResourcePreparationFailed
+        )
     }) || matches!(
         activation.status,
         crate::runtime::activation::GenerationStatus::Failed
@@ -889,7 +892,10 @@ fn rollback_result_status(rollback: &RollbackResult) -> StatusCode {
     {
         StatusCode::BAD_REQUEST
     } else if rollback.rejected_changes.iter().any(|rejection| {
-        matches!(rejection.kind, RejectedChangeKind::ResourcePreparationFailed)
+        matches!(
+            rejection.kind,
+            RejectedChangeKind::ResourcePreparationFailed
+        )
     }) || matches!(
         rollback.status,
         crate::runtime::activation::GenerationStatus::Failed
@@ -931,7 +937,7 @@ mod tests {
     use super::*;
     use crate::runtime::activation::{
         ActivationRequest, GenerationHistoryEntry, GenerationOperation, GenerationStatus,
-        ReloadDiff, RejectedChange, RejectedChangeKind, RollbackRequest,
+        RejectedChange, RejectedChangeKind, ReloadDiff, RollbackRequest,
     };
 
     fn rejected_change(reason: RuntimeRejectionReason, kind: RejectedChangeKind) -> RejectedChange {
@@ -947,7 +953,10 @@ mod tests {
         }
     }
 
-    fn history_entry(operation: GenerationOperation, status: GenerationStatus) -> GenerationHistoryEntry {
+    fn history_entry(
+        operation: GenerationOperation,
+        status: GenerationStatus,
+    ) -> GenerationHistoryEntry {
         GenerationHistoryEntry {
             generation: 2,
             operation,
@@ -985,7 +994,10 @@ mod tests {
         };
 
         assert_eq!(activation_result_status(&activation), StatusCode::CONFLICT);
-        assert_eq!(legacy_reload_result_status(&activation), StatusCode::CONFLICT);
+        assert_eq!(
+            legacy_reload_result_status(&activation),
+            StatusCode::CONFLICT
+        );
     }
 
     #[test]

--- a/crates/edge/src/quic_listener/control_api/reload.rs
+++ b/crates/edge/src/quic_listener/control_api/reload.rs
@@ -119,6 +119,7 @@ impl QUICListener {
             &runtime_bundle_handle,
             ActivationRequest {
                 requested_by: Some("control_api".to_string()),
+                trigger_source: Some("control_api".to_string()),
                 reason: Some("runtime_reload".to_string()),
                 expected_generation: Some(runtime.generation()),
                 requested_at_ms: crate::watchdog::time::now_millis(),

--- a/crates/edge/src/quic_listener/control_api/reload.rs
+++ b/crates/edge/src/quic_listener/control_api/reload.rs
@@ -8,7 +8,7 @@ use crate::runtime::{
     activation::{
         ActivationRequest, ActivationResult, RejectedChangeKind, ReloadConfigInput,
         ReloadPlan, RollbackRequest, RollbackResult, RuntimeActivationService,
-        RuntimeRejectionReason, plan_runtime_reload,
+        RuntimeRejectionReason,
     },
     bundle::{ActiveRuntimeGeneration, RuntimeBundleHandle},
     policy::{ReloadCompatibilityAuthority, TransitionRejection},
@@ -146,9 +146,13 @@ impl QUICListener {
             &activation_request,
             &reload_input,
         );
-        let plan = plan_runtime_reload(&current, activation_request, reload_input);
-        Self::record_control_api_plan_result(&runtime_bundle_handle, "validate", &plan.plan);
-        Self::json_response(StatusCode::OK, plan.plan)
+        let plan = RuntimeActivationService::validate_reload(
+            &runtime_bundle_handle,
+            activation_request,
+            reload_input,
+        );
+        Self::record_control_api_plan_result(&runtime_bundle_handle, "validate", &plan);
+        Self::json_response(StatusCode::OK, plan)
     }
 
     pub(super) async fn handle_control_api_runtime_preview(
@@ -177,9 +181,13 @@ impl QUICListener {
             &activation_request,
             &reload_input,
         );
-        let plan = plan_runtime_reload(&current, activation_request, reload_input);
-        Self::record_control_api_plan_result(&runtime_bundle_handle, "preview", &plan.plan);
-        Self::json_response(StatusCode::OK, plan.plan)
+        let plan = RuntimeActivationService::preview_reload(
+            &runtime_bundle_handle,
+            activation_request,
+            reload_input,
+        );
+        Self::record_control_api_plan_result(&runtime_bundle_handle, "preview", &plan);
+        Self::json_response(StatusCode::OK, plan)
     }
 
     pub(super) async fn handle_control_api_runtime_activate(

--- a/crates/edge/src/quic_listener/control_api/reload.rs
+++ b/crates/edge/src/quic_listener/control_api/reload.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
 use http_body_util::{BodyExt, Full};
 use serde::{Deserialize, de::DeserializeOwned};
+use std::sync::Arc;
 
 use super::*;
 use crate::runtime::{
@@ -9,7 +10,7 @@ use crate::runtime::{
         ReloadPlan, RollbackRequest, RollbackResult, RuntimeActivationService,
         RuntimeRejectionReason, plan_runtime_reload,
     },
-    bundle::ActiveRuntimeGeneration,
+    bundle::{ActiveRuntimeGeneration, RuntimeBundleHandle},
     policy::{ReloadCompatibilityAuthority, TransitionRejection},
 };
 
@@ -132,12 +133,21 @@ impl QUICListener {
             Ok(payload) => payload,
             Err(response) => return response,
         };
-        let plan = plan_runtime_reload(
-            &current,
-            Self::control_api_activation_request(&plan_request, current.generation(), "runtime_validate"),
-            Self::control_api_reload_config_input(&current, plan_request.config_path),
+        let activation_request = Self::control_api_activation_request(
+            &plan_request,
+            current.generation(),
+            "runtime_validate",
         );
-        Self::record_control_api_plan_rejection(state, "validate", &plan.plan);
+        let reload_input =
+            Self::control_api_reload_config_input(&current, plan_request.config_path);
+        Self::record_control_api_plan_attempt(
+            &runtime_bundle_handle,
+            "validate",
+            &activation_request,
+            &reload_input,
+        );
+        let plan = plan_runtime_reload(&current, activation_request, reload_input);
+        Self::record_control_api_plan_result(&runtime_bundle_handle, "validate", &plan.plan);
         Self::json_response(StatusCode::OK, plan.plan)
     }
 
@@ -154,12 +164,21 @@ impl QUICListener {
             Ok(payload) => payload,
             Err(response) => return response,
         };
-        let plan = plan_runtime_reload(
-            &current,
-            Self::control_api_activation_request(&plan_request, current.generation(), "runtime_preview"),
-            Self::control_api_reload_config_input(&current, plan_request.config_path),
+        let activation_request = Self::control_api_activation_request(
+            &plan_request,
+            current.generation(),
+            "runtime_preview",
         );
-        Self::record_control_api_plan_rejection(state, "preview", &plan.plan);
+        let reload_input =
+            Self::control_api_reload_config_input(&current, plan_request.config_path);
+        Self::record_control_api_plan_attempt(
+            &runtime_bundle_handle,
+            "preview",
+            &activation_request,
+            &reload_input,
+        );
+        let plan = plan_runtime_reload(&current, activation_request, reload_input);
+        Self::record_control_api_plan_result(&runtime_bundle_handle, "preview", &plan.plan);
         Self::json_response(StatusCode::OK, plan.plan)
     }
 
@@ -170,13 +189,10 @@ impl QUICListener {
         match Self::perform_control_api_runtime_activation(req, state, "runtime_activate").await {
             Ok(activation) => Self::json_response(StatusCode::ACCEPTED, activation),
             Err(ControlApiActivationError::Response(response)) => response,
-            Err(ControlApiActivationError::Activation(activation)) => {
-                Self::record_control_api_activation_rejection(state, &activation);
-                Self::json_response(
-                    activation_result_status(&activation),
-                    activation_error_payload(&activation, activation_error(&activation)),
-                )
-            }
+            Err(ControlApiActivationError::Activation(activation)) => Self::json_response(
+                activation_result_status(&activation),
+                activation_error_payload(&activation, activation_error(&activation)),
+            ),
         }
     }
 
@@ -195,13 +211,10 @@ impl QUICListener {
                 }),
             ),
             Err(ControlApiActivationError::Response(response)) => response,
-            Err(ControlApiActivationError::Activation(activation)) => {
-                Self::record_control_api_activation_rejection(state, &activation);
-                Self::json_response(
-                    legacy_reload_result_status(&activation),
-                    legacy_reload_error_payload(&activation, activation_error(&activation)),
-                )
-            }
+            Err(ControlApiActivationError::Activation(activation)) => Self::json_response(
+                legacy_reload_result_status(&activation),
+                legacy_reload_error_payload(&activation, activation_error(&activation)),
+            ),
         }
     }
 
@@ -230,16 +243,25 @@ impl QUICListener {
             Self::control_api_json_body_or_default::<ControlApiRuntimePlanRequest>(req)
                 .await
                 .map_err(ControlApiActivationError::Response)?;
+        let activation_request = Self::control_api_activation_request(
+            &plan_request,
+            runtime.generation(),
+            default_reason,
+        );
+        let reload_input =
+            Self::control_api_reload_config_input(&runtime, plan_request.config_path);
+        Self::record_control_api_activation_attempt(
+            &runtime_bundle_handle,
+            &activation_request,
+            &reload_input,
+        );
         let current_log_level = runtime.startup().log_config.level.clone();
         let activation = RuntimeActivationService::activate_reload(
             &runtime_bundle_handle,
-            Self::control_api_activation_request(
-                &plan_request,
-                runtime.generation(),
-                default_reason,
-            ),
-            Self::control_api_reload_config_input(&runtime, plan_request.config_path),
+            activation_request,
+            reload_input,
         );
+        Self::record_control_api_activation_outcome(&runtime_bundle_handle, &activation);
         if !activation.succeeded() {
             return Err(ControlApiActivationError::Activation(activation));
         }
@@ -284,8 +306,8 @@ impl QUICListener {
                 requested_at_ms: crate::watchdog::time::now_millis(),
             },
         );
+        Self::record_control_api_rollback_outcome(&runtime_bundle_handle, &rollback);
         if !rollback.succeeded() {
-            Self::record_control_api_rollback_rejection(state, &rollback);
             return Self::json_response(
                 rollback_result_status(&rollback),
                 rollback_error_payload(&rollback, rollback_error(&rollback)),
@@ -631,15 +653,39 @@ impl QUICListener {
         }
     }
 
-    fn record_control_api_plan_rejection(
-        state: &crate::quic_listener::runtime_state::ControlApiServiceCtx,
+    fn record_control_api_plan_attempt(
+        handle: &RuntimeBundleHandle,
+        operation: &str,
+        request: &ActivationRequest,
+        input: &ReloadConfigInput,
+    ) {
+        let current = handle.current_view();
+        let metrics = Arc::clone(&current.shared_services().metrics);
+        match operation {
+            "validate" => metrics.inc_runtime_validation_attempt(),
+            "preview" => metrics.inc_runtime_preview_attempt(),
+            _ => {}
+        }
+        info!(
+            "runtime {} requested active_generation={} expected_generation={:?} config_source={} requested_by={:?} trigger_source={:?}",
+            operation,
+            current.generation(),
+            request.expected_generation,
+            input.source_label(),
+            request.requested_by,
+            request.trigger_source,
+        );
+    }
+
+    fn record_control_api_plan_result(
+        handle: &RuntimeBundleHandle,
         operation: &str,
         plan: &ReloadPlan,
     ) {
         if let Some(reason) = plan.primary_rejection_reason() {
-            state.current_service_state()
-                .metrics()
-                .inc_runtime_rejection_reason(reason);
+            let current = handle.current_view();
+            let metrics = Arc::clone(&current.shared_services().metrics);
+            metrics.inc_runtime_rejection_reason(reason);
             warn!(
                 "runtime {} rejected generation={} reason={} summary={}",
                 operation,
@@ -649,41 +695,82 @@ impl QUICListener {
                     .as_deref()
                     .unwrap_or(plan.summary.as_str())
             );
-        }
-    }
-
-    fn record_control_api_activation_rejection(
-        state: &crate::quic_listener::runtime_state::ControlApiServiceCtx,
-        activation: &ActivationResult,
-    ) {
-        if let Some(reason) = activation.primary_rejection_reason() {
-            state.current_service_state()
-                .metrics()
-                .inc_runtime_rejection_reason(reason);
-            warn!(
-                "runtime activation rejected active_generation={} candidate_generation={} reason={} error={}",
-                activation.active_generation,
-                activation.history_entry.generation,
-                reason.slug(),
-                activation_error(activation)
+        } else {
+            info!(
+                "runtime {} accepted candidate_generation={} summary={}",
+                operation,
+                plan.candidate_generation,
+                plan.summary
             );
         }
     }
 
-    fn record_control_api_rollback_rejection(
-        state: &crate::quic_listener::runtime_state::ControlApiServiceCtx,
+    fn record_control_api_activation_attempt(
+        handle: &RuntimeBundleHandle,
+        request: &ActivationRequest,
+        input: &ReloadConfigInput,
+    ) {
+        let current = handle.current_view();
+        info!(
+            "runtime activation requested active_generation={} expected_generation={:?} config_source={} requested_by={:?} trigger_source={:?}",
+            current.generation(),
+            request.expected_generation,
+            input.source_label(),
+            request.requested_by,
+            request.trigger_source,
+        );
+    }
+
+    fn record_control_api_activation_outcome(
+        handle: &RuntimeBundleHandle,
+        activation: &ActivationResult,
+    ) {
+        let current = handle.current_view();
+        let metrics = Arc::clone(&current.shared_services().metrics);
+        let outcome = activation.outcome_reason();
+        metrics.record_runtime_activation_outcome(outcome);
+        if let Some(reason) = activation.primary_rejection_reason() {
+            metrics.inc_runtime_rejection_reason(reason);
+            warn!(
+                "runtime activation rejected active_generation={} candidate_generation={} reason={} error={}",
+                activation.active_generation,
+                activation.history_entry.generation,
+                outcome.slug(),
+                activation_error(activation)
+            );
+        } else if let Some(activated_generation) = activation.activated_generation {
+            info!(
+                "runtime activation succeeded active_generation={} activated_generation={} reason={}",
+                activation.active_generation,
+                activated_generation,
+                outcome.slug()
+            );
+        }
+    }
+
+    fn record_control_api_rollback_outcome(
+        handle: &RuntimeBundleHandle,
         rollback: &RollbackResult,
     ) {
+        let current = handle.current_view();
+        let metrics = Arc::clone(&current.shared_services().metrics);
+        let outcome = rollback.outcome_reason();
+        metrics.record_runtime_rollback_outcome(outcome);
         if let Some(reason) = rollback.primary_rejection_reason() {
-            state.current_service_state()
-                .metrics()
-                .inc_runtime_rejection_reason(reason);
+            metrics.inc_runtime_rejection_reason(reason);
             warn!(
                 "runtime rollback rejected active_generation={} target_generation={} reason={} error={}",
                 rollback.active_generation,
                 rollback.request.target_generation,
-                reason.slug(),
+                outcome.slug(),
                 rollback_error(rollback)
+            );
+        } else if let Some(rolled_back_to) = rollback.rolled_back_to {
+            info!(
+                "runtime rollback succeeded active_generation={} rolled_back_to={} reason={}",
+                rollback.active_generation,
+                rolled_back_to,
+                outcome.slug()
             );
         }
     }

--- a/crates/edge/src/quic_listener/control_api/reload.rs
+++ b/crates/edge/src/quic_listener/control_api/reload.rs
@@ -1,7 +1,8 @@
+use std::sync::Arc;
+
 use bytes::Bytes;
 use http_body_util::{BodyExt, Full};
 use serde::{Deserialize, de::DeserializeOwned};
-use std::sync::Arc;
 
 use super::*;
 use crate::runtime::{
@@ -212,15 +213,26 @@ impl QUICListener {
         state: &crate::quic_listener::runtime_state::ControlApiServiceCtx,
     ) -> Response<Full<Bytes>> {
         match Self::perform_control_api_runtime_activation(req, state, "runtime_reload").await {
-            Ok(activation) => Self::json_response(
-                StatusCode::ACCEPTED,
-                json!({
-                    "reloaded": true,
-                    "generation": activation.activated_generation.expect("successful activation must set activated_generation"),
-                    "candidate_generation": activation.history_entry.generation,
-                    "status": activation.status,
-                }),
-            ),
+            Ok(activation) => {
+                let Some(generation) = activation.activated_generation else {
+                    return Self::json_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        json!({
+                            "reloaded": false,
+                            "error": "activation succeeded without an activated generation",
+                        }),
+                    );
+                };
+                Self::json_response(
+                    StatusCode::ACCEPTED,
+                    json!({
+                        "reloaded": true,
+                        "generation": generation,
+                        "candidate_generation": activation.history_entry.generation,
+                        "status": activation.status,
+                    }),
+                )
+            }
             Err(ControlApiActivationError::Response(response)) => response,
             Err(ControlApiActivationError::Activation(activation)) => Self::json_response(
                 legacy_reload_result_status(&activation),
@@ -276,9 +288,15 @@ impl QUICListener {
         if !activation.succeeded() {
             return Err(ControlApiActivationError::Activation(activation));
         }
-        let generation = activation
-            .activated_generation
-            .expect("successful activation must set activated_generation");
+        let Some(generation) = activation.activated_generation else {
+            return Err(ControlApiActivationError::Response(Self::json_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                json!({
+                    "reloaded": false,
+                    "error": "activation succeeded without an activated generation",
+                }),
+            )));
+        };
         let next_log_level = runtime_bundle_handle
             .current_view()
             .startup()
@@ -801,17 +819,12 @@ fn activation_result_status(activation: &ActivationResult) -> StatusCode {
         matches!(
             rejection.kind,
             RejectedChangeKind::ResourcePreparationFailed
+                | RejectedChangeKind::RuntimeStateUnavailable
         )
     }) || matches!(
         activation.status,
         crate::runtime::activation::GenerationStatus::Failed
     ) {
-        StatusCode::INTERNAL_SERVER_ERROR
-    } else if activation
-        .rejected_changes
-        .iter()
-        .any(|rejection| matches!(rejection.kind, RejectedChangeKind::RuntimeStateUnavailable))
-    {
         StatusCode::INTERNAL_SERVER_ERROR
     } else {
         StatusCode::CONFLICT

--- a/crates/edge/src/quic_listener/control_api/render.rs
+++ b/crates/edge/src/quic_listener/control_api/render.rs
@@ -6,11 +6,11 @@ use serde::Serialize;
 use spooky_lb::health::HealthFailureReason;
 
 use super::{state::ControlApiState, *};
+use crate::runtime::activation::GenerationHistoryEntry;
 use crate::runtime::backend::state::{
     BackendHealthState, BackendLifecycleInventorySnapshot, BackendMembershipState,
     BackendPoolPlacementSnapshot,
 };
-use crate::runtime::activation::GenerationHistoryEntry;
 
 /// Map a backend health-failure reason to the canonical control-plane token.
 ///
@@ -274,7 +274,10 @@ impl QUICListener {
 
         Self::json_response(
             StatusCode::OK,
-            ControlApiRuntimeHistoryGenerationPayload { generation, entries },
+            ControlApiRuntimeHistoryGenerationPayload {
+                generation,
+                entries,
+            },
         )
     }
 }

--- a/crates/edge/src/quic_listener/control_api/render.rs
+++ b/crates/edge/src/quic_listener/control_api/render.rs
@@ -12,6 +12,7 @@ use crate::runtime::{
         BackendHealthState, BackendLifecycleInventorySnapshot, BackendMembershipState,
         BackendPoolPlacementSnapshot,
     },
+    bundle::RuntimeGenerationRecord,
 };
 
 /// Map a backend health-failure reason to the canonical control-plane token.
@@ -163,13 +164,25 @@ struct ControlApiRuntimeGenerationPayload {
 #[derive(Serialize)]
 struct ControlApiRuntimeHistoryPayload {
     active_generation: u64,
+    retained_generations: Vec<ControlApiRetainedGenerationPayload>,
     entries: Vec<GenerationHistoryEntry>,
 }
 
 #[derive(Serialize)]
 struct ControlApiRuntimeHistoryGenerationPayload {
     generation: u64,
+    retained_generation: ControlApiRetainedGenerationPayload,
     entries: Vec<GenerationHistoryEntry>,
+}
+
+#[derive(Serialize)]
+struct ControlApiRetainedGenerationPayload {
+    generation: u64,
+    status: &'static str,
+    rollback_candidate: bool,
+    has_bundle: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    note: Option<String>,
 }
 
 impl QUICListener {
@@ -246,6 +259,11 @@ impl QUICListener {
             StatusCode::OK,
             ControlApiRuntimeHistoryPayload {
                 active_generation: runtime_bundle_handle.current_generation(),
+                retained_generations: runtime_bundle_handle
+                    .generation_history()
+                    .into_iter()
+                    .map(ControlApiRetainedGenerationPayload::from_record)
+                    .collect(),
                 entries: runtime_bundle_handle.generation_change_history(),
             },
         )
@@ -265,22 +283,35 @@ impl QUICListener {
             .into_iter()
             .filter(|entry| entry.generation == generation)
             .collect::<Vec<_>>();
-        if entries.is_empty() {
+        let Some(record) = runtime_bundle_handle.generation_record(generation) else {
             return Self::json_response(
                 StatusCode::NOT_FOUND,
                 json!({
                     "error": format!("generation {generation} not found in runtime history"),
                 }),
             );
-        }
+        };
 
         Self::json_response(
             StatusCode::OK,
             ControlApiRuntimeHistoryGenerationPayload {
                 generation,
+                retained_generation: ControlApiRetainedGenerationPayload::from_record(record),
                 entries,
             },
         )
+    }
+}
+
+impl ControlApiRetainedGenerationPayload {
+    fn from_record(record: RuntimeGenerationRecord) -> Self {
+        Self {
+            generation: record.generation(),
+            status: record.status().as_str(),
+            rollback_candidate: record.status().is_rollback_candidate(),
+            has_bundle: record.has_bundle(),
+            note: record.note().map(ToOwned::to_owned),
+        }
     }
 }
 

--- a/crates/edge/src/quic_listener/control_api/render.rs
+++ b/crates/edge/src/quic_listener/control_api/render.rs
@@ -10,6 +10,7 @@ use crate::runtime::backend::state::{
     BackendHealthState, BackendLifecycleInventorySnapshot, BackendMembershipState,
     BackendPoolPlacementSnapshot,
 };
+use crate::runtime::activation::GenerationHistoryEntry;
 
 /// Map a backend health-failure reason to the canonical control-plane token.
 ///
@@ -157,6 +158,18 @@ struct ControlApiRuntimeGenerationPayload {
     config_path: String,
 }
 
+#[derive(Serialize)]
+struct ControlApiRuntimeHistoryPayload {
+    active_generation: u64,
+    entries: Vec<GenerationHistoryEntry>,
+}
+
+#[derive(Serialize)]
+struct ControlApiRuntimeHistoryGenerationPayload {
+    generation: u64,
+    entries: Vec<GenerationHistoryEntry>,
+}
+
 impl QUICListener {
     pub(super) fn json_response<T>(status: StatusCode, value: T) -> Response<Full<Bytes>>
     where
@@ -217,6 +230,52 @@ impl QUICListener {
     ) -> Response<Full<Bytes>> {
         let payload = ControlApiRuntimePayload::from_state(state);
         Self::json_response(StatusCode::OK, payload)
+    }
+
+    pub(super) fn render_control_api_runtime_history(
+        state: &ControlApiState,
+    ) -> Response<Full<Bytes>> {
+        let runtime_state = state.current_service_state();
+        let Some(runtime_bundle_handle) = runtime_state.runtime_bundle_handle().cloned() else {
+            return Self::control_api_not_found_response();
+        };
+
+        Self::json_response(
+            StatusCode::OK,
+            ControlApiRuntimeHistoryPayload {
+                active_generation: runtime_bundle_handle.current_generation(),
+                entries: runtime_bundle_handle.generation_change_history(),
+            },
+        )
+    }
+
+    pub(super) fn render_control_api_runtime_history_generation(
+        state: &ControlApiState,
+        generation: u64,
+    ) -> Response<Full<Bytes>> {
+        let runtime_state = state.current_service_state();
+        let Some(runtime_bundle_handle) = runtime_state.runtime_bundle_handle().cloned() else {
+            return Self::control_api_not_found_response();
+        };
+
+        let entries = runtime_bundle_handle
+            .generation_change_history()
+            .into_iter()
+            .filter(|entry| entry.generation == generation)
+            .collect::<Vec<_>>();
+        if entries.is_empty() {
+            return Self::json_response(
+                StatusCode::NOT_FOUND,
+                json!({
+                    "error": format!("generation {generation} not found in runtime history"),
+                }),
+            );
+        }
+
+        Self::json_response(
+            StatusCode::OK,
+            ControlApiRuntimeHistoryGenerationPayload { generation, entries },
+        )
     }
 }
 

--- a/crates/edge/src/quic_listener/control_api/render.rs
+++ b/crates/edge/src/quic_listener/control_api/render.rs
@@ -6,10 +6,12 @@ use serde::Serialize;
 use spooky_lb::health::HealthFailureReason;
 
 use super::{state::ControlApiState, *};
-use crate::runtime::activation::GenerationHistoryEntry;
-use crate::runtime::backend::state::{
-    BackendHealthState, BackendLifecycleInventorySnapshot, BackendMembershipState,
-    BackendPoolPlacementSnapshot,
+use crate::runtime::{
+    activation::GenerationHistoryEntry,
+    backend::state::{
+        BackendHealthState, BackendLifecycleInventorySnapshot, BackendMembershipState,
+        BackendPoolPlacementSnapshot,
+    },
 };
 
 /// Map a backend health-failure reason to the canonical control-plane token.

--- a/crates/edge/src/quic_listener/control_api/service.rs
+++ b/crates/edge/src/quic_listener/control_api/service.rs
@@ -242,7 +242,7 @@ impl QUICListener {
         let io = TokioIo::new(tls_stream);
         let service = service_fn(move |req: Request<Incoming>| {
             let state = state.clone();
-            async move { Ok::<_, hyper::Error>(Self::handle_control_api_request(req, &state)) }
+            async move { Ok::<_, hyper::Error>(Self::handle_control_api_request(req, &state).await) }
         });
 
         let serve = http1::Builder::new().serve_connection(io, service);

--- a/crates/edge/src/quic_listener/control_api/state.rs
+++ b/crates/edge/src/quic_listener/control_api/state.rs
@@ -22,6 +22,30 @@ impl ControlApiPaths {
             reload_certs_path: endpoint.reload_certs_path.clone(),
         }
     }
+
+    pub(super) fn runtime_validate_path(&self) -> String {
+        format!("{}/validate", self.runtime_path)
+    }
+
+    pub(super) fn runtime_preview_path(&self) -> String {
+        format!("{}/preview", self.runtime_path)
+    }
+
+    pub(super) fn runtime_activate_path(&self) -> String {
+        format!("{}/activate", self.runtime_path)
+    }
+
+    pub(super) fn runtime_rollback_path(&self) -> String {
+        format!("{}/rollback", self.runtime_path)
+    }
+
+    pub(super) fn runtime_history_path(&self) -> String {
+        format!("{}/history", self.runtime_path)
+    }
+
+    pub(super) fn runtime_history_entry_prefix(&self) -> String {
+        format!("{}/", self.runtime_history_path())
+    }
 }
 
 pub(super) type ControlApiState = ControlApiServiceCtx;

--- a/crates/edge/src/quic_listener/control_api/tests.rs
+++ b/crates/edge/src/quic_listener/control_api/tests.rs
@@ -662,6 +662,206 @@ fn rollback_service_rejects_incomplete_or_failed_prepare_targets_without_mutatio
     assert_eq!(events[0].entry.config_source, "generation:9");
 }
 
+#[test]
+fn validate_plan_does_not_mutate_the_active_generation() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+    let config_path = dir.path().join("runtime.yaml");
+    let current_config = test_config(cert.clone(), key.clone());
+    write_config_file(&config_path, &current_config);
+
+    let bundle =
+        runtime_bundle_from_config(config_path.to_string_lossy().as_ref(), &current_config);
+    let handle = RuntimeBundleHandle::new(bundle);
+    let generation_before = handle.current_generation();
+    let log_level_before = handle.current_view().startup().log_config.level.clone();
+
+    let mut restart_required = test_config(cert, key);
+    restart_required.performance.control_plane_threads = current_config
+        .performance
+        .control_plane_threads
+        .saturating_add(1);
+    write_config_file(&config_path, &restart_required);
+
+    let plan = plan_runtime_reload(
+        &handle.current_view(),
+        planner_request(generation_before),
+        ReloadConfigInput::Path {
+            path: config_path.to_string_lossy().to_string(),
+        },
+    );
+
+    assert!(!plan.can_activate());
+    assert_eq!(handle.current_generation(), generation_before);
+    assert_eq!(handle.current_view().startup().log_config.level, log_level_before);
+    assert_eq!(
+        handle
+            .current_view()
+            .runtime_config()
+            .policies
+            .transport
+            .control_plane_threads,
+        current_config.performance.control_plane_threads.max(1)
+    );
+}
+
+#[test]
+fn preview_plan_returns_expected_diff_without_mutating_the_active_generation() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+    let config_path = dir.path().join("runtime.yaml");
+    let current_config = test_config(cert.clone(), key.clone());
+    write_config_file(&config_path, &current_config);
+
+    let bundle =
+        runtime_bundle_from_config(config_path.to_string_lossy().as_ref(), &current_config);
+    let handle = RuntimeBundleHandle::new(bundle);
+    let generation_before = handle.current_generation();
+
+    let mut next_config = test_config(cert, key);
+    next_config.log.level = "debug".to_string();
+    write_config_file(&config_path, &next_config);
+
+    let plan = plan_runtime_reload(
+        &handle.current_view(),
+        planner_request(generation_before),
+        ReloadConfigInput::Path {
+            path: config_path.to_string_lossy().to_string(),
+        },
+    );
+
+    assert!(plan.can_activate());
+    assert_eq!(handle.current_generation(), generation_before);
+    let reloadable = plan
+        .plan
+        .diff
+        .reloadable_entries()
+        .into_iter()
+        .find(|entry| entry.domain == "observability_control_plane")
+        .expect("reloadable observability diff");
+    assert!(reloadable.summary.contains("log(level=info"));
+    assert!(reloadable.summary.contains("log(level=debug"));
+}
+
+#[test]
+fn invalid_activation_leaves_active_generation_unchanged() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+    let config_path = dir.path().join("runtime.yaml");
+    let current_config = test_config(cert, key);
+    write_config_file(&config_path, &current_config);
+
+    let bundle =
+        runtime_bundle_from_config(config_path.to_string_lossy().as_ref(), &current_config);
+    let handle = RuntimeBundleHandle::new(bundle);
+    let generation_before = handle.current_generation();
+
+    std::fs::write(
+        &config_path,
+        "version: 1\nlisten:\n  protocol: \"http3\"\n",
+    )
+    .expect("write invalid config");
+
+    let activation = RuntimeActivationService::activate_reload(
+        &handle,
+        planner_request(generation_before),
+        ReloadConfigInput::Path {
+            path: config_path.to_string_lossy().to_string(),
+        },
+    );
+
+    assert!(!activation.succeeded());
+    assert_eq!(activation.activated_generation, None);
+    assert_eq!(activation.status, GenerationStatus::Rejected);
+    assert_eq!(handle.current_generation(), generation_before);
+    assert!(
+        activation.rejected_changes.iter().any(|rejection| {
+            rejection.kind == RejectedChangeKind::InvalidConfiguration
+                && rejection.reason == RuntimeRejectionReason::InvalidConfig
+        }),
+        "expected invalid config rejection: {:?}",
+        activation.rejected_changes
+    );
+}
+
+#[test]
+fn runtime_history_records_activate_fail_and_rollback_flow() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+    let config_path = dir.path().join("runtime.yaml");
+
+    let generation_one = test_config(cert.clone(), key.clone());
+    write_config_file(&config_path, &generation_one);
+    let mut bundle_one = runtime_bundle_from_config("gen-1.yaml", &generation_one);
+    bundle_one.generation = 1;
+    let handle = RuntimeBundleHandle::new(bundle_one);
+
+    let mut generation_two = test_config(cert.clone(), key.clone());
+    generation_two.log.level = "debug".to_string();
+    write_config_file(&config_path, &generation_two);
+    let activation = RuntimeActivationService::activate_reload(
+        &handle,
+        planner_request(handle.current_generation()),
+        ReloadConfigInput::Path {
+            path: config_path.to_string_lossy().to_string(),
+        },
+    );
+    assert!(activation.succeeded());
+
+    let mut rejected = test_config(cert, key);
+    rejected.performance.control_plane_threads = generation_two
+        .performance
+        .control_plane_threads
+        .saturating_add(1);
+    write_config_file(&config_path, &rejected);
+    let failed = RuntimeActivationService::activate_reload(
+        &handle,
+        planner_request(handle.current_generation()),
+        ReloadConfigInput::Path {
+            path: config_path.to_string_lossy().to_string(),
+        },
+    );
+    assert!(!failed.succeeded());
+
+    let rollback = RuntimeActivationService::rollback_generation(
+        &handle,
+        rollback_request(1, handle.current_generation()),
+    );
+    assert!(rollback.succeeded());
+
+    let history = handle.generation_change_history();
+    let operations = history
+        .iter()
+        .map(|entry| (entry.operation, entry.status))
+        .take(8)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        operations,
+        vec![
+            (GenerationOperation::Rollback, GenerationStatus::RolledBack),
+            (GenerationOperation::Activate, GenerationStatus::Rejected),
+            (GenerationOperation::Preview, GenerationStatus::Rejected),
+            (GenerationOperation::Validate, GenerationStatus::Rejected),
+            (GenerationOperation::Activate, GenerationStatus::Active),
+            (GenerationOperation::Preview, GenerationStatus::Staged),
+            (GenerationOperation::Validate, GenerationStatus::Staged),
+        ]
+    );
+    assert_eq!(handle.current_generation(), 3);
+    assert_eq!(
+        handle
+            .current_view()
+            .runtime_config()
+            .upstreams
+            .get("api")
+            .expect("active upstream")
+            .backends[0]
+            .backend
+            .address,
+        "http://127.0.0.1:7001"
+    );
+}
+
 // Domain: watchdog service state transitions and restart environment handling.
 #[test]
 fn watchdog_restart_env_keeps_path_when_present() {

--- a/crates/edge/src/quic_listener/control_api/tests.rs
+++ b/crates/edge/src/quic_listener/control_api/tests.rs
@@ -15,10 +15,10 @@ use tempfile::tempdir;
 
 use super::{state::ControlApiState, *};
 use crate::runtime::activation::{
-    ActivationRequest, GenerationEventKind, GenerationOperation, GenerationStatus,
-    PlanningPhase, PlanningPhaseStatus, RejectedChangeKind, RuntimeRejectionReason,
-    ReloadCompatibilityClassification, ReloadConfigInput, ReloadDiffDisposition,
-    RollbackRequest, RuntimeActivationService, plan_runtime_reload,
+    ActivationRequest, GenerationEventKind, GenerationOperation, GenerationStatus, PlanningPhase,
+    PlanningPhaseStatus, RejectedChangeKind, ReloadCompatibilityClassification, ReloadConfigInput,
+    ReloadDiffDisposition, RollbackRequest, RuntimeActivationService, RuntimeRejectionReason,
+    plan_runtime_reload,
 };
 
 /// Render the typed startup-owned compatibility result into the flat list of
@@ -360,8 +360,7 @@ fn staged_reload_planner_classifies_restart_required_changes_without_mutation() 
     assert!(
         plan.plan.rejected_changes.iter().any(|rejection| {
             rejection.kind == RejectedChangeKind::RestartRequired
-                && rejection.field_path.as_deref()
-                    == Some("performance.control_plane_threads")
+                && rejection.field_path.as_deref() == Some("performance.control_plane_threads")
         }),
         "expected a startup-owned restart-required rejection"
     );
@@ -372,7 +371,10 @@ fn staged_reload_planner_classifies_restart_required_changes_without_mutation() 
             .iter()
             .any(|entry| entry.domain == "observability_control_plane"
                 && entry.disposition == ReloadDiffDisposition::RejectedStartupOwned
-                && matches!(entry.change, crate::runtime::activation::ReloadChangeKind::Modified)),
+                && matches!(
+                    entry.change,
+                    crate::runtime::activation::ReloadChangeKind::Modified
+                )),
         "expected control-plane startup-owned drift to be separated as rejected startup-owned"
     );
 }
@@ -409,7 +411,10 @@ fn staged_reload_planner_marks_log_level_change_as_reloadable_domain_diff() {
             .iter()
             .any(|entry| entry.domain == "observability_control_plane"
                 && entry.disposition == ReloadDiffDisposition::Reloadable
-                && matches!(entry.change, crate::runtime::activation::ReloadChangeKind::Modified)
+                && matches!(
+                    entry.change,
+                    crate::runtime::activation::ReloadChangeKind::Modified
+                )
                 && entry.summary.contains("log(level=info")
                 && entry.summary.contains("log(level=debug")),
         "expected log.level drift to show up as a reloadable observability/control-plane diff"
@@ -442,14 +447,23 @@ fn activation_service_commits_reloadable_candidate_and_advances_generation() {
         },
     );
 
-    assert!(activation.succeeded(), "activation should succeed: {activation:?}");
+    assert!(
+        activation.succeeded(),
+        "activation should succeed: {activation:?}"
+    );
     assert_eq!(activation.status, GenerationStatus::Active);
     assert_eq!(activation.active_generation, generation_before + 1);
     assert_eq!(activation.activated_generation, Some(generation_before + 1));
     assert_eq!(handle.current_generation(), generation_before + 1);
-    assert_eq!(activation.history_entry.operation, GenerationOperation::Activate);
+    assert_eq!(
+        activation.history_entry.operation,
+        GenerationOperation::Activate
+    );
     assert_eq!(activation.history_entry.status, GenerationStatus::Active);
-    assert_eq!(activation.history_entry.config_source, config_path.to_string_lossy());
+    assert_eq!(
+        activation.history_entry.config_source,
+        config_path.to_string_lossy()
+    );
     assert_eq!(activation.history_entry.config_version, Some(1));
     assert_eq!(
         activation.history_entry.trigger_source.as_deref(),
@@ -495,8 +509,10 @@ fn activation_service_rejects_restart_required_changes_without_mutating_active_g
     let generation_before = handle.current_generation();
 
     let mut next_config = test_config(cert, key);
-    next_config.performance.control_plane_threads =
-        current_config.performance.control_plane_threads.saturating_add(2);
+    next_config.performance.control_plane_threads = current_config
+        .performance
+        .control_plane_threads
+        .saturating_add(2);
     write_config_file(&config_path, &next_config);
 
     let activation = RuntimeActivationService::activate_reload(
@@ -515,14 +531,16 @@ fn activation_service_rejects_restart_required_changes_without_mutating_active_g
     assert_eq!(activation.active_generation, generation_before);
     assert_eq!(activation.activated_generation, None);
     assert_eq!(handle.current_generation(), generation_before);
-    assert_eq!(activation.history_entry.operation, GenerationOperation::Activate);
+    assert_eq!(
+        activation.history_entry.operation,
+        GenerationOperation::Activate
+    );
     assert_eq!(activation.history_entry.status, GenerationStatus::Rejected);
     assert!(
         activation.rejected_changes.iter().any(|rejection| {
             rejection.kind == RejectedChangeKind::RestartRequired
                 && rejection.reason == RuntimeRejectionReason::StartupOwnedChange
-                && rejection.field_path.as_deref()
-                    == Some("performance.control_plane_threads")
+                && rejection.field_path.as_deref() == Some("performance.control_plane_threads")
                 && !rejection.active_generation_changed
         }),
         "expected a restart-required rejection without live mutation: {:?}",
@@ -574,24 +592,26 @@ fn rollback_service_restores_retained_generation_by_id_and_records_rollback_stat
     bundle_three.generation = 3;
 
     let handle = RuntimeBundleHandle::new(bundle_one);
-    handle
-        .replace(bundle_two)
-        .expect("install generation 2");
-    handle
-        .replace(bundle_three)
-        .expect("install generation 3");
+    handle.replace(bundle_two).expect("install generation 2");
+    handle.replace(bundle_three).expect("install generation 3");
 
     let rollback = RuntimeActivationService::rollback_generation(
         &handle,
         rollback_request(1, handle.current_generation()),
     );
 
-    assert!(rollback.succeeded(), "rollback should succeed: {rollback:?}");
+    assert!(
+        rollback.succeeded(),
+        "rollback should succeed: {rollback:?}"
+    );
     assert_eq!(rollback.status, GenerationStatus::RolledBack);
     assert_eq!(rollback.rolled_back_to, Some(1));
     assert_eq!(rollback.active_generation, 4);
     assert_eq!(handle.current_generation(), 4);
-    assert_eq!(rollback.history_entry.operation, GenerationOperation::Rollback);
+    assert_eq!(
+        rollback.history_entry.operation,
+        GenerationOperation::Rollback
+    );
     assert_eq!(rollback.history_entry.status, GenerationStatus::RolledBack);
     assert_eq!(
         handle
@@ -617,10 +637,7 @@ fn rollback_service_restores_retained_generation_by_id_and_records_rollback_stat
     assert_eq!(events[0].kind, GenerationEventKind::RollbackSucceeded);
     assert_eq!(events[0].entry.config_source, "gen-1.yaml");
     assert_eq!(events[0].entry.config_version, Some(1));
-    assert_eq!(
-        events[0].entry.trigger_source.as_deref(),
-        Some("unit_test")
-    );
+    assert_eq!(events[0].entry.trigger_source.as_deref(), Some("unit_test"));
 }
 
 #[test]
@@ -634,8 +651,10 @@ fn rollback_service_rejects_incomplete_or_failed_prepare_targets_without_mutatio
     let active_generation = handle.current_generation();
     handle.record_failed_prepare(9, "candidate generation never prepared");
 
-    let rollback =
-        RuntimeActivationService::rollback_generation(&handle, rollback_request(9, active_generation));
+    let rollback = RuntimeActivationService::rollback_generation(
+        &handle,
+        rollback_request(9, active_generation),
+    );
 
     assert!(
         !rollback.succeeded(),
@@ -649,8 +668,7 @@ fn rollback_service_rejects_incomplete_or_failed_prepare_targets_without_mutatio
         rollback.rejected_changes.iter().any(|rejection| {
             rejection.kind == RejectedChangeKind::RuntimeStateUnavailable
                 && rejection.reason == RuntimeRejectionReason::RollbackNotAllowed
-                && rejection.field_path.as_deref()
-                    == Some("runtime.rollback.target_generation")
+                && rejection.field_path.as_deref() == Some("runtime.rollback.target_generation")
         }),
         "expected rollback rejection for incomplete target: {:?}",
         rollback.rejected_changes
@@ -693,7 +711,10 @@ fn validate_plan_does_not_mutate_the_active_generation() {
 
     assert!(!plan.can_activate());
     assert_eq!(handle.current_generation(), generation_before);
-    assert_eq!(handle.current_view().startup().log_config.level, log_level_before);
+    assert_eq!(
+        handle.current_view().startup().log_config.level,
+        log_level_before
+    );
     assert_eq!(
         handle
             .current_view()
@@ -756,11 +777,8 @@ fn invalid_activation_leaves_active_generation_unchanged() {
     let handle = RuntimeBundleHandle::new(bundle);
     let generation_before = handle.current_generation();
 
-    std::fs::write(
-        &config_path,
-        "version: 1\nlisten:\n  protocol: \"http3\"\n",
-    )
-    .expect("write invalid config");
+    std::fs::write(&config_path, "version: 1\nlisten:\n  protocol: \"http3\"\n")
+        .expect("write invalid config");
 
     let activation = RuntimeActivationService::activate_reload(
         &handle,
@@ -1434,13 +1452,14 @@ async fn control_api_runtime_history_generation_filters_to_requested_generation(
     );
     assert!(activation.succeeded());
 
-    let payload =
-        json_body(QUICListener::render_control_api_runtime_history_generation(&state, 1)).await;
+    let payload = json_body(QUICListener::render_control_api_runtime_history_generation(
+        &state, 1,
+    ))
+    .await;
     assert_eq!(payload["generation"], 1);
     assert_eq!(payload["entries"].as_array().map(Vec::len), Some(3));
 
-    let missing =
-        QUICListener::render_control_api_runtime_history_generation(&state, 99);
+    let missing = QUICListener::render_control_api_runtime_history_generation(&state, 99);
     assert_eq!(missing.status(), StatusCode::NOT_FOUND);
 }
 

--- a/crates/edge/src/quic_listener/control_api/tests.rs
+++ b/crates/edge/src/quic_listener/control_api/tests.rs
@@ -1526,11 +1526,20 @@ async fn control_api_runtime_history_renders_recorded_generation_changes() {
     );
     assert_eq!(payload["retained_generations"][0]["generation"], 1);
     assert_eq!(payload["retained_generations"][0]["status"], "active");
-    assert_eq!(payload["retained_generations"][0]["rollback_candidate"], false);
+    assert_eq!(
+        payload["retained_generations"][0]["rollback_candidate"],
+        false
+    );
     assert_eq!(payload["retained_generations"][0]["has_bundle"], true);
     assert_eq!(payload["retained_generations"][1]["generation"], 9);
-    assert_eq!(payload["retained_generations"][1]["status"], "failed_prepare");
-    assert_eq!(payload["retained_generations"][1]["rollback_candidate"], false);
+    assert_eq!(
+        payload["retained_generations"][1]["status"],
+        "failed_prepare"
+    );
+    assert_eq!(
+        payload["retained_generations"][1]["rollback_candidate"],
+        false
+    );
     assert_eq!(payload["retained_generations"][1]["has_bundle"], false);
     assert_eq!(
         payload["retained_generations"][1]["note"],
@@ -1538,7 +1547,10 @@ async fn control_api_runtime_history_renders_recorded_generation_changes() {
     );
     assert_eq!(payload["retained_generations"][2]["generation"], 0);
     assert_eq!(payload["retained_generations"][2]["status"], "previous");
-    assert_eq!(payload["retained_generations"][2]["rollback_candidate"], true);
+    assert_eq!(
+        payload["retained_generations"][2]["rollback_candidate"],
+        true
+    );
     assert_eq!(payload["retained_generations"][2]["has_bundle"], true);
     assert_eq!(payload["entries"].as_array().map(Vec::len), Some(1));
     assert_eq!(payload["entries"][0]["operation"], "activate");

--- a/crates/edge/src/quic_listener/control_api/tests.rs
+++ b/crates/edge/src/quic_listener/control_api/tests.rs
@@ -17,7 +17,8 @@ use super::{state::ControlApiState, *};
 use crate::runtime::activation::{
     ActivationRequest, GenerationOperation, GenerationStatus, PlanningPhase,
     PlanningPhaseStatus, RejectedChangeKind, ReloadCompatibilityClassification,
-    ReloadConfigInput, ReloadDiffDisposition, RuntimeActivationService, plan_runtime_reload,
+    ReloadConfigInput, ReloadDiffDisposition, RollbackRequest, RuntimeActivationService,
+    plan_runtime_reload,
 };
 
 /// Render the typed startup-owned compatibility result into the flat list of
@@ -222,6 +223,16 @@ fn planner_request(expected_generation: u64) -> ActivationRequest {
         reason: Some("planner_contract".to_string()),
         expected_generation: Some(expected_generation),
         requested_at_ms: 1,
+    }
+}
+
+fn rollback_request(target_generation: u64, expected_active_generation: u64) -> RollbackRequest {
+    RollbackRequest {
+        target_generation,
+        requested_by: Some("test".to_string()),
+        reason: Some("rollback_contract".to_string()),
+        expected_active_generation: Some(expected_active_generation),
+        requested_at_ms: 2,
     }
 }
 
@@ -493,6 +504,116 @@ fn activation_service_rejects_restart_required_changes_without_mutating_active_g
         }),
         "expected a restart-required rejection without live mutation: {:?}",
         activation.rejected_changes
+    );
+}
+
+#[test]
+fn rollback_service_restores_retained_generation_by_id_and_records_rollback_status() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+
+    let mut generation_one = test_config(cert.clone(), key.clone());
+    generation_one
+        .upstream
+        .get_mut("api")
+        .expect("api upstream")
+        .backends[0]
+        .address = "http://127.0.0.1:7001".to_string();
+    let mut generation_two = test_config(cert.clone(), key.clone());
+    generation_two.log.level = "debug".to_string();
+    generation_two
+        .upstream
+        .get_mut("api")
+        .expect("api upstream")
+        .backends[0]
+        .address = "http://127.0.0.1:7002".to_string();
+    let mut generation_three = test_config(cert, key);
+    generation_three.log.level = "trace".to_string();
+    generation_three
+        .upstream
+        .get_mut("api")
+        .expect("api upstream")
+        .backends[0]
+        .address = "http://127.0.0.1:7003".to_string();
+
+    let mut bundle_one = runtime_bundle_from_config("gen-1.yaml", &generation_one);
+    bundle_one.generation = 1;
+    let mut bundle_two = runtime_bundle_from_config("gen-2.yaml", &generation_two);
+    bundle_two.generation = 2;
+    let mut bundle_three = runtime_bundle_from_config("gen-3.yaml", &generation_three);
+    bundle_three.generation = 3;
+
+    let handle = RuntimeBundleHandle::new(bundle_one);
+    handle
+        .replace(bundle_two)
+        .expect("install generation 2");
+    handle
+        .replace(bundle_three)
+        .expect("install generation 3");
+
+    let rollback = RuntimeActivationService::rollback_generation(
+        &handle,
+        rollback_request(1, handle.current_generation()),
+    );
+
+    assert!(rollback.succeeded(), "rollback should succeed: {rollback:?}");
+    assert_eq!(rollback.status, GenerationStatus::RolledBack);
+    assert_eq!(rollback.rolled_back_to, Some(1));
+    assert_eq!(rollback.active_generation, 4);
+    assert_eq!(handle.current_generation(), 4);
+    assert_eq!(rollback.history_entry.operation, GenerationOperation::Rollback);
+    assert_eq!(rollback.history_entry.status, GenerationStatus::RolledBack);
+    assert_eq!(
+        handle
+            .current_view()
+            .runtime_config()
+            .upstreams
+            .get("api")
+            .expect("active upstream")
+            .backends[0]
+            .backend
+            .address,
+        "http://127.0.0.1:7001"
+    );
+
+    let history = handle.generation_history();
+    assert_eq!(history[1].generation(), 3);
+    assert_eq!(
+        history[1].status(),
+        crate::runtime::bundle::RuntimeGenerationRecordStatus::RolledBack
+    );
+}
+
+#[test]
+fn rollback_service_rejects_incomplete_or_failed_prepare_targets_without_mutation() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+    let handle = RuntimeBundleHandle::new(runtime_bundle_from_config(
+        "active.yaml",
+        &test_config(cert, key),
+    ));
+    let active_generation = handle.current_generation();
+    handle.record_failed_prepare(9, "candidate generation never prepared");
+
+    let rollback =
+        RuntimeActivationService::rollback_generation(&handle, rollback_request(9, active_generation));
+
+    assert!(
+        !rollback.succeeded(),
+        "failed-prepare history entries must not be rollbackable"
+    );
+    assert_eq!(rollback.status, GenerationStatus::Rejected);
+    assert_eq!(rollback.rolled_back_to, None);
+    assert_eq!(rollback.active_generation, active_generation);
+    assert_eq!(handle.current_generation(), active_generation);
+    assert!(
+        rollback.rejected_changes.iter().any(|rejection| {
+            rejection.kind == RejectedChangeKind::RuntimeStateUnavailable
+                && rejection.field_path.as_deref()
+                    == Some("runtime.rollback.target_generation")
+        }),
+        "expected rollback rejection for incomplete target: {:?}",
+        rollback.rejected_changes
     );
 }
 

--- a/crates/edge/src/quic_listener/control_api/tests.rs
+++ b/crates/edge/src/quic_listener/control_api/tests.rs
@@ -16,7 +16,8 @@ use tempfile::tempdir;
 use super::{state::ControlApiState, *};
 use crate::runtime::activation::{
     ActivationRequest, PlanningPhase, PlanningPhaseStatus, RejectedChangeKind,
-    ReloadCompatibilityClassification, ReloadConfigInput, plan_runtime_reload,
+    ReloadCompatibilityClassification, ReloadConfigInput, ReloadDiffDisposition,
+    plan_runtime_reload,
 };
 
 /// Render the typed startup-owned compatibility result into the flat list of
@@ -295,6 +296,17 @@ fn staged_reload_planner_reports_reloadable_candidate_snapshot() {
     );
     assert_eq!(snapshot.upstream_count, 1);
     assert_eq!(snapshot.backend_count, 1);
+    assert!(
+        plan.plan
+            .diff
+            .entries
+            .iter()
+            .any(|entry| entry.domain == "observability_control_plane"
+                && entry.disposition == ReloadDiffDisposition::NoOp),
+        "expected identical config to produce a no-op observability/control-plane diff"
+    );
+    assert!(plan.plan.diff.reloadable_entries().is_empty());
+    assert!(plan.plan.diff.rejected_startup_owned_entries().is_empty());
 }
 
 #[test]
@@ -340,6 +352,56 @@ fn staged_reload_planner_classifies_restart_required_changes_without_mutation() 
         }),
         "expected a startup-owned restart-required rejection"
     );
+    assert!(
+        plan.plan
+            .diff
+            .entries
+            .iter()
+            .any(|entry| entry.domain == "observability_control_plane"
+                && entry.disposition == ReloadDiffDisposition::RejectedStartupOwned
+                && matches!(entry.change, crate::runtime::activation::ReloadChangeKind::Modified)),
+        "expected control-plane startup-owned drift to be separated as rejected startup-owned"
+    );
+}
+
+#[test]
+fn staged_reload_planner_marks_log_level_change_as_reloadable_domain_diff() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+    let config_path = dir.path().join("runtime.yaml");
+    let current_config = test_config(cert.clone(), key.clone());
+    write_config_file(&config_path, &current_config);
+
+    let bundle =
+        runtime_bundle_from_config(config_path.to_string_lossy().as_ref(), &current_config);
+    let current = RuntimeBundleHandle::new(bundle).current_view();
+
+    let mut next_config = test_config(cert, key);
+    next_config.log.level = "debug".to_string();
+    write_config_file(&config_path, &next_config);
+
+    let plan = plan_runtime_reload(
+        &current,
+        planner_request(current.generation()),
+        ReloadConfigInput::Path {
+            path: config_path.to_string_lossy().to_string(),
+        },
+    );
+
+    assert!(plan.can_activate());
+    assert!(
+        plan.plan
+            .diff
+            .entries
+            .iter()
+            .any(|entry| entry.domain == "observability_control_plane"
+                && entry.disposition == ReloadDiffDisposition::Reloadable
+                && matches!(entry.change, crate::runtime::activation::ReloadChangeKind::Modified)
+                && entry.summary.contains("log(level=info")
+                && entry.summary.contains("log(level=debug")),
+        "expected log.level drift to show up as a reloadable observability/control-plane diff"
+    );
+    assert_eq!(plan.plan.diff.reloadable_entries().len(), 1);
 }
 
 // Domain: watchdog service state transitions and restart environment handling.

--- a/crates/edge/src/quic_listener/control_api/tests.rs
+++ b/crates/edge/src/quic_listener/control_api/tests.rs
@@ -481,18 +481,14 @@ fn activation_service_commits_reloadable_candidate_and_advances_generation() {
     assert_eq!(handle.current_view().startup().log_config.level, "debug");
 
     let history = handle.generation_change_history();
-    assert_eq!(history.len(), 3);
+    assert_eq!(history.len(), 1);
     assert_eq!(history[0].operation, GenerationOperation::Activate);
-    assert_eq!(history[1].operation, GenerationOperation::Preview);
-    assert_eq!(history[2].operation, GenerationOperation::Validate);
     assert_eq!(history[0].config_source, config_path.to_string_lossy());
     assert_eq!(history[0].config_version, Some(1));
 
     let events = handle.generation_change_events();
-    assert_eq!(events.len(), 3);
+    assert_eq!(events.len(), 1);
     assert_eq!(events[0].kind, GenerationEventKind::ActivationSucceeded);
-    assert_eq!(events[1].kind, GenerationEventKind::Preview);
-    assert_eq!(events[2].kind, GenerationEventKind::Validation);
 }
 
 #[test]
@@ -605,11 +601,9 @@ fn activation_service_rejects_restart_required_changes_without_mutating_active_g
     );
 
     let events = handle.generation_change_events();
-    assert_eq!(events.len(), 3);
+    assert_eq!(events.len(), 1);
     assert_eq!(events[0].kind, GenerationEventKind::ActivationFailed);
     assert_eq!(events[0].entry.status, GenerationStatus::Rejected);
-    assert_eq!(events[1].kind, GenerationEventKind::Preview);
-    assert_eq!(events[2].kind, GenerationEventKind::Validation);
 }
 
 #[test]
@@ -784,6 +778,57 @@ fn validate_plan_does_not_mutate_the_active_generation() {
 }
 
 #[test]
+fn validate_and_preview_record_only_the_requested_history_operation() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+    let config_path = dir.path().join("runtime.yaml");
+    let current_config = test_config(cert.clone(), key.clone());
+    write_config_file(&config_path, &current_config);
+
+    let bundle =
+        runtime_bundle_from_config(config_path.to_string_lossy().as_ref(), &current_config);
+    let handle = RuntimeBundleHandle::new(bundle);
+
+    let validate_plan = RuntimeActivationService::validate_reload(
+        &handle,
+        planner_request(handle.current_generation()),
+        ReloadConfigInput::Path {
+            path: config_path.to_string_lossy().to_string(),
+        },
+    );
+    assert_eq!(validate_plan.candidate_status, GenerationStatus::Staged);
+
+    let validate_history = handle.generation_change_history();
+    assert_eq!(validate_history.len(), 1);
+    assert_eq!(validate_history[0].operation, GenerationOperation::Validate);
+    let validate_events = handle.generation_change_events();
+    assert_eq!(validate_events.len(), 1);
+    assert_eq!(validate_events[0].kind, GenerationEventKind::Validation);
+
+    let mut next_config = test_config(cert, key);
+    next_config.log.level = "debug".to_string();
+    write_config_file(&config_path, &next_config);
+
+    let preview_plan = RuntimeActivationService::preview_reload(
+        &handle,
+        planner_request(handle.current_generation()),
+        ReloadConfigInput::Path {
+            path: config_path.to_string_lossy().to_string(),
+        },
+    );
+    assert_eq!(preview_plan.candidate_status, GenerationStatus::Staged);
+
+    let preview_history = handle.generation_change_history();
+    assert_eq!(preview_history.len(), 2);
+    assert_eq!(preview_history[0].operation, GenerationOperation::Preview);
+    assert_eq!(preview_history[1].operation, GenerationOperation::Validate);
+    let preview_events = handle.generation_change_events();
+    assert_eq!(preview_events.len(), 2);
+    assert_eq!(preview_events[0].kind, GenerationEventKind::Preview);
+    assert_eq!(preview_events[1].kind, GenerationEventKind::Validation);
+}
+
+#[test]
 fn preview_plan_returns_expected_diff_without_mutating_the_active_generation() {
     let dir = tempdir().expect("tempdir");
     let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
@@ -915,11 +960,7 @@ fn runtime_history_records_activate_fail_and_rollback_flow() {
         vec![
             (GenerationOperation::Rollback, GenerationStatus::RolledBack),
             (GenerationOperation::Activate, GenerationStatus::Rejected),
-            (GenerationOperation::Preview, GenerationStatus::Rejected),
-            (GenerationOperation::Validate, GenerationStatus::Rejected),
             (GenerationOperation::Activate, GenerationStatus::Active),
-            (GenerationOperation::Preview, GenerationStatus::Staged),
-            (GenerationOperation::Validate, GenerationStatus::Staged),
         ]
     );
     assert_eq!(handle.current_generation(), 3);
@@ -1478,10 +1519,8 @@ async fn control_api_runtime_history_renders_recorded_generation_changes() {
 
     let payload = json_body(QUICListener::render_control_api_runtime_history(&state)).await;
     assert_eq!(payload["active_generation"], 1);
-    assert_eq!(payload["entries"].as_array().map(Vec::len), Some(3));
+    assert_eq!(payload["entries"].as_array().map(Vec::len), Some(1));
     assert_eq!(payload["entries"][0]["operation"], "activate");
-    assert_eq!(payload["entries"][1]["operation"], "preview");
-    assert_eq!(payload["entries"][2]["operation"], "validate");
 }
 
 #[tokio::test]
@@ -1514,7 +1553,7 @@ async fn control_api_runtime_history_generation_filters_to_requested_generation(
     ))
     .await;
     assert_eq!(payload["generation"], 1);
-    assert_eq!(payload["entries"].as_array().map(Vec::len), Some(3));
+    assert_eq!(payload["entries"].as_array().map(Vec::len), Some(1));
 
     let missing = QUICListener::render_control_api_runtime_history_generation(&state, 99);
     assert_eq!(missing.status(), StatusCode::NOT_FOUND);

--- a/crates/edge/src/quic_listener/control_api/tests.rs
+++ b/crates/edge/src/quic_listener/control_api/tests.rs
@@ -15,9 +15,9 @@ use tempfile::tempdir;
 
 use super::{state::ControlApiState, *};
 use crate::runtime::activation::{
-    ActivationRequest, PlanningPhase, PlanningPhaseStatus, RejectedChangeKind,
-    ReloadCompatibilityClassification, ReloadConfigInput, ReloadDiffDisposition,
-    plan_runtime_reload,
+    ActivationRequest, GenerationOperation, GenerationStatus, PlanningPhase,
+    PlanningPhaseStatus, RejectedChangeKind, ReloadCompatibilityClassification,
+    ReloadConfigInput, ReloadDiffDisposition, RuntimeActivationService, plan_runtime_reload,
 };
 
 /// Render the typed startup-owned compatibility result into the flat list of
@@ -402,6 +402,98 @@ fn staged_reload_planner_marks_log_level_change_as_reloadable_domain_diff() {
         "expected log.level drift to show up as a reloadable observability/control-plane diff"
     );
     assert_eq!(plan.plan.diff.reloadable_entries().len(), 1);
+}
+
+#[test]
+fn activation_service_commits_reloadable_candidate_and_advances_generation() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+    let config_path = dir.path().join("runtime.yaml");
+    let current_config = test_config(cert.clone(), key.clone());
+    write_config_file(&config_path, &current_config);
+
+    let bundle =
+        runtime_bundle_from_config(config_path.to_string_lossy().as_ref(), &current_config);
+    let handle = RuntimeBundleHandle::new(bundle);
+    let generation_before = handle.current_generation();
+
+    let mut next_config = test_config(cert, key);
+    next_config.log.level = "debug".to_string();
+    write_config_file(&config_path, &next_config);
+
+    let activation = RuntimeActivationService::activate_reload(
+        &handle,
+        planner_request(generation_before),
+        ReloadConfigInput::Path {
+            path: config_path.to_string_lossy().to_string(),
+        },
+    );
+
+    assert!(activation.succeeded(), "activation should succeed: {activation:?}");
+    assert_eq!(activation.status, GenerationStatus::Active);
+    assert_eq!(activation.active_generation, generation_before + 1);
+    assert_eq!(activation.activated_generation, Some(generation_before + 1));
+    assert_eq!(handle.current_generation(), generation_before + 1);
+    assert_eq!(activation.history_entry.operation, GenerationOperation::Activate);
+    assert_eq!(activation.history_entry.status, GenerationStatus::Active);
+    assert!(
+        activation
+            .history_entry
+            .diff
+            .reloadable_entries()
+            .iter()
+            .any(|entry| entry.domain == "observability_control_plane"),
+        "expected activation history to preserve the planned reloadable diff"
+    );
+    assert_eq!(handle.current_view().startup().log_config.level, "debug");
+}
+
+#[test]
+fn activation_service_rejects_restart_required_changes_without_mutating_active_generation() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+    let config_path = dir.path().join("runtime.yaml");
+    let current_config = test_config(cert.clone(), key.clone());
+    write_config_file(&config_path, &current_config);
+
+    let bundle =
+        runtime_bundle_from_config(config_path.to_string_lossy().as_ref(), &current_config);
+    let handle = RuntimeBundleHandle::new(bundle);
+    let generation_before = handle.current_generation();
+
+    let mut next_config = test_config(cert, key);
+    next_config.performance.control_plane_threads =
+        current_config.performance.control_plane_threads.saturating_add(2);
+    write_config_file(&config_path, &next_config);
+
+    let activation = RuntimeActivationService::activate_reload(
+        &handle,
+        planner_request(generation_before),
+        ReloadConfigInput::Path {
+            path: config_path.to_string_lossy().to_string(),
+        },
+    );
+
+    assert!(
+        !activation.succeeded(),
+        "restart-required activation must be rejected"
+    );
+    assert_eq!(activation.status, GenerationStatus::Rejected);
+    assert_eq!(activation.active_generation, generation_before);
+    assert_eq!(activation.activated_generation, None);
+    assert_eq!(handle.current_generation(), generation_before);
+    assert_eq!(activation.history_entry.operation, GenerationOperation::Activate);
+    assert_eq!(activation.history_entry.status, GenerationStatus::Rejected);
+    assert!(
+        activation.rejected_changes.iter().any(|rejection| {
+            rejection.kind == RejectedChangeKind::RestartRequired
+                && rejection.field_path.as_deref()
+                    == Some("performance.control_plane_threads")
+                && !rejection.active_generation_changed
+        }),
+        "expected a restart-required rejection without live mutation: {:?}",
+        activation.rejected_changes
+    );
 }
 
 // Domain: watchdog service state transitions and restart environment handling.

--- a/crates/edge/src/quic_listener/control_api/tests.rs
+++ b/crates/edge/src/quic_listener/control_api/tests.rs
@@ -15,10 +15,10 @@ use tempfile::tempdir;
 
 use super::{state::ControlApiState, *};
 use crate::runtime::activation::{
-    ActivationRequest, GenerationOperation, GenerationStatus, PlanningPhase,
-    PlanningPhaseStatus, RejectedChangeKind, ReloadCompatibilityClassification,
-    ReloadConfigInput, ReloadDiffDisposition, RollbackRequest, RuntimeActivationService,
-    plan_runtime_reload,
+    ActivationRequest, GenerationEventKind, GenerationOperation, GenerationStatus,
+    PlanningPhase, PlanningPhaseStatus, RejectedChangeKind,
+    ReloadCompatibilityClassification, ReloadConfigInput, ReloadDiffDisposition,
+    RollbackRequest, RuntimeActivationService, plan_runtime_reload,
 };
 
 /// Render the typed startup-owned compatibility result into the flat list of
@@ -220,6 +220,7 @@ fn default_control_api_state() -> ControlApiState {
 fn planner_request(expected_generation: u64) -> ActivationRequest {
     ActivationRequest {
         requested_by: Some("test".to_string()),
+        trigger_source: Some("unit_test".to_string()),
         reason: Some("planner_contract".to_string()),
         expected_generation: Some(expected_generation),
         requested_at_ms: 1,
@@ -230,6 +231,7 @@ fn rollback_request(target_generation: u64, expected_active_generation: u64) -> 
     RollbackRequest {
         target_generation,
         requested_by: Some("test".to_string()),
+        trigger_source: Some("unit_test".to_string()),
         reason: Some("rollback_contract".to_string()),
         expected_active_generation: Some(expected_active_generation),
         requested_at_ms: 2,
@@ -447,6 +449,12 @@ fn activation_service_commits_reloadable_candidate_and_advances_generation() {
     assert_eq!(handle.current_generation(), generation_before + 1);
     assert_eq!(activation.history_entry.operation, GenerationOperation::Activate);
     assert_eq!(activation.history_entry.status, GenerationStatus::Active);
+    assert_eq!(activation.history_entry.config_source, config_path.to_string_lossy());
+    assert_eq!(activation.history_entry.config_version, Some(1));
+    assert_eq!(
+        activation.history_entry.trigger_source.as_deref(),
+        Some("unit_test")
+    );
     assert!(
         activation
             .history_entry
@@ -457,6 +465,20 @@ fn activation_service_commits_reloadable_candidate_and_advances_generation() {
         "expected activation history to preserve the planned reloadable diff"
     );
     assert_eq!(handle.current_view().startup().log_config.level, "debug");
+
+    let history = handle.generation_change_history();
+    assert_eq!(history.len(), 3);
+    assert_eq!(history[0].operation, GenerationOperation::Activate);
+    assert_eq!(history[1].operation, GenerationOperation::Preview);
+    assert_eq!(history[2].operation, GenerationOperation::Validate);
+    assert_eq!(history[0].config_source, config_path.to_string_lossy());
+    assert_eq!(history[0].config_version, Some(1));
+
+    let events = handle.generation_change_events();
+    assert_eq!(events.len(), 3);
+    assert_eq!(events[0].kind, GenerationEventKind::ActivationSucceeded);
+    assert_eq!(events[1].kind, GenerationEventKind::Preview);
+    assert_eq!(events[2].kind, GenerationEventKind::Validation);
 }
 
 #[test]
@@ -505,6 +527,13 @@ fn activation_service_rejects_restart_required_changes_without_mutating_active_g
         "expected a restart-required rejection without live mutation: {:?}",
         activation.rejected_changes
     );
+
+    let events = handle.generation_change_events();
+    assert_eq!(events.len(), 3);
+    assert_eq!(events[0].kind, GenerationEventKind::ActivationFailed);
+    assert_eq!(events[0].entry.status, GenerationStatus::Rejected);
+    assert_eq!(events[1].kind, GenerationEventKind::Preview);
+    assert_eq!(events[2].kind, GenerationEventKind::Validation);
 }
 
 #[test]
@@ -582,6 +611,15 @@ fn rollback_service_restores_retained_generation_by_id_and_records_rollback_stat
         history[1].status(),
         crate::runtime::bundle::RuntimeGenerationRecordStatus::RolledBack
     );
+
+    let events = handle.generation_change_events();
+    assert_eq!(events[0].kind, GenerationEventKind::RollbackSucceeded);
+    assert_eq!(events[0].entry.config_source, "gen-1.yaml");
+    assert_eq!(events[0].entry.config_version, Some(1));
+    assert_eq!(
+        events[0].entry.trigger_source.as_deref(),
+        Some("unit_test")
+    );
 }
 
 #[test]
@@ -615,6 +653,11 @@ fn rollback_service_rejects_incomplete_or_failed_prepare_targets_without_mutatio
         "expected rollback rejection for incomplete target: {:?}",
         rollback.rejected_changes
     );
+
+    let events = handle.generation_change_events();
+    assert_eq!(events[0].kind, GenerationEventKind::RollbackFailed);
+    assert_eq!(events[0].entry.status, GenerationStatus::Rejected);
+    assert_eq!(events[0].entry.config_source, "generation:9");
 }
 
 // Domain: watchdog service state transitions and restart environment handling.

--- a/crates/edge/src/quic_listener/control_api/tests.rs
+++ b/crates/edge/src/quic_listener/control_api/tests.rs
@@ -496,6 +496,63 @@ fn activation_service_commits_reloadable_candidate_and_advances_generation() {
 }
 
 #[test]
+fn activation_from_alternate_config_path_updates_default_runtime_source() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+    let primary_path = dir.path().join("primary.yaml");
+    let canary_path = dir.path().join("canary.yaml");
+
+    let current_config = test_config(cert.clone(), key.clone());
+    write_config_file(&primary_path, &current_config);
+
+    let bundle =
+        runtime_bundle_from_config(primary_path.to_string_lossy().as_ref(), &current_config);
+    let handle = RuntimeBundleHandle::new(bundle);
+    let generation_before = handle.current_generation();
+
+    let mut canary_config = test_config(cert, key);
+    canary_config.log.level = "debug".to_string();
+    write_config_file(&canary_path, &canary_config);
+
+    let activation = RuntimeActivationService::activate_reload(
+        &handle,
+        planner_request(generation_before),
+        ReloadConfigInput::Path {
+            path: canary_path.to_string_lossy().to_string(),
+        },
+    );
+
+    assert!(activation.succeeded(), "canary activation should succeed");
+    assert_eq!(
+        handle.current_view().startup().config_path,
+        canary_path.to_string_lossy()
+    );
+    assert_eq!(
+        activation.history_entry.config_source,
+        canary_path.to_string_lossy()
+    );
+
+    let mut followup_config = canary_config.clone();
+    followup_config.log.level = "warn".to_string();
+    write_config_file(&canary_path, &followup_config);
+
+    let followup = RuntimeActivationService::activate_reload(
+        &handle,
+        planner_request(handle.current_generation()),
+        ReloadConfigInput::Path {
+            path: handle.current_view().startup().config_path.clone(),
+        },
+    );
+
+    assert!(followup.succeeded(), "follow-up activation should succeed");
+    assert_eq!(handle.current_view().startup().log_config.level, "warn");
+    assert_eq!(
+        handle.current_view().startup().config_path,
+        canary_path.to_string_lossy()
+    );
+}
+
+#[test]
 fn activation_service_rejects_restart_required_changes_without_mutating_active_generation() {
     let dir = tempdir().expect("tempdir");
     let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");

--- a/crates/edge/src/quic_listener/control_api/tests.rs
+++ b/crates/edge/src/quic_listener/control_api/tests.rs
@@ -14,6 +14,10 @@ use spooky_config::{
 use tempfile::tempdir;
 
 use super::{state::ControlApiState, *};
+use crate::runtime::activation::{
+    ActivationRequest, PlanningPhase, PlanningPhaseStatus, RejectedChangeKind,
+    ReloadCompatibilityClassification, ReloadConfigInput, plan_runtime_reload,
+};
 
 /// Render the typed startup-owned compatibility result into the flat list of
 /// operator strings the assertions below were written against.
@@ -103,6 +107,54 @@ fn runtime_bundle_from_config(config_path: &str, config: &SpookyConfigConfig) ->
         .expect("runtime bundle")
 }
 
+fn write_config_file(path: &Path, config: &SpookyConfigConfig) {
+    let backend = config
+        .upstream
+        .get("api")
+        .and_then(|upstream| upstream.backends.first())
+        .expect("api upstream backend");
+    let upstream = config.upstream.get("api").expect("api upstream");
+    let yaml = format!(
+        r#"version: {version}
+listen:
+  protocol: "{protocol}"
+  address: "{address}"
+  port: {port}
+  tls:
+    cert: "{cert}"
+    key: "{key}"
+upstream:
+  api:
+    load_balancing:
+      type: "{lb_type}"
+    route:
+      path_prefix: "{path_prefix}"
+    backends:
+      - id: "{backend_id}"
+        address: "{backend_address}"
+        weight: {backend_weight}
+performance:
+  control_plane_threads: {control_plane_threads}
+log:
+  level: "{log_level}"
+"#,
+        version = config.version,
+        protocol = config.listen.protocol,
+        address = config.listen.address,
+        port = config.listen.port,
+        cert = config.listen.tls.cert,
+        key = config.listen.tls.key,
+        lb_type = upstream.load_balancing.lb_type,
+        path_prefix = upstream.route.path_prefix.as_deref().unwrap_or("/"),
+        backend_id = backend.id,
+        backend_address = backend.address,
+        backend_weight = backend.weight,
+        control_plane_threads = config.performance.control_plane_threads,
+        log_level = config.log.level,
+    );
+    std::fs::write(path, yaml).expect("write config file");
+}
+
 fn control_api_state_with_runtime_bundle(
     startup: &SpookyConfigConfig,
     reloaded: &SpookyConfigConfig,
@@ -163,6 +215,15 @@ fn default_control_api_state() -> ControlApiState {
     control_api_state_with_runtime_bundle(&startup, &startup)
 }
 
+fn planner_request(expected_generation: u64) -> ActivationRequest {
+    ActivationRequest {
+        requested_by: Some("test".to_string()),
+        reason: Some("planner_contract".to_string()),
+        expected_generation: Some(expected_generation),
+        requested_at_ms: 1,
+    }
+}
+
 fn assert_structured_resource_preflight_message(
     rejection: &crate::runtime::policy::TransitionRejection,
 ) {
@@ -179,6 +240,105 @@ fn assert_structured_resource_preflight_message(
         format!(
             "runtime reload rejected: could not prepare {field}: {detail}; active runtime unchanged (no change applied)"
         )
+    );
+}
+
+#[test]
+fn staged_reload_planner_reports_reloadable_candidate_snapshot() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+    let config = test_config(cert, key);
+    let config_path = dir.path().join("runtime.yaml");
+    write_config_file(&config_path, &config);
+
+    let bundle = runtime_bundle_from_config(config_path.to_string_lossy().as_ref(), &config);
+    let current = RuntimeBundleHandle::new(bundle).current_view();
+    let plan = plan_runtime_reload(
+        &current,
+        planner_request(current.generation()),
+        ReloadConfigInput::Path {
+            path: config_path.to_string_lossy().to_string(),
+        },
+    );
+
+    assert!(plan.can_activate());
+    assert_eq!(
+        plan.plan.compatibility,
+        ReloadCompatibilityClassification::LiveReloadable
+    );
+    assert_eq!(
+        plan.plan.phase_status(PlanningPhase::ReadConfig),
+        Some(PlanningPhaseStatus::Accepted)
+    );
+    assert_eq!(
+        plan.plan.phase_status(PlanningPhase::ValidateConfig),
+        Some(PlanningPhaseStatus::Accepted)
+    );
+    assert_eq!(
+        plan.plan.phase_status(PlanningPhase::NormalizeRuntime),
+        Some(PlanningPhaseStatus::Accepted)
+    );
+    assert_eq!(
+        plan.plan.phase_status(PlanningPhase::EvaluateCompatibility),
+        Some(PlanningPhaseStatus::Accepted)
+    );
+
+    let snapshot = plan
+        .plan
+        .candidate_snapshot
+        .as_ref()
+        .expect("candidate snapshot");
+    assert_eq!(snapshot.generation, current.generation() + 1);
+    assert_eq!(
+        snapshot.config_path,
+        config_path.to_string_lossy().to_string()
+    );
+    assert_eq!(snapshot.upstream_count, 1);
+    assert_eq!(snapshot.backend_count, 1);
+}
+
+#[test]
+fn staged_reload_planner_classifies_restart_required_changes_without_mutation() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+    let config_path = dir.path().join("runtime.yaml");
+    let current_config = test_config(cert.clone(), key.clone());
+    write_config_file(&config_path, &current_config);
+
+    let bundle =
+        runtime_bundle_from_config(config_path.to_string_lossy().as_ref(), &current_config);
+    let current = RuntimeBundleHandle::new(bundle).current_view();
+
+    let mut next_config = test_config(cert, key);
+    next_config.performance.control_plane_threads = 4;
+    write_config_file(&config_path, &next_config);
+
+    let plan = plan_runtime_reload(
+        &current,
+        planner_request(current.generation()),
+        ReloadConfigInput::Path {
+            path: config_path.to_string_lossy().to_string(),
+        },
+    );
+
+    assert!(!plan.can_activate());
+    assert_eq!(
+        plan.plan.compatibility,
+        ReloadCompatibilityClassification::RestartRequired
+    );
+    assert_eq!(
+        plan.plan.phase_status(PlanningPhase::EvaluateCompatibility),
+        Some(PlanningPhaseStatus::Rejected)
+    );
+    assert!(plan.plan.candidate_snapshot.is_some());
+    assert!(plan.plan.rejection_summary.is_some());
+    assert!(
+        plan.plan.rejected_changes.iter().any(|rejection| {
+            rejection.kind == RejectedChangeKind::RestartRequired
+                && rejection.field_path.as_deref()
+                    == Some("performance.control_plane_threads")
+        }),
+        "expected a startup-owned restart-required rejection"
     );
 }
 

--- a/crates/edge/src/quic_listener/control_api/tests.rs
+++ b/crates/edge/src/quic_listener/control_api/tests.rs
@@ -1516,9 +1516,30 @@ async fn control_api_runtime_history_renders_recorded_generation_changes() {
         },
     );
     assert!(activation.succeeded());
+    runtime_handle.record_failed_prepare(9, "candidate generation never prepared");
 
     let payload = json_body(QUICListener::render_control_api_runtime_history(&state)).await;
     assert_eq!(payload["active_generation"], 1);
+    assert_eq!(
+        payload["retained_generations"].as_array().map(Vec::len),
+        Some(3)
+    );
+    assert_eq!(payload["retained_generations"][0]["generation"], 1);
+    assert_eq!(payload["retained_generations"][0]["status"], "active");
+    assert_eq!(payload["retained_generations"][0]["rollback_candidate"], false);
+    assert_eq!(payload["retained_generations"][0]["has_bundle"], true);
+    assert_eq!(payload["retained_generations"][1]["generation"], 9);
+    assert_eq!(payload["retained_generations"][1]["status"], "failed_prepare");
+    assert_eq!(payload["retained_generations"][1]["rollback_candidate"], false);
+    assert_eq!(payload["retained_generations"][1]["has_bundle"], false);
+    assert_eq!(
+        payload["retained_generations"][1]["note"],
+        "candidate generation never prepared"
+    );
+    assert_eq!(payload["retained_generations"][2]["generation"], 0);
+    assert_eq!(payload["retained_generations"][2]["status"], "previous");
+    assert_eq!(payload["retained_generations"][2]["rollback_candidate"], true);
+    assert_eq!(payload["retained_generations"][2]["has_bundle"], true);
     assert_eq!(payload["entries"].as_array().map(Vec::len), Some(1));
     assert_eq!(payload["entries"][0]["operation"], "activate");
 }
@@ -1553,6 +1574,10 @@ async fn control_api_runtime_history_generation_filters_to_requested_generation(
     ))
     .await;
     assert_eq!(payload["generation"], 1);
+    assert_eq!(payload["retained_generation"]["generation"], 1);
+    assert_eq!(payload["retained_generation"]["status"], "active");
+    assert_eq!(payload["retained_generation"]["rollback_candidate"], false);
+    assert_eq!(payload["retained_generation"]["has_bundle"], true);
     assert_eq!(payload["entries"].as_array().map(Vec::len), Some(1));
 
     let missing = QUICListener::render_control_api_runtime_history_generation(&state, 99);

--- a/crates/edge/src/quic_listener/control_api/tests.rs
+++ b/crates/edge/src/quic_listener/control_api/tests.rs
@@ -746,9 +746,39 @@ fn control_api_route_gating_accepts_only_canonical_method_and_path_pairs() {
             Some(super::auth::ControlApiRoute::Runtime),
         ),
         (
+            Method::GET,
+            paths.runtime_history_path(),
+            Some(super::auth::ControlApiRoute::RuntimeHistory),
+        ),
+        (
+            Method::GET,
+            format!("{}/2", paths.runtime_history_path()),
+            Some(super::auth::ControlApiRoute::RuntimeHistoryGeneration(2)),
+        ),
+        (
             Method::POST,
             paths.reload_certs_path.clone(),
             Some(super::auth::ControlApiRoute::ReloadCerts),
+        ),
+        (
+            Method::POST,
+            paths.runtime_validate_path(),
+            Some(super::auth::ControlApiRoute::RuntimeValidate),
+        ),
+        (
+            Method::POST,
+            paths.runtime_preview_path(),
+            Some(super::auth::ControlApiRoute::RuntimePreview),
+        ),
+        (
+            Method::POST,
+            paths.runtime_activate_path(),
+            Some(super::auth::ControlApiRoute::RuntimeActivate),
+        ),
+        (
+            Method::POST,
+            paths.runtime_rollback_path(),
+            Some(super::auth::ControlApiRoute::RuntimeRollback),
         ),
         (
             Method::POST,
@@ -761,6 +791,7 @@ fn control_api_route_gating_accepts_only_canonical_method_and_path_pairs() {
             Some(super::auth::ControlApiRoute::Restart),
         ),
         (Method::POST, paths.runtime_path.clone(), None),
+        (Method::POST, paths.runtime_history_path(), None),
         (Method::GET, paths.reload_path.clone(), None),
         (Method::GET, "/missing".to_string(), None),
     ];
@@ -824,6 +855,31 @@ async fn control_api_gate_returns_canonical_unauthorized_payloads_per_route() {
         (
             Method::GET,
             paths.runtime_path.clone(),
+            serde_json::json!({ "error": "unauthorized" }),
+        ),
+        (
+            Method::POST,
+            paths.runtime_validate_path(),
+            serde_json::json!({ "error": "unauthorized" }),
+        ),
+        (
+            Method::POST,
+            paths.runtime_preview_path(),
+            serde_json::json!({ "error": "unauthorized" }),
+        ),
+        (
+            Method::POST,
+            paths.runtime_activate_path(),
+            serde_json::json!({ "error": "unauthorized" }),
+        ),
+        (
+            Method::POST,
+            paths.runtime_rollback_path(),
+            serde_json::json!({ "error": "unauthorized" }),
+        ),
+        (
+            Method::GET,
+            paths.runtime_history_path(),
             serde_json::json!({ "error": "unauthorized" }),
         ),
         (
@@ -1116,6 +1172,74 @@ fn control_api_backend_inventory_and_summary_share_one_canonical_snapshot_contra
     assert!(backend.placements[0].healthy);
     assert_eq!(summary.total_backends, 1);
     assert_eq!(summary.healthy_backends, 1);
+}
+
+#[tokio::test]
+async fn control_api_runtime_history_renders_recorded_generation_changes() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+    let config_path = dir.path().join("runtime.yaml");
+    let current_config = test_config(cert.clone(), key.clone());
+    write_config_file(&config_path, &current_config);
+
+    let bundle =
+        runtime_bundle_from_config(config_path.to_string_lossy().as_ref(), &current_config);
+    let (state, runtime_handle) = runtime_bundle_control_api_state(bundle);
+
+    let mut next_config = test_config(cert, key);
+    next_config.log.level = "debug".to_string();
+    write_config_file(&config_path, &next_config);
+
+    let activation = RuntimeActivationService::activate_reload(
+        runtime_handle.as_ref(),
+        planner_request(runtime_handle.current_generation()),
+        ReloadConfigInput::Path {
+            path: config_path.to_string_lossy().to_string(),
+        },
+    );
+    assert!(activation.succeeded());
+
+    let payload = json_body(QUICListener::render_control_api_runtime_history(&state)).await;
+    assert_eq!(payload["active_generation"], 1);
+    assert_eq!(payload["entries"].as_array().map(Vec::len), Some(3));
+    assert_eq!(payload["entries"][0]["operation"], "activate");
+    assert_eq!(payload["entries"][1]["operation"], "preview");
+    assert_eq!(payload["entries"][2]["operation"], "validate");
+}
+
+#[tokio::test]
+async fn control_api_runtime_history_generation_filters_to_requested_generation() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+    let config_path = dir.path().join("runtime.yaml");
+    let current_config = test_config(cert.clone(), key.clone());
+    write_config_file(&config_path, &current_config);
+
+    let bundle =
+        runtime_bundle_from_config(config_path.to_string_lossy().as_ref(), &current_config);
+    let (state, runtime_handle) = runtime_bundle_control_api_state(bundle);
+
+    let mut next_config = test_config(cert, key);
+    next_config.log.level = "debug".to_string();
+    write_config_file(&config_path, &next_config);
+
+    let activation = RuntimeActivationService::activate_reload(
+        runtime_handle.as_ref(),
+        planner_request(runtime_handle.current_generation()),
+        ReloadConfigInput::Path {
+            path: config_path.to_string_lossy().to_string(),
+        },
+    );
+    assert!(activation.succeeded());
+
+    let payload =
+        json_body(QUICListener::render_control_api_runtime_history_generation(&state, 1)).await;
+    assert_eq!(payload["generation"], 1);
+    assert_eq!(payload["entries"].as_array().map(Vec::len), Some(3));
+
+    let missing =
+        QUICListener::render_control_api_runtime_history_generation(&state, 99);
+    assert_eq!(missing.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]

--- a/crates/edge/src/quic_listener/control_api/tests.rs
+++ b/crates/edge/src/quic_listener/control_api/tests.rs
@@ -16,7 +16,7 @@ use tempfile::tempdir;
 use super::{state::ControlApiState, *};
 use crate::runtime::activation::{
     ActivationRequest, GenerationEventKind, GenerationOperation, GenerationStatus,
-    PlanningPhase, PlanningPhaseStatus, RejectedChangeKind,
+    PlanningPhase, PlanningPhaseStatus, RejectedChangeKind, RuntimeRejectionReason,
     ReloadCompatibilityClassification, ReloadConfigInput, ReloadDiffDisposition,
     RollbackRequest, RuntimeActivationService, plan_runtime_reload,
 };
@@ -520,6 +520,7 @@ fn activation_service_rejects_restart_required_changes_without_mutating_active_g
     assert!(
         activation.rejected_changes.iter().any(|rejection| {
             rejection.kind == RejectedChangeKind::RestartRequired
+                && rejection.reason == RuntimeRejectionReason::StartupOwnedChange
                 && rejection.field_path.as_deref()
                     == Some("performance.control_plane_threads")
                 && !rejection.active_generation_changed
@@ -647,6 +648,7 @@ fn rollback_service_rejects_incomplete_or_failed_prepare_targets_without_mutatio
     assert!(
         rollback.rejected_changes.iter().any(|rejection| {
             rejection.kind == RejectedChangeKind::RuntimeStateUnavailable
+                && rejection.reason == RuntimeRejectionReason::RollbackNotAllowed
                 && rejection.field_path.as_deref()
                     == Some("runtime.rollback.target_generation")
         }),

--- a/crates/edge/src/quic_listener/control_plane.rs
+++ b/crates/edge/src/quic_listener/control_plane.rs
@@ -86,7 +86,7 @@ impl QUICListener {
         });
     }
 
-    pub(super) fn spawn_generation_background_tasks_for_runtime(
+    pub(crate) fn spawn_generation_background_tasks_for_runtime(
         config: &RuntimeConfig,
         shared_state: &SharedRuntimeState,
     ) {

--- a/crates/edge/src/runtime/activation.rs
+++ b/crates/edge/src/runtime/activation.rs
@@ -1,0 +1,299 @@
+//! Canonical activation, preview, and rollback contract for runtime generations.
+//!
+//! This module intentionally contains *only* the typed domain vocabulary for
+//! config validation, reload preview, activation, rollback, and history. It does
+//! not perform any runtime mutation itself. Control-plane handlers and future
+//! activation services should consume these types rather than inventing
+//! endpoint-local request/result payloads.
+
+use serde::{Deserialize, Serialize};
+
+use crate::runtime::policy::{TransitionRejection, TransitionRejectionKind};
+
+/// Stable identifier for a published or staged runtime generation.
+pub type GenerationId = u64;
+
+/// Milliseconds since the Unix epoch.
+///
+/// Stored as an integer so the activation contract stays transport-agnostic and
+/// trivially serializable for control-plane responses and audit history.
+pub type TimestampMillis = u64;
+
+/// Coarse kind of generation operation recorded in history.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum GenerationOperation {
+    Validate,
+    Preview,
+    Activate,
+    Rollback,
+}
+
+/// Lifecycle status for a runtime generation or staged candidate.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum GenerationStatus {
+    Staged,
+    Active,
+    Superseded,
+    RollbackCandidate,
+    RolledBack,
+    Rejected,
+    Failed,
+}
+
+impl GenerationStatus {
+    pub fn is_active(self) -> bool {
+        matches!(self, Self::Active)
+    }
+
+    pub fn is_rollback_candidate(self) -> bool {
+        matches!(self, Self::RollbackCandidate | Self::Superseded)
+    }
+}
+
+/// Kind of field/domain diff detected between the active and candidate
+/// generations.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum ReloadChangeKind {
+    Added,
+    Modified,
+    Removed,
+    Unchanged,
+}
+
+/// One operator-visible entry in a reload preview diff.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReloadDiffEntry {
+    pub domain: String,
+    pub change: ReloadChangeKind,
+    pub summary: String,
+}
+
+/// Canonical preview diff for a staged reload candidate.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReloadDiff {
+    pub entries: Vec<ReloadDiffEntry>,
+}
+
+impl ReloadDiff {
+    pub fn is_noop(&self) -> bool {
+        self.entries.is_empty()
+            || self
+                .entries
+                .iter()
+                .all(|entry| matches!(entry.change, ReloadChangeKind::Unchanged))
+    }
+}
+
+/// Stable rejection category for preview/activation/rollback flows.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum RejectedChangeKind {
+    RestartRequired,
+    ResourcePreparationFailed,
+    InvalidConfiguration,
+    IllegalTransition,
+    RuntimeStateUnavailable,
+}
+
+impl From<TransitionRejectionKind> for RejectedChangeKind {
+    fn from(value: TransitionRejectionKind) -> Self {
+        match value {
+            TransitionRejectionKind::RestartRequired => Self::RestartRequired,
+            TransitionRejectionKind::ResourcePreparationFailed => {
+                Self::ResourcePreparationFailed
+            }
+            TransitionRejectionKind::InvalidConfiguration => Self::InvalidConfiguration,
+            TransitionRejectionKind::IllegalTransition => Self::IllegalTransition,
+            TransitionRejectionKind::RuntimeStateUnavailable => Self::RuntimeStateUnavailable,
+        }
+    }
+}
+
+/// Canonical operator-visible rejection payload for a planned change.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RejectedChange {
+    pub kind: RejectedChangeKind,
+    pub field_path: Option<String>,
+    pub current_value: Option<String>,
+    pub requested_value: Option<String>,
+    pub operator_action: String,
+    pub active_generation_changed: bool,
+    pub message: String,
+}
+
+impl From<TransitionRejection> for RejectedChange {
+    fn from(value: TransitionRejection) -> Self {
+        let message = value.to_string();
+        Self {
+            kind: value.kind.into(),
+            field_path: value.field_path,
+            current_value: value.current_mode,
+            requested_value: value.requested_mode,
+            operator_action: value.operator_action.to_string(),
+            active_generation_changed: value.active_runtime_changed,
+            message,
+        }
+    }
+}
+
+/// Activation request metadata.
+///
+/// This intentionally carries only operator/audit context and concurrency
+/// expectations. The actual config source stays outside this step until the
+/// activation service is implemented.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ActivationRequest {
+    pub requested_by: Option<String>,
+    pub reason: Option<String>,
+    pub expected_generation: Option<GenerationId>,
+    pub requested_at_ms: TimestampMillis,
+}
+
+/// Rollback request metadata.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RollbackRequest {
+    pub target_generation: GenerationId,
+    pub requested_by: Option<String>,
+    pub reason: Option<String>,
+    pub expected_active_generation: Option<GenerationId>,
+    pub requested_at_ms: TimestampMillis,
+}
+
+/// Canonical staged plan returned by validate/preview flows.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReloadPlan {
+    pub request: ActivationRequest,
+    pub current_generation: Option<GenerationId>,
+    pub candidate_generation: GenerationId,
+    pub candidate_status: GenerationStatus,
+    pub summary: String,
+    pub diff: ReloadDiff,
+    pub rejected_changes: Vec<RejectedChange>,
+}
+
+impl ReloadPlan {
+    pub fn can_activate(&self) -> bool {
+        self.rejected_changes.is_empty() && !matches!(self.candidate_status, GenerationStatus::Rejected)
+    }
+}
+
+/// Audit/history record for validation, preview, activation, and rollback.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GenerationHistoryEntry {
+    pub generation: GenerationId,
+    pub operation: GenerationOperation,
+    pub status: GenerationStatus,
+    pub requested_by: Option<String>,
+    pub requested_at_ms: TimestampMillis,
+    pub completed_at_ms: Option<TimestampMillis>,
+    pub summary: String,
+    pub diff: ReloadDiff,
+    pub rejected_changes: Vec<RejectedChange>,
+}
+
+/// Canonical activation result payload.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ActivationResult {
+    pub request: ActivationRequest,
+    pub active_generation: GenerationId,
+    pub activated_generation: Option<GenerationId>,
+    pub status: GenerationStatus,
+    pub rejected_changes: Vec<RejectedChange>,
+    pub history_entry: GenerationHistoryEntry,
+}
+
+impl ActivationResult {
+    pub fn succeeded(&self) -> bool {
+        self.activated_generation.is_some() && self.rejected_changes.is_empty()
+    }
+}
+
+/// Canonical rollback result payload.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RollbackResult {
+    pub request: RollbackRequest,
+    pub active_generation: GenerationId,
+    pub rolled_back_to: Option<GenerationId>,
+    pub status: GenerationStatus,
+    pub rejected_changes: Vec<RejectedChange>,
+    pub history_entry: GenerationHistoryEntry,
+}
+
+impl RollbackResult {
+    pub fn succeeded(&self) -> bool {
+        self.rolled_back_to.is_some() && self.rejected_changes.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::policy::TransitionRejection;
+
+    #[test]
+    fn rejected_change_preserves_transition_rejection_contract() {
+        let rejection = TransitionRejection::restart_required(
+            "performance.worker_threads",
+            "1",
+            "8",
+        );
+        let rejected = RejectedChange::from(rejection);
+
+        assert_eq!(rejected.kind, RejectedChangeKind::RestartRequired);
+        assert_eq!(
+            rejected.field_path.as_deref(),
+            Some("performance.worker_threads")
+        );
+        assert_eq!(rejected.operator_action, "restart the process to apply this change");
+        assert!(!rejected.active_generation_changed);
+        assert!(rejected.message.contains("restart"));
+    }
+
+    #[test]
+    fn reload_plan_only_activates_without_rejections() {
+        let plan = ReloadPlan {
+            request: ActivationRequest {
+                requested_by: Some("operator".to_string()),
+                reason: Some("rotate routes".to_string()),
+                expected_generation: Some(7),
+                requested_at_ms: 1_720_000_000_000,
+            },
+            current_generation: Some(7),
+            candidate_generation: 8,
+            candidate_status: GenerationStatus::Staged,
+            summary: "listener policies unchanged".to_string(),
+            diff: ReloadDiff::default(),
+            rejected_changes: Vec::new(),
+        };
+        assert!(plan.can_activate());
+
+        let mut rejected = plan.clone();
+        rejected.rejected_changes.push(RejectedChange {
+            kind: RejectedChangeKind::InvalidConfiguration,
+            field_path: Some("resilience.watchdog".to_string()),
+            current_value: None,
+            requested_value: Some("0".to_string()),
+            operator_action: "fix the configuration and retry the reload".to_string(),
+            active_generation_changed: false,
+            message: "invalid watchdog value".to_string(),
+        });
+        assert!(!rejected.can_activate());
+    }
+
+    #[test]
+    fn reload_diff_reports_noop_when_no_effective_changes_exist() {
+        assert!(ReloadDiff::default().is_noop());
+
+        let diff = ReloadDiff {
+            entries: vec![ReloadDiffEntry {
+                domain: "observability.metrics".to_string(),
+                change: ReloadChangeKind::Unchanged,
+                summary: "no effective change".to_string(),
+            }],
+        };
+        assert!(diff.is_noop());
+    }
+}

--- a/crates/edge/src/runtime/activation.rs
+++ b/crates/edge/src/runtime/activation.rs
@@ -6,9 +6,19 @@
 //! activation services should consume these types rather than inventing
 //! endpoint-local request/result payloads.
 
-use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
-use crate::runtime::policy::{TransitionRejection, TransitionRejectionKind};
+use serde::{Deserialize, Serialize};
+use spooky_config::{loader::read_config, runtime::RuntimeConfig};
+
+use crate::{
+    runtime::{
+        bundle::{ActiveRuntimeGeneration, RuntimeBundle},
+        generation::CarriedProcessSharedServices,
+        listener::QUICListener,
+        policy::{TransitionRejection, TransitionRejectionKind, render_rejections},
+    },
+};
 
 /// Stable identifier for a published or staged runtime generation.
 pub type GenerationId = u64;
@@ -18,6 +28,16 @@ pub type GenerationId = u64;
 /// Stored as an integer so the activation contract stays transport-agnostic and
 /// trivially serializable for control-plane responses and audit history.
 pub type TimestampMillis = u64;
+
+/// Raw configuration source for staged validation/planning.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReloadConfigInput {
+    Path { path: String },
+}
+
+impl ReloadConfigInput {
+}
 
 /// Coarse kind of generation operation recorded in history.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
@@ -43,13 +63,63 @@ pub enum GenerationStatus {
 }
 
 impl GenerationStatus {
+    #[must_use]
     pub fn is_active(self) -> bool {
         matches!(self, Self::Active)
     }
 
+    #[must_use]
     pub fn is_rollback_candidate(self) -> bool {
         matches!(self, Self::RollbackCandidate | Self::Superseded)
     }
+}
+
+/// Staged validation/planning phase.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum PlanningPhase {
+    ReadConfig,
+    ValidateConfig,
+    NormalizeRuntime,
+    EvaluateCompatibility,
+}
+
+/// Result for an individual staged validation/planning phase.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum PlanningPhaseStatus {
+    Accepted,
+    Rejected,
+    Skipped,
+}
+
+/// One staged validation/planning outcome.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PlanningPhaseResult {
+    pub phase: PlanningPhase,
+    pub status: PlanningPhaseStatus,
+    pub summary: String,
+}
+
+/// Coarse classification for the compatibility outcome of a staged reload.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum ReloadCompatibilityClassification {
+    NotEvaluated,
+    LiveReloadable,
+    RestartRequired,
+    Rejected,
+}
+
+/// Operator-visible summary of the next generation the planner would activate.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProposedGenerationSnapshot {
+    pub generation: GenerationId,
+    pub config_path: String,
+    pub log_level: String,
+    pub listener_labels: Vec<String>,
+    pub upstream_count: usize,
+    pub backend_count: usize,
 }
 
 /// Kind of field/domain diff detected between the active and candidate
@@ -78,6 +148,7 @@ pub struct ReloadDiff {
 }
 
 impl ReloadDiff {
+    #[must_use]
     pub fn is_noop(&self) -> bool {
         self.entries.is_empty()
             || self
@@ -139,6 +210,40 @@ impl From<TransitionRejection> for RejectedChange {
     }
 }
 
+impl RejectedChange {
+    fn invalid_configuration(message: impl Into<String>) -> Self {
+        let message = message.into();
+        Self {
+            kind: RejectedChangeKind::InvalidConfiguration,
+            field_path: None,
+            current_value: None,
+            requested_value: None,
+            operator_action: "fix the configuration and retry the reload".to_string(),
+            active_generation_changed: false,
+            message,
+        }
+    }
+
+    fn resource_preparation_failed(field_path: impl Into<String>, detail: impl Into<String>) -> Self {
+        let field_path = field_path.into();
+        let detail = detail.into();
+        let message = format!(
+            "runtime reload rejected: could not prepare {field_path}: {detail}; active runtime unchanged (no change applied)"
+        );
+        Self {
+            kind: RejectedChangeKind::ResourcePreparationFailed,
+            field_path: Some(field_path),
+            current_value: None,
+            requested_value: Some(detail),
+            operator_action:
+                "resolve the resource conflict (e.g. free the address/port) and retry the reload"
+                    .to_string(),
+            active_generation_changed: false,
+            message,
+        }
+    }
+}
+
 /// Activation request metadata.
 ///
 /// This intentionally carries only operator/audit context and concurrency
@@ -170,13 +275,29 @@ pub struct ReloadPlan {
     pub candidate_generation: GenerationId,
     pub candidate_status: GenerationStatus,
     pub summary: String,
+    pub validation: Vec<PlanningPhaseResult>,
+    pub compatibility: ReloadCompatibilityClassification,
+    pub candidate_snapshot: Option<ProposedGenerationSnapshot>,
+    pub rejection_summary: Option<String>,
     pub diff: ReloadDiff,
     pub rejected_changes: Vec<RejectedChange>,
 }
 
 impl ReloadPlan {
+    #[must_use]
     pub fn can_activate(&self) -> bool {
-        self.rejected_changes.is_empty() && !matches!(self.candidate_status, GenerationStatus::Rejected)
+        self.rejected_changes.is_empty()
+            && self.candidate_snapshot.is_some()
+            && self.compatibility == ReloadCompatibilityClassification::LiveReloadable
+            && !matches!(self.candidate_status, GenerationStatus::Rejected)
+    }
+
+    #[must_use]
+    pub fn phase_status(&self, phase: PlanningPhase) -> Option<PlanningPhaseStatus> {
+        self.validation
+            .iter()
+            .find(|result| result.phase == phase)
+            .map(|result| result.status)
     }
 }
 
@@ -206,6 +327,7 @@ pub struct ActivationResult {
 }
 
 impl ActivationResult {
+    #[must_use]
     pub fn succeeded(&self) -> bool {
         self.activated_generation.is_some() && self.rejected_changes.is_empty()
     }
@@ -223,8 +345,378 @@ pub struct RollbackResult {
 }
 
 impl RollbackResult {
+    #[must_use]
     pub fn succeeded(&self) -> bool {
         self.rolled_back_to.is_some() && self.rejected_changes.is_empty()
+    }
+}
+
+/// Internal, non-serialized staged runtime reload result.
+///
+/// This is the pure planning payload that control-plane code can validate and
+/// preview before any activation mutates the active bundle.
+pub(crate) struct StagedRuntimeReloadPlan {
+    pub(crate) plan: ReloadPlan,
+    pub(crate) next_runtime: Option<RuntimeBundle>,
+    pub(crate) current_log_level: String,
+    pub(crate) next_log_level: Option<String>,
+}
+
+impl StagedRuntimeReloadPlan {
+    #[must_use]
+    pub(crate) fn can_activate(&self) -> bool {
+        self.plan.can_activate() && self.next_runtime.is_some()
+    }
+}
+
+pub(crate) fn plan_runtime_reload(
+    current: &ActiveRuntimeGeneration,
+    request: ActivationRequest,
+    input: ReloadConfigInput,
+) -> StagedRuntimeReloadPlan {
+    let current_generation = Some(current.generation());
+    let candidate_generation = current.generation().saturating_add(1);
+    let current_log_level = current.startup().log_config.level.clone();
+    let mut validation = Vec::with_capacity(4);
+
+    let config = match input {
+        ReloadConfigInput::Path { path } => match read_config(&path) {
+            Ok(config) => {
+                validation.push(PlanningPhaseResult {
+                    phase: PlanningPhase::ReadConfig,
+                    status: PlanningPhaseStatus::Accepted,
+                    summary: format!("read config from '{path}'"),
+                });
+                config
+            }
+            Err(err) => {
+                validation.push(PlanningPhaseResult {
+                    phase: PlanningPhase::ReadConfig,
+                    status: PlanningPhaseStatus::Rejected,
+                    summary: err.clone(),
+                });
+                return rejected_reload_plan(
+                    request,
+                    current_generation,
+                    candidate_generation,
+                    current_log_level,
+                    validation,
+                    vec![
+                        RejectedChange::invalid_configuration(err),
+                    ],
+                );
+            }
+        },
+    };
+
+    match spooky_config::validator::validate(&config) {
+        Ok(()) => validation.push(PlanningPhaseResult {
+            phase: PlanningPhase::ValidateConfig,
+            status: PlanningPhaseStatus::Accepted,
+            summary: "raw config validation passed".to_string(),
+        }),
+        Err(err) => {
+            let message = format!("Configuration validation failed: {err}");
+            validation.push(PlanningPhaseResult {
+                phase: PlanningPhase::ValidateConfig,
+                status: PlanningPhaseStatus::Rejected,
+                summary: message.clone(),
+            });
+            return rejected_reload_plan(
+                request,
+                current_generation,
+                candidate_generation,
+                current_log_level,
+                validation,
+                vec![RejectedChange::invalid_configuration(message)],
+            );
+        }
+    }
+
+    let runtime_config = match RuntimeConfig::from_config(&config) {
+        Ok(runtime_config) => runtime_config,
+        Err(err) => {
+            let message = format!("Runtime configuration normalization failed: {err}");
+            validation.push(PlanningPhaseResult {
+                phase: PlanningPhase::NormalizeRuntime,
+                status: PlanningPhaseStatus::Rejected,
+                summary: message.clone(),
+            });
+            return rejected_reload_plan(
+                request,
+                current_generation,
+                candidate_generation,
+                current_log_level,
+                validation,
+                vec![RejectedChange::invalid_configuration(message)],
+            );
+        }
+    };
+
+    let carried = CarriedProcessSharedServices::from_active(current.shared_services());
+    let next_shared_state =
+        match QUICListener::build_shared_state_with_carried(&runtime_config, Some(carried)) {
+            Ok(shared_state) => {
+                validation.push(PlanningPhaseResult {
+                    phase: PlanningPhase::NormalizeRuntime,
+                    status: PlanningPhaseStatus::Accepted,
+                    summary: "runtime generation assembled successfully".to_string(),
+                });
+                Arc::new(shared_state)
+            }
+            Err(err) => {
+                let rejected = RejectedChange::resource_preparation_failed(
+                    "runtime generation",
+                    err.to_string(),
+                );
+                validation.push(PlanningPhaseResult {
+                    phase: PlanningPhase::NormalizeRuntime,
+                    status: PlanningPhaseStatus::Rejected,
+                    summary: rejected.message.clone(),
+                });
+                return rejected_reload_plan(
+                    request,
+                    current_generation,
+                    candidate_generation,
+                    current_log_level,
+                    validation,
+                    vec![rejected],
+                );
+            }
+        };
+
+    let next_runtime = RuntimeBundle {
+        generation: candidate_generation,
+        startup: crate::runtime::generation::StartupOwnedRuntimeState {
+            config_path: current.startup().config_path.clone(),
+            log_config: config.log.clone(),
+        },
+        runtime_config,
+        shared_state: next_shared_state,
+    };
+    let next_log_level = next_runtime.startup.log_config.level.clone();
+    let candidate_snapshot = Some(snapshot_from_bundle(&next_runtime));
+    let diff = build_reload_diff(current.bundle(), &next_runtime);
+
+    let compatibility_rejections: Result<(), Vec<TransitionRejection>> =
+        QUICListener::evaluate_runtime_reload_compatibility(current, &next_runtime);
+    let (compatibility, rejected_changes, compatibility_summary, candidate_status) =
+        match compatibility_rejections {
+            Ok(()) => (
+                ReloadCompatibilityClassification::LiveReloadable,
+                Vec::new(),
+                "reload candidate is live-reloadable".to_string(),
+                GenerationStatus::Staged,
+            ),
+            Err(rejections) => {
+                let classification = classify_compatibility(&rejections);
+                let rendered = render_rejections(rejections.as_slice());
+                (
+                    classification,
+                    rejections.into_iter().map(RejectedChange::from).collect(),
+                    rendered,
+                    GenerationStatus::Rejected,
+                )
+            }
+        };
+    validation.push(PlanningPhaseResult {
+        phase: PlanningPhase::EvaluateCompatibility,
+        status: if rejected_changes.is_empty() {
+            PlanningPhaseStatus::Accepted
+        } else {
+            PlanningPhaseStatus::Rejected
+        },
+        summary: compatibility_summary.clone(),
+    });
+
+    let rejection_summary = (!rejected_changes.is_empty()).then(|| compatibility_summary.clone());
+    let summary = if rejected_changes.is_empty() {
+        format!(
+            "validated reload candidate for generation {candidate_generation}; ready for activation"
+        )
+    } else {
+        format!("validated reload candidate for generation {candidate_generation}; activation blocked")
+    };
+
+    StagedRuntimeReloadPlan {
+        plan: ReloadPlan {
+            request,
+            current_generation,
+            candidate_generation,
+            candidate_status,
+            summary,
+            validation,
+            compatibility,
+            candidate_snapshot,
+            rejection_summary,
+            diff,
+            rejected_changes,
+        },
+        next_runtime: Some(next_runtime),
+        current_log_level,
+        next_log_level: Some(next_log_level),
+    }
+}
+
+fn rejected_reload_plan(
+    request: ActivationRequest,
+    current_generation: Option<GenerationId>,
+    candidate_generation: GenerationId,
+    current_log_level: String,
+    mut validation: Vec<PlanningPhaseResult>,
+    rejected_changes: Vec<RejectedChange>,
+) -> StagedRuntimeReloadPlan {
+    if validation.iter().all(|step| step.phase != PlanningPhase::NormalizeRuntime) {
+        validation.push(PlanningPhaseResult {
+            phase: PlanningPhase::NormalizeRuntime,
+            status: PlanningPhaseStatus::Skipped,
+            summary: "skipped because an earlier validation phase failed".to_string(),
+        });
+    }
+    if validation
+        .iter()
+        .all(|step| step.phase != PlanningPhase::EvaluateCompatibility)
+    {
+        validation.push(PlanningPhaseResult {
+            phase: PlanningPhase::EvaluateCompatibility,
+            status: PlanningPhaseStatus::Skipped,
+            summary: "skipped because no valid candidate generation was assembled".to_string(),
+        });
+    }
+
+    let rejection_summary = Some(render_rejected_changes(&rejected_changes));
+    StagedRuntimeReloadPlan {
+        plan: ReloadPlan {
+            request,
+            current_generation,
+            candidate_generation,
+            candidate_status: GenerationStatus::Rejected,
+            summary: format!(
+                "reload candidate for generation {candidate_generation} was rejected during staged validation"
+            ),
+            validation,
+            compatibility: ReloadCompatibilityClassification::NotEvaluated,
+            candidate_snapshot: None,
+            rejection_summary,
+            diff: ReloadDiff::default(),
+            rejected_changes,
+        },
+        next_runtime: None,
+        current_log_level,
+        next_log_level: None,
+    }
+}
+
+fn render_rejected_changes(rejected_changes: &[RejectedChange]) -> String {
+    rejected_changes
+        .iter()
+        .map(|rejected| rejected.message.as_str())
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+fn classify_compatibility(
+    rejections: &[TransitionRejection],
+) -> ReloadCompatibilityClassification {
+    if rejections.is_empty() {
+        ReloadCompatibilityClassification::LiveReloadable
+    } else if rejections.iter().any(TransitionRejection::requires_restart) {
+        ReloadCompatibilityClassification::RestartRequired
+    } else {
+        ReloadCompatibilityClassification::Rejected
+    }
+}
+
+fn snapshot_from_bundle(bundle: &RuntimeBundle) -> ProposedGenerationSnapshot {
+    let state = bundle.shared_state.generation_state();
+    let mut listener_labels = state.listener_runtime_configs.keys().cloned().collect::<Vec<_>>();
+    listener_labels.sort_unstable();
+
+    ProposedGenerationSnapshot {
+        generation: bundle.generation,
+        config_path: bundle.startup.config_path.clone(),
+        log_level: bundle.startup.log_config.level.clone(),
+        listener_labels,
+        upstream_count: state.upstream_policies.len(),
+        backend_count: state.backend_endpoints.len(),
+    }
+}
+
+fn build_reload_diff(current: &RuntimeBundle, next: &RuntimeBundle) -> ReloadDiff {
+    let mut entries = Vec::new();
+
+    let current_log_level = current.startup.log_config.level.as_str();
+    let next_log_level = next.startup.log_config.level.as_str();
+    entries.push(ReloadDiffEntry {
+        domain: "log.level".to_string(),
+        change: if current_log_level == next_log_level {
+            ReloadChangeKind::Unchanged
+        } else {
+            ReloadChangeKind::Modified
+        },
+        summary: format!("log.level: {current_log_level} -> {next_log_level}"),
+    });
+
+    let current_listeners = sorted_listener_labels(current);
+    let next_listeners = sorted_listener_labels(next);
+    entries.push(ReloadDiffEntry {
+        domain: "listeners".to_string(),
+        change: slice_change_kind(&current_listeners, &next_listeners),
+        summary: format!(
+            "listeners: [{}] -> [{}]",
+            current_listeners.join(", "),
+            next_listeners.join(", ")
+        ),
+    });
+
+    let current_upstreams = current.shared_state.generation_state().upstream_policies.len();
+    let next_upstreams = next.shared_state.generation_state().upstream_policies.len();
+    entries.push(ReloadDiffEntry {
+        domain: "upstreams".to_string(),
+        change: count_change_kind(current_upstreams, next_upstreams),
+        summary: format!("upstreams: {current_upstreams} -> {next_upstreams}"),
+    });
+
+    let current_backends = current.shared_state.generation_state().backend_endpoints.len();
+    let next_backends = next.shared_state.generation_state().backend_endpoints.len();
+    entries.push(ReloadDiffEntry {
+        domain: "backends".to_string(),
+        change: count_change_kind(current_backends, next_backends),
+        summary: format!("backends: {current_backends} -> {next_backends}"),
+    });
+
+    ReloadDiff { entries }
+}
+
+fn sorted_listener_labels(bundle: &RuntimeBundle) -> Vec<String> {
+    let mut labels = bundle
+        .shared_state
+        .generation_state()
+        .listener_runtime_configs
+        .keys()
+        .cloned()
+        .collect::<Vec<_>>();
+    labels.sort_unstable();
+    labels
+}
+
+fn count_change_kind(current: usize, next: usize) -> ReloadChangeKind {
+    match next.cmp(&current) {
+        std::cmp::Ordering::Less => ReloadChangeKind::Removed,
+        std::cmp::Ordering::Equal => ReloadChangeKind::Unchanged,
+        std::cmp::Ordering::Greater => ReloadChangeKind::Added,
+    }
+}
+
+fn slice_change_kind(current: &[String], next: &[String]) -> ReloadChangeKind {
+    if current == next {
+        ReloadChangeKind::Unchanged
+    } else if current.is_empty() && !next.is_empty() {
+        ReloadChangeKind::Added
+    } else if !current.is_empty() && next.is_empty() {
+        ReloadChangeKind::Removed
+    } else {
+        ReloadChangeKind::Modified
     }
 }
 
@@ -265,6 +757,21 @@ mod tests {
             candidate_generation: 8,
             candidate_status: GenerationStatus::Staged,
             summary: "listener policies unchanged".to_string(),
+            validation: vec![PlanningPhaseResult {
+                phase: PlanningPhase::EvaluateCompatibility,
+                status: PlanningPhaseStatus::Accepted,
+                summary: "reload candidate is live-reloadable".to_string(),
+            }],
+            compatibility: ReloadCompatibilityClassification::LiveReloadable,
+            candidate_snapshot: Some(ProposedGenerationSnapshot {
+                generation: 8,
+                config_path: "config.yaml".to_string(),
+                log_level: "info".to_string(),
+                listener_labels: vec!["edge-primary".to_string()],
+                upstream_count: 1,
+                backend_count: 2,
+            }),
+            rejection_summary: None,
             diff: ReloadDiff::default(),
             rejected_changes: Vec::new(),
         };

--- a/crates/edge/src/runtime/activation.rs
+++ b/crates/edge/src/runtime/activation.rs
@@ -259,6 +259,90 @@ impl RuntimeRejectionReason {
     }
 }
 
+/// Stable operator-visible outcome reason shared across activation and rollback
+/// observability surfaces.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeOperationOutcomeReason {
+    Applied,
+    InvalidConfig,
+    StartupOwnedChange,
+    BindConflict,
+    ResourcePrepareFailed,
+    IncompatibleReload,
+    UnknownGeneration,
+    RollbackNotAllowed,
+}
+
+impl RuntimeOperationOutcomeReason {
+    pub const COUNT: usize = 8;
+    pub const ALL: [Self; Self::COUNT] = [
+        Self::Applied,
+        Self::InvalidConfig,
+        Self::StartupOwnedChange,
+        Self::BindConflict,
+        Self::ResourcePrepareFailed,
+        Self::IncompatibleReload,
+        Self::UnknownGeneration,
+        Self::RollbackNotAllowed,
+    ];
+
+    #[must_use]
+    pub const fn index(self) -> usize {
+        match self {
+            Self::Applied => 0,
+            Self::InvalidConfig => 1,
+            Self::StartupOwnedChange => 2,
+            Self::BindConflict => 3,
+            Self::ResourcePrepareFailed => 4,
+            Self::IncompatibleReload => 5,
+            Self::UnknownGeneration => 6,
+            Self::RollbackNotAllowed => 7,
+        }
+    }
+
+    #[must_use]
+    pub fn slug(self) -> &'static str {
+        match self {
+            Self::Applied => "applied",
+            Self::InvalidConfig => "invalid_config",
+            Self::StartupOwnedChange => "startup_owned_change",
+            Self::BindConflict => "bind_conflict",
+            Self::ResourcePrepareFailed => "resource_prepare_failed",
+            Self::IncompatibleReload => "incompatible_reload",
+            Self::UnknownGeneration => "unknown_generation",
+            Self::RollbackNotAllowed => "rollback_not_allowed",
+        }
+    }
+
+    #[must_use]
+    pub fn result_label(self) -> &'static str {
+        match self {
+            Self::Applied => "success",
+            Self::InvalidConfig
+            | Self::StartupOwnedChange
+            | Self::BindConflict
+            | Self::ResourcePrepareFailed
+            | Self::IncompatibleReload
+            | Self::UnknownGeneration
+            | Self::RollbackNotAllowed => "failure",
+        }
+    }
+
+    #[must_use]
+    pub fn from_rejection_reason(reason: RuntimeRejectionReason) -> Self {
+        match reason {
+            RuntimeRejectionReason::InvalidConfig => Self::InvalidConfig,
+            RuntimeRejectionReason::StartupOwnedChange => Self::StartupOwnedChange,
+            RuntimeRejectionReason::BindConflict => Self::BindConflict,
+            RuntimeRejectionReason::ResourcePrepareFailed => Self::ResourcePrepareFailed,
+            RuntimeRejectionReason::IncompatibleReload => Self::IncompatibleReload,
+            RuntimeRejectionReason::UnknownGeneration => Self::UnknownGeneration,
+            RuntimeRejectionReason::RollbackNotAllowed => Self::RollbackNotAllowed,
+        }
+    }
+}
+
 impl From<TransitionRejectionKind> for RejectedChangeKind {
     fn from(value: TransitionRejectionKind) -> Self {
         match value {
@@ -491,6 +575,13 @@ impl ActivationResult {
     pub fn primary_rejection_reason(&self) -> Option<RuntimeRejectionReason> {
         self.rejected_changes.first().map(|rejection| rejection.reason)
     }
+
+    #[must_use]
+    pub fn outcome_reason(&self) -> RuntimeOperationOutcomeReason {
+        self.primary_rejection_reason()
+            .map(RuntimeOperationOutcomeReason::from_rejection_reason)
+            .unwrap_or(RuntimeOperationOutcomeReason::Applied)
+    }
 }
 
 /// Canonical rollback result payload.
@@ -513,6 +604,13 @@ impl RollbackResult {
     #[must_use]
     pub fn primary_rejection_reason(&self) -> Option<RuntimeRejectionReason> {
         self.rejected_changes.first().map(|rejection| rejection.reason)
+    }
+
+    #[must_use]
+    pub fn outcome_reason(&self) -> RuntimeOperationOutcomeReason {
+        self.primary_rejection_reason()
+            .map(RuntimeOperationOutcomeReason::from_rejection_reason)
+            .unwrap_or(RuntimeOperationOutcomeReason::Applied)
     }
 }
 

--- a/crates/edge/src/runtime/activation.rs
+++ b/crates/edge/src/runtime/activation.rs
@@ -40,6 +40,15 @@ pub enum ReloadConfigInput {
     Path { path: String },
 }
 
+impl ReloadConfigInput {
+    #[must_use]
+    pub fn source_label(&self) -> String {
+        match self {
+            Self::Path { path } => path.clone(),
+        }
+    }
+}
+
 /// Coarse kind of generation operation recorded in history.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
@@ -48,6 +57,18 @@ pub enum GenerationOperation {
     Preview,
     Activate,
     Rollback,
+}
+
+/// Structured runtime generation event kinds.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum GenerationEventKind {
+    Validation,
+    Preview,
+    ActivationSucceeded,
+    ActivationFailed,
+    RollbackSucceeded,
+    RollbackFailed,
 }
 
 /// Lifecycle status for a runtime generation or staged candidate.
@@ -297,6 +318,7 @@ impl RejectedChange {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ActivationRequest {
     pub requested_by: Option<String>,
+    pub trigger_source: Option<String>,
     pub reason: Option<String>,
     pub expected_generation: Option<GenerationId>,
     pub requested_at_ms: TimestampMillis,
@@ -307,6 +329,7 @@ pub struct ActivationRequest {
 pub struct RollbackRequest {
     pub target_generation: GenerationId,
     pub requested_by: Option<String>,
+    pub trigger_source: Option<String>,
     pub reason: Option<String>,
     pub expected_active_generation: Option<GenerationId>,
     pub requested_at_ms: TimestampMillis,
@@ -316,6 +339,8 @@ pub struct RollbackRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ReloadPlan {
     pub request: ActivationRequest,
+    pub config_source: String,
+    pub config_version: Option<u32>,
     pub current_generation: Option<GenerationId>,
     pub candidate_generation: GenerationId,
     pub candidate_status: GenerationStatus,
@@ -352,12 +377,23 @@ pub struct GenerationHistoryEntry {
     pub generation: GenerationId,
     pub operation: GenerationOperation,
     pub status: GenerationStatus,
+    pub config_source: String,
+    pub config_version: Option<u32>,
     pub requested_by: Option<String>,
+    pub trigger_source: Option<String>,
     pub requested_at_ms: TimestampMillis,
     pub completed_at_ms: Option<TimestampMillis>,
     pub summary: String,
     pub diff: ReloadDiff,
     pub rejected_changes: Vec<RejectedChange>,
+}
+
+/// Structured change event emitted for runtime generation activity.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GenerationChangeEvent {
+    pub kind: GenerationEventKind,
+    pub emitted_at_ms: TimestampMillis,
+    pub entry: GenerationHistoryEntry,
 }
 
 /// Canonical activation result payload.
@@ -428,14 +464,17 @@ impl RuntimeActivationService {
         let current = handle.current_view();
         let active_generation = current.generation();
         let current_log_level = current.startup().log_config.level.clone();
+        let config_source = input.source_label();
 
         if let Some(expected_generation) = request.expected_generation
             && expected_generation != active_generation
         {
-            return rejected_activation_result(
+            let result = rejected_activation_result(
                 request,
                 active_generation,
                 active_generation.saturating_add(1),
+                config_source,
+                None,
                 ReloadDiff::default(),
                 vec![RejectedChange {
                     kind: RejectedChangeKind::IllegalTransition,
@@ -452,9 +491,12 @@ impl RuntimeActivationService {
                 }],
                 "activation request targeted a stale runtime generation".to_string(),
             );
+            record_activation_result(handle, &result);
+            return result;
         }
 
         let plan = plan_runtime_reload(&current, request.clone(), input);
+        record_reload_plan_events(handle, &plan.plan);
         if !plan.can_activate() {
             if plan
                 .plan
@@ -475,10 +517,12 @@ impl RuntimeActivationService {
                         .unwrap_or_else(|| plan.plan.summary.clone()),
                 );
             }
-            return rejected_activation_result(
+            let result = rejected_activation_result(
                 request,
                 active_generation,
                 plan.plan.candidate_generation,
+                plan.plan.config_source.clone(),
+                plan.plan.config_version,
                 plan.plan.diff.clone(),
                 plan.plan.rejected_changes.clone(),
                 plan.plan
@@ -486,23 +530,33 @@ impl RuntimeActivationService {
                     .clone()
                     .unwrap_or_else(|| plan.plan.summary.clone()),
             );
+            record_activation_result(handle, &result);
+            return result;
         }
 
         if let Some(rejection) = handle.lifecycle().check_reload_allowed().rejection() {
-            return rejected_activation_result(
+            let result = rejected_activation_result(
                 request,
                 active_generation,
                 plan.plan.candidate_generation,
+                plan.plan.config_source.clone(),
+                plan.plan.config_version,
                 plan.plan.diff.clone(),
                 vec![RejectedChange::from(rejection)],
                 rejection.to_string(),
             );
+            record_activation_result(handle, &result);
+            return result;
         }
 
-        match commit_staged_runtime_reload(handle, plan) {
+        let config_source = plan.plan.config_source.clone();
+        let config_version = plan.plan.config_version;
+        let result = match commit_staged_runtime_reload(handle, plan) {
             Ok((generation, diff)) => successful_activation_result(
                 request,
                 generation,
+                config_source,
+                config_version,
                 diff,
                 current_log_level,
                 handle.current_view().startup().log_config.level.clone(),
@@ -511,10 +565,14 @@ impl RuntimeActivationService {
                 request,
                 handle.current_generation(),
                 candidate_generation,
+                config_source,
+                config_version,
                 diff,
                 err,
             ),
-        }
+        };
+        record_activation_result(handle, &result);
+        result
     }
 
     pub(crate) fn rollback_generation(
@@ -524,13 +582,16 @@ impl RuntimeActivationService {
         let current = handle.current_view();
         let active_generation = current.generation();
         let target_generation = request.target_generation;
+        let fallback_config_source = format!("generation:{target_generation}");
 
         if let Some(expected_active_generation) = request.expected_active_generation
             && expected_active_generation != active_generation
         {
-            return rejected_rollback_result(
+            let result = rejected_rollback_result(
                 request,
                 active_generation,
+                None,
+                fallback_config_source.clone(),
                 None,
                 ReloadDiff::default(),
                 vec![RejectedChange {
@@ -548,12 +609,16 @@ impl RuntimeActivationService {
                 }],
                 "rollback request targeted a stale runtime generation".to_string(),
             );
+            record_rollback_result(handle, &result);
+            return result;
         }
 
         if request.target_generation == active_generation {
-            return rejected_rollback_result(
+            let result = rejected_rollback_result(
                 request,
                 active_generation,
+                None,
+                fallback_config_source.clone(),
                 None,
                 ReloadDiff::default(),
                 vec![RejectedChange {
@@ -572,12 +637,16 @@ impl RuntimeActivationService {
                 }],
                 "rollback target is already the active generation".to_string(),
             );
+            record_rollback_result(handle, &result);
+            return result;
         }
 
         let Some(target_record) = handle.generation_record(target_generation) else {
-            return rejected_rollback_result(
+            let result = rejected_rollback_result(
                 request,
                 active_generation,
+                None,
+                fallback_config_source.clone(),
                 None,
                 ReloadDiff::default(),
                 vec![RejectedChange {
@@ -595,13 +664,17 @@ impl RuntimeActivationService {
                 }],
                 "rollback target is not retained in runtime history".to_string(),
             );
+            record_rollback_result(handle, &result);
+            return result;
         };
 
         if !target_record.status().is_rollback_candidate() || !target_record.has_bundle() {
-            return rejected_rollback_result(
+            let result = rejected_rollback_result(
                 request,
                 active_generation,
                 Some(target_generation),
+                fallback_config_source.clone(),
+                None,
                 ReloadDiff::default(),
                 vec![RejectedChange {
                     kind: RejectedChangeKind::RuntimeStateUnavailable,
@@ -619,37 +692,49 @@ impl RuntimeActivationService {
                 }],
                 "rollback target is incomplete or unusable".to_string(),
             );
+            record_rollback_result(handle, &result);
+            return result;
         }
 
         if let Some(rejection) = handle.lifecycle().check_reload_allowed().rejection() {
-            return rejected_rollback_result(
+            let result = rejected_rollback_result(
                 request,
                 active_generation,
                 Some(target_generation),
+                fallback_config_source.clone(),
+                None,
                 ReloadDiff::default(),
                 vec![RejectedChange::from(rejection)],
                 rejection.to_string(),
             );
+            record_rollback_result(handle, &result);
+            return result;
         }
 
         let target_bundle = target_record
             .bundle()
             .cloned()
             .expect("rollback candidate record with bundle");
+        let rollback_config_source = target_bundle.startup.config_path.clone();
+        let rollback_config_version = Some(target_bundle.runtime_config.version);
         let candidate_generation = active_generation.saturating_add(1);
         let prepared = match prepare_rollback_bundle(&current, &target_bundle, candidate_generation)
         {
             Ok(prepared) => prepared,
             Err(rejected) => {
                 handle.record_failed_prepare(candidate_generation, rejected.message.clone());
-                return rejected_rollback_result(
+                let result = rejected_rollback_result(
                     request,
                     active_generation,
                     Some(target_generation),
+                    rollback_config_source.clone(),
+                    rollback_config_version,
                     ReloadDiff::default(),
                     vec![rejected],
                     "rollback preparation failed".to_string(),
                 );
+                record_rollback_result(handle, &result);
+                return result;
             }
         };
 
@@ -662,14 +747,18 @@ impl RuntimeActivationService {
                 &prepared,
                 rejected_startup_owned_domains(&rejected_changes),
             );
-            return rejected_rollback_result(
+            let result = rejected_rollback_result(
                 request,
                 active_generation,
                 Some(target_generation),
+                rollback_config_source.clone(),
+                rollback_config_version,
                 diff,
                 rejected_changes,
                 render_rejections(rejections.as_slice()),
             );
+            record_rollback_result(handle, &result);
+            return result;
         }
 
         let diff = build_reload_diff(
@@ -677,7 +766,7 @@ impl RuntimeActivationService {
             &prepared,
             std::collections::HashSet::new(),
         );
-        match commit_runtime_bundle_swap(
+        let result = match commit_runtime_bundle_swap(
             handle,
             prepared,
             RuntimeGenerationRecordStatus::RolledBack,
@@ -686,16 +775,22 @@ impl RuntimeActivationService {
                 request,
                 generation,
                 target_generation,
+                rollback_config_source,
+                rollback_config_version,
                 diff,
             ),
             Err(err) => failed_rollback_result(
                 request,
                 handle.current_generation(),
                 target_generation,
+                rollback_config_source,
+                rollback_config_version,
                 diff,
                 err.to_string(),
             ),
-        }
+        };
+        record_rollback_result(handle, &result);
+        result
     }
 }
 
@@ -704,6 +799,7 @@ pub(crate) fn plan_runtime_reload(
     request: ActivationRequest,
     input: ReloadConfigInput,
 ) -> StagedRuntimeReloadPlan {
+    let config_source = input.source_label();
     let current_generation = Some(current.generation());
     let candidate_generation = current.generation().saturating_add(1);
     let mut validation = Vec::with_capacity(4);
@@ -726,6 +822,8 @@ pub(crate) fn plan_runtime_reload(
                 });
                 return rejected_reload_plan(
                     request,
+                    config_source,
+                    None,
                     current_generation,
                     candidate_generation,
                     validation,
@@ -752,6 +850,8 @@ pub(crate) fn plan_runtime_reload(
             });
             return rejected_reload_plan(
                 request,
+                config_source,
+                Some(config.version),
                 current_generation,
                 candidate_generation,
                 validation,
@@ -771,6 +871,8 @@ pub(crate) fn plan_runtime_reload(
             });
             return rejected_reload_plan(
                 request,
+                config_source,
+                Some(config.version),
                 current_generation,
                 candidate_generation,
                 validation,
@@ -802,6 +904,8 @@ pub(crate) fn plan_runtime_reload(
                 });
                 return rejected_reload_plan(
                     request,
+                    config_source,
+                    Some(config.version),
                     current_generation,
                     candidate_generation,
                     validation,
@@ -869,6 +973,8 @@ pub(crate) fn plan_runtime_reload(
     StagedRuntimeReloadPlan {
         plan: ReloadPlan {
             request,
+            config_source,
+            config_version: Some(config.version),
             current_generation,
             candidate_generation,
             candidate_status,
@@ -940,10 +1046,105 @@ fn prepare_rollback_bundle(
     })
 }
 
+fn record_reload_plan_events(handle: &RuntimeBundleHandle, plan: &ReloadPlan) {
+    let validation_entry = validation_history_entry(plan);
+    record_history_event(handle, GenerationEventKind::Validation, validation_entry);
+
+    let preview_entry = preview_history_entry(plan);
+    record_history_event(handle, GenerationEventKind::Preview, preview_entry);
+}
+
+fn record_activation_result(handle: &RuntimeBundleHandle, result: &ActivationResult) {
+    let kind = if result.succeeded() {
+        GenerationEventKind::ActivationSucceeded
+    } else {
+        GenerationEventKind::ActivationFailed
+    };
+    record_history_event(handle, kind, result.history_entry.clone());
+}
+
+fn record_rollback_result(handle: &RuntimeBundleHandle, result: &RollbackResult) {
+    let kind = if result.succeeded() {
+        GenerationEventKind::RollbackSucceeded
+    } else {
+        GenerationEventKind::RollbackFailed
+    };
+    record_history_event(handle, kind, result.history_entry.clone());
+}
+
+fn record_history_event(
+    handle: &RuntimeBundleHandle,
+    kind: GenerationEventKind,
+    entry: GenerationHistoryEntry,
+) {
+    let emitted_at_ms = entry.completed_at_ms.unwrap_or(entry.requested_at_ms);
+    handle.record_generation_history_entry(entry.clone());
+    handle.record_generation_change_event(GenerationChangeEvent {
+        kind,
+        emitted_at_ms,
+        entry,
+    });
+}
+
+fn validation_history_entry(plan: &ReloadPlan) -> GenerationHistoryEntry {
+    let completed_at_ms = crate::watchdog::time::now_millis();
+    let status = if plan
+        .validation
+        .iter()
+        .any(|result| matches!(result.status, PlanningPhaseStatus::Rejected))
+    {
+        GenerationStatus::Rejected
+    } else {
+        GenerationStatus::Staged
+    };
+    GenerationHistoryEntry {
+        generation: plan.candidate_generation,
+        operation: GenerationOperation::Validate,
+        status,
+        config_source: plan.config_source.clone(),
+        config_version: plan.config_version,
+        requested_by: plan.request.requested_by.clone(),
+        trigger_source: plan.request.trigger_source.clone(),
+        requested_at_ms: plan.request.requested_at_ms,
+        completed_at_ms: Some(completed_at_ms),
+        summary: summarize_validation_results(plan),
+        diff: ReloadDiff::default(),
+        rejected_changes: plan.rejected_changes.clone(),
+    }
+}
+
+fn preview_history_entry(plan: &ReloadPlan) -> GenerationHistoryEntry {
+    let completed_at_ms = crate::watchdog::time::now_millis();
+    GenerationHistoryEntry {
+        generation: plan.candidate_generation,
+        operation: GenerationOperation::Preview,
+        status: plan.candidate_status,
+        config_source: plan.config_source.clone(),
+        config_version: plan.config_version,
+        requested_by: plan.request.requested_by.clone(),
+        trigger_source: plan.request.trigger_source.clone(),
+        requested_at_ms: plan.request.requested_at_ms,
+        completed_at_ms: Some(completed_at_ms),
+        summary: plan.summary.clone(),
+        diff: plan.diff.clone(),
+        rejected_changes: plan.rejected_changes.clone(),
+    }
+}
+
+fn summarize_validation_results(plan: &ReloadPlan) -> String {
+    plan.validation
+        .iter()
+        .map(|result| format!("{:?}: {}", result.phase, result.summary))
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
 fn successful_rollback_result(
     request: RollbackRequest,
     generation: GenerationId,
     target_generation: GenerationId,
+    config_source: String,
+    config_version: Option<u32>,
     diff: ReloadDiff,
 ) -> RollbackResult {
     let completed_at_ms = crate::watchdog::time::now_millis();
@@ -951,7 +1152,10 @@ fn successful_rollback_result(
         generation,
         operation: GenerationOperation::Rollback,
         status: GenerationStatus::RolledBack,
+        config_source,
+        config_version,
         requested_by: request.requested_by.clone(),
+        trigger_source: request.trigger_source.clone(),
         requested_at_ms: request.requested_at_ms,
         completed_at_ms: Some(completed_at_ms),
         summary: format!(
@@ -976,6 +1180,8 @@ fn rejected_rollback_result(
     request: RollbackRequest,
     active_generation: GenerationId,
     target_generation: Option<GenerationId>,
+    config_source: String,
+    config_version: Option<u32>,
     diff: ReloadDiff,
     rejected_changes: Vec<RejectedChange>,
     summary: String,
@@ -985,7 +1191,10 @@ fn rejected_rollback_result(
         generation: target_generation.unwrap_or(active_generation.saturating_add(1)),
         operation: GenerationOperation::Rollback,
         status: GenerationStatus::Rejected,
+        config_source,
+        config_version,
         requested_by: request.requested_by.clone(),
+        trigger_source: request.trigger_source.clone(),
         requested_at_ms: request.requested_at_ms,
         completed_at_ms: Some(completed_at_ms),
         summary,
@@ -1007,6 +1216,8 @@ fn failed_rollback_result(
     request: RollbackRequest,
     active_generation: GenerationId,
     target_generation: GenerationId,
+    config_source: String,
+    config_version: Option<u32>,
     diff: ReloadDiff,
     error: String,
 ) -> RollbackResult {
@@ -1026,7 +1237,10 @@ fn failed_rollback_result(
         generation: active_generation.saturating_add(1),
         operation: GenerationOperation::Rollback,
         status: GenerationStatus::Failed,
+        config_source,
+        config_version,
         requested_by: request.requested_by.clone(),
+        trigger_source: request.trigger_source.clone(),
         requested_at_ms: request.requested_at_ms,
         completed_at_ms: Some(completed_at_ms),
         summary: format!(
@@ -1050,6 +1264,8 @@ fn failed_rollback_result(
 fn successful_activation_result(
     request: ActivationRequest,
     generation: GenerationId,
+    config_source: String,
+    config_version: Option<u32>,
     diff: ReloadDiff,
     previous_log_level: String,
     active_log_level: String,
@@ -1059,7 +1275,10 @@ fn successful_activation_result(
         generation,
         operation: GenerationOperation::Activate,
         status: GenerationStatus::Active,
+        config_source,
+        config_version,
         requested_by: request.requested_by.clone(),
+        trigger_source: request.trigger_source.clone(),
         requested_at_ms: request.requested_at_ms,
         completed_at_ms: Some(completed_at_ms),
         summary: format!(
@@ -1083,6 +1302,8 @@ fn rejected_activation_result(
     request: ActivationRequest,
     active_generation: GenerationId,
     candidate_generation: GenerationId,
+    config_source: String,
+    config_version: Option<u32>,
     diff: ReloadDiff,
     rejected_changes: Vec<RejectedChange>,
     summary: String,
@@ -1092,7 +1313,10 @@ fn rejected_activation_result(
         generation: candidate_generation,
         operation: GenerationOperation::Activate,
         status: GenerationStatus::Rejected,
+        config_source,
+        config_version,
         requested_by: request.requested_by.clone(),
+        trigger_source: request.trigger_source.clone(),
         requested_at_ms: request.requested_at_ms,
         completed_at_ms: Some(completed_at_ms),
         summary,
@@ -1114,6 +1338,8 @@ fn failed_activation_result(
     request: ActivationRequest,
     active_generation: GenerationId,
     candidate_generation: GenerationId,
+    config_source: String,
+    config_version: Option<u32>,
     diff: ReloadDiff,
     error: String,
 ) -> ActivationResult {
@@ -1133,7 +1359,10 @@ fn failed_activation_result(
         generation: candidate_generation,
         operation: GenerationOperation::Activate,
         status: GenerationStatus::Failed,
+        config_source,
+        config_version,
         requested_by: request.requested_by.clone(),
+        trigger_source: request.trigger_source.clone(),
         requested_at_ms: request.requested_at_ms,
         completed_at_ms: Some(completed_at_ms),
         summary: format!("failed to activate runtime generation {candidate_generation}: {error}"),
@@ -1153,6 +1382,8 @@ fn failed_activation_result(
 
 fn rejected_reload_plan(
     request: ActivationRequest,
+    config_source: String,
+    config_version: Option<u32>,
     current_generation: Option<GenerationId>,
     candidate_generation: GenerationId,
     mut validation: Vec<PlanningPhaseResult>,
@@ -1180,6 +1411,8 @@ fn rejected_reload_plan(
     StagedRuntimeReloadPlan {
         plan: ReloadPlan {
             request,
+            config_source,
+            config_version,
             current_generation,
             candidate_generation,
             candidate_status: GenerationStatus::Rejected,
@@ -1526,10 +1759,13 @@ mod tests {
         let plan = ReloadPlan {
             request: ActivationRequest {
                 requested_by: Some("operator".to_string()),
+                trigger_source: Some("unit_test".to_string()),
                 reason: Some("rotate routes".to_string()),
                 expected_generation: Some(7),
                 requested_at_ms: 1_720_000_000_000,
             },
+            config_source: "config.yaml".to_string(),
+            config_version: Some(1),
             current_generation: Some(7),
             candidate_generation: 8,
             candidate_status: GenerationStatus::Staged,

--- a/crates/edge/src/runtime/activation.rs
+++ b/crates/edge/src/runtime/activation.rs
@@ -10,10 +10,14 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 use spooky_config::{loader::read_config, runtime::RuntimeConfig};
+use spooky_errors::ProxyError;
 
 use crate::{
     runtime::{
-        bundle::{ActiveRuntimeGeneration, RuntimeBundle, RuntimeBundleHandle},
+        bundle::{
+            ActiveRuntimeGeneration, RuntimeBundle, RuntimeBundleHandle,
+            RuntimeGenerationRecordStatus,
+        },
         generation::CarriedProcessSharedServices,
         listener::QUICListener,
         policy::{TransitionRejection, TransitionRejectionKind, render_rejections},
@@ -512,6 +516,187 @@ impl RuntimeActivationService {
             ),
         }
     }
+
+    pub(crate) fn rollback_generation(
+        handle: &RuntimeBundleHandle,
+        request: RollbackRequest,
+    ) -> RollbackResult {
+        let current = handle.current_view();
+        let active_generation = current.generation();
+        let target_generation = request.target_generation;
+
+        if let Some(expected_active_generation) = request.expected_active_generation
+            && expected_active_generation != active_generation
+        {
+            return rejected_rollback_result(
+                request,
+                active_generation,
+                None,
+                ReloadDiff::default(),
+                vec![RejectedChange {
+                    kind: RejectedChangeKind::IllegalTransition,
+                    field_path: Some("runtime.generation".to_string()),
+                    current_value: Some(active_generation.to_string()),
+                    requested_value: Some(expected_active_generation.to_string()),
+                    operator_action:
+                        "refresh the active generation view and retry the rollback".to_string(),
+                    active_generation_changed: false,
+                    message: format!(
+                        "runtime rollback rejected: expected active generation {} but current active generation is {}",
+                        expected_active_generation, active_generation
+                    ),
+                }],
+                "rollback request targeted a stale runtime generation".to_string(),
+            );
+        }
+
+        if request.target_generation == active_generation {
+            return rejected_rollback_result(
+                request,
+                active_generation,
+                None,
+                ReloadDiff::default(),
+                vec![RejectedChange {
+                    kind: RejectedChangeKind::IllegalTransition,
+                    field_path: Some("runtime.rollback.target_generation".to_string()),
+                    current_value: Some(active_generation.to_string()),
+                    requested_value: Some(active_generation.to_string()),
+                    operator_action:
+                        "choose an older retained generation if rollback is still required"
+                            .to_string(),
+                    active_generation_changed: false,
+                    message: format!(
+                        "runtime rollback rejected: generation {} is already active",
+                        active_generation
+                    ),
+                }],
+                "rollback target is already the active generation".to_string(),
+            );
+        }
+
+        let Some(target_record) = handle.generation_record(target_generation) else {
+            return rejected_rollback_result(
+                request,
+                active_generation,
+                None,
+                ReloadDiff::default(),
+                vec![RejectedChange {
+                    kind: RejectedChangeKind::RuntimeStateUnavailable,
+                    field_path: Some("runtime.rollback.target_generation".to_string()),
+                    current_value: None,
+                    requested_value: Some(target_generation.to_string()),
+                    operator_action:
+                        "choose a retained known-good generation from runtime history".to_string(),
+                    active_generation_changed: false,
+                    message: format!(
+                        "runtime rollback rejected: generation {} is not retained as a rollback candidate",
+                        target_generation
+                    ),
+                }],
+                "rollback target is not retained in runtime history".to_string(),
+            );
+        };
+
+        if !target_record.status().is_rollback_candidate() || !target_record.has_bundle() {
+            return rejected_rollback_result(
+                request,
+                active_generation,
+                Some(target_generation),
+                ReloadDiff::default(),
+                vec![RejectedChange {
+                    kind: RejectedChangeKind::RuntimeStateUnavailable,
+                    field_path: Some("runtime.rollback.target_generation".to_string()),
+                    current_value: Some(target_record.generation().to_string()),
+                    requested_value: Some(target_record.status().as_str().to_string()),
+                    operator_action:
+                        "choose a complete retained generation with a usable runtime bundle"
+                            .to_string(),
+                    active_generation_changed: false,
+                    message: format!(
+                        "runtime rollback rejected: generation {} is incomplete or not a usable rollback candidate",
+                        target_generation
+                    ),
+                }],
+                "rollback target is incomplete or unusable".to_string(),
+            );
+        }
+
+        if let Some(rejection) = handle.lifecycle().check_reload_allowed().rejection() {
+            return rejected_rollback_result(
+                request,
+                active_generation,
+                Some(target_generation),
+                ReloadDiff::default(),
+                vec![RejectedChange::from(rejection)],
+                rejection.to_string(),
+            );
+        }
+
+        let target_bundle = target_record
+            .bundle()
+            .cloned()
+            .expect("rollback candidate record with bundle");
+        let candidate_generation = active_generation.saturating_add(1);
+        let prepared = match prepare_rollback_bundle(&current, &target_bundle, candidate_generation)
+        {
+            Ok(prepared) => prepared,
+            Err(rejected) => {
+                handle.record_failed_prepare(candidate_generation, rejected.message.clone());
+                return rejected_rollback_result(
+                    request,
+                    active_generation,
+                    Some(target_generation),
+                    ReloadDiff::default(),
+                    vec![rejected],
+                    "rollback preparation failed".to_string(),
+                );
+            }
+        };
+
+        let compatibility_rejections =
+            QUICListener::evaluate_runtime_reload_compatibility(&current, &prepared);
+        if let Err(rejections) = compatibility_rejections {
+            let rejected_changes = rejections.iter().map(RejectedChange::from).collect::<Vec<_>>();
+            let diff = build_reload_diff(
+                current.bundle(),
+                &prepared,
+                rejected_startup_owned_domains(&rejected_changes),
+            );
+            return rejected_rollback_result(
+                request,
+                active_generation,
+                Some(target_generation),
+                diff,
+                rejected_changes,
+                render_rejections(rejections.as_slice()),
+            );
+        }
+
+        let diff = build_reload_diff(
+            current.bundle(),
+            &prepared,
+            std::collections::HashSet::new(),
+        );
+        match commit_runtime_bundle_swap(
+            handle,
+            prepared,
+            RuntimeGenerationRecordStatus::RolledBack,
+        ) {
+            Ok(generation) => successful_rollback_result(
+                request,
+                generation,
+                target_generation,
+                diff,
+            ),
+            Err(err) => failed_rollback_result(
+                request,
+                handle.current_generation(),
+                target_generation,
+                diff,
+                err.to_string(),
+            ),
+        }
+    }
 }
 
 pub(crate) fn plan_runtime_reload(
@@ -713,14 +898,153 @@ fn commit_staged_runtime_reload(
         )
     })?;
 
+    commit_runtime_bundle_swap(
+        handle,
+        next_runtime,
+        RuntimeGenerationRecordStatus::Previous,
+    )
+    .map(|generation| (generation, diff.clone()))
+    .map_err(|err| (candidate_generation, diff, err.to_string()))
+}
+
+fn commit_runtime_bundle_swap(
+    handle: &RuntimeBundleHandle,
+    next_runtime: RuntimeBundle,
+    previous_status: RuntimeGenerationRecordStatus,
+) -> Result<GenerationId, ProxyError> {
     QUICListener::spawn_generation_background_tasks_for_runtime(
         &next_runtime.runtime_config,
         next_runtime.shared_state.as_ref(),
     );
     handle
-        .replace(next_runtime)
-        .map(|generation| (generation, diff.clone()))
-        .map_err(|err| (candidate_generation, diff, err.to_string()))
+        .replace_with_archive_status(next_runtime, previous_status)
+}
+
+fn prepare_rollback_bundle(
+    current: &ActiveRuntimeGeneration,
+    target: &RuntimeBundle,
+    candidate_generation: GenerationId,
+) -> Result<RuntimeBundle, RejectedChange> {
+    let carried = CarriedProcessSharedServices::from_active(current.shared_services());
+    let next_shared_state =
+        QUICListener::build_shared_state_with_carried(&target.runtime_config, Some(carried))
+            .map_err(|err| {
+                RejectedChange::resource_preparation_failed("runtime rollback", err.to_string())
+            })?;
+
+    Ok(RuntimeBundle {
+        generation: candidate_generation,
+        startup: target.startup.clone(),
+        runtime_config: target.runtime_config.clone(),
+        shared_state: Arc::new(next_shared_state),
+    })
+}
+
+fn successful_rollback_result(
+    request: RollbackRequest,
+    generation: GenerationId,
+    target_generation: GenerationId,
+    diff: ReloadDiff,
+) -> RollbackResult {
+    let completed_at_ms = crate::watchdog::time::now_millis();
+    let history_entry = GenerationHistoryEntry {
+        generation,
+        operation: GenerationOperation::Rollback,
+        status: GenerationStatus::RolledBack,
+        requested_by: request.requested_by.clone(),
+        requested_at_ms: request.requested_at_ms,
+        completed_at_ms: Some(completed_at_ms),
+        summary: format!(
+            "rolled back runtime to retained generation {} as new active generation {}",
+            target_generation, generation
+        ),
+        diff,
+        rejected_changes: Vec::new(),
+    };
+
+    RollbackResult {
+        request,
+        active_generation: generation,
+        rolled_back_to: Some(target_generation),
+        status: GenerationStatus::RolledBack,
+        rejected_changes: Vec::new(),
+        history_entry,
+    }
+}
+
+fn rejected_rollback_result(
+    request: RollbackRequest,
+    active_generation: GenerationId,
+    target_generation: Option<GenerationId>,
+    diff: ReloadDiff,
+    rejected_changes: Vec<RejectedChange>,
+    summary: String,
+) -> RollbackResult {
+    let completed_at_ms = crate::watchdog::time::now_millis();
+    let history_entry = GenerationHistoryEntry {
+        generation: target_generation.unwrap_or(active_generation.saturating_add(1)),
+        operation: GenerationOperation::Rollback,
+        status: GenerationStatus::Rejected,
+        requested_by: request.requested_by.clone(),
+        requested_at_ms: request.requested_at_ms,
+        completed_at_ms: Some(completed_at_ms),
+        summary,
+        diff,
+        rejected_changes: rejected_changes.clone(),
+    };
+
+    RollbackResult {
+        request,
+        active_generation,
+        rolled_back_to: None,
+        status: GenerationStatus::Rejected,
+        rejected_changes,
+        history_entry,
+    }
+}
+
+fn failed_rollback_result(
+    request: RollbackRequest,
+    active_generation: GenerationId,
+    target_generation: GenerationId,
+    diff: ReloadDiff,
+    error: String,
+) -> RollbackResult {
+    let rejected_changes = vec![RejectedChange {
+        kind: RejectedChangeKind::RuntimeStateUnavailable,
+        field_path: Some("runtime.rollback".to_string()),
+        current_value: Some(active_generation.to_string()),
+        requested_value: Some(target_generation.to_string()),
+        operator_action:
+            "inspect runtime state and retry the rollback once the runtime is healthy"
+                .to_string(),
+        active_generation_changed: false,
+        message: error.clone(),
+    }];
+    let completed_at_ms = crate::watchdog::time::now_millis();
+    let history_entry = GenerationHistoryEntry {
+        generation: active_generation.saturating_add(1),
+        operation: GenerationOperation::Rollback,
+        status: GenerationStatus::Failed,
+        requested_by: request.requested_by.clone(),
+        requested_at_ms: request.requested_at_ms,
+        completed_at_ms: Some(completed_at_ms),
+        summary: format!(
+            "failed to roll back runtime to retained generation {}: {}",
+            target_generation, error
+        ),
+        diff,
+        rejected_changes: rejected_changes.clone(),
+    };
+
+    RollbackResult {
+        request,
+        active_generation,
+        rolled_back_to: None,
+        status: GenerationStatus::Failed,
+        rejected_changes,
+        history_entry,
+    }
 }
 
 fn successful_activation_result(

--- a/crates/edge/src/runtime/activation.rs
+++ b/crates/edge/src/runtime/activation.rs
@@ -638,6 +638,22 @@ impl StagedRuntimeReloadPlan {
 pub(crate) struct RuntimeActivationService;
 
 impl RuntimeActivationService {
+    pub(crate) fn validate_reload(
+        handle: &RuntimeBundleHandle,
+        request: ActivationRequest,
+        input: ReloadConfigInput,
+    ) -> ReloadPlan {
+        Self::stage_reload(handle, request, input).plan
+    }
+
+    pub(crate) fn preview_reload(
+        handle: &RuntimeBundleHandle,
+        request: ActivationRequest,
+        input: ReloadConfigInput,
+    ) -> ReloadPlan {
+        Self::stage_reload(handle, request, input).plan
+    }
+
     pub(crate) fn activate_reload(
         handle: &RuntimeBundleHandle,
         request: ActivationRequest,
@@ -678,8 +694,7 @@ impl RuntimeActivationService {
             return result;
         }
 
-        let plan = plan_runtime_reload(&current, request.clone(), input);
-        record_reload_plan_events(handle, &plan.plan);
+        let plan = Self::stage_reload(handle, request.clone(), input);
         if !plan.can_activate() {
             if plan
                 .plan
@@ -978,6 +993,17 @@ impl RuntimeActivationService {
         };
         record_rollback_result(handle, &result);
         result
+    }
+
+    fn stage_reload(
+        handle: &RuntimeBundleHandle,
+        request: ActivationRequest,
+        input: ReloadConfigInput,
+    ) -> StagedRuntimeReloadPlan {
+        let current = handle.current_view();
+        let plan = plan_runtime_reload(&current, request, input);
+        record_reload_plan_events(handle, &plan.plan);
+        plan
     }
 }
 

--- a/crates/edge/src/runtime/activation.rs
+++ b/crates/edge/src/runtime/activation.rs
@@ -671,7 +671,9 @@ impl RuntimeActivationService {
         request: ActivationRequest,
         input: ReloadConfigInput,
     ) -> ReloadPlan {
-        Self::stage_reload(handle, request, input).plan
+        let plan = Self::stage_reload(handle, request, input);
+        record_validation_result(handle, &plan.plan);
+        plan.plan
     }
 
     pub(crate) fn preview_reload(
@@ -679,7 +681,9 @@ impl RuntimeActivationService {
         request: ActivationRequest,
         input: ReloadConfigInput,
     ) -> ReloadPlan {
-        Self::stage_reload(handle, request, input).plan
+        let plan = Self::stage_reload(handle, request, input);
+        record_preview_result(handle, &plan.plan);
+        plan.plan
     }
 
     pub(crate) fn activate_reload(
@@ -1053,9 +1057,8 @@ impl RuntimeActivationService {
         input: ReloadConfigInput,
     ) -> StagedRuntimeReloadPlan {
         let current = handle.current_view();
-        let plan = plan_runtime_reload(&current, request, input);
-        record_reload_plan_events(handle, &plan.plan);
-        plan
+        let _ = handle;
+        plan_runtime_reload(&current, request, input)
     }
 }
 
@@ -1313,10 +1316,12 @@ fn prepare_rollback_bundle(
     })
 }
 
-fn record_reload_plan_events(handle: &RuntimeBundleHandle, plan: &ReloadPlan) {
+fn record_validation_result(handle: &RuntimeBundleHandle, plan: &ReloadPlan) {
     let validation_entry = validation_history_entry(plan);
     record_history_event(handle, GenerationEventKind::Validation, validation_entry);
+}
 
+fn record_preview_result(handle: &RuntimeBundleHandle, plan: &ReloadPlan) {
     let preview_entry = preview_history_entry(plan);
     record_history_event(handle, GenerationEventKind::Preview, preview_entry);
 }

--- a/crates/edge/src/runtime/activation.rs
+++ b/crates/edge/src/runtime/activation.rs
@@ -13,7 +13,7 @@ use spooky_config::{loader::read_config, runtime::RuntimeConfig};
 
 use crate::{
     runtime::{
-        bundle::{ActiveRuntimeGeneration, RuntimeBundle},
+        bundle::{ActiveRuntimeGeneration, RuntimeBundle, RuntimeBundleHandle},
         generation::CarriedProcessSharedServices,
         listener::QUICListener,
         policy::{TransitionRejection, TransitionRejectionKind, render_rejections},
@@ -233,15 +233,20 @@ pub struct RejectedChange {
 
 impl From<TransitionRejection> for RejectedChange {
     fn from(value: TransitionRejection) -> Self {
-        let message = value.to_string();
+        Self::from(&value)
+    }
+}
+
+impl From<&TransitionRejection> for RejectedChange {
+    fn from(value: &TransitionRejection) -> Self {
         Self {
             kind: value.kind.into(),
-            field_path: value.field_path,
-            current_value: value.current_mode,
-            requested_value: value.requested_mode,
+            field_path: value.field_path.clone(),
+            current_value: value.current_mode.clone(),
+            requested_value: value.requested_mode.clone(),
             operator_action: value.operator_action.to_string(),
             active_generation_changed: value.active_runtime_changed,
-            message,
+            message: value.to_string(),
         }
     }
 }
@@ -394,14 +399,99 @@ impl RollbackResult {
 pub(crate) struct StagedRuntimeReloadPlan {
     pub(crate) plan: ReloadPlan,
     pub(crate) next_runtime: Option<RuntimeBundle>,
-    pub(crate) current_log_level: String,
-    pub(crate) next_log_level: Option<String>,
 }
 
 impl StagedRuntimeReloadPlan {
     #[must_use]
     pub(crate) fn can_activate(&self) -> bool {
         self.plan.can_activate() && self.next_runtime.is_some()
+    }
+}
+
+/// Canonical runtime activation service.
+///
+/// This owns the activation transaction for runtime reloads:
+/// staged validation/planning, final lifecycle gate, generation swap, and the
+/// explicit result object returned to control-plane callers.
+pub(crate) struct RuntimeActivationService;
+
+impl RuntimeActivationService {
+    pub(crate) fn activate_reload(
+        handle: &RuntimeBundleHandle,
+        request: ActivationRequest,
+        input: ReloadConfigInput,
+    ) -> ActivationResult {
+        let current = handle.current_view();
+        let active_generation = current.generation();
+        let current_log_level = current.startup().log_config.level.clone();
+
+        if let Some(expected_generation) = request.expected_generation
+            && expected_generation != active_generation
+        {
+            return rejected_activation_result(
+                request,
+                active_generation,
+                active_generation.saturating_add(1),
+                ReloadDiff::default(),
+                vec![RejectedChange {
+                    kind: RejectedChangeKind::IllegalTransition,
+                    field_path: Some("runtime.generation".to_string()),
+                    current_value: Some(active_generation.to_string()),
+                    requested_value: Some(expected_generation.to_string()),
+                    operator_action:
+                        "refresh the active generation view and retry the activation".to_string(),
+                    active_generation_changed: false,
+                    message: format!(
+                        "runtime reload rejected: expected active generation {} but current active generation is {}",
+                        expected_generation, active_generation
+                    ),
+                }],
+                "activation request targeted a stale runtime generation".to_string(),
+            );
+        }
+
+        let plan = plan_runtime_reload(&current, request.clone(), input);
+        if !plan.can_activate() {
+            return rejected_activation_result(
+                request,
+                active_generation,
+                plan.plan.candidate_generation,
+                plan.plan.diff.clone(),
+                plan.plan.rejected_changes.clone(),
+                plan.plan
+                    .rejection_summary
+                    .clone()
+                    .unwrap_or_else(|| plan.plan.summary.clone()),
+            );
+        }
+
+        if let Some(rejection) = handle.lifecycle().check_reload_allowed().rejection() {
+            return rejected_activation_result(
+                request,
+                active_generation,
+                plan.plan.candidate_generation,
+                plan.plan.diff.clone(),
+                vec![RejectedChange::from(rejection)],
+                rejection.to_string(),
+            );
+        }
+
+        match commit_staged_runtime_reload(handle, plan) {
+            Ok((generation, diff)) => successful_activation_result(
+                request,
+                generation,
+                diff,
+                current_log_level,
+                handle.current_view().startup().log_config.level.clone(),
+            ),
+            Err((candidate_generation, diff, err)) => failed_activation_result(
+                request,
+                handle.current_generation(),
+                candidate_generation,
+                diff,
+                err,
+            ),
+        }
     }
 }
 
@@ -412,7 +502,6 @@ pub(crate) fn plan_runtime_reload(
 ) -> StagedRuntimeReloadPlan {
     let current_generation = Some(current.generation());
     let candidate_generation = current.generation().saturating_add(1);
-    let current_log_level = current.startup().log_config.level.clone();
     let mut validation = Vec::with_capacity(4);
 
     let config = match input {
@@ -435,7 +524,6 @@ pub(crate) fn plan_runtime_reload(
                     request,
                     current_generation,
                     candidate_generation,
-                    current_log_level,
                     validation,
                     vec![
                         RejectedChange::invalid_configuration(err),
@@ -462,7 +550,6 @@ pub(crate) fn plan_runtime_reload(
                 request,
                 current_generation,
                 candidate_generation,
-                current_log_level,
                 validation,
                 vec![RejectedChange::invalid_configuration(message)],
             );
@@ -482,7 +569,6 @@ pub(crate) fn plan_runtime_reload(
                 request,
                 current_generation,
                 candidate_generation,
-                current_log_level,
                 validation,
                 vec![RejectedChange::invalid_configuration(message)],
             );
@@ -514,7 +600,6 @@ pub(crate) fn plan_runtime_reload(
                     request,
                     current_generation,
                     candidate_generation,
-                    current_log_level,
                     validation,
                     vec![rejected],
                 );
@@ -530,7 +615,6 @@ pub(crate) fn plan_runtime_reload(
         runtime_config,
         shared_state: next_shared_state,
     };
-    let next_log_level = next_runtime.startup.log_config.level.clone();
     let candidate_snapshot = Some(snapshot_from_bundle(&next_runtime));
 
     let compatibility_rejections: Result<(), Vec<TransitionRejection>> =
@@ -593,8 +677,134 @@ pub(crate) fn plan_runtime_reload(
             rejected_changes,
         },
         next_runtime: Some(next_runtime),
-        current_log_level,
-        next_log_level: Some(next_log_level),
+    }
+}
+
+fn commit_staged_runtime_reload(
+    handle: &RuntimeBundleHandle,
+    plan: StagedRuntimeReloadPlan,
+) -> Result<(GenerationId, ReloadDiff), (GenerationId, ReloadDiff, String)> {
+    let candidate_generation = plan.plan.candidate_generation;
+    let diff = plan.plan.diff.clone();
+    let next_runtime = plan.next_runtime.ok_or_else(|| {
+        (
+            candidate_generation,
+            diff.clone(),
+            "staged reload plan missing next runtime".to_string(),
+        )
+    })?;
+
+    QUICListener::spawn_generation_background_tasks_for_runtime(
+        &next_runtime.runtime_config,
+        next_runtime.shared_state.as_ref(),
+    );
+    handle
+        .replace(next_runtime)
+        .map(|generation| (generation, diff.clone()))
+        .map_err(|err| (candidate_generation, diff, err.to_string()))
+}
+
+fn successful_activation_result(
+    request: ActivationRequest,
+    generation: GenerationId,
+    diff: ReloadDiff,
+    previous_log_level: String,
+    active_log_level: String,
+) -> ActivationResult {
+    let completed_at_ms = crate::watchdog::time::now_millis();
+    let history_entry = GenerationHistoryEntry {
+        generation,
+        operation: GenerationOperation::Activate,
+        status: GenerationStatus::Active,
+        requested_by: request.requested_by.clone(),
+        requested_at_ms: request.requested_at_ms,
+        completed_at_ms: Some(completed_at_ms),
+        summary: format!(
+            "activated runtime generation {generation} (log.level: {previous_log_level} -> {active_log_level})"
+        ),
+        diff,
+        rejected_changes: Vec::new(),
+    };
+
+    ActivationResult {
+        request,
+        active_generation: generation,
+        activated_generation: Some(generation),
+        status: GenerationStatus::Active,
+        rejected_changes: Vec::new(),
+        history_entry,
+    }
+}
+
+fn rejected_activation_result(
+    request: ActivationRequest,
+    active_generation: GenerationId,
+    candidate_generation: GenerationId,
+    diff: ReloadDiff,
+    rejected_changes: Vec<RejectedChange>,
+    summary: String,
+) -> ActivationResult {
+    let completed_at_ms = crate::watchdog::time::now_millis();
+    let history_entry = GenerationHistoryEntry {
+        generation: candidate_generation,
+        operation: GenerationOperation::Activate,
+        status: GenerationStatus::Rejected,
+        requested_by: request.requested_by.clone(),
+        requested_at_ms: request.requested_at_ms,
+        completed_at_ms: Some(completed_at_ms),
+        summary,
+        diff,
+        rejected_changes: rejected_changes.clone(),
+    };
+
+    ActivationResult {
+        request,
+        active_generation,
+        activated_generation: None,
+        status: GenerationStatus::Rejected,
+        rejected_changes,
+        history_entry,
+    }
+}
+
+fn failed_activation_result(
+    request: ActivationRequest,
+    active_generation: GenerationId,
+    candidate_generation: GenerationId,
+    diff: ReloadDiff,
+    error: String,
+) -> ActivationResult {
+    let rejected_changes = vec![RejectedChange {
+        kind: RejectedChangeKind::RuntimeStateUnavailable,
+        field_path: Some("runtime.activation".to_string()),
+        current_value: Some(active_generation.to_string()),
+        requested_value: Some(candidate_generation.to_string()),
+        operator_action:
+            "inspect runtime state and retry the activation once the runtime is healthy"
+                .to_string(),
+        active_generation_changed: false,
+        message: error.clone(),
+    }];
+    let completed_at_ms = crate::watchdog::time::now_millis();
+    let history_entry = GenerationHistoryEntry {
+        generation: candidate_generation,
+        operation: GenerationOperation::Activate,
+        status: GenerationStatus::Failed,
+        requested_by: request.requested_by.clone(),
+        requested_at_ms: request.requested_at_ms,
+        completed_at_ms: Some(completed_at_ms),
+        summary: format!("failed to activate runtime generation {candidate_generation}: {error}"),
+        diff,
+        rejected_changes: rejected_changes.clone(),
+    };
+
+    ActivationResult {
+        request,
+        active_generation,
+        activated_generation: None,
+        status: GenerationStatus::Failed,
+        rejected_changes,
+        history_entry,
     }
 }
 
@@ -602,7 +812,6 @@ fn rejected_reload_plan(
     request: ActivationRequest,
     current_generation: Option<GenerationId>,
     candidate_generation: GenerationId,
-    current_log_level: String,
     mut validation: Vec<PlanningPhaseResult>,
     rejected_changes: Vec<RejectedChange>,
 ) -> StagedRuntimeReloadPlan {
@@ -642,8 +851,6 @@ fn rejected_reload_plan(
             rejected_changes,
         },
         next_runtime: None,
-        current_log_level,
-        next_log_level: None,
     }
 }
 

--- a/crates/edge/src/runtime/activation.rs
+++ b/crates/edge/src/runtime/activation.rs
@@ -2007,4 +2007,143 @@ mod tests {
         };
         assert!(diff.is_noop());
     }
+
+    #[test]
+    fn compatibility_classification_distinguishes_reloadable_restart_required_and_rejected() {
+        assert_eq!(
+            classify_compatibility(&[]),
+            ReloadCompatibilityClassification::LiveReloadable
+        );
+
+        let restart_required = [TransitionRejection::restart_required(
+            "performance.worker_threads",
+            "1",
+            "8",
+        )];
+        assert_eq!(
+            classify_compatibility(&restart_required),
+            ReloadCompatibilityClassification::RestartRequired
+        );
+
+        let rejected = [TransitionRejection::resource_preflight_failed(
+            "metrics listener",
+            "127.0.0.1:9090",
+            "bind conflict on 127.0.0.1:9090",
+        )];
+        assert_eq!(
+            classify_compatibility(&rejected),
+            ReloadCompatibilityClassification::Rejected
+        );
+    }
+
+    #[test]
+    fn transition_rejections_map_to_stable_runtime_rejection_reasons() {
+        let startup_owned = RejectedChange::from(TransitionRejection::restart_required(
+            "performance.worker_threads",
+            "1",
+            "8",
+        ));
+        assert_eq!(
+            startup_owned.reason,
+            RuntimeRejectionReason::StartupOwnedChange
+        );
+
+        let bind_conflict = RejectedChange::from(TransitionRejection::resource_preflight_failed(
+            "metrics listener",
+            "127.0.0.1:9090",
+            "bind conflict on 127.0.0.1:9090",
+        ));
+        assert_eq!(bind_conflict.reason, RuntimeRejectionReason::BindConflict);
+
+        let incompatible = RejectedChange::from(TransitionRejection {
+            kind: crate::runtime::policy::TransitionRejectionKind::IllegalTransition,
+            field_path: None,
+            current_mode: Some("Draining".to_string()),
+            requested_mode: Some("Reload".to_string()),
+            operator_action:
+                "wait for the current lifecycle phase to complete; the requested transition is not legal now",
+            active_runtime_changed: false,
+            verbatim: None,
+        });
+        assert_eq!(
+            incompatible.reason,
+            RuntimeRejectionReason::IncompatibleReload
+        );
+    }
+
+    #[test]
+    fn activation_and_rollback_results_expose_stable_outcome_reasons() {
+        let request = ActivationRequest {
+            requested_by: Some("operator".to_string()),
+            trigger_source: Some("unit_test".to_string()),
+            reason: Some("reload".to_string()),
+            expected_generation: Some(3),
+            requested_at_ms: 10,
+        };
+        let rejected = RejectedChange {
+            reason: RuntimeRejectionReason::InvalidConfig,
+            kind: RejectedChangeKind::InvalidConfiguration,
+            field_path: Some("log.level".to_string()),
+            current_value: Some("info".to_string()),
+            requested_value: Some("".to_string()),
+            operator_action: "fix config".to_string(),
+            active_generation_changed: false,
+            message: "invalid config".to_string(),
+        };
+        let activation = ActivationResult {
+            request: request.clone(),
+            active_generation: 3,
+            activated_generation: None,
+            status: GenerationStatus::Rejected,
+            rejected_changes: vec![rejected.clone()],
+            history_entry: GenerationHistoryEntry {
+                generation: 4,
+                operation: GenerationOperation::Activate,
+                status: GenerationStatus::Rejected,
+                config_source: "runtime.yaml".to_string(),
+                config_version: Some(1),
+                requested_by: Some("operator".to_string()),
+                trigger_source: Some("unit_test".to_string()),
+                requested_at_ms: 10,
+                completed_at_ms: Some(11),
+                summary: "rejected".to_string(),
+                diff: ReloadDiff::default(),
+                rejected_changes: vec![rejected.clone()],
+            },
+        };
+        assert_eq!(
+            activation.outcome_reason(),
+            RuntimeOperationOutcomeReason::InvalidConfig
+        );
+
+        let rollback = RollbackResult {
+            request: RollbackRequest {
+                target_generation: 2,
+                requested_by: Some("operator".to_string()),
+                trigger_source: Some("unit_test".to_string()),
+                reason: Some("rollback".to_string()),
+                expected_active_generation: Some(4),
+                requested_at_ms: 12,
+            },
+            active_generation: 5,
+            rolled_back_to: Some(2),
+            status: GenerationStatus::RolledBack,
+            rejected_changes: Vec::new(),
+            history_entry: GenerationHistoryEntry {
+                generation: 5,
+                operation: GenerationOperation::Rollback,
+                status: GenerationStatus::RolledBack,
+                config_source: "generation:2".to_string(),
+                config_version: Some(1),
+                requested_by: Some("operator".to_string()),
+                trigger_source: Some("unit_test".to_string()),
+                requested_at_ms: 12,
+                completed_at_ms: Some(13),
+                summary: "rolled back".to_string(),
+                diff: ReloadDiff::default(),
+                rejected_changes: Vec::new(),
+            },
+        };
+        assert_eq!(rollback.outcome_reason(), RuntimeOperationOutcomeReason::Applied);
+    }
 }

--- a/crates/edge/src/runtime/activation.rs
+++ b/crates/edge/src/runtime/activation.rs
@@ -1180,7 +1180,7 @@ pub(crate) fn plan_runtime_reload(
     let next_runtime = RuntimeBundle {
         generation: candidate_generation,
         startup: crate::runtime::generation::StartupOwnedRuntimeState {
-            config_path: current.startup().config_path.clone(),
+            config_path: config_source.clone(),
             log_config: config.log.clone(),
         },
         runtime_config,

--- a/crates/edge/src/runtime/activation.rs
+++ b/crates/edge/src/runtime/activation.rs
@@ -36,9 +36,6 @@ pub enum ReloadConfigInput {
     Path { path: String },
 }
 
-impl ReloadConfigInput {
-}
-
 /// Coarse kind of generation operation recorded in history.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
@@ -133,11 +130,21 @@ pub enum ReloadChangeKind {
     Unchanged,
 }
 
+/// Operator-visible disposition for a diff domain.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum ReloadDiffDisposition {
+    Reloadable,
+    RejectedStartupOwned,
+    NoOp,
+}
+
 /// One operator-visible entry in a reload preview diff.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ReloadDiffEntry {
     pub domain: String,
     pub change: ReloadChangeKind,
+    pub disposition: ReloadDiffDisposition,
     pub summary: String,
 }
 
@@ -154,7 +161,36 @@ impl ReloadDiff {
             || self
                 .entries
                 .iter()
-                .all(|entry| matches!(entry.change, ReloadChangeKind::Unchanged))
+                .all(|entry| matches!(entry.disposition, ReloadDiffDisposition::NoOp))
+    }
+
+    #[must_use]
+    pub fn reloadable_entries(&self) -> Vec<&ReloadDiffEntry> {
+        self.entries
+            .iter()
+            .filter(|entry| matches!(entry.disposition, ReloadDiffDisposition::Reloadable))
+            .collect()
+    }
+
+    #[must_use]
+    pub fn rejected_startup_owned_entries(&self) -> Vec<&ReloadDiffEntry> {
+        self.entries
+            .iter()
+            .filter(|entry| {
+                matches!(
+                    entry.disposition,
+                    ReloadDiffDisposition::RejectedStartupOwned
+                )
+            })
+            .collect()
+    }
+
+    #[must_use]
+    pub fn noop_entries(&self) -> Vec<&ReloadDiffEntry> {
+        self.entries
+            .iter()
+            .filter(|entry| matches!(entry.disposition, ReloadDiffDisposition::NoOp))
+            .collect()
     }
 }
 
@@ -496,7 +532,6 @@ pub(crate) fn plan_runtime_reload(
     };
     let next_log_level = next_runtime.startup.log_config.level.clone();
     let candidate_snapshot = Some(snapshot_from_bundle(&next_runtime));
-    let diff = build_reload_diff(current.bundle(), &next_runtime);
 
     let compatibility_rejections: Result<(), Vec<TransitionRejection>> =
         QUICListener::evaluate_runtime_reload_compatibility(current, &next_runtime);
@@ -528,6 +563,11 @@ pub(crate) fn plan_runtime_reload(
         },
         summary: compatibility_summary.clone(),
     });
+    let diff = build_reload_diff(
+        current.bundle(),
+        &next_runtime,
+        rejected_startup_owned_domains(&rejected_changes),
+    );
 
     let rejection_summary = (!rejected_changes.is_empty()).then(|| compatibility_summary.clone());
     let summary = if rejected_changes.is_empty() {
@@ -642,73 +682,240 @@ fn snapshot_from_bundle(bundle: &RuntimeBundle) -> ProposedGenerationSnapshot {
     }
 }
 
-fn build_reload_diff(current: &RuntimeBundle, next: &RuntimeBundle) -> ReloadDiff {
-    let mut entries = Vec::new();
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum ReloadDiffDomain {
+    Listeners,
+    RoutesUpstreams,
+    BackendPolicies,
+    AuthAdmissionResilience,
+    ObservabilityControlPlane,
+}
 
-    let current_log_level = current.startup.log_config.level.as_str();
-    let next_log_level = next.startup.log_config.level.as_str();
-    entries.push(ReloadDiffEntry {
-        domain: "log.level".to_string(),
-        change: if current_log_level == next_log_level {
-            ReloadChangeKind::Unchanged
-        } else {
-            ReloadChangeKind::Modified
-        },
-        summary: format!("log.level: {current_log_level} -> {next_log_level}"),
-    });
+impl ReloadDiffDomain {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Listeners => "listeners",
+            Self::RoutesUpstreams => "routes_upstreams",
+            Self::BackendPolicies => "backend_policies",
+            Self::AuthAdmissionResilience => "auth_admission_resilience",
+            Self::ObservabilityControlPlane => "observability_control_plane",
+        }
+    }
+}
 
-    let current_listeners = sorted_listener_labels(current);
-    let next_listeners = sorted_listener_labels(next);
-    entries.push(ReloadDiffEntry {
-        domain: "listeners".to_string(),
-        change: slice_change_kind(&current_listeners, &next_listeners),
-        summary: format!(
-            "listeners: [{}] -> [{}]",
-            current_listeners.join(", "),
-            next_listeners.join(", ")
+fn build_reload_diff(
+    current: &RuntimeBundle,
+    next: &RuntimeBundle,
+    rejected_domains: std::collections::HashSet<ReloadDiffDomain>,
+) -> ReloadDiff {
+    let specs = [
+        (
+            ReloadDiffDomain::Listeners,
+            summarize_listeners(current),
+            summarize_listeners(next),
         ),
-    });
+        (
+            ReloadDiffDomain::RoutesUpstreams,
+            summarize_routes_upstreams(current),
+            summarize_routes_upstreams(next),
+        ),
+        (
+            ReloadDiffDomain::BackendPolicies,
+            summarize_backend_policies(current),
+            summarize_backend_policies(next),
+        ),
+        (
+            ReloadDiffDomain::AuthAdmissionResilience,
+            summarize_auth_admission_resilience(current),
+            summarize_auth_admission_resilience(next),
+        ),
+        (
+            ReloadDiffDomain::ObservabilityControlPlane,
+            summarize_observability_control_plane(current),
+            summarize_observability_control_plane(next),
+        ),
+    ];
 
-    let current_upstreams = current.shared_state.generation_state().upstream_policies.len();
-    let next_upstreams = next.shared_state.generation_state().upstream_policies.len();
-    entries.push(ReloadDiffEntry {
-        domain: "upstreams".to_string(),
-        change: count_change_kind(current_upstreams, next_upstreams),
-        summary: format!("upstreams: {current_upstreams} -> {next_upstreams}"),
-    });
+    let entries = specs
+        .into_iter()
+        .map(|(domain, current_summary, next_summary)| {
+            let change = text_change_kind(&current_summary, &next_summary);
+            let disposition = if matches!(change, ReloadChangeKind::Unchanged) {
+                ReloadDiffDisposition::NoOp
+            } else if rejected_domains.contains(&domain) {
+                ReloadDiffDisposition::RejectedStartupOwned
+            } else {
+                ReloadDiffDisposition::Reloadable
+            };
 
-    let current_backends = current.shared_state.generation_state().backend_endpoints.len();
-    let next_backends = next.shared_state.generation_state().backend_endpoints.len();
-    entries.push(ReloadDiffEntry {
-        domain: "backends".to_string(),
-        change: count_change_kind(current_backends, next_backends),
-        summary: format!("backends: {current_backends} -> {next_backends}"),
-    });
+            ReloadDiffEntry {
+                domain: domain.as_str().to_string(),
+                change,
+                disposition,
+                summary: format!(
+                    "{}: [{}] -> [{}]",
+                    domain.as_str(),
+                    current_summary,
+                    next_summary
+                ),
+            }
+        })
+        .collect();
 
     ReloadDiff { entries }
 }
 
-fn sorted_listener_labels(bundle: &RuntimeBundle) -> Vec<String> {
-    let mut labels = bundle
-        .shared_state
-        .generation_state()
-        .listener_runtime_configs
-        .keys()
-        .cloned()
+fn summarize_listeners(bundle: &RuntimeBundle) -> String {
+    let mut listeners = bundle
+        .runtime_config
+        .listeners
+        .iter()
+        .map(|listener| {
+            format!(
+                "{}:{:?}:{}:{}:{}:client_auth(enabled={},required={})",
+                listener.index,
+                listener.source,
+                listener.listen.protocol,
+                listener.listen.address,
+                listener.listen.port,
+                listener.tls.client_auth.enabled,
+                listener.tls.client_auth.require_client_cert,
+            )
+        })
         .collect::<Vec<_>>();
-    labels.sort_unstable();
-    labels
+    listeners.sort_unstable();
+    listeners.join(" | ")
 }
 
-fn count_change_kind(current: usize, next: usize) -> ReloadChangeKind {
-    match next.cmp(&current) {
-        std::cmp::Ordering::Less => ReloadChangeKind::Removed,
-        std::cmp::Ordering::Equal => ReloadChangeKind::Unchanged,
-        std::cmp::Ordering::Greater => ReloadChangeKind::Added,
-    }
+fn summarize_routes_upstreams(bundle: &RuntimeBundle) -> String {
+    let mut upstreams = bundle
+        .runtime_config
+        .upstreams
+        .iter()
+        .map(|(name, upstream)| {
+            format!(
+                "{}:{}:{:?}:{:?}:{:?}:{}:{:?}",
+                name,
+                upstream.load_balancing.strategy.canonical_name(),
+                upstream.route.host,
+                upstream.route.path_prefix,
+                upstream.route.method,
+                upstream.policy.protocol.0.allow_connect,
+                upstream.load_balancing.key_spec
+            )
+        })
+        .collect::<Vec<_>>();
+    upstreams.sort_unstable();
+    upstreams.join(" | ")
 }
 
-fn slice_change_kind(current: &[String], next: &[String]) -> ReloadChangeKind {
+fn summarize_backend_policies(bundle: &RuntimeBundle) -> String {
+    let mut upstreams = bundle
+        .runtime_config
+        .upstreams
+        .iter()
+        .map(|(name, upstream)| {
+            let backend_ids = upstream
+                .backends
+                .iter()
+                .map(|backend| {
+                    format!(
+                        "{}:{:?}:{:?}:hc={}",
+                        backend.backend.id,
+                        backend.endpoint.transport_kind,
+                        backend.endpoint.address_kind,
+                        backend.health_check.is_some()
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(",");
+            format!(
+                "{}:tls(v={},sni={}):dns(enabled={},refresh={}s):{}",
+                name,
+                upstream.backend_tls_policy().verify_certificates,
+                upstream.backend_tls_policy().strict_sni,
+                bundle.runtime_config.performance.backend_dns_refresh_enabled,
+                bundle
+                    .runtime_config
+                    .performance
+                    .backend_dns_refresh_interval_ms
+                    / 1000,
+                backend_ids
+            )
+        })
+        .collect::<Vec<_>>();
+    upstreams.sort_unstable();
+    upstreams.join(" | ")
+}
+
+fn summarize_auth_admission_resilience(bundle: &RuntimeBundle) -> String {
+    let mut auth = bundle
+        .runtime_config
+        .upstreams
+        .iter()
+        .map(|(name, upstream)| {
+            format!(
+                "{}:api_key={}:jwt={}:external={}:scopes={}:roles={}",
+                name,
+                upstream.policy.upstream_auth.api_key.is_some(),
+                upstream.policy.upstream_auth.jwt.is_some(),
+                upstream.policy.upstream_auth.external_auth.is_some(),
+                upstream.policy.upstream_auth.required_scopes.join(","),
+                upstream.policy.upstream_auth.required_roles.join(","),
+            )
+        })
+        .collect::<Vec<_>>();
+    auth.sort_unstable();
+
+    let admission = &bundle.runtime_config.policies.admission;
+    let rate_limits = &bundle.runtime_config.policies.rate_limits;
+    let resilience = format!(
+        "adaptive={}..{:?};route_queue={}..{};circuit={}#{};hedging={}@{:?};retry={}@{};brownout={}%;watchdog={};scoped_rate_limits={}",
+        admission.adaptive_admission.min_limit,
+        admission.adaptive_admission.max_limit,
+        admission.route_queue.default_cap,
+        admission.route_queue.global_cap,
+        admission.circuit_breaker.enabled,
+        admission.circuit_breaker.failure_threshold,
+        admission.hedging.enabled,
+        admission.hedging.delay,
+        admission.retry_budget.enabled,
+        admission.retry_budget.ratio_percent,
+        admission.brownout.trigger_inflight_percent,
+        admission.watchdog.enabled,
+        rate_limits.scoped_limits.len(),
+    );
+
+    format!("auth=[{}]; policies=[{}]", auth.join(" | "), resilience)
+}
+
+fn summarize_observability_control_plane(bundle: &RuntimeBundle) -> String {
+    let startup = bundle.startup();
+    let observability = &bundle.runtime_config.observability;
+    let performance = &bundle.runtime_config.performance;
+    format!(
+        "log(level={},format={:?},file_enabled={},file_path={});control_api(enabled={},bind={}:{},path={});metrics(enabled={},bind={}:{},path={});tracing(enabled={},service={},otlp={:?},ratio={});control_plane_threads={}",
+        startup.log_config.level,
+        startup.log_config.format,
+        startup.log_config.file.enabled,
+        startup.log_config.file.path,
+        observability.control_api.enabled,
+        observability.control_api.address,
+        observability.control_api.port,
+        observability.control_api.runtime_path,
+        observability.metrics.enabled,
+        observability.metrics.address,
+        observability.metrics.port,
+        observability.metrics.path,
+        observability.tracing.enabled,
+        observability.tracing.service_name,
+        observability.tracing.otlp_endpoint,
+        observability.tracing.sample_ratio,
+        performance.control_plane_threads,
+    )
+}
+
+fn text_change_kind(current: &str, next: &str) -> ReloadChangeKind {
     if current == next {
         ReloadChangeKind::Unchanged
     } else if current.is_empty() && !next.is_empty() {
@@ -718,6 +925,26 @@ fn slice_change_kind(current: &[String], next: &[String]) -> ReloadChangeKind {
     } else {
         ReloadChangeKind::Modified
     }
+}
+
+fn rejected_startup_owned_domains(
+    rejected_changes: &[RejectedChange],
+) -> std::collections::HashSet<ReloadDiffDomain> {
+    rejected_changes
+        .iter()
+        .filter(|rejection| rejection.kind == RejectedChangeKind::RestartRequired)
+        .filter_map(|rejection| rejection.field_path.as_deref())
+        .filter_map(|field_path| {
+            if field_path.starts_with("log.")
+                || field_path.starts_with("observability.tracing.")
+                || field_path == "performance.control_plane_threads"
+            {
+                Some(ReloadDiffDomain::ObservabilityControlPlane)
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -798,6 +1025,7 @@ mod tests {
             entries: vec![ReloadDiffEntry {
                 domain: "observability.metrics".to_string(),
                 change: ReloadChangeKind::Unchanged,
+                disposition: ReloadDiffDisposition::NoOp,
                 summary: "no effective change".to_string(),
             }],
         };

--- a/crates/edge/src/runtime/activation.rs
+++ b/crates/edge/src/runtime/activation.rs
@@ -230,6 +230,35 @@ pub enum RejectedChangeKind {
     RuntimeStateUnavailable,
 }
 
+/// Stable operator-visible rejection reason shared across logs, metrics, and
+/// control-plane responses.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeRejectionReason {
+    InvalidConfig,
+    StartupOwnedChange,
+    BindConflict,
+    ResourcePrepareFailed,
+    IncompatibleReload,
+    UnknownGeneration,
+    RollbackNotAllowed,
+}
+
+impl RuntimeRejectionReason {
+    #[must_use]
+    pub fn slug(self) -> &'static str {
+        match self {
+            Self::InvalidConfig => "invalid_config",
+            Self::StartupOwnedChange => "startup_owned_change",
+            Self::BindConflict => "bind_conflict",
+            Self::ResourcePrepareFailed => "resource_prepare_failed",
+            Self::IncompatibleReload => "incompatible_reload",
+            Self::UnknownGeneration => "unknown_generation",
+            Self::RollbackNotAllowed => "rollback_not_allowed",
+        }
+    }
+}
+
 impl From<TransitionRejectionKind> for RejectedChangeKind {
     fn from(value: TransitionRejectionKind) -> Self {
         match value {
@@ -247,6 +276,7 @@ impl From<TransitionRejectionKind> for RejectedChangeKind {
 /// Canonical operator-visible rejection payload for a planned change.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RejectedChange {
+    pub reason: RuntimeRejectionReason,
     pub kind: RejectedChangeKind,
     pub field_path: Option<String>,
     pub current_value: Option<String>,
@@ -265,6 +295,7 @@ impl From<TransitionRejection> for RejectedChange {
 impl From<&TransitionRejection> for RejectedChange {
     fn from(value: &TransitionRejection) -> Self {
         Self {
+            reason: runtime_rejection_reason_for_transition(value),
             kind: value.kind.into(),
             field_path: value.field_path.clone(),
             current_value: value.current_mode.clone(),
@@ -280,6 +311,7 @@ impl RejectedChange {
     fn invalid_configuration(message: impl Into<String>) -> Self {
         let message = message.into();
         Self {
+            reason: RuntimeRejectionReason::InvalidConfig,
             kind: RejectedChangeKind::InvalidConfiguration,
             field_path: None,
             current_value: None,
@@ -297,6 +329,7 @@ impl RejectedChange {
             "runtime reload rejected: could not prepare {field_path}: {detail}; active runtime unchanged (no change applied)"
         );
         Self {
+            reason: runtime_rejection_reason_for_resource_failure(&field_path, &detail),
             kind: RejectedChangeKind::ResourcePreparationFailed,
             field_path: Some(field_path),
             current_value: None,
@@ -307,6 +340,42 @@ impl RejectedChange {
             active_generation_changed: false,
             message,
         }
+    }
+
+    #[must_use]
+    pub fn reason_slug(&self) -> &'static str {
+        self.reason.slug()
+    }
+}
+
+fn runtime_rejection_reason_for_transition(
+    rejection: &TransitionRejection,
+) -> RuntimeRejectionReason {
+    match rejection.kind {
+        TransitionRejectionKind::RestartRequired => RuntimeRejectionReason::StartupOwnedChange,
+        TransitionRejectionKind::InvalidConfiguration => RuntimeRejectionReason::InvalidConfig,
+        TransitionRejectionKind::IllegalTransition => RuntimeRejectionReason::IncompatibleReload,
+        TransitionRejectionKind::RuntimeStateUnavailable => RuntimeRejectionReason::UnknownGeneration,
+        TransitionRejectionKind::ResourcePreparationFailed => {
+            let field_path = rejection.field_path.as_deref().unwrap_or_default();
+            let detail = rejection.requested_mode.as_deref().unwrap_or_default();
+            runtime_rejection_reason_for_resource_failure(field_path, detail)
+        }
+    }
+}
+
+fn runtime_rejection_reason_for_resource_failure(
+    field_path: &str,
+    detail: &str,
+) -> RuntimeRejectionReason {
+    if field_path.contains("listener")
+        || field_path.contains("endpoint")
+        || detail.contains("Address already in use")
+        || detail.contains("AddrInUse")
+    {
+        RuntimeRejectionReason::BindConflict
+    } else {
+        RuntimeRejectionReason::ResourcePrepareFailed
     }
 }
 
@@ -369,6 +438,11 @@ impl ReloadPlan {
             .find(|result| result.phase == phase)
             .map(|result| result.status)
     }
+
+    #[must_use]
+    pub fn primary_rejection_reason(&self) -> Option<RuntimeRejectionReason> {
+        self.rejected_changes.first().map(|rejection| rejection.reason)
+    }
 }
 
 /// Audit/history record for validation, preview, activation, and rollback.
@@ -412,6 +486,11 @@ impl ActivationResult {
     pub fn succeeded(&self) -> bool {
         self.activated_generation.is_some() && self.rejected_changes.is_empty()
     }
+
+    #[must_use]
+    pub fn primary_rejection_reason(&self) -> Option<RuntimeRejectionReason> {
+        self.rejected_changes.first().map(|rejection| rejection.reason)
+    }
 }
 
 /// Canonical rollback result payload.
@@ -429,6 +508,11 @@ impl RollbackResult {
     #[must_use]
     pub fn succeeded(&self) -> bool {
         self.rolled_back_to.is_some() && self.rejected_changes.is_empty()
+    }
+
+    #[must_use]
+    pub fn primary_rejection_reason(&self) -> Option<RuntimeRejectionReason> {
+        self.rejected_changes.first().map(|rejection| rejection.reason)
     }
 }
 
@@ -477,6 +561,7 @@ impl RuntimeActivationService {
                 None,
                 ReloadDiff::default(),
                 vec![RejectedChange {
+                    reason: RuntimeRejectionReason::UnknownGeneration,
                     kind: RejectedChangeKind::IllegalTransition,
                     field_path: Some("runtime.generation".to_string()),
                     current_value: Some(active_generation.to_string()),
@@ -595,6 +680,7 @@ impl RuntimeActivationService {
                 None,
                 ReloadDiff::default(),
                 vec![RejectedChange {
+                    reason: RuntimeRejectionReason::UnknownGeneration,
                     kind: RejectedChangeKind::IllegalTransition,
                     field_path: Some("runtime.generation".to_string()),
                     current_value: Some(active_generation.to_string()),
@@ -622,6 +708,7 @@ impl RuntimeActivationService {
                 None,
                 ReloadDiff::default(),
                 vec![RejectedChange {
+                    reason: RuntimeRejectionReason::RollbackNotAllowed,
                     kind: RejectedChangeKind::IllegalTransition,
                     field_path: Some("runtime.rollback.target_generation".to_string()),
                     current_value: Some(active_generation.to_string()),
@@ -650,6 +737,7 @@ impl RuntimeActivationService {
                 None,
                 ReloadDiff::default(),
                 vec![RejectedChange {
+                    reason: RuntimeRejectionReason::UnknownGeneration,
                     kind: RejectedChangeKind::RuntimeStateUnavailable,
                     field_path: Some("runtime.rollback.target_generation".to_string()),
                     current_value: None,
@@ -677,6 +765,7 @@ impl RuntimeActivationService {
                 None,
                 ReloadDiff::default(),
                 vec![RejectedChange {
+                    reason: RuntimeRejectionReason::RollbackNotAllowed,
                     kind: RejectedChangeKind::RuntimeStateUnavailable,
                     field_path: Some("runtime.rollback.target_generation".to_string()),
                     current_value: Some(target_record.generation().to_string()),
@@ -1222,6 +1311,7 @@ fn failed_rollback_result(
     error: String,
 ) -> RollbackResult {
     let rejected_changes = vec![RejectedChange {
+        reason: RuntimeRejectionReason::RollbackNotAllowed,
         kind: RejectedChangeKind::RuntimeStateUnavailable,
         field_path: Some("runtime.rollback".to_string()),
         current_value: Some(active_generation.to_string()),
@@ -1344,6 +1434,7 @@ fn failed_activation_result(
     error: String,
 ) -> ActivationResult {
     let rejected_changes = vec![RejectedChange {
+        reason: RuntimeRejectionReason::IncompatibleReload,
         kind: RejectedChangeKind::RuntimeStateUnavailable,
         field_path: Some("runtime.activation".to_string()),
         current_value: Some(active_generation.to_string()),
@@ -1792,6 +1883,7 @@ mod tests {
 
         let mut rejected = plan.clone();
         rejected.rejected_changes.push(RejectedChange {
+            reason: RuntimeRejectionReason::InvalidConfig,
             kind: RejectedChangeKind::InvalidConfiguration,
             field_path: Some("resilience.watchdog".to_string()),
             current_value: None,

--- a/crates/edge/src/runtime/activation.rs
+++ b/crates/edge/src/runtime/activation.rs
@@ -12,16 +12,13 @@ use serde::{Deserialize, Serialize};
 use spooky_config::{loader::read_config, runtime::RuntimeConfig};
 use spooky_errors::ProxyError;
 
-use crate::{
-    runtime::{
-        bundle::{
-            ActiveRuntimeGeneration, RuntimeBundle, RuntimeBundleHandle,
-            RuntimeGenerationRecordStatus,
-        },
-        generation::CarriedProcessSharedServices,
-        listener::QUICListener,
-        policy::{TransitionRejection, TransitionRejectionKind, render_rejections},
+use crate::runtime::{
+    bundle::{
+        ActiveRuntimeGeneration, RuntimeBundle, RuntimeBundleHandle, RuntimeGenerationRecordStatus,
     },
+    generation::CarriedProcessSharedServices,
+    listener::QUICListener,
+    policy::{TransitionRejection, TransitionRejectionKind, render_rejections},
 };
 
 /// Stable identifier for a published or staged runtime generation.
@@ -347,9 +344,7 @@ impl From<TransitionRejectionKind> for RejectedChangeKind {
     fn from(value: TransitionRejectionKind) -> Self {
         match value {
             TransitionRejectionKind::RestartRequired => Self::RestartRequired,
-            TransitionRejectionKind::ResourcePreparationFailed => {
-                Self::ResourcePreparationFailed
-            }
+            TransitionRejectionKind::ResourcePreparationFailed => Self::ResourcePreparationFailed,
             TransitionRejectionKind::InvalidConfiguration => Self::InvalidConfiguration,
             TransitionRejectionKind::IllegalTransition => Self::IllegalTransition,
             TransitionRejectionKind::RuntimeStateUnavailable => Self::RuntimeStateUnavailable,
@@ -406,7 +401,10 @@ impl RejectedChange {
         }
     }
 
-    fn resource_preparation_failed(field_path: impl Into<String>, detail: impl Into<String>) -> Self {
+    fn resource_preparation_failed(
+        field_path: impl Into<String>,
+        detail: impl Into<String>,
+    ) -> Self {
         let field_path = field_path.into();
         let detail = detail.into();
         let message = format!(
@@ -439,7 +437,9 @@ fn runtime_rejection_reason_for_transition(
         TransitionRejectionKind::RestartRequired => RuntimeRejectionReason::StartupOwnedChange,
         TransitionRejectionKind::InvalidConfiguration => RuntimeRejectionReason::InvalidConfig,
         TransitionRejectionKind::IllegalTransition => RuntimeRejectionReason::IncompatibleReload,
-        TransitionRejectionKind::RuntimeStateUnavailable => RuntimeRejectionReason::UnknownGeneration,
+        TransitionRejectionKind::RuntimeStateUnavailable => {
+            RuntimeRejectionReason::UnknownGeneration
+        }
         TransitionRejectionKind::ResourcePreparationFailed => {
             let field_path = rejection.field_path.as_deref().unwrap_or_default();
             let detail = rejection.requested_mode.as_deref().unwrap_or_default();
@@ -525,7 +525,9 @@ impl ReloadPlan {
 
     #[must_use]
     pub fn primary_rejection_reason(&self) -> Option<RuntimeRejectionReason> {
-        self.rejected_changes.first().map(|rejection| rejection.reason)
+        self.rejected_changes
+            .first()
+            .map(|rejection| rejection.reason)
     }
 }
 
@@ -573,7 +575,9 @@ impl ActivationResult {
 
     #[must_use]
     pub fn primary_rejection_reason(&self) -> Option<RuntimeRejectionReason> {
-        self.rejected_changes.first().map(|rejection| rejection.reason)
+        self.rejected_changes
+            .first()
+            .map(|rejection| rejection.reason)
     }
 
     #[must_use]
@@ -603,7 +607,9 @@ impl RollbackResult {
 
     #[must_use]
     pub fn primary_rejection_reason(&self) -> Option<RuntimeRejectionReason> {
-        self.rejected_changes.first().map(|rejection| rejection.reason)
+        self.rejected_changes
+            .first()
+            .map(|rejection| rejection.reason)
     }
 
     #[must_use]
@@ -680,8 +686,8 @@ impl RuntimeActivationService {
                     field_path: Some("runtime.generation".to_string()),
                     current_value: Some(active_generation.to_string()),
                     requested_value: Some(expected_generation.to_string()),
-                    operator_action:
-                        "refresh the active generation view and retry the activation".to_string(),
+                    operator_action: "refresh the active generation view and retry the activation"
+                        .to_string(),
                     active_generation_changed: false,
                     message: format!(
                         "runtime reload rejected: expected active generation {} but current active generation is {}",
@@ -696,17 +702,12 @@ impl RuntimeActivationService {
 
         let plan = Self::stage_reload(handle, request.clone(), input);
         if !plan.can_activate() {
-            if plan
-                .plan
-                .rejected_changes
-                .iter()
-                .any(|rejection| {
-                    matches!(
-                        rejection.kind,
-                        RejectedChangeKind::ResourcePreparationFailed
-                    )
-                })
-            {
+            if plan.plan.rejected_changes.iter().any(|rejection| {
+                matches!(
+                    rejection.kind,
+                    RejectedChangeKind::ResourcePreparationFailed
+                )
+            }) {
                 handle.record_failed_prepare(
                     plan.plan.candidate_generation,
                     plan.plan
@@ -798,8 +799,8 @@ impl RuntimeActivationService {
                     field_path: Some("runtime.generation".to_string()),
                     current_value: Some(active_generation.to_string()),
                     requested_value: Some(expected_active_generation.to_string()),
-                    operator_action:
-                        "refresh the active generation view and retry the rollback".to_string(),
+                    operator_action: "refresh the active generation view and retry the rollback"
+                        .to_string(),
                     active_generation_changed: false,
                     message: format!(
                         "runtime rollback rejected: expected active generation {} but current active generation is {}",
@@ -855,8 +856,8 @@ impl RuntimeActivationService {
                     field_path: Some("runtime.rollback.target_generation".to_string()),
                     current_value: None,
                     requested_value: Some(target_generation.to_string()),
-                    operator_action:
-                        "choose a retained known-good generation from runtime history".to_string(),
+                    operator_action: "choose a retained known-good generation from runtime history"
+                        .to_string(),
                     active_generation_changed: false,
                     message: format!(
                         "runtime rollback rejected: generation {} is not retained as a rollback candidate",
@@ -943,7 +944,10 @@ impl RuntimeActivationService {
         let compatibility_rejections =
             QUICListener::evaluate_runtime_reload_compatibility(&current, &prepared);
         if let Err(rejections) = compatibility_rejections {
-            let rejected_changes = rejections.iter().map(RejectedChange::from).collect::<Vec<_>>();
+            let rejected_changes = rejections
+                .iter()
+                .map(RejectedChange::from)
+                .collect::<Vec<_>>();
             let diff = build_reload_diff(
                 current.bundle(),
                 &prepared,
@@ -1040,9 +1044,7 @@ pub(crate) fn plan_runtime_reload(
                     current_generation,
                     candidate_generation,
                     validation,
-                    vec![
-                        RejectedChange::invalid_configuration(err),
-                    ],
+                    vec![RejectedChange::invalid_configuration(err)],
                 );
             }
         },
@@ -1180,7 +1182,9 @@ pub(crate) fn plan_runtime_reload(
             "validated reload candidate for generation {candidate_generation}; ready for activation"
         )
     } else {
-        format!("validated reload candidate for generation {candidate_generation}; activation blocked")
+        format!(
+            "validated reload candidate for generation {candidate_generation}; activation blocked"
+        )
     };
 
     StagedRuntimeReloadPlan {
@@ -1235,8 +1239,7 @@ fn commit_runtime_bundle_swap(
         &next_runtime.runtime_config,
         next_runtime.shared_state.as_ref(),
     );
-    handle
-        .replace_with_archive_status(next_runtime, previous_status)
+    handle.replace_with_archive_status(next_runtime, previous_status)
 }
 
 fn prepare_rollback_bundle(
@@ -1389,6 +1392,7 @@ fn successful_rollback_result(
     }
 }
 
+#[warn(clippy::too_many_arguments)]
 fn rejected_rollback_result(
     request: RollbackRequest,
     active_generation: GenerationId,
@@ -1440,9 +1444,8 @@ fn failed_rollback_result(
         field_path: Some("runtime.rollback".to_string()),
         current_value: Some(active_generation.to_string()),
         requested_value: Some(target_generation.to_string()),
-        operator_action:
-            "inspect runtime state and retry the rollback once the runtime is healthy"
-                .to_string(),
+        operator_action: "inspect runtime state and retry the rollback once the runtime is healthy"
+            .to_string(),
         active_generation_changed: false,
         message: error.clone(),
     }];
@@ -1512,6 +1515,7 @@ fn successful_activation_result(
     }
 }
 
+#[warn(clippy::too_many_arguments)]
 fn rejected_activation_result(
     request: ActivationRequest,
     active_generation: GenerationId,
@@ -1564,8 +1568,7 @@ fn failed_activation_result(
         current_value: Some(active_generation.to_string()),
         requested_value: Some(candidate_generation.to_string()),
         operator_action:
-            "inspect runtime state and retry the activation once the runtime is healthy"
-                .to_string(),
+            "inspect runtime state and retry the activation once the runtime is healthy".to_string(),
         active_generation_changed: false,
         message: error.clone(),
     }];
@@ -1604,7 +1607,10 @@ fn rejected_reload_plan(
     mut validation: Vec<PlanningPhaseResult>,
     rejected_changes: Vec<RejectedChange>,
 ) -> StagedRuntimeReloadPlan {
-    if validation.iter().all(|step| step.phase != PlanningPhase::NormalizeRuntime) {
+    if validation
+        .iter()
+        .all(|step| step.phase != PlanningPhase::NormalizeRuntime)
+    {
         validation.push(PlanningPhaseResult {
             phase: PlanningPhase::NormalizeRuntime,
             status: PlanningPhaseStatus::Skipped,
@@ -1653,9 +1659,7 @@ fn render_rejected_changes(rejected_changes: &[RejectedChange]) -> String {
         .join("; ")
 }
 
-fn classify_compatibility(
-    rejections: &[TransitionRejection],
-) -> ReloadCompatibilityClassification {
+fn classify_compatibility(rejections: &[TransitionRejection]) -> ReloadCompatibilityClassification {
     if rejections.is_empty() {
         ReloadCompatibilityClassification::LiveReloadable
     } else if rejections.iter().any(TransitionRejection::requires_restart) {
@@ -1667,7 +1671,11 @@ fn classify_compatibility(
 
 fn snapshot_from_bundle(bundle: &RuntimeBundle) -> ProposedGenerationSnapshot {
     let state = bundle.shared_state.generation_state();
-    let mut listener_labels = state.listener_runtime_configs.keys().cloned().collect::<Vec<_>>();
+    let mut listener_labels = state
+        .listener_runtime_configs
+        .keys()
+        .cloned()
+        .collect::<Vec<_>>();
     listener_labels.sort_unstable();
 
     ProposedGenerationSnapshot {
@@ -1832,7 +1840,10 @@ fn summarize_backend_policies(bundle: &RuntimeBundle) -> String {
                 name,
                 upstream.backend_tls_policy().verify_certificates,
                 upstream.backend_tls_policy().strict_sni,
-                bundle.runtime_config.performance.backend_dns_refresh_enabled,
+                bundle
+                    .runtime_config
+                    .performance
+                    .backend_dns_refresh_enabled,
                 bundle
                     .runtime_config
                     .performance
@@ -1952,11 +1963,8 @@ mod tests {
 
     #[test]
     fn rejected_change_preserves_transition_rejection_contract() {
-        let rejection = TransitionRejection::restart_required(
-            "performance.worker_threads",
-            "1",
-            "8",
-        );
+        let rejection =
+            TransitionRejection::restart_required("performance.worker_threads", "1", "8");
         let rejected = RejectedChange::from(rejection);
 
         assert_eq!(rejected.kind, RejectedChangeKind::RestartRequired);
@@ -1964,7 +1972,10 @@ mod tests {
             rejected.field_path.as_deref(),
             Some("performance.worker_threads")
         );
-        assert_eq!(rejected.operator_action, "restart the process to apply this change");
+        assert_eq!(
+            rejected.operator_action,
+            "restart the process to apply this change"
+        );
         assert!(!rejected.active_generation_changed);
         assert!(rejected.message.contains("restart"));
     }
@@ -2086,8 +2097,7 @@ mod tests {
             field_path: None,
             current_mode: Some("Draining".to_string()),
             requested_mode: Some("Reload".to_string()),
-            operator_action:
-                "wait for the current lifecycle phase to complete; the requested transition is not legal now",
+            operator_action: "wait for the current lifecycle phase to complete; the requested transition is not legal now",
             active_runtime_changed: false,
             verbatim: None,
         });
@@ -2170,6 +2180,9 @@ mod tests {
                 rejected_changes: Vec::new(),
             },
         };
-        assert_eq!(rollback.outcome_reason(), RuntimeOperationOutcomeReason::Applied);
+        assert_eq!(
+            rollback.outcome_reason(),
+            RuntimeOperationOutcomeReason::Applied
+        );
     }
 }

--- a/crates/edge/src/runtime/activation.rs
+++ b/crates/edge/src/runtime/activation.rs
@@ -643,6 +643,28 @@ impl StagedRuntimeReloadPlan {
 /// explicit result object returned to control-plane callers.
 pub(crate) struct RuntimeActivationService;
 
+struct RejectedRollbackResultInput {
+    request: RollbackRequest,
+    active_generation: GenerationId,
+    target_generation: Option<GenerationId>,
+    config_source: String,
+    config_version: Option<u32>,
+    diff: ReloadDiff,
+    rejected_changes: Vec<RejectedChange>,
+    summary: String,
+}
+
+struct RejectedActivationResultInput {
+    request: ActivationRequest,
+    active_generation: GenerationId,
+    candidate_generation: GenerationId,
+    config_source: String,
+    config_version: Option<u32>,
+    diff: ReloadDiff,
+    rejected_changes: Vec<RejectedChange>,
+    summary: String,
+}
+
 impl RuntimeActivationService {
     pub(crate) fn validate_reload(
         handle: &RuntimeBundleHandle,
@@ -673,14 +695,14 @@ impl RuntimeActivationService {
         if let Some(expected_generation) = request.expected_generation
             && expected_generation != active_generation
         {
-            let result = rejected_activation_result(
+            let result = rejected_activation_result(RejectedActivationResultInput {
                 request,
                 active_generation,
-                active_generation.saturating_add(1),
+                candidate_generation: active_generation.saturating_add(1),
                 config_source,
-                None,
-                ReloadDiff::default(),
-                vec![RejectedChange {
+                config_version: None,
+                diff: ReloadDiff::default(),
+                rejected_changes: vec![RejectedChange {
                     reason: RuntimeRejectionReason::UnknownGeneration,
                     kind: RejectedChangeKind::IllegalTransition,
                     field_path: Some("runtime.generation".to_string()),
@@ -694,8 +716,8 @@ impl RuntimeActivationService {
                         expected_generation, active_generation
                     ),
                 }],
-                "activation request targeted a stale runtime generation".to_string(),
-            );
+                summary: "activation request targeted a stale runtime generation".to_string(),
+            });
             record_activation_result(handle, &result);
             return result;
         }
@@ -716,34 +738,35 @@ impl RuntimeActivationService {
                         .unwrap_or_else(|| plan.plan.summary.clone()),
                 );
             }
-            let result = rejected_activation_result(
+            let result = rejected_activation_result(RejectedActivationResultInput {
                 request,
                 active_generation,
-                plan.plan.candidate_generation,
-                plan.plan.config_source.clone(),
-                plan.plan.config_version,
-                plan.plan.diff.clone(),
-                plan.plan.rejected_changes.clone(),
-                plan.plan
+                candidate_generation: plan.plan.candidate_generation,
+                config_source: plan.plan.config_source.clone(),
+                config_version: plan.plan.config_version,
+                diff: plan.plan.diff.clone(),
+                rejected_changes: plan.plan.rejected_changes.clone(),
+                summary: plan
+                    .plan
                     .rejection_summary
                     .clone()
                     .unwrap_or_else(|| plan.plan.summary.clone()),
-            );
+            });
             record_activation_result(handle, &result);
             return result;
         }
 
         if let Some(rejection) = handle.lifecycle().check_reload_allowed().rejection() {
-            let result = rejected_activation_result(
+            let result = rejected_activation_result(RejectedActivationResultInput {
                 request,
                 active_generation,
-                plan.plan.candidate_generation,
-                plan.plan.config_source.clone(),
-                plan.plan.config_version,
-                plan.plan.diff.clone(),
-                vec![RejectedChange::from(rejection)],
-                rejection.to_string(),
-            );
+                candidate_generation: plan.plan.candidate_generation,
+                config_source: plan.plan.config_source.clone(),
+                config_version: plan.plan.config_version,
+                diff: plan.plan.diff.clone(),
+                rejected_changes: vec![RejectedChange::from(rejection)],
+                summary: rejection.to_string(),
+            });
             record_activation_result(handle, &result);
             return result;
         }
@@ -786,14 +809,14 @@ impl RuntimeActivationService {
         if let Some(expected_active_generation) = request.expected_active_generation
             && expected_active_generation != active_generation
         {
-            let result = rejected_rollback_result(
+            let result = rejected_rollback_result(RejectedRollbackResultInput {
                 request,
                 active_generation,
-                None,
-                fallback_config_source.clone(),
-                None,
-                ReloadDiff::default(),
-                vec![RejectedChange {
+                target_generation: None,
+                config_source: fallback_config_source.clone(),
+                config_version: None,
+                diff: ReloadDiff::default(),
+                rejected_changes: vec![RejectedChange {
                     reason: RuntimeRejectionReason::UnknownGeneration,
                     kind: RejectedChangeKind::IllegalTransition,
                     field_path: Some("runtime.generation".to_string()),
@@ -807,21 +830,21 @@ impl RuntimeActivationService {
                         expected_active_generation, active_generation
                     ),
                 }],
-                "rollback request targeted a stale runtime generation".to_string(),
-            );
+                summary: "rollback request targeted a stale runtime generation".to_string(),
+            });
             record_rollback_result(handle, &result);
             return result;
         }
 
         if request.target_generation == active_generation {
-            let result = rejected_rollback_result(
+            let result = rejected_rollback_result(RejectedRollbackResultInput {
                 request,
                 active_generation,
-                None,
-                fallback_config_source.clone(),
-                None,
-                ReloadDiff::default(),
-                vec![RejectedChange {
+                target_generation: None,
+                config_source: fallback_config_source.clone(),
+                config_version: None,
+                diff: ReloadDiff::default(),
+                rejected_changes: vec![RejectedChange {
                     reason: RuntimeRejectionReason::RollbackNotAllowed,
                     kind: RejectedChangeKind::IllegalTransition,
                     field_path: Some("runtime.rollback.target_generation".to_string()),
@@ -836,21 +859,21 @@ impl RuntimeActivationService {
                         active_generation
                     ),
                 }],
-                "rollback target is already the active generation".to_string(),
-            );
+                summary: "rollback target is already the active generation".to_string(),
+            });
             record_rollback_result(handle, &result);
             return result;
         }
 
         let Some(target_record) = handle.generation_record(target_generation) else {
-            let result = rejected_rollback_result(
+            let result = rejected_rollback_result(RejectedRollbackResultInput {
                 request,
                 active_generation,
-                None,
-                fallback_config_source.clone(),
-                None,
-                ReloadDiff::default(),
-                vec![RejectedChange {
+                target_generation: None,
+                config_source: fallback_config_source.clone(),
+                config_version: None,
+                diff: ReloadDiff::default(),
+                rejected_changes: vec![RejectedChange {
                     reason: RuntimeRejectionReason::UnknownGeneration,
                     kind: RejectedChangeKind::RuntimeStateUnavailable,
                     field_path: Some("runtime.rollback.target_generation".to_string()),
@@ -864,21 +887,21 @@ impl RuntimeActivationService {
                         target_generation
                     ),
                 }],
-                "rollback target is not retained in runtime history".to_string(),
-            );
+                summary: "rollback target is not retained in runtime history".to_string(),
+            });
             record_rollback_result(handle, &result);
             return result;
         };
 
         if !target_record.status().is_rollback_candidate() || !target_record.has_bundle() {
-            let result = rejected_rollback_result(
+            let result = rejected_rollback_result(RejectedRollbackResultInput {
                 request,
                 active_generation,
-                Some(target_generation),
-                fallback_config_source.clone(),
-                None,
-                ReloadDiff::default(),
-                vec![RejectedChange {
+                target_generation: Some(target_generation),
+                config_source: fallback_config_source.clone(),
+                config_version: None,
+                diff: ReloadDiff::default(),
+                rejected_changes: vec![RejectedChange {
                     reason: RuntimeRejectionReason::RollbackNotAllowed,
                     kind: RejectedChangeKind::RuntimeStateUnavailable,
                     field_path: Some("runtime.rollback.target_generation".to_string()),
@@ -893,31 +916,55 @@ impl RuntimeActivationService {
                         target_generation
                     ),
                 }],
-                "rollback target is incomplete or unusable".to_string(),
-            );
+                summary: "rollback target is incomplete or unusable".to_string(),
+            });
             record_rollback_result(handle, &result);
             return result;
         }
 
         if let Some(rejection) = handle.lifecycle().check_reload_allowed().rejection() {
-            let result = rejected_rollback_result(
+            let result = rejected_rollback_result(RejectedRollbackResultInput {
                 request,
                 active_generation,
-                Some(target_generation),
-                fallback_config_source.clone(),
-                None,
-                ReloadDiff::default(),
-                vec![RejectedChange::from(rejection)],
-                rejection.to_string(),
-            );
+                target_generation: Some(target_generation),
+                config_source: fallback_config_source.clone(),
+                config_version: None,
+                diff: ReloadDiff::default(),
+                rejected_changes: vec![RejectedChange::from(rejection)],
+                summary: rejection.to_string(),
+            });
             record_rollback_result(handle, &result);
             return result;
         }
 
-        let target_bundle = target_record
-            .bundle()
-            .cloned()
-            .expect("rollback candidate record with bundle");
+        let Some(target_bundle) = target_record.bundle().cloned() else {
+            let result = rejected_rollback_result(RejectedRollbackResultInput {
+                request,
+                active_generation,
+                target_generation: Some(target_generation),
+                config_source: fallback_config_source.clone(),
+                config_version: None,
+                diff: ReloadDiff::default(),
+                rejected_changes: vec![RejectedChange {
+                    reason: RuntimeRejectionReason::RollbackNotAllowed,
+                    kind: RejectedChangeKind::RuntimeStateUnavailable,
+                    field_path: Some("runtime.rollback.target_generation".to_string()),
+                    current_value: Some(target_record.generation().to_string()),
+                    requested_value: Some("missing_bundle".to_string()),
+                    operator_action:
+                        "choose a complete retained generation with a usable runtime bundle"
+                            .to_string(),
+                    active_generation_changed: false,
+                    message: format!(
+                        "runtime rollback rejected: generation {} has no retained runtime bundle",
+                        target_generation
+                    ),
+                }],
+                summary: "rollback target has no retained runtime bundle".to_string(),
+            });
+            record_rollback_result(handle, &result);
+            return result;
+        };
         let rollback_config_source = target_bundle.startup.config_path.clone();
         let rollback_config_version = Some(target_bundle.runtime_config.version);
         let candidate_generation = active_generation.saturating_add(1);
@@ -925,17 +972,18 @@ impl RuntimeActivationService {
         {
             Ok(prepared) => prepared,
             Err(rejected) => {
+                let rejected = *rejected;
                 handle.record_failed_prepare(candidate_generation, rejected.message.clone());
-                let result = rejected_rollback_result(
+                let result = rejected_rollback_result(RejectedRollbackResultInput {
                     request,
                     active_generation,
-                    Some(target_generation),
-                    rollback_config_source.clone(),
-                    rollback_config_version,
-                    ReloadDiff::default(),
-                    vec![rejected],
-                    "rollback preparation failed".to_string(),
-                );
+                    target_generation: Some(target_generation),
+                    config_source: rollback_config_source.clone(),
+                    config_version: rollback_config_version,
+                    diff: ReloadDiff::default(),
+                    rejected_changes: vec![rejected],
+                    summary: "rollback preparation failed".to_string(),
+                });
                 record_rollback_result(handle, &result);
                 return result;
             }
@@ -953,16 +1001,16 @@ impl RuntimeActivationService {
                 &prepared,
                 rejected_startup_owned_domains(&rejected_changes),
             );
-            let result = rejected_rollback_result(
+            let result = rejected_rollback_result(RejectedRollbackResultInput {
                 request,
                 active_generation,
-                Some(target_generation),
-                rollback_config_source.clone(),
-                rollback_config_version,
+                target_generation: Some(target_generation),
+                config_source: rollback_config_source.clone(),
+                config_version: rollback_config_version,
                 diff,
                 rejected_changes,
-                render_rejections(rejections.as_slice()),
-            );
+                summary: render_rejections(rejections.as_slice()),
+            });
             record_rollback_result(handle, &result);
             return result;
         }
@@ -1246,12 +1294,15 @@ fn prepare_rollback_bundle(
     current: &ActiveRuntimeGeneration,
     target: &RuntimeBundle,
     candidate_generation: GenerationId,
-) -> Result<RuntimeBundle, RejectedChange> {
+) -> Result<RuntimeBundle, Box<RejectedChange>> {
     let carried = CarriedProcessSharedServices::from_active(current.shared_services());
     let next_shared_state =
         QUICListener::build_shared_state_with_carried(&target.runtime_config, Some(carried))
             .map_err(|err| {
-                RejectedChange::resource_preparation_failed("runtime rollback", err.to_string())
+                Box::new(RejectedChange::resource_preparation_failed(
+                    "runtime rollback",
+                    err.to_string(),
+                ))
             })?;
 
     Ok(RuntimeBundle {
@@ -1392,39 +1443,31 @@ fn successful_rollback_result(
     }
 }
 
-#[warn(clippy::too_many_arguments)]
-fn rejected_rollback_result(
-    request: RollbackRequest,
-    active_generation: GenerationId,
-    target_generation: Option<GenerationId>,
-    config_source: String,
-    config_version: Option<u32>,
-    diff: ReloadDiff,
-    rejected_changes: Vec<RejectedChange>,
-    summary: String,
-) -> RollbackResult {
+fn rejected_rollback_result(input: RejectedRollbackResultInput) -> RollbackResult {
     let completed_at_ms = crate::watchdog::time::now_millis();
     let history_entry = GenerationHistoryEntry {
-        generation: target_generation.unwrap_or(active_generation.saturating_add(1)),
+        generation: input
+            .target_generation
+            .unwrap_or(input.active_generation.saturating_add(1)),
         operation: GenerationOperation::Rollback,
         status: GenerationStatus::Rejected,
-        config_source,
-        config_version,
-        requested_by: request.requested_by.clone(),
-        trigger_source: request.trigger_source.clone(),
-        requested_at_ms: request.requested_at_ms,
+        config_source: input.config_source,
+        config_version: input.config_version,
+        requested_by: input.request.requested_by.clone(),
+        trigger_source: input.request.trigger_source.clone(),
+        requested_at_ms: input.request.requested_at_ms,
         completed_at_ms: Some(completed_at_ms),
-        summary,
-        diff,
-        rejected_changes: rejected_changes.clone(),
+        summary: input.summary,
+        diff: input.diff,
+        rejected_changes: input.rejected_changes.clone(),
     };
 
     RollbackResult {
-        request,
-        active_generation,
+        request: input.request,
+        active_generation: input.active_generation,
         rolled_back_to: None,
         status: GenerationStatus::Rejected,
-        rejected_changes,
+        rejected_changes: input.rejected_changes,
         history_entry,
     }
 }
@@ -1515,39 +1558,29 @@ fn successful_activation_result(
     }
 }
 
-#[warn(clippy::too_many_arguments)]
-fn rejected_activation_result(
-    request: ActivationRequest,
-    active_generation: GenerationId,
-    candidate_generation: GenerationId,
-    config_source: String,
-    config_version: Option<u32>,
-    diff: ReloadDiff,
-    rejected_changes: Vec<RejectedChange>,
-    summary: String,
-) -> ActivationResult {
+fn rejected_activation_result(input: RejectedActivationResultInput) -> ActivationResult {
     let completed_at_ms = crate::watchdog::time::now_millis();
     let history_entry = GenerationHistoryEntry {
-        generation: candidate_generation,
+        generation: input.candidate_generation,
         operation: GenerationOperation::Activate,
         status: GenerationStatus::Rejected,
-        config_source,
-        config_version,
-        requested_by: request.requested_by.clone(),
-        trigger_source: request.trigger_source.clone(),
-        requested_at_ms: request.requested_at_ms,
+        config_source: input.config_source,
+        config_version: input.config_version,
+        requested_by: input.request.requested_by.clone(),
+        trigger_source: input.request.trigger_source.clone(),
+        requested_at_ms: input.request.requested_at_ms,
         completed_at_ms: Some(completed_at_ms),
-        summary,
-        diff,
-        rejected_changes: rejected_changes.clone(),
+        summary: input.summary,
+        diff: input.diff,
+        rejected_changes: input.rejected_changes.clone(),
     };
 
     ActivationResult {
-        request,
-        active_generation,
+        request: input.request,
+        active_generation: input.active_generation,
         activated_generation: None,
         status: GenerationStatus::Rejected,
-        rejected_changes,
+        rejected_changes: input.rejected_changes,
         history_entry,
     }
 }

--- a/crates/edge/src/runtime/activation.rs
+++ b/crates/edge/src/runtime/activation.rs
@@ -452,6 +452,25 @@ impl RuntimeActivationService {
 
         let plan = plan_runtime_reload(&current, request.clone(), input);
         if !plan.can_activate() {
+            if plan
+                .plan
+                .rejected_changes
+                .iter()
+                .any(|rejection| {
+                    matches!(
+                        rejection.kind,
+                        RejectedChangeKind::ResourcePreparationFailed
+                    )
+                })
+            {
+                handle.record_failed_prepare(
+                    plan.plan.candidate_generation,
+                    plan.plan
+                        .rejection_summary
+                        .clone()
+                        .unwrap_or_else(|| plan.plan.summary.clone()),
+                );
+            }
             return rejected_activation_result(
                 request,
                 active_generation,

--- a/crates/edge/src/runtime/bundle.rs
+++ b/crates/edge/src/runtime/bundle.rs
@@ -314,9 +314,7 @@ impl RuntimeBundleHandle {
             .read()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .iter()
-            .find(|entry| {
-                entry.generation == generation && entry.status.is_rollback_candidate()
-            })
+            .find(|entry| entry.generation == generation && entry.status.is_rollback_candidate())
             .and_then(|entry| entry.bundle.clone())
     }
 
@@ -414,6 +412,7 @@ impl RuntimeBundleHandle {
     /// A reload commit is only legal while the process is `Running`. If a drain or
     /// shutdown has begun, the swap is rejected before touching the active
     /// generation, so a reload cannot race a shutdown into ambiguous state.
+    #[warn(dead_code)]
     pub(crate) fn replace(&self, bundle: RuntimeBundle) -> Result<u64, ProxyError> {
         self.replace_with_archive_status(bundle, RuntimeGenerationRecordStatus::Previous)
     }
@@ -952,10 +951,7 @@ mod tests {
             assert_eq!(history[0].generation(), 2);
             assert_eq!(history[0].status(), RuntimeGenerationRecordStatus::Active);
             assert_eq!(history[1].generation(), previous_generation);
-            assert_eq!(
-                history[1].status(),
-                RuntimeGenerationRecordStatus::Previous
-            );
+            assert_eq!(history[1].status(), RuntimeGenerationRecordStatus::Previous);
             let rollback = handle
                 .rollback_candidate(previous_generation)
                 .expect("previous generation should be retained");
@@ -991,10 +987,7 @@ mod tests {
             assert_eq!(history[0].generation(), 3);
             assert_eq!(history[0].status(), RuntimeGenerationRecordStatus::Active);
             assert_eq!(history[1].generation(), 2);
-            assert_eq!(
-                history[1].status(),
-                RuntimeGenerationRecordStatus::Previous
-            );
+            assert_eq!(history[1].status(), RuntimeGenerationRecordStatus::Previous);
             assert_eq!(history[2].generation(), 1);
             assert_eq!(
                 history[2].status(),
@@ -1083,8 +1076,18 @@ mod tests {
             let handle = RuntimeBundleHandle::new(current_bundle);
 
             let initial_metrics = Arc::clone(&handle.current_view().shared_services().metrics);
-            assert_eq!(initial_metrics.runtime_active_generation.load(Ordering::Relaxed), 1);
-            assert_eq!(initial_metrics.runtime_history_depth.load(Ordering::Relaxed), 0);
+            assert_eq!(
+                initial_metrics
+                    .runtime_active_generation
+                    .load(Ordering::Relaxed),
+                1
+            );
+            assert_eq!(
+                initial_metrics
+                    .runtime_history_depth
+                    .load(Ordering::Relaxed),
+                0
+            );
 
             handle.record_generation_history_entry(GenerationHistoryEntry {
                 generation: 2,
@@ -1101,13 +1104,26 @@ mod tests {
                 rejected_changes: Vec::new(),
             });
 
-            assert_eq!(initial_metrics.runtime_history_depth.load(Ordering::Relaxed), 1);
+            assert_eq!(
+                initial_metrics
+                    .runtime_history_depth
+                    .load(Ordering::Relaxed),
+                1
+            );
 
             handle.replace(next_bundle).expect("replace");
 
             let next_metrics = Arc::clone(&handle.current_view().shared_services().metrics);
-            assert_eq!(next_metrics.runtime_active_generation.load(Ordering::Relaxed), 2);
-            assert_eq!(next_metrics.runtime_history_depth.load(Ordering::Relaxed), 1);
+            assert_eq!(
+                next_metrics
+                    .runtime_active_generation
+                    .load(Ordering::Relaxed),
+                2
+            );
+            assert_eq!(
+                next_metrics.runtime_history_depth.load(Ordering::Relaxed),
+                1
+            );
         }
     }
 }

--- a/crates/edge/src/runtime/bundle.rs
+++ b/crates/edge/src/runtime/bundle.rs
@@ -414,7 +414,7 @@ impl RuntimeBundleHandle {
     /// A reload commit is only legal while the process is `Running`. If a drain or
     /// shutdown has begun, the swap is rejected before touching the active
     /// generation, so a reload cannot race a shutdown into ambiguous state.
-    pub fn replace(&self, bundle: RuntimeBundle) -> Result<u64, ProxyError> {
+    pub(crate) fn replace(&self, bundle: RuntimeBundle) -> Result<u64, ProxyError> {
         self.replace_with_archive_status(bundle, RuntimeGenerationRecordStatus::Previous)
     }
 

--- a/crates/edge/src/runtime/bundle.rs
+++ b/crates/edge/src/runtime/bundle.rs
@@ -114,6 +114,17 @@ impl RuntimeGenerationRecordStatus {
     pub fn is_rollback_candidate(self) -> bool {
         matches!(self, Self::Previous | Self::RolledBack | Self::Superseded)
     }
+
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Previous => "previous",
+            Self::FailedPrepare => "failed_prepare",
+            Self::RolledBack => "rolled_back",
+            Self::Superseded => "superseded",
+        }
+    }
 }
 
 /// Retained runtime generation metadata owned by [`RuntimeBundleHandle`].
@@ -167,6 +178,11 @@ impl RuntimeGenerationRecord {
     #[must_use]
     pub fn note(&self) -> Option<&str> {
         self.note.as_deref()
+    }
+
+    #[must_use]
+    pub fn has_bundle(&self) -> bool {
+        self.bundle.is_some()
     }
 }
 
@@ -295,6 +311,20 @@ impl RuntimeBundleHandle {
             .and_then(|entry| entry.bundle.clone())
     }
 
+    pub fn generation_record(&self, generation: u64) -> Option<RuntimeGenerationRecord> {
+        let current = self.current();
+        if current.generation == generation {
+            return Some(RuntimeGenerationRecord::active(current));
+        }
+
+        self.history
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .iter()
+            .find(|entry| entry.generation == generation)
+            .cloned()
+    }
+
     pub(crate) fn record_failed_prepare(&self, generation: u64, note: impl Into<String>) {
         let mut history = self
             .history
@@ -337,6 +367,14 @@ impl RuntimeBundleHandle {
     /// shutdown has begun, the swap is rejected before touching the active
     /// generation, so a reload cannot race a shutdown into ambiguous state.
     pub fn replace(&self, bundle: RuntimeBundle) -> Result<u64, ProxyError> {
+        self.replace_with_archive_status(bundle, RuntimeGenerationRecordStatus::Previous)
+    }
+
+    pub(crate) fn replace_with_archive_status(
+        &self,
+        bundle: RuntimeBundle,
+        previous_status: RuntimeGenerationRecordStatus,
+    ) -> Result<u64, ProxyError> {
         let generation = bundle.generation;
         let next_tasks = Arc::clone(&bundle.shared_state.generation_state().generation_tasks);
 
@@ -372,7 +410,7 @@ impl RuntimeBundleHandle {
         };
         // Retire only the previous generation's generation-owned background tasks.
         // Startup-owned and process-shared resources are not torn down here.
-        self.archive_previous_generation(previous.clone());
+        self.archive_previous_generation(previous.clone(), previous_status);
         previous
             .shared_state
             .generation_state()
@@ -388,7 +426,11 @@ impl RuntimeBundleHandle {
         Ok(generation)
     }
 
-    fn archive_previous_generation(&self, previous: Arc<RuntimeBundle>) {
+    fn archive_previous_generation(
+        &self,
+        previous: Arc<RuntimeBundle>,
+        status: RuntimeGenerationRecordStatus,
+    ) {
         let mut history = self
             .history
             .write()
@@ -401,7 +443,7 @@ impl RuntimeBundleHandle {
         history.retain(|entry| entry.generation != previous.generation);
         history.push_front(RuntimeGenerationRecord::archived(
             previous.generation,
-            RuntimeGenerationRecordStatus::Previous,
+            status,
             Some(previous),
             None,
         ));

--- a/crates/edge/src/runtime/bundle.rs
+++ b/crates/edge/src/runtime/bundle.rs
@@ -412,7 +412,7 @@ impl RuntimeBundleHandle {
     /// A reload commit is only legal while the process is `Running`. If a drain or
     /// shutdown has begun, the swap is rejected before touching the active
     /// generation, so a reload cannot race a shutdown into ambiguous state.
-    #[warn(dead_code)]
+    #[cfg(test)]
     pub(crate) fn replace(&self, bundle: RuntimeBundle) -> Result<u64, ProxyError> {
         self.replace_with_archive_status(bundle, RuntimeGenerationRecordStatus::Previous)
     }

--- a/crates/edge/src/runtime/bundle.rs
+++ b/crates/edge/src/runtime/bundle.rs
@@ -210,13 +210,15 @@ impl RuntimeBundleHandle {
         // here (see `begin_drain`/`begin_shutdown`).
         let lifecycle = RuntimeLifecycleState::new();
         let _ = lifecycle.mark_running();
-        Self {
+        let handle = Self {
             inner: Arc::new(RwLock::new(Arc::new(bundle))),
             history: Arc::new(RwLock::new(VecDeque::new())),
             generation_history: Arc::new(RwLock::new(VecDeque::new())),
             generation_events: Arc::new(RwLock::new(VecDeque::new())),
             lifecycle: Arc::new(lifecycle),
-        }
+        };
+        handle.sync_runtime_observability_metrics();
+        handle
     }
 
     /// The shared process lifecycle state machine (Phase 6). All clones of this
@@ -351,12 +353,15 @@ impl RuntimeBundleHandle {
     }
 
     pub(crate) fn record_generation_history_entry(&self, entry: GenerationHistoryEntry) {
-        let mut history = self
-            .generation_history
-            .write()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        history.push_front(entry);
-        trim_bounded_history(&mut history, MAX_GENERATION_HISTORY_ENTRIES);
+        {
+            let mut history = self
+                .generation_history
+                .write()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            history.push_front(entry);
+            trim_bounded_history(&mut history, MAX_GENERATION_HISTORY_ENTRIES);
+        }
+        self.sync_runtime_observability_metrics();
     }
 
     pub(crate) fn record_generation_change_event(&self, event: GenerationChangeEvent) {
@@ -466,7 +471,20 @@ impl RuntimeBundleHandle {
             generation,
             self.lifecycle.phase()
         );
+        self.sync_runtime_observability_metrics();
         Ok(generation)
+    }
+
+    fn sync_runtime_observability_metrics(&self) {
+        let current = self.current();
+        let history_depth = self
+            .generation_history
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .len();
+        let metrics = &current.shared_state.shared_services().metrics;
+        metrics.set_runtime_active_generation(current.generation);
+        metrics.set_runtime_history_depth(history_depth);
     }
 
     fn archive_previous_generation(
@@ -1018,6 +1036,47 @@ mod tests {
             assert!(history[1].bundle().is_none());
             assert_eq!(handle.current_generation(), 1);
             assert!(handle.rollback_candidate(2).is_none());
+        }
+
+        #[test]
+        fn runtime_observability_metrics_follow_active_generation_and_history_depth() {
+            let dir = tempdir().expect("tempdir");
+            let (current_bundle, next_bundle) = runtime_bundle_pair(
+                dir.path(),
+                "startup.yaml",
+                "http://127.0.0.1:7001",
+                2,
+                "reloaded.yaml",
+                "http://127.0.0.1:7002",
+            );
+            let handle = RuntimeBundleHandle::new(current_bundle);
+
+            let initial_metrics = Arc::clone(&handle.current_view().shared_services().metrics);
+            assert_eq!(initial_metrics.runtime_active_generation.load(Ordering::Relaxed), 1);
+            assert_eq!(initial_metrics.runtime_history_depth.load(Ordering::Relaxed), 0);
+
+            handle.record_generation_history_entry(GenerationHistoryEntry {
+                generation: 2,
+                operation: crate::runtime::activation::GenerationOperation::Validate,
+                status: crate::runtime::activation::GenerationStatus::Staged,
+                config_source: "startup.yaml".to_string(),
+                config_version: Some(1),
+                requested_by: Some("test".to_string()),
+                trigger_source: Some("test".to_string()),
+                requested_at_ms: 1,
+                completed_at_ms: Some(2),
+                summary: "validated".to_string(),
+                diff: crate::runtime::activation::ReloadDiff::default(),
+                rejected_changes: Vec::new(),
+            });
+
+            assert_eq!(initial_metrics.runtime_history_depth.load(Ordering::Relaxed), 1);
+
+            handle.replace(next_bundle).expect("replace");
+
+            let next_metrics = Arc::clone(&handle.current_view().shared_services().metrics);
+            assert_eq!(next_metrics.runtime_active_generation.load(Ordering::Relaxed), 2);
+            assert_eq!(next_metrics.runtime_history_depth.load(Ordering::Relaxed), 1);
         }
     }
 }

--- a/crates/edge/src/runtime/bundle.rs
+++ b/crates/edge/src/runtime/bundle.rs
@@ -9,6 +9,7 @@ use spooky_config::runtime::{ListenerRuntimeConfig, RuntimeConfig};
 use spooky_errors::ProxyError;
 
 use crate::runtime::{
+    activation::{GenerationChangeEvent, GenerationHistoryEntry},
     generation::{
         RuntimeGenerationState, RuntimeGenerationView, RuntimeSharedServices,
         StartupOwnedRuntimeState,
@@ -94,6 +95,8 @@ impl ActiveRuntimeGeneration {
 }
 
 const MAX_ARCHIVED_RUNTIME_GENERATIONS: usize = 8;
+const MAX_GENERATION_HISTORY_ENTRIES: usize = 32;
+const MAX_GENERATION_CHANGE_EVENTS: usize = 64;
 
 /// Runtime-owned lifecycle status for retained generations.
 ///
@@ -194,6 +197,8 @@ impl RuntimeGenerationRecord {
 pub struct RuntimeBundleHandle {
     inner: Arc<RwLock<Arc<RuntimeBundle>>>,
     history: Arc<RwLock<VecDeque<RuntimeGenerationRecord>>>,
+    generation_history: Arc<RwLock<VecDeque<GenerationHistoryEntry>>>,
+    generation_events: Arc<RwLock<VecDeque<GenerationChangeEvent>>>,
     lifecycle: Arc<RuntimeLifecycleState>,
 }
 
@@ -208,6 +213,8 @@ impl RuntimeBundleHandle {
         Self {
             inner: Arc::new(RwLock::new(Arc::new(bundle))),
             history: Arc::new(RwLock::new(VecDeque::new())),
+            generation_history: Arc::new(RwLock::new(VecDeque::new())),
+            generation_events: Arc::new(RwLock::new(VecDeque::new())),
             lifecycle: Arc::new(lifecycle),
         }
     }
@@ -323,6 +330,42 @@ impl RuntimeBundleHandle {
             .iter()
             .find(|entry| entry.generation == generation)
             .cloned()
+    }
+
+    pub fn generation_change_history(&self) -> Vec<GenerationHistoryEntry> {
+        self.generation_history
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .iter()
+            .cloned()
+            .collect()
+    }
+
+    pub fn generation_change_events(&self) -> Vec<GenerationChangeEvent> {
+        self.generation_events
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .iter()
+            .cloned()
+            .collect()
+    }
+
+    pub(crate) fn record_generation_history_entry(&self, entry: GenerationHistoryEntry) {
+        let mut history = self
+            .generation_history
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        history.push_front(entry);
+        trim_bounded_history(&mut history, MAX_GENERATION_HISTORY_ENTRIES);
+    }
+
+    pub(crate) fn record_generation_change_event(&self, event: GenerationChangeEvent) {
+        let mut events = self
+            .generation_events
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        events.push_front(event);
+        trim_bounded_history(&mut events, MAX_GENERATION_CHANGE_EVENTS);
     }
 
     pub(crate) fn record_failed_prepare(&self, generation: u64, note: impl Into<String>) {
@@ -453,6 +496,12 @@ impl RuntimeBundleHandle {
 
 fn trim_runtime_generation_history(history: &mut VecDeque<RuntimeGenerationRecord>) {
     while history.len() > MAX_ARCHIVED_RUNTIME_GENERATIONS {
+        history.pop_back();
+    }
+}
+
+fn trim_bounded_history<T>(history: &mut VecDeque<T>, max_len: usize) {
+    while history.len() > max_len {
         history.pop_back();
     }
 }

--- a/crates/edge/src/runtime/bundle.rs
+++ b/crates/edge/src/runtime/bundle.rs
@@ -1039,6 +1039,37 @@ mod tests {
         }
 
         #[test]
+        fn rollback_candidate_selection_prefers_active_and_excludes_failed_prepare_entries() {
+            let dir = tempdir().expect("tempdir");
+            let (current_bundle, next_bundle) = runtime_bundle_pair(
+                dir.path(),
+                "startup.yaml",
+                "http://127.0.0.1:7001",
+                2,
+                "reloaded.yaml",
+                "http://127.0.0.1:7002",
+            );
+            let handle = RuntimeBundleHandle::new(current_bundle);
+
+            let active = handle
+                .rollback_candidate(1)
+                .expect("active generation should be addressable as a rollback target");
+            assert_eq!(active.generation, 1);
+
+            handle.record_failed_prepare(9, "candidate not fully prepared");
+            assert!(
+                handle.rollback_candidate(9).is_none(),
+                "failed-prepare entries must not be exposed as rollback candidates"
+            );
+
+            handle.replace(next_bundle).expect("replace");
+            let previous = handle
+                .rollback_candidate(1)
+                .expect("previous known-good generation should stay rollbackable");
+            assert_eq!(previous.generation, 1);
+        }
+
+        #[test]
         fn runtime_observability_metrics_follow_active_generation_and_history_depth() {
             let dir = tempdir().expect("tempdir");
             let (current_bundle, next_bundle) = runtime_bundle_pair(

--- a/crates/edge/src/runtime/bundle.rs
+++ b/crates/edge/src/runtime/bundle.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::VecDeque,
     sync::{Arc, RwLock},
     time::Duration,
 };
@@ -92,6 +93,83 @@ impl ActiveRuntimeGeneration {
     }
 }
 
+const MAX_ARCHIVED_RUNTIME_GENERATIONS: usize = 8;
+
+/// Runtime-owned lifecycle status for retained generations.
+///
+/// This is intentionally narrower than the control-plane activation contract.
+/// It answers one ownership question only: how the runtime handle currently
+/// classifies a retained generation for rollback/history purposes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RuntimeGenerationRecordStatus {
+    Active,
+    Previous,
+    FailedPrepare,
+    RolledBack,
+    Superseded,
+}
+
+impl RuntimeGenerationRecordStatus {
+    #[must_use]
+    pub fn is_rollback_candidate(self) -> bool {
+        matches!(self, Self::Previous | Self::RolledBack | Self::Superseded)
+    }
+}
+
+/// Retained runtime generation metadata owned by [`RuntimeBundleHandle`].
+#[derive(Clone)]
+pub struct RuntimeGenerationRecord {
+    generation: u64,
+    status: RuntimeGenerationRecordStatus,
+    bundle: Option<Arc<RuntimeBundle>>,
+    note: Option<String>,
+}
+
+impl RuntimeGenerationRecord {
+    fn active(bundle: Arc<RuntimeBundle>) -> Self {
+        Self {
+            generation: bundle.generation,
+            status: RuntimeGenerationRecordStatus::Active,
+            bundle: Some(bundle),
+            note: None,
+        }
+    }
+
+    fn archived(
+        generation: u64,
+        status: RuntimeGenerationRecordStatus,
+        bundle: Option<Arc<RuntimeBundle>>,
+        note: Option<String>,
+    ) -> Self {
+        Self {
+            generation,
+            status,
+            bundle,
+            note,
+        }
+    }
+
+    #[must_use]
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    #[must_use]
+    pub fn status(&self) -> RuntimeGenerationRecordStatus {
+        self.status
+    }
+
+    #[must_use]
+    pub fn bundle(&self) -> Option<&Arc<RuntimeBundle>> {
+        self.bundle.as_ref()
+    }
+
+    #[must_use]
+    pub fn note(&self) -> Option<&str> {
+        self.note.as_deref()
+    }
+}
+
 /// Atomic handle for publishing and reading the active runtime generation.
 ///
 /// Ownership of reload lifecycle transitions stays here. Callers that only need
@@ -99,6 +177,7 @@ impl ActiveRuntimeGeneration {
 #[derive(Clone)]
 pub struct RuntimeBundleHandle {
     inner: Arc<RwLock<Arc<RuntimeBundle>>>,
+    history: Arc<RwLock<VecDeque<RuntimeGenerationRecord>>>,
     lifecycle: Arc<RuntimeLifecycleState>,
 }
 
@@ -112,6 +191,7 @@ impl RuntimeBundleHandle {
         let _ = lifecycle.mark_running();
         Self {
             inner: Arc::new(RwLock::new(Arc::new(bundle))),
+            history: Arc::new(RwLock::new(VecDeque::new())),
             lifecycle: Arc::new(lifecycle),
         }
     }
@@ -179,6 +259,57 @@ impl RuntimeBundleHandle {
         self.with_current_generation(|current| f(current.view()))
     }
 
+    /// Snapshot the active and retained generations known to the runtime.
+    ///
+    /// The first entry is always the live active generation. Archived entries are
+    /// ordered newest-first behind it and capped in memory.
+    pub fn generation_history(&self) -> Vec<RuntimeGenerationRecord> {
+        let active = RuntimeGenerationRecord::active(self.current());
+        let archived = self
+            .history
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        let mut history = Vec::with_capacity(archived.len() + 1);
+        history.push(active);
+        history.extend(archived);
+        history
+    }
+
+    /// Return a retained rollback candidate by generation, if still available.
+    pub fn rollback_candidate(&self, generation: u64) -> Option<Arc<RuntimeBundle>> {
+        let current = self.current();
+        if current.generation == generation {
+            return Some(current);
+        }
+
+        self.history
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .iter()
+            .find(|entry| {
+                entry.generation == generation && entry.status.is_rollback_candidate()
+            })
+            .and_then(|entry| entry.bundle.clone())
+    }
+
+    pub(crate) fn record_failed_prepare(&self, generation: u64, note: impl Into<String>) {
+        let mut history = self
+            .history
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        history.retain(|entry| entry.generation != generation);
+        history.push_front(RuntimeGenerationRecord::archived(
+            generation,
+            RuntimeGenerationRecordStatus::FailedPrepare,
+            None,
+            Some(note.into()),
+        ));
+        trim_runtime_generation_history(&mut history);
+    }
+
     /// Atomically install `bundle` as the active generation, returning its
     /// generation number.
     ///
@@ -241,6 +372,7 @@ impl RuntimeBundleHandle {
         };
         // Retire only the previous generation's generation-owned background tasks.
         // Startup-owned and process-shared resources are not torn down here.
+        self.archive_previous_generation(previous.clone());
         previous
             .shared_state
             .generation_state()
@@ -254,6 +386,32 @@ impl RuntimeBundleHandle {
             self.lifecycle.phase()
         );
         Ok(generation)
+    }
+
+    fn archive_previous_generation(&self, previous: Arc<RuntimeBundle>) {
+        let mut history = self
+            .history
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        for entry in history.iter_mut() {
+            if entry.status == RuntimeGenerationRecordStatus::Previous {
+                entry.status = RuntimeGenerationRecordStatus::Superseded;
+            }
+        }
+        history.retain(|entry| entry.generation != previous.generation);
+        history.push_front(RuntimeGenerationRecord::archived(
+            previous.generation,
+            RuntimeGenerationRecordStatus::Previous,
+            Some(previous),
+            None,
+        ));
+        trim_runtime_generation_history(&mut history);
+    }
+}
+
+fn trim_runtime_generation_history(history: &mut VecDeque<RuntimeGenerationRecord>) {
+    while history.len() > MAX_ARCHIVED_RUNTIME_GENERATIONS {
+        history.pop_back();
     }
 }
 
@@ -659,6 +817,116 @@ mod tests {
             active_task.abort();
             tokio::time::sleep(Duration::from_millis(20)).await;
             assert!(active_completed.load(Ordering::Acquire));
+        }
+    }
+
+    mod runtime_generation_history {
+        use super::*;
+
+        #[test]
+        fn replacement_retains_previous_generation_as_rollback_candidate() {
+            let dir = tempdir().expect("tempdir");
+            let (current_bundle, next_bundle) = runtime_bundle_pair(
+                dir.path(),
+                "startup.yaml",
+                "http://127.0.0.1:7001",
+                2,
+                "reloaded.yaml",
+                "http://127.0.0.1:7002",
+            );
+            let previous_generation = current_bundle.generation;
+            let handle = RuntimeBundleHandle::new(current_bundle);
+
+            handle.replace(next_bundle).expect("replace");
+
+            let history = handle.generation_history();
+            assert_eq!(history[0].generation(), 2);
+            assert_eq!(history[0].status(), RuntimeGenerationRecordStatus::Active);
+            assert_eq!(history[1].generation(), previous_generation);
+            assert_eq!(
+                history[1].status(),
+                RuntimeGenerationRecordStatus::Previous
+            );
+            let rollback = handle
+                .rollback_candidate(previous_generation)
+                .expect("previous generation should be retained");
+            assert_eq!(rollback.generation, previous_generation);
+        }
+
+        #[test]
+        fn replacement_marks_older_retained_generations_as_superseded() {
+            let dir = tempdir().expect("tempdir");
+            let (bundle_one, bundle_two) = runtime_bundle_pair(
+                dir.path(),
+                "one.yaml",
+                "http://127.0.0.1:7001",
+                2,
+                "two.yaml",
+                "http://127.0.0.1:7002",
+            );
+            let (_, mut bundle_three) = runtime_bundle_pair(
+                dir.path(),
+                "unused.yaml",
+                "http://127.0.0.1:7003",
+                3,
+                "three.yaml",
+                "http://127.0.0.1:7004",
+            );
+            bundle_three.generation = 3;
+            let handle = RuntimeBundleHandle::new(bundle_one);
+
+            handle.replace(bundle_two).expect("first replace");
+            handle.replace(bundle_three).expect("second replace");
+
+            let history = handle.generation_history();
+            assert_eq!(history[0].generation(), 3);
+            assert_eq!(history[0].status(), RuntimeGenerationRecordStatus::Active);
+            assert_eq!(history[1].generation(), 2);
+            assert_eq!(
+                history[1].status(),
+                RuntimeGenerationRecordStatus::Previous
+            );
+            assert_eq!(history[2].generation(), 1);
+            assert_eq!(
+                history[2].status(),
+                RuntimeGenerationRecordStatus::Superseded
+            );
+            assert!(
+                handle.rollback_candidate(1).is_some(),
+                "superseded known-good generations should remain rollback candidates"
+            );
+        }
+
+        #[test]
+        fn failed_prepare_history_is_retained_without_mutating_active_generation() {
+            let dir = tempdir().expect("tempdir");
+            let (current_bundle, _) = runtime_bundle_pair(
+                dir.path(),
+                "runtime.yaml",
+                "http://127.0.0.1:7001",
+                2,
+                "unused.yaml",
+                "http://127.0.0.1:7002",
+            );
+            let handle = RuntimeBundleHandle::new(current_bundle);
+
+            handle.record_failed_prepare(2, "could not prepare runtime generation");
+
+            let history = handle.generation_history();
+            assert_eq!(history[0].generation(), 1);
+            assert_eq!(history[0].status(), RuntimeGenerationRecordStatus::Active);
+            assert_eq!(history[1].generation(), 2);
+            assert_eq!(
+                history[1].status(),
+                RuntimeGenerationRecordStatus::FailedPrepare
+            );
+            assert_eq!(
+                history[1].note(),
+                Some("could not prepare runtime generation")
+            );
+            assert!(history[1].bundle().is_none());
+            assert_eq!(handle.current_generation(), 1);
+            assert!(handle.rollback_candidate(2).is_none());
         }
     }
 }

--- a/crates/edge/src/runtime/mod.rs
+++ b/crates/edge/src/runtime/mod.rs
@@ -4,6 +4,7 @@
 //! state types. Connection plumbing, generation swaps, and TLS/task internals
 //! remain crate-private implementation details.
 
+pub mod activation;
 pub mod backend;
 pub mod bundle;
 pub(crate) mod connection;

--- a/crates/edge/tests/backend_failure_and_recovery.rs
+++ b/crates/edge/tests/backend_failure_and_recovery.rs
@@ -101,18 +101,21 @@ fn consistent_hash_upstream(backends: Vec<Backend>) -> Upstream {
     upstream_with_policy("consistent-hash", Some("header:x-tenant-id"), backends)
 }
 
+/// Probe tenant keys until one hashes to `expected_body`'s backend.
+///
+/// The hash ring is built from backend addresses, and both test backends share a
+/// randomly reserved port. For some ports none of the first ~128 `tenant-N` keys land
+/// on a given backend, so the key space has to be wide enough to survive an unlucky
+/// port. A request error just means "not this key" — keep probing.
 fn find_consistent_hash_key_for_backend(
     harness: &BackendLifecycleHarness,
     expected_body: &str,
 ) -> Option<String> {
-    for idx in 0..128 {
+    (0..2048).find_map(|idx| {
         let key = format!("tenant-{idx}");
         let response = run_keyed_request(harness, &key).ok()?;
-        if response.status == 200 && response.body_text() == expected_body {
-            return Some(key);
-        }
-    }
-    None
+        (response.status == 200 && response.body_text() == expected_body).then_some(key)
+    })
 }
 
 fn wait_for_backend_health_state(

--- a/crates/edge/tests/regression/metrics.rs
+++ b/crates/edge/tests/regression/metrics.rs
@@ -2,13 +2,11 @@
 
 use std::{sync::atomic::Ordering, time::Duration};
 
+use spooky_edge::runtime::activation::{RuntimeOperationOutcomeReason, RuntimeRejectionReason};
 use spooky_edge::{Metrics, OverloadShedReason, RouteOutcome};
 use spooky_errors::{
     HedgeOutcomeTelemetryReason, HedgeTriggerTelemetryReason, RetryAttemptTelemetryReason,
     RetryPolicyDenialReason,
-};
-use spooky_edge::runtime::activation::{
-    RuntimeOperationOutcomeReason, RuntimeRejectionReason,
 };
 
 #[test]

--- a/crates/edge/tests/regression/metrics.rs
+++ b/crates/edge/tests/regression/metrics.rs
@@ -2,8 +2,10 @@
 
 use std::{sync::atomic::Ordering, time::Duration};
 
-use spooky_edge::runtime::activation::{RuntimeOperationOutcomeReason, RuntimeRejectionReason};
-use spooky_edge::{Metrics, OverloadShedReason, RouteOutcome};
+use spooky_edge::{
+    Metrics, OverloadShedReason, RouteOutcome,
+    runtime::activation::{RuntimeOperationOutcomeReason, RuntimeRejectionReason},
+};
 use spooky_errors::{
     HedgeOutcomeTelemetryReason, HedgeTriggerTelemetryReason, RetryAttemptTelemetryReason,
     RetryPolicyDenialReason,

--- a/crates/edge/tests/regression/metrics.rs
+++ b/crates/edge/tests/regression/metrics.rs
@@ -7,7 +7,9 @@ use spooky_errors::{
     HedgeOutcomeTelemetryReason, HedgeTriggerTelemetryReason, RetryAttemptTelemetryReason,
     RetryPolicyDenialReason,
 };
-use spooky_edge::runtime::activation::RuntimeRejectionReason;
+use spooky_edge::runtime::activation::{
+    RuntimeOperationOutcomeReason, RuntimeRejectionReason,
+};
 
 #[test]
 fn metrics_render_includes_route_percentiles() {
@@ -162,6 +164,33 @@ fn metrics_render_includes_runtime_rejection_reason_vocab() {
         "spooky_runtime_rejections_total{reason=\"incompatible_reload\"} 1",
         "spooky_runtime_rejections_total{reason=\"unknown_generation\"} 1",
         "spooky_runtime_rejections_total{reason=\"rollback_not_allowed\"} 1",
+    ] {
+        assert!(output.contains(expected), "missing metric line: {expected}");
+    }
+}
+
+#[test]
+fn metrics_render_includes_runtime_activation_observability_contract() {
+    let metrics = Metrics::default();
+    metrics.inc_runtime_validation_attempt();
+    metrics.inc_runtime_preview_attempt();
+    metrics.record_runtime_activation_outcome(RuntimeOperationOutcomeReason::Applied);
+    metrics.record_runtime_activation_outcome(RuntimeOperationOutcomeReason::InvalidConfig);
+    metrics.record_runtime_rollback_outcome(RuntimeOperationOutcomeReason::Applied);
+    metrics.record_runtime_rollback_outcome(RuntimeOperationOutcomeReason::RollbackNotAllowed);
+    metrics.set_runtime_active_generation(12);
+    metrics.set_runtime_history_depth(3);
+
+    let output = metrics.render_prometheus();
+    for expected in [
+        "spooky_runtime_validation_attempts_total 1",
+        "spooky_runtime_preview_attempts_total 1",
+        "spooky_runtime_activation_total{result=\"success\",reason=\"applied\"} 1",
+        "spooky_runtime_activation_total{result=\"failure\",reason=\"invalid_config\"} 1",
+        "spooky_runtime_rollback_total{result=\"success\",reason=\"applied\"} 1",
+        "spooky_runtime_rollback_total{result=\"failure\",reason=\"rollback_not_allowed\"} 1",
+        "spooky_runtime_active_generation 12",
+        "spooky_runtime_history_depth 3",
     ] {
         assert!(output.contains(expected), "missing metric line: {expected}");
     }

--- a/crates/edge/tests/regression/metrics.rs
+++ b/crates/edge/tests/regression/metrics.rs
@@ -7,6 +7,7 @@ use spooky_errors::{
     HedgeOutcomeTelemetryReason, HedgeTriggerTelemetryReason, RetryAttemptTelemetryReason,
     RetryPolicyDenialReason,
 };
+use spooky_edge::runtime::activation::RuntimeRejectionReason;
 
 #[test]
 fn metrics_render_includes_route_percentiles() {
@@ -139,6 +140,31 @@ fn metrics_render_includes_overload_reasons_and_hedge_counters() {
     assert!(output.contains("spooky_control_api_connection_limit_drops 1\n"));
     assert!(output.contains("spooky_circuit_breaker_rejected_total 0\n"));
     assert!(output.contains("spooky_brownout_active 0\n"));
+}
+
+#[test]
+fn metrics_render_includes_runtime_rejection_reason_vocab() {
+    let metrics = Metrics::default();
+    metrics.inc_runtime_rejection_reason(RuntimeRejectionReason::InvalidConfig);
+    metrics.inc_runtime_rejection_reason(RuntimeRejectionReason::StartupOwnedChange);
+    metrics.inc_runtime_rejection_reason(RuntimeRejectionReason::BindConflict);
+    metrics.inc_runtime_rejection_reason(RuntimeRejectionReason::ResourcePrepareFailed);
+    metrics.inc_runtime_rejection_reason(RuntimeRejectionReason::IncompatibleReload);
+    metrics.inc_runtime_rejection_reason(RuntimeRejectionReason::UnknownGeneration);
+    metrics.inc_runtime_rejection_reason(RuntimeRejectionReason::RollbackNotAllowed);
+
+    let output = metrics.render_prometheus();
+    for expected in [
+        "spooky_runtime_rejections_total{reason=\"invalid_config\"} 1",
+        "spooky_runtime_rejections_total{reason=\"startup_owned_change\"} 1",
+        "spooky_runtime_rejections_total{reason=\"bind_conflict\"} 1",
+        "spooky_runtime_rejections_total{reason=\"resource_prepare_failed\"} 1",
+        "spooky_runtime_rejections_total{reason=\"incompatible_reload\"} 1",
+        "spooky_runtime_rejections_total{reason=\"unknown_generation\"} 1",
+        "spooky_runtime_rejections_total{reason=\"rollback_not_allowed\"} 1",
+    ] {
+        assert!(output.contains(expected), "missing metric line: {expected}");
+    }
 }
 
 #[test]

--- a/crates/edge/tests/runtime_swap.rs
+++ b/crates/edge/tests/runtime_swap.rs
@@ -388,7 +388,7 @@ fn runtime_reload_is_rejected_after_listener_lifecycle_leaves_running() {
         .expect("rewrite live-reloadable config");
 
     let rejection = harness
-        .trigger_runtime_reload_expect(http::StatusCode::INTERNAL_SERVER_ERROR)
+        .trigger_runtime_reload_expect(http::StatusCode::CONFLICT)
         .expect("reload rejection after drain");
     assert_eq!(rejection["reloaded"], false);
     let error = rejection["error"]

--- a/docs/reference/control-api-reference.md
+++ b/docs/reference/control-api-reference.md
@@ -11,6 +11,9 @@ Current endpoint family:
 - health
 - readiness
 - runtime snapshot
+- staged activation: validate, preview, activate
+- rollback
+- generation history
 - certificate reload
 - full config reload
 - restart request
@@ -87,11 +90,140 @@ Expected use:
 - rollout validation
 - incident response
 
+### `POST /admin/runtime/validate`
+
+Purpose:
+
+- parse and validate a candidate config, and report whether it could be activated — without touching the running runtime
+
+Returns `200` with a plan describing the candidate generation, a per-domain diff, and any rejected changes. A config that cannot be activated still returns `200`; inspect `rejected_changes` and `candidate_status` rather than relying on the status code.
+
+Accepts the same optional body fields as `/admin/runtime/reload`.
+
+Expected use:
+
+- CI gating on config changes before a deploy
+- confirming a config is loadable before scheduling a maintenance window
+
+### `POST /admin/runtime/preview`
+
+Purpose:
+
+- same planning work as validate, recorded in generation history as an operator preview
+
+Returns `200` with the same plan shape as validate. Neither endpoint mutates the active generation.
+
+Expected use:
+
+- operator dry-run immediately before an activation, when you want the attempt in the audit trail
+
+### `POST /admin/runtime/activate`
+
+Purpose:
+
+- stage and commit a config change, returning the structured activation result
+
+Returns `202` on success. Failures are classified rather than collapsed into `500`:
+
+| Status | Meaning |
+| --- | --- |
+| `400` | the candidate config is invalid |
+| `409` | conflict — a stale `expected_generation`, or changes that require a restart |
+| `500` | resource preparation failed, or the runtime swap itself failed |
+
+Accepts the same optional body fields as `/admin/runtime/reload`.
+
+Expected use:
+
+- the preferred activation path — prefer this over the legacy `/reload` shortcut, since it returns the full diff, rejection detail, and generation history entry
+
+### `POST /admin/runtime/rollback`
+
+Purpose:
+
+- restore a previously retained runtime generation
+
+Required request body:
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `target_generation` | integer | The retained generation to restore. Required. |
+| `expected_active_generation` | integer | Reject with `409` unless this matches the active generation. |
+| `requested_by` | string | Recorded in generation history for audit. |
+| `reason` | string | Recorded in generation history for audit. |
+
+Returns `202` on success. Failures:
+
+| Status | Meaning |
+| --- | --- |
+| `404` | the target generation is not retained (unknown generation) |
+| `409` | the target is retained but not rollback-eligible, or the active generation moved |
+| `500` | resource preparation failed, or the rollback swap itself failed |
+
+Use `GET /admin/runtime/history` first to pick a target whose `rollback_candidate` is `true`.
+
+Example:
+
+```bash
+curl -k --http1.1 -X POST https://127.0.0.1:9890/admin/runtime/rollback \
+  -H "Authorization: Bearer <token>" \
+  -H "content-type: application/json" \
+  -d '{"target_generation": 3}'
+```
+
+### `GET /admin/runtime/history`
+
+Purpose:
+
+- list retained runtime generations and the recorded history of control-plane operations
+
+Response shape:
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `active_generation` | integer | The generation currently serving traffic. |
+| `retained_generations` | array | Retained generation records — the state needed to choose a rollback target. |
+| `entries` | array | Operation log (validate, preview, activate, rollback), newest first. |
+
+Each entry in `retained_generations`:
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `generation` | integer | The generation number. |
+| `status` | string | One of `active`, `previous`, `failed_prepare`, `rolled_back`, `superseded`. |
+| `rollback_candidate` | bool | Whether `/admin/runtime/rollback` will accept this generation as a target. |
+| `has_bundle` | bool | Whether the runtime bundle is still retained. A rollback target needs `true`. |
+| `note` | string | Present only when there is explanatory detail, e.g. why a staged prepare failed. |
+
+`status: failed_prepare` records a candidate generation that was never successfully prepared; it has `has_bundle: false` and carries the failure reason in `note`.
+
+Expected use:
+
+- choosing a safe rollback target
+- auditing who changed runtime config, when, and from which config source
+- diagnosing why a staged activation never committed
+
+### `GET /admin/runtime/history/{generation}`
+
+Purpose:
+
+- the retained-generation record and operation entries for a single generation
+
+Returns `200` with `generation`, a single `retained_generation` object (same shape as above), and the `entries` recorded against it. Returns `404` if that generation is not retained.
+
 ### `POST /admin/runtime/reload`
+
+Legacy shortcut. Prefer `POST /admin/runtime/activate`, which returns the full diff and rejection detail.
 
 Purpose:
 
 - reload the full config from disk and apply changes to upstreams, backends, policies, timeouts, and `log.level`
+
+Config source:
+
+- with no request body, the reload re-reads the **currently active runtime config source**
+- on a freshly started process that source is the path passed at startup, but activating an alternate `config_path` makes that file the active source for every later reload
+- pass `config_path` in the body to read a different file; a successful activation makes that path the new active source
 
 Important scope note:
 
@@ -104,11 +236,29 @@ Expected use:
 - adding or removing backends
 - changing load balancing, timeouts, resilience, or routing policy at runtime
 
+Optional request body:
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `config_path` | string | Read this config file instead of the active source. On success it becomes the new active source. |
+| `expected_generation` | integer | Reject with `409` unless this matches the active generation (optimistic concurrency). |
+| `requested_by` | string | Recorded in generation history for audit. |
+| `reason` | string | Recorded in generation history for audit. |
+
 Example:
 
 ```bash
 curl -k --http1.1 -X POST https://127.0.0.1:9890/admin/runtime/reload \
   -H "Authorization: Bearer <token>"
+```
+
+Activating an alternate config file:
+
+```bash
+curl -k --http1.1 -X POST https://127.0.0.1:9890/admin/runtime/reload \
+  -H "Authorization: Bearer <token>" \
+  -H "content-type: application/json" \
+  -d '{"config_path": "/etc/spooky/canary.yaml"}'
 ```
 
 ### `POST /admin/runtime/reload-certs`
@@ -141,7 +291,9 @@ Expected use:
 ## Operator Notes
 
 - use cert reload for cert-only changes
-- use full config reload for backend, policy, timeout, or routing changes that don't require rebinding listeners
+- use `validate` (or `preview`) then `activate` for backend, policy, timeout, or routing changes that don't require rebinding listeners — `activate` reports the diff and classifies failures, unlike the legacy `/reload`
+- pass `expected_generation` on `activate` and `rollback` so a concurrent change fails with `409` instead of silently overwriting
+- check `GET /admin/runtime/history` for a target with `rollback_candidate: true` before calling `rollback`
 - use drain-and-restart when listener addresses or control API/metrics bind must change
 - keep rollback available before using restart-triggering control-plane actions in production
 - all curl invocations must use `--http1.1` — the control API does not support HTTP/2


### PR DESCRIPTION
## Summary
This PR adds a canonical runtime activation flow for config changes in `edge`, with staged validation, preview diffs, explicit activation/rollback results, bounded generation history, and control-plane endpoints built on a single activation service.

## What Changed
- Added canonical runtime activation domain types for:
  - reload plans and diffs
  - activation and rollback requests/results
  - generation history entries and status
  - stable rejection and outcome reasons
- Added staged validation/planning that:
  - parses and validates config
  - normalizes runtime config
  - evaluates reload compatibility
  - produces a proposed next-generation snapshot
  - returns typed rejection reasons without mutating the active runtime
- Added canonical runtime diff generation across operator-meaningful domains:
  - listeners
  - routes/upstreams
  - backend policies
  - auth/admission/resilience
  - observability/control-plane settings
- Added activation transaction flow that:
  - validates
  - plans
  - prepares resources
  - swaps generation only on success
  - preserves the active generation on any failure path
- Added rollback by generation id with bounded known-good history retention.
- Added structured generation history and change events for:
  - validate
  - preview
  - activate success/failure
  - rollback success/failure
- Added control API endpoints for:
  - `POST /admin/runtime/validate`
  - `POST /admin/runtime/preview`
  - `POST /admin/runtime/activate`
  - `POST /admin/runtime/rollback`
  - `GET /admin/runtime/history`
  - `GET /admin/runtime/history/:generation`
- Added runtime activation observability:
  - validation/preview attempt counters
  - activation/rollback outcome counters
  - active generation gauge
  - history depth gauge
  - stable reason vocabulary across metrics, logs, and API payloads
- Finalized boundaries so reload handling flows through `RuntimeActivationService`, with control API acting as orchestration only.

## Why
This closes the gap between basic live reload and operator-safe runtime change management. The new flow supports safe preview, typed rejection, bounded rollback, and auditable runtime generation history without partial mutation of the active generation.

## Verification
Test coverage was added and expanded for:
- diff generation
- compatibility classification
- rejection reason mapping
- rollback candidate selection
- validate/preview non-mutation behavior
- activation success/failure swap behavior
- rollback restoration behavior
- generation history sequencing
- activation/rollback observability contract

## Notes
- Previous known-good generations are retained in bounded in-memory history first.
- Startup-owned changes are still rejected as non-reloadable and surfaced through stable typed reasons.
- Listener cert reload remains a separate operational flow; this PR is specifically about runtime generation activation and rollback.