### PR TITLE
feat: ship the observability operator bundle with packaged dashboards, rules, control-plane linkage, and QUIC traffic support

### DIFF
--- a/crates/edge/Cargo.toml
+++ b/crates/edge/Cargo.toml
@@ -54,3 +54,4 @@ hyper.workspace = true
 hyper-util.workspace = true
 tokio.workspace = true
 libc.workspace = true
+serde_yaml.workspace = true

--- a/crates/edge/src/observability/mod.rs
+++ b/crates/edge/src/observability/mod.rs
@@ -836,14 +836,15 @@ mod tests {
             }
             JsonValue::Object(values) => {
                 for (key, value) in values {
-                    if key == "expr" && let Some(expr) = value.as_str() {
+                    if key == "expr"
+                        && let Some(expr) = value.as_str()
+                    {
                         exprs.push(expr.to_string());
                     }
                     collect_json_exprs(value, exprs);
                 }
             }
-            JsonValue::Null | JsonValue::Bool(_) | JsonValue::Number(_) | JsonValue::String(_) => {
-            }
+            JsonValue::Null | JsonValue::Bool(_) | JsonValue::Number(_) | JsonValue::String(_) => {}
         }
     }
 
@@ -856,14 +857,15 @@ mod tests {
             }
             YamlValue::Mapping(values) => {
                 for (key, value) in values {
-                    if key.as_str() == Some("expr") && let Some(expr) = value.as_str() {
+                    if key.as_str() == Some("expr")
+                        && let Some(expr) = value.as_str()
+                    {
                         exprs.push(expr.to_string());
                     }
                     collect_yaml_exprs(value, exprs);
                 }
             }
-            YamlValue::Null | YamlValue::Bool(_) | YamlValue::Number(_) | YamlValue::String(_) => {
-            }
+            YamlValue::Null | YamlValue::Bool(_) | YamlValue::Number(_) | YamlValue::String(_) => {}
             YamlValue::Tagged(tagged) => collect_yaml_exprs(&tagged.value, exprs),
         }
     }
@@ -891,10 +893,7 @@ mod tests {
             );
         }
 
-        for relative in [
-            "prometheus/recording-rules.yaml",
-            "prometheus/alerts.yaml",
-        ] {
+        for relative in ["prometheus/recording-rules.yaml", "prometheus/alerts.yaml"] {
             let path = root.join(relative);
             let source = fs::read_to_string(&path).expect("read Prometheus rule file");
             let value: YamlValue = serde_yaml::from_str(&source).expect("parse Prometheus yaml");

--- a/crates/edge/src/observability/mod.rs
+++ b/crates/edge/src/observability/mod.rs
@@ -774,6 +774,15 @@ impl From<HedgePolicyDenialReason> for HedgeDecisionReason {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        collections::BTreeSet,
+        fs,
+        path::{Path, PathBuf},
+    };
+
+    use serde_json::Value as JsonValue;
+    use serde_yaml::Value as YamlValue;
+
     use super::*;
 
     fn assert_unique_slug_family(slugs: &[&str], family: &str) {
@@ -809,6 +818,197 @@ mod tests {
             format!("reason={reason}"),
             "structured logs should render the canonical reason token verbatim"
         );
+    }
+
+    fn workspace_root() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .canonicalize()
+            .expect("workspace root")
+    }
+
+    fn collect_json_exprs(value: &JsonValue, exprs: &mut Vec<String>) {
+        match value {
+            JsonValue::Array(values) => {
+                for value in values {
+                    collect_json_exprs(value, exprs);
+                }
+            }
+            JsonValue::Object(values) => {
+                for (key, value) in values {
+                    if key == "expr" && let Some(expr) = value.as_str() {
+                        exprs.push(expr.to_string());
+                    }
+                    collect_json_exprs(value, exprs);
+                }
+            }
+            JsonValue::Null | JsonValue::Bool(_) | JsonValue::Number(_) | JsonValue::String(_) => {
+            }
+        }
+    }
+
+    fn collect_yaml_exprs(value: &YamlValue, exprs: &mut Vec<String>) {
+        match value {
+            YamlValue::Sequence(values) => {
+                for value in values {
+                    collect_yaml_exprs(value, exprs);
+                }
+            }
+            YamlValue::Mapping(values) => {
+                for (key, value) in values {
+                    if key.as_str() == Some("expr") && let Some(expr) = value.as_str() {
+                        exprs.push(expr.to_string());
+                    }
+                    collect_yaml_exprs(value, exprs);
+                }
+            }
+            YamlValue::Null | YamlValue::Bool(_) | YamlValue::Number(_) | YamlValue::String(_) => {
+            }
+            YamlValue::Tagged(tagged) => collect_yaml_exprs(&tagged.value, exprs),
+        }
+    }
+
+    fn packaged_observability_exprs() -> Vec<(PathBuf, String)> {
+        let root = workspace_root().join("deploy/observability");
+        let mut exprs = Vec::new();
+
+        let mut dashboards = fs::read_dir(root.join("grafana"))
+            .expect("grafana dashboards directory")
+            .map(|entry| entry.expect("dashboard dir entry").path())
+            .filter(|path| path.extension().and_then(|value| value.to_str()) == Some("json"))
+            .collect::<Vec<_>>();
+        dashboards.sort();
+
+        for dashboard in dashboards {
+            let source = fs::read_to_string(&dashboard).expect("read dashboard");
+            let value: JsonValue = serde_json::from_str(&source).expect("parse dashboard json");
+            let mut dashboard_exprs = Vec::new();
+            collect_json_exprs(&value, &mut dashboard_exprs);
+            exprs.extend(
+                dashboard_exprs
+                    .into_iter()
+                    .map(|expr| (dashboard.clone(), expr)),
+            );
+        }
+
+        for relative in [
+            "prometheus/recording-rules.yaml",
+            "prometheus/alerts.yaml",
+        ] {
+            let path = root.join(relative);
+            let source = fs::read_to_string(&path).expect("read Prometheus rule file");
+            let value: YamlValue = serde_yaml::from_str(&source).expect("parse Prometheus yaml");
+            let mut rule_exprs = Vec::new();
+            collect_yaml_exprs(&value, &mut rule_exprs);
+            exprs.extend(rule_exprs.into_iter().map(|expr| (path.clone(), expr)));
+        }
+
+        exprs
+    }
+
+    fn extract_label_matcher_values(expr: &str, label: &str) -> BTreeSet<String> {
+        let mut tokens = BTreeSet::new();
+
+        for operator in ["=\"", "!=\"", "=~\"", "!~\""] {
+            let needle = format!("{label}{operator}");
+            let mut search_start = 0;
+
+            while let Some(offset) = expr[search_start..].find(&needle) {
+                let value_start = search_start + offset + needle.len();
+                let Some(value_end) = expr[value_start..].find('"') else {
+                    break;
+                };
+                let raw = &expr[value_start..value_start + value_end];
+                if operator.contains('~') {
+                    for token in raw.split('|') {
+                        let token = token.trim();
+                        if !token.is_empty() {
+                            tokens.insert(token.to_string());
+                        }
+                    }
+                } else if !raw.trim().is_empty() {
+                    tokens.insert(raw.trim().to_string());
+                }
+                search_start = value_start + value_end + 1;
+            }
+        }
+
+        tokens
+    }
+
+    fn canonical_packaged_reason_tokens() -> BTreeSet<&'static str> {
+        [
+            RequestOutcomeReason::Completed.slug(),
+            RequestOutcomeReason::Cancelled.slug(),
+            RequestOutcomeReason::TimedOut.slug(),
+            RequestOutcomeReason::AuthDenied.slug(),
+            RequestOutcomeReason::RateLimited.slug(),
+            RequestOutcomeReason::Overloaded.slug(),
+            RequestOutcomeReason::ValidationRejected.slug(),
+            RequestOutcomeReason::BackendTransportFailed.slug(),
+            RequestOutcomeReason::BackendProtocolFailed.slug(),
+            RequestOutcomeReason::BackendTlsFailed.slug(),
+            RequestOutcomeReason::BackendBridgeFailed.slug(),
+            BackendHealthReason::ActiveProbeSuccess.slug(),
+            BackendHealthReason::ActiveProbeFailure.slug(),
+            BackendHealthReason::PassiveSuccess.slug(),
+            BackendHealthReason::PassiveFailure.slug(),
+            BackendHealthReason::DnsRefreshFailed.slug(),
+            BackendHealthReason::EmptyResolutionRetained.slug(),
+            BackendHealthReason::PoolPoisoned.slug(),
+            RetryDecisionReason::UpstreamTimeout.slug(),
+            RetryDecisionReason::UpstreamTransportFailure.slug(),
+            RetryDecisionReason::UpstreamProtocolFailure.slug(),
+            RetryDecisionReason::RetryBudgetDenied.slug(),
+            RetryDecisionReason::RetryPolicyDisabled.slug(),
+            RetryDecisionReason::IdempotencyDenied.slug(),
+            HedgeDecisionReason::DelayElapsed.slug(),
+            HedgeDecisionReason::HedgingDisabled.slug(),
+            HedgeDecisionReason::PrimaryCompleted.slug(),
+            HedgeDecisionReason::RequestBodyNotReplayable.slug(),
+            HedgeDecisionReason::TunnelRequest.slug(),
+            HedgeDecisionReason::MethodNotAllowed.slug(),
+            HedgeDecisionReason::AlternateBackendUnavailable.slug(),
+            HedgeDecisionReason::HedgeBudgetDenied.slug(),
+            AdmissionDecisionReason::AuthDenied.slug(),
+            AdmissionDecisionReason::AuthUnavailable.slug(),
+            AdmissionDecisionReason::RateLimited.slug(),
+            AdmissionDecisionReason::Overloaded.slug(),
+            AdmissionDecisionReason::ValidationRejected.slug(),
+            AdmissionDecisionReason::PolicyRejected.slug(),
+            AdmissionOverloadCause::Brownout.slug(),
+            AdmissionOverloadCause::AdaptiveAdmission.slug(),
+            AdmissionOverloadCause::RouteCap.slug(),
+            AdmissionOverloadCause::RouteGlobalCap.slug(),
+            AdmissionOverloadCause::GlobalInflight.slug(),
+            AdmissionOverloadCause::UpstreamInflight.slug(),
+            AdmissionOverloadCause::BackendInflight.slug(),
+            AdmissionOverloadCause::CircuitOpen.slug(),
+            AdmissionOverloadCause::RequestBufferCap.slug(),
+            AdmissionOverloadCause::ResponsePrebufferCap.slug(),
+            AdmissionOverloadCause::ConnectionCap.slug(),
+            QuotaPolicyDecision::Allowed.slug(),
+            QuotaPolicyDecision::Denied.slug(),
+            QuotaPolicyDecision::ShadowDenied.slug(),
+            QuotaPolicyDecision::FailedOpen.slug(),
+            QuotaPolicyDecision::FailedClosed.slug(),
+            QuotaPolicyDecision::NotApplied.slug(),
+            QuotaPolicyReason::Allowed.slug(),
+            QuotaPolicyReason::NotApplied.slug(),
+            QuotaPolicyReason::BurstQuotaExhausted.slug(),
+            QuotaPolicyReason::SustainedQuotaExhausted.slug(),
+            QuotaPolicyReason::SelectorIdentityMissing.slug(),
+            QuotaPolicyReason::SelectorIdentityInvalid.slug(),
+            QuotaPolicyReason::BackendTimeout.slug(),
+            QuotaPolicyReason::BackendUnavailable.slug(),
+            QuotaPolicyReason::BackendError.slug(),
+            QuotaBackendHealthReason::Available.slug(),
+            QuotaBackendHealthReason::Timeout.slug(),
+            QuotaBackendHealthReason::Unavailable.slug(),
+            QuotaBackendHealthReason::Error.slug(),
+        ]
+        .into_iter()
+        .collect()
     }
 
     mod canonical_observability_slug_stability {
@@ -1256,6 +1456,31 @@ mod tests {
             assert_eq!(
                 OverloadShedReason::GlobalInflight.reason_label(),
                 AdmissionOverloadCause::GlobalInflight.slug()
+            );
+        }
+
+        #[test]
+        fn packaged_dashboards_and_alerts_only_reference_canonical_reason_vocabularies() {
+            let canonical = canonical_packaged_reason_tokens();
+            let mut unknown = Vec::new();
+
+            for (path, expr) in packaged_observability_exprs() {
+                for label in ["reason", "decision"] {
+                    for token in extract_label_matcher_values(&expr, label) {
+                        if !canonical.contains(token.as_str()) {
+                            unknown.push(format!(
+                                "{} references unknown {label} slug `{token}` in `{expr}`",
+                                path.display()
+                            ));
+                        }
+                    }
+                }
+            }
+
+            assert!(
+                unknown.is_empty(),
+                "packaged observability artifacts drifted from the canonical reason vocabulary:\n{}",
+                unknown.join("\n")
             );
         }
 

--- a/crates/edge/src/quic_listener/admission.rs
+++ b/crates/edge/src/quic_listener/admission.rs
@@ -3798,8 +3798,9 @@ mod tests {
     }
 
     mod post_auth_admission_execution {
-        use super::*;
         use spooky_config::config::QuotaBackendFailurePolicy;
+
+        use super::*;
 
         fn test_pending_forward_for_api(headers: Vec<quiche::h3::Header>) -> PendingForward {
             PendingForward::sample_for_test(headers)

--- a/crates/edge/src/quic_listener/control_api/admin_identity.rs
+++ b/crates/edge/src/quic_listener/control_api/admin_identity.rs
@@ -46,6 +46,10 @@ pub(super) struct AdminIdentity {
 pub(super) struct ControlApiRequestContext {
     pub(super) peer_addr: SocketAddr,
     pub(super) mtls_identity: Option<AdminMtlsIdentity>,
+    pub(super) listener: Option<String>,
+    pub(super) request_id: Option<String>,
+    pub(super) trace_id: Option<String>,
+    pub(super) span_id: Option<String>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -68,6 +72,7 @@ impl QUICListener {
         peer_addr: SocketAddr,
         peer_certificates: Option<&[CertificateDer<'static>]>,
         identity_source: Option<&ControlApiIdentitySourcePolicy>,
+        listener: Option<String>,
     ) -> ControlApiRequestContext {
         let mtls_identity = peer_certificates
             .and_then(|certs| certs.first())
@@ -75,7 +80,36 @@ impl QUICListener {
         ControlApiRequestContext {
             peer_addr,
             mtls_identity,
+            listener,
+            request_id: None,
+            trace_id: None,
+            span_id: None,
         }
+    }
+
+    pub(super) fn augment_control_api_request_context<B>(
+        mut context: ControlApiRequestContext,
+        req: &::http::Request<B>,
+    ) -> ControlApiRequestContext {
+        context.request_id = req
+            .headers()
+            .get("x-request-id")
+            .and_then(|value| value.to_str().ok())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned);
+        if let Some((trace_id, span_id)) = req
+            .headers()
+            .get("traceparent")
+            .and_then(|value| value.to_str().ok())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .and_then(parse_traceparent)
+        {
+            context.trace_id = Some(trace_id);
+            context.span_id = Some(span_id);
+        }
+        context
     }
 
     fn parse_admin_mtls_identity(

--- a/crates/edge/src/quic_listener/control_api/audit.rs
+++ b/crates/edge/src/quic_listener/control_api/audit.rs
@@ -15,6 +15,8 @@ use super::{
 };
 use crate::REQUEST_ID_COUNTER;
 
+const ADMIN_AUDIT_SCHEMA_VERSION: &str = "v1";
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub(in crate::quic_listener) struct ControlApiAdminAuditEmitter {
     pub(in crate::quic_listener) enabled: bool,
@@ -45,8 +47,22 @@ pub(in crate::quic_listener) enum ControlApiAdminAuditTarget {
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub(in crate::quic_listener) struct AdminAuditEvent {
+    pub(in crate::quic_listener) schema_version: &'static str,
+    pub(in crate::quic_listener) event_id: String,
     pub(in crate::quic_listener) event_type: AdminAuditEventType,
     pub(in crate::quic_listener) time_unix_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(in crate::quic_listener) request_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(in crate::quic_listener) trace_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(in crate::quic_listener) span_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(in crate::quic_listener) listener: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(in crate::quic_listener) upstream: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(in crate::quic_listener) backend: Option<String>,
     pub(in crate::quic_listener) actor: AdminAuditActor,
     pub(in crate::quic_listener) action: AdminAuditAction,
     pub(in crate::quic_listener) target: AdminAuditTarget,
@@ -54,10 +70,24 @@ pub(in crate::quic_listener) struct AdminAuditEvent {
     pub(in crate::quic_listener) result: AdminAuditResult,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(in crate::quic_listener) reason: Option<String>,
-    pub(in crate::quic_listener) event_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(in crate::quic_listener) failure_class: Option<AdminAuditFailureClass>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(in crate::quic_listener) peer_addr: Option<String>,
     pub(in crate::quic_listener) authn: AdminAuditAuthn,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(in crate::quic_listener) enum AdminAuditFailureClass {
+    Authentication,
+    Authorization,
+    SourcePolicy,
+    RequestValidation,
+    RuntimeConfig,
+    RuntimeState,
+    ListenerTls,
+    Watchdog,
 }
 
 #[allow(dead_code)]
@@ -203,20 +233,37 @@ impl QUICListener {
         if !emitter.enabled {
             return;
         }
+        let reason = reason
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned);
 
         let event = AdminAuditEvent {
+            schema_version: ADMIN_AUDIT_SCHEMA_VERSION,
+            event_id: format!(
+                "control-api-audit-{}",
+                REQUEST_ID_COUNTER.fetch_add(1, Ordering::Relaxed)
+            ),
             event_type,
             time_unix_ms: crate::watchdog::time::now_millis(),
+            request_id: Self::control_api_audit_request_id(request_context),
+            trace_id: Self::control_api_audit_trace_id(request_context),
+            span_id: Self::control_api_audit_span_id(request_context),
+            listener: Self::control_api_audit_listener(request_context),
+            upstream: None,
+            backend: None,
             actor: AdminAuditActor::from_identity(identity),
             action,
             target,
             generation,
             result,
-            reason,
-            event_id: format!(
-                "control-api-audit-{}",
-                REQUEST_ID_COUNTER.fetch_add(1, Ordering::Relaxed)
+            failure_class: Self::control_api_audit_failure_class(
+                event_type,
+                result,
+                reason.as_deref(),
             ),
+            reason,
             peer_addr: Self::control_api_audit_peer_addr(identity, request_context),
             authn: AdminAuditAuthn::from_identity(identity),
         };
@@ -372,6 +419,70 @@ impl QUICListener {
             .or_else(|| request_context.map(|context| context.peer_addr))
             .map(|addr| addr.to_string())
     }
+
+    fn control_api_audit_request_id(
+        request_context: Option<&ControlApiRequestContext>,
+    ) -> Option<String> {
+        request_context.and_then(|context| context.request_id.clone())
+    }
+
+    fn control_api_audit_trace_id(
+        request_context: Option<&ControlApiRequestContext>,
+    ) -> Option<String> {
+        request_context.and_then(|context| context.trace_id.clone())
+    }
+
+    fn control_api_audit_span_id(
+        request_context: Option<&ControlApiRequestContext>,
+    ) -> Option<String> {
+        request_context.and_then(|context| context.span_id.clone())
+    }
+
+    fn control_api_audit_listener(
+        request_context: Option<&ControlApiRequestContext>,
+    ) -> Option<String> {
+        request_context.and_then(|context| context.listener.clone())
+    }
+
+    fn control_api_audit_failure_class(
+        event_type: AdminAuditEventType,
+        result: AdminAuditResult,
+        reason: Option<&str>,
+    ) -> Option<AdminAuditFailureClass> {
+        if matches!(result, AdminAuditResult::Success) {
+            return None;
+        }
+
+        match reason {
+            Some("missing_authentication")
+            | Some("invalid_authorization_header")
+            | Some("invalid_bearer_token") => {
+                return Some(AdminAuditFailureClass::Authentication);
+            }
+            Some("insufficient_role") => {
+                return Some(AdminAuditFailureClass::Authorization);
+            }
+            Some("missing_peer_context") | Some("source_ip_not_allowed") => {
+                return Some(AdminAuditFailureClass::SourcePolicy);
+            }
+            Some("invalid_request_body") => {
+                return Some(AdminAuditFailureClass::RequestValidation);
+            }
+            _ => {}
+        }
+
+        match event_type {
+            AdminAuditEventType::Auth => Some(AdminAuditFailureClass::Authentication),
+            AdminAuditEventType::RuntimeSnapshot => Some(AdminAuditFailureClass::RuntimeState),
+            AdminAuditEventType::RuntimeValidate
+            | AdminAuditEventType::RuntimePreview
+            | AdminAuditEventType::RuntimeReload
+            | AdminAuditEventType::RuntimeActivate
+            | AdminAuditEventType::RuntimeRollback => Some(AdminAuditFailureClass::RuntimeConfig),
+            AdminAuditEventType::RuntimeRestart => Some(AdminAuditFailureClass::Watchdog),
+            AdminAuditEventType::CertReload => Some(AdminAuditFailureClass::ListenerTls),
+        }
+    }
 }
 
 impl ControlApiAdminAuditEmitter {
@@ -434,8 +545,16 @@ mod tests {
             mtls_san: vec!["spiffe://alice".to_string()],
         };
         let event = AdminAuditEvent {
+            schema_version: ADMIN_AUDIT_SCHEMA_VERSION,
+            event_id: "evt-1".to_string(),
             event_type: AdminAuditEventType::RuntimeReload,
             time_unix_ms: 42,
+            request_id: Some("req-7".to_string()),
+            trace_id: Some("4bf92f3577b34da6a3ce929d0e0e4736".to_string()),
+            span_id: Some("00f067aa0ba902b7".to_string()),
+            listener: Some("edge-primary".to_string()),
+            upstream: None,
+            backend: None,
             actor: AdminAuditActor::from_identity(Some(&identity)),
             action: AdminAuditAction::RuntimeReloadAttempt,
             target: AdminAuditTarget {
@@ -450,13 +569,19 @@ mod tests {
             },
             result: AdminAuditResult::Success,
             reason: Some("operator_requested".to_string()),
-            event_id: "evt-1".to_string(),
+            failure_class: None,
             peer_addr: Some("127.0.0.1:9999".to_string()),
             authn: AdminAuditAuthn::from_identity(Some(&identity)),
         };
 
         let value = serde_json::to_value(&event).expect("serialize audit event");
+        assert_eq!(value["schema_version"], "v1");
+        assert_eq!(value["event_id"], "evt-1");
         assert_eq!(value["event_type"], "runtime_reload");
+        assert_eq!(value["request_id"], "req-7");
+        assert_eq!(value["trace_id"], "4bf92f3577b34da6a3ce929d0e0e4736");
+        assert_eq!(value["span_id"], "00f067aa0ba902b7");
+        assert_eq!(value["listener"], "edge-primary");
         assert_eq!(value["action"], "runtime_reload.attempt");
         assert_eq!(value["result"], "success");
         assert_eq!(value["actor"]["id"], "alice");
@@ -464,5 +589,36 @@ mod tests {
         assert_eq!(value["authn"]["mechanisms"][0], "bearer_token");
         assert_eq!(value["generation"]["active_generation"], 7);
         assert_eq!(value["generation"]["candidate_generation"], 8);
+        assert!(value.get("failure_class").is_none());
+        assert!(value.get("upstream").is_none());
+        assert!(value.get("backend").is_none());
+    }
+
+    #[test]
+    fn admin_audit_failure_class_serializes_low_cardinality_category() {
+        assert_eq!(
+            QUICListener::control_api_audit_failure_class(
+                AdminAuditEventType::RuntimeValidate,
+                AdminAuditResult::Failed,
+                Some("invalid_request_body"),
+            ),
+            Some(AdminAuditFailureClass::RequestValidation)
+        );
+        assert_eq!(
+            QUICListener::control_api_audit_failure_class(
+                AdminAuditEventType::Auth,
+                AdminAuditResult::Denied,
+                Some("invalid_bearer_token"),
+            ),
+            Some(AdminAuditFailureClass::Authentication)
+        );
+        assert_eq!(
+            QUICListener::control_api_audit_failure_class(
+                AdminAuditEventType::RuntimeRestart,
+                AdminAuditResult::Failed,
+                Some("watchdog_disabled"),
+            ),
+            Some(AdminAuditFailureClass::Watchdog)
+        );
     }
 }

--- a/crates/edge/src/quic_listener/control_api/audit.rs
+++ b/crates/edge/src/quic_listener/control_api/audit.rs
@@ -575,23 +575,42 @@ mod tests {
         };
 
         let value = serde_json::to_value(&event).expect("serialize audit event");
-        assert_eq!(value["schema_version"], "v1");
-        assert_eq!(value["event_id"], "evt-1");
-        assert_eq!(value["event_type"], "runtime_reload");
-        assert_eq!(value["request_id"], "req-7");
-        assert_eq!(value["trace_id"], "4bf92f3577b34da6a3ce929d0e0e4736");
-        assert_eq!(value["span_id"], "00f067aa0ba902b7");
-        assert_eq!(value["listener"], "edge-primary");
-        assert_eq!(value["action"], "runtime_reload.attempt");
-        assert_eq!(value["result"], "success");
-        assert_eq!(value["actor"]["id"], "alice");
-        assert_eq!(value["actor"]["roles"][0], "operator");
-        assert_eq!(value["authn"]["mechanisms"][0], "bearer_token");
-        assert_eq!(value["generation"]["active_generation"], 7);
-        assert_eq!(value["generation"]["candidate_generation"], 8);
-        assert!(value.get("failure_class").is_none());
-        assert!(value.get("upstream").is_none());
-        assert!(value.get("backend").is_none());
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "schema_version": "v1",
+                "event_id": "evt-1",
+                "event_type": "runtime_reload",
+                "time_unix_ms": 42,
+                "request_id": "req-7",
+                "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+                "span_id": "00f067aa0ba902b7",
+                "listener": "edge-primary",
+                "actor": {
+                    "id": "alice",
+                    "roles": ["operator"],
+                    "authn_mechanisms": ["bearer_token"],
+                    "mtls_subject": "CN=alice"
+                },
+                "action": "runtime_reload.attempt",
+                "target": {
+                    "route": "/admin/runtime/reload",
+                    "resource": "control_api",
+                    "config_path": "/etc/spooky/config.yaml"
+                },
+                "generation": {
+                    "active_generation": 7,
+                    "candidate_generation": 8
+                },
+                "result": "success",
+                "reason": "operator_requested",
+                "peer_addr": "127.0.0.1:9999",
+                "authn": {
+                    "mechanisms": ["bearer_token"],
+                    "mtls_subject": "CN=alice"
+                }
+            })
+        );
     }
 
     #[test]

--- a/crates/edge/src/quic_listener/control_api/audit.rs
+++ b/crates/edge/src/quic_listener/control_api/audit.rs
@@ -15,7 +15,7 @@ use super::{
 };
 use crate::REQUEST_ID_COUNTER;
 
-const ADMIN_AUDIT_SCHEMA_VERSION: &str = "v1";
+pub(super) const ADMIN_AUDIT_SCHEMA_VERSION: &str = "v1";
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub(in crate::quic_listener) struct ControlApiAdminAuditEmitter {

--- a/crates/edge/src/quic_listener/control_api/render.rs
+++ b/crates/edge/src/quic_listener/control_api/render.rs
@@ -8,12 +8,16 @@ use spooky_lb::health::HealthFailureReason;
 
 use super::{state::ControlApiState, *};
 use crate::{
+    quic_listener::control_api::audit::ADMIN_AUDIT_SCHEMA_VERSION,
     resilience::quota::{
         QuotaBackendErrorSnapshot, QuotaBackendStatusSnapshot, QuotaPolicyIntrospectionSnapshot,
         QuotaSelectorIntrospectionSnapshot, QuotaWindowIntrospectionSnapshot,
     },
     runtime::{
-        activation::GenerationHistoryEntry,
+        activation::{
+            GenerationChangeEvent, GenerationEventKind, GenerationHistoryEntry,
+            GenerationOperation, GenerationStatus,
+        },
         backend::state::{
             BackendHealthState, BackendLifecycleInventorySnapshot, BackendMembershipState,
             BackendPoolPlacementSnapshot,
@@ -21,6 +25,9 @@ use crate::{
         bundle::RuntimeGenerationRecord,
     },
 };
+
+const OBSERVABILITY_CONTRACT_VERSION: &str = "v1";
+const RECENT_ADMIN_ACTION_LIMIT: usize = 5;
 
 /// Map a backend health-failure reason to the canonical control-plane token.
 ///
@@ -66,6 +73,7 @@ struct ControlApiRuntimePayload {
     watchdog: ControlApiRuntimeWatchdogPayload,
     adaptive_admission: ControlApiAdaptiveAdmissionPayload,
     quota: ControlApiQuotaPayload,
+    observability: ControlApiObservabilityPayload,
     auth: ControlApiAuthPayload,
     jwks: ControlApiJwksPayload,
     backends: ControlApiBackendInventoryPayload,
@@ -155,6 +163,77 @@ struct ControlApiQuotaSelectorPayload {
 struct ControlApiQuotaWindowPayload {
     requests: u64,
     window_secs: u64,
+}
+
+#[derive(Serialize)]
+struct ControlApiObservabilityPayload {
+    contract_version: &'static str,
+    audit_schema_version: &'static str,
+    current_generation: Option<u64>,
+    documentation: ControlApiObservabilityDocumentationPayload,
+    dashboard_packages: Vec<ControlApiObservabilityDashboardPayload>,
+    backend_health_summary: ControlApiBackendHealthSummaryPayload,
+    quota_backend_health_summary: ControlApiQuotaBackendHealthSummaryPayload,
+    recent_admin_actions: Vec<ControlApiRecentAdminActionPayload>,
+}
+
+#[derive(Serialize)]
+struct ControlApiObservabilityDocumentationPayload {
+    observability_contract: &'static str,
+    control_plane_operations: &'static str,
+    metrics_and_alerts_operations: &'static str,
+    distributed_quota_operations: &'static str,
+}
+
+#[derive(Serialize)]
+struct ControlApiObservabilityDashboardPayload {
+    dashboard_id: &'static str,
+    definition_path: &'static str,
+    focus: &'static str,
+}
+
+#[derive(Serialize)]
+struct ControlApiBackendHealthSummaryPayload {
+    availability: &'static str,
+    placed_total: usize,
+    healthy: usize,
+    unhealthy: usize,
+    unknown: usize,
+    active_membership: usize,
+    suppressed_membership: usize,
+    removed_membership: usize,
+}
+
+#[derive(Serialize)]
+struct ControlApiQuotaBackendHealthSummaryPayload {
+    enabled: bool,
+    active_backend: String,
+    availability: String,
+    degraded: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    health_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_observed_at_unix_ms: Option<u64>,
+    recent_error_count: usize,
+}
+
+#[derive(Serialize)]
+struct ControlApiRecentAdminActionPayload {
+    kind: GenerationEventKind,
+    operation: GenerationOperation,
+    generation: u64,
+    status: GenerationStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    config_version: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    requested_by: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    trigger_source: Option<String>,
+    requested_at_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    completed_at_ms: Option<u64>,
+    event_emitted_at_ms: u64,
+    summary: String,
 }
 
 #[derive(Serialize)]
@@ -314,6 +393,7 @@ struct ControlApiRuntimeGenerationPayload {
 #[derive(Serialize)]
 struct ControlApiRuntimeHistoryPayload {
     active_generation: u64,
+    observability: ControlApiObservabilityPayload,
     retained_generations: Vec<ControlApiRetainedGenerationPayload>,
     entries: Vec<GenerationHistoryEntry>,
 }
@@ -321,6 +401,7 @@ struct ControlApiRuntimeHistoryPayload {
 #[derive(Serialize)]
 struct ControlApiRuntimeHistoryGenerationPayload {
     generation: u64,
+    observability: ControlApiObservabilityPayload,
     retained_generation: ControlApiRetainedGenerationPayload,
     entries: Vec<GenerationHistoryEntry>,
 }
@@ -404,11 +485,25 @@ impl QUICListener {
         let Some(runtime_bundle_handle) = runtime_state.runtime_bundle_handle().cloned() else {
             return Self::control_api_not_found_response();
         };
+        let backend_inventory = runtime_state.snapshot_backend_inventory();
+        let backend_summary = backend_inventory.summary();
+        let quota_backend_status = runtime_state.resilience().quota.backend_status_snapshot(
+            runtime_state
+                .resilience()
+                .quota_backend_initialization_error
+                .as_ref(),
+        );
 
         Self::json_response(
             StatusCode::OK,
             ControlApiRuntimeHistoryPayload {
                 active_generation: runtime_bundle_handle.current_generation(),
+                observability: ControlApiObservabilityPayload::from_runtime_state(
+                    &runtime_state,
+                    &backend_inventory,
+                    &backend_summary,
+                    &quota_backend_status,
+                ),
                 retained_generations: runtime_bundle_handle
                     .generation_history()
                     .into_iter()
@@ -427,6 +522,14 @@ impl QUICListener {
         let Some(runtime_bundle_handle) = runtime_state.runtime_bundle_handle().cloned() else {
             return Self::control_api_not_found_response();
         };
+        let backend_inventory = runtime_state.snapshot_backend_inventory();
+        let backend_summary = backend_inventory.summary();
+        let quota_backend_status = runtime_state.resilience().quota.backend_status_snapshot(
+            runtime_state
+                .resilience()
+                .quota_backend_initialization_error
+                .as_ref(),
+        );
 
         let entries = runtime_bundle_handle
             .generation_change_history()
@@ -446,6 +549,12 @@ impl QUICListener {
             StatusCode::OK,
             ControlApiRuntimeHistoryGenerationPayload {
                 generation,
+                observability: ControlApiObservabilityPayload::from_runtime_state(
+                    &runtime_state,
+                    &backend_inventory,
+                    &backend_summary,
+                    &quota_backend_status,
+                ),
                 retained_generation: ControlApiRetainedGenerationPayload::from_record(record),
                 entries,
             },
@@ -475,6 +584,9 @@ impl ControlApiRuntimePayload {
         let listener_tls_store = state.listener_tls_store();
         let backend_inventory = state.snapshot_backend_inventory();
         let backend_summary = backend_inventory.summary();
+        let quota_backend_status = resilience
+            .quota
+            .backend_status_snapshot(resilience.quota_backend_initialization_error.as_ref());
         let jwks_sources = crate::quic_listener::admission::snapshot_runtime_jwks_sources(
             runtime.runtime_config(),
         );
@@ -520,9 +632,15 @@ impl ControlApiRuntimePayload {
                 current_limit: resilience.adaptive_admission.current_limit(),
                 inflight_percent: resilience.adaptive_admission.inflight_percent(),
             },
-            quota: ControlApiQuotaPayload::from_runtime(
+            quota: ControlApiQuotaPayload::from_snapshot(
                 resilience.quota.as_ref(),
-                resilience.quota_backend_initialization_error.as_ref(),
+                quota_backend_status.clone(),
+            ),
+            observability: ControlApiObservabilityPayload::from_runtime_state(
+                &state,
+                &backend_inventory,
+                &backend_summary,
+                &quota_backend_status,
             ),
             auth: ControlApiAuthPayload {
                 providers: auth_providers,
@@ -619,11 +737,10 @@ impl ControlApiRuntimePayload {
 }
 
 impl ControlApiQuotaPayload {
-    fn from_runtime(
+    fn from_snapshot(
         runtime: &crate::resilience::quota::QuotaRuntime,
-        initialization_error: Option<&crate::resilience::quota::QuotaCounterBackendError>,
+        backend_status: QuotaBackendStatusSnapshot,
     ) -> Self {
-        let backend_status = runtime.backend_status_snapshot(initialization_error);
         Self {
             enabled: runtime.enabled,
             enforcement: runtime.enforcement.slug(),
@@ -635,6 +752,81 @@ impl ControlApiQuotaPayload {
                 .into_iter()
                 .map(ControlApiQuotaPolicyPayload::from_snapshot)
                 .collect(),
+        }
+    }
+}
+
+impl ControlApiObservabilityPayload {
+    fn from_runtime_state(
+        state: &super::context::ControlApiServiceState,
+        backend_inventory: &BackendLifecycleInventorySnapshot,
+        backend_summary: &crate::runtime::backend::state::BackendLifecycleInventorySummary,
+        quota_backend_status: &QuotaBackendStatusSnapshot,
+    ) -> Self {
+        Self {
+            contract_version: OBSERVABILITY_CONTRACT_VERSION,
+            audit_schema_version: ADMIN_AUDIT_SCHEMA_VERSION,
+            current_generation: state
+                .generation
+                .as_ref()
+                .map(|generation| generation.generation()),
+            documentation: ControlApiObservabilityDocumentationPayload {
+                observability_contract: "docs/architecture/observability-contract.md",
+                control_plane_operations: "docs/operations/control-plane.md",
+                metrics_and_alerts_operations: "docs/operations/metrics-and-alerts.md",
+                distributed_quota_operations: "docs/operations/distributed-quota.md",
+            },
+            dashboard_packages: vec![
+                ControlApiObservabilityDashboardPayload {
+                    dashboard_id: "edge_traffic",
+                    definition_path: "deploy/observability/grafana/edge-traffic.json",
+                    focus: "edge traffic, status mix, and latency",
+                },
+                ControlApiObservabilityDashboardPayload {
+                    dashboard_id: "admission_overload",
+                    definition_path: "deploy/observability/grafana/admission-overload.json",
+                    focus: "admission, overload, quota, and auth outcomes",
+                },
+                ControlApiObservabilityDashboardPayload {
+                    dashboard_id: "backend_health",
+                    definition_path: "deploy/observability/grafana/backend-health.json",
+                    focus: "backend health, dns refresh, and client rotations",
+                },
+                ControlApiObservabilityDashboardPayload {
+                    dashboard_id: "retries_hedges",
+                    definition_path: "deploy/observability/grafana/retries-hedges.json",
+                    focus: "retry amplification and hedge effectiveness",
+                },
+                ControlApiObservabilityDashboardPayload {
+                    dashboard_id: "tls_certificates",
+                    definition_path: "deploy/observability/grafana/tls-certificates.json",
+                    focus: "tls handshake failures and certificate expiry",
+                },
+                ControlApiObservabilityDashboardPayload {
+                    dashboard_id: "control_plane",
+                    definition_path: "deploy/observability/grafana/control-plane.json",
+                    focus: "runtime activity, watchdog state, and control-plane health",
+                },
+            ],
+            backend_health_summary: ControlApiBackendHealthSummaryPayload::from_inventory(
+                backend_inventory,
+                *backend_summary,
+            ),
+            quota_backend_health_summary: ControlApiQuotaBackendHealthSummaryPayload::from_snapshot(
+                state.resilience().quota.enabled,
+                quota_backend_status,
+            ),
+            recent_admin_actions: state
+                .runtime_bundle_handle()
+                .map(|handle| {
+                    handle
+                        .generation_change_events()
+                        .into_iter()
+                        .take(RECENT_ADMIN_ACTION_LIMIT)
+                        .map(ControlApiRecentAdminActionPayload::from_event)
+                        .collect()
+                })
+                .unwrap_or_default(),
         }
     }
 }
@@ -651,6 +843,84 @@ impl ControlApiQuotaBackendStatusPayload {
                 .into_iter()
                 .map(ControlApiQuotaBackendErrorPayload::from_snapshot)
                 .collect(),
+        }
+    }
+}
+
+impl ControlApiBackendHealthSummaryPayload {
+    fn from_inventory(
+        inventory: &BackendLifecycleInventorySnapshot,
+        summary: crate::runtime::backend::state::BackendLifecycleInventorySummary,
+    ) -> Self {
+        let mut unhealthy = 0;
+        let mut unknown = 0;
+        let mut active_membership = 0;
+        let mut suppressed_membership = 0;
+        let mut removed_membership = 0;
+
+        for backend in &inventory.backends {
+            match backend.health {
+                BackendHealthState::Healthy => {}
+                BackendHealthState::Unhealthy { .. } => unhealthy += 1,
+                BackendHealthState::Unknown => unknown += 1,
+            }
+
+            match backend.membership {
+                BackendMembershipState::Active => active_membership += 1,
+                BackendMembershipState::Suppressed => suppressed_membership += 1,
+                BackendMembershipState::Removed => removed_membership += 1,
+            }
+        }
+
+        let availability = if summary.total_backends == 0 {
+            "empty"
+        } else if unhealthy == 0 && unknown == 0 {
+            "healthy"
+        } else {
+            "degraded"
+        };
+
+        Self {
+            availability,
+            placed_total: summary.total_backends,
+            healthy: summary.healthy_backends,
+            unhealthy,
+            unknown,
+            active_membership,
+            suppressed_membership,
+            removed_membership,
+        }
+    }
+}
+
+impl ControlApiQuotaBackendHealthSummaryPayload {
+    fn from_snapshot(enabled: bool, snapshot: &QuotaBackendStatusSnapshot) -> Self {
+        Self {
+            enabled,
+            active_backend: snapshot.backend_mode.clone(),
+            availability: snapshot.availability.clone(),
+            degraded: snapshot.degraded,
+            health_reason: snapshot.health_reason.clone(),
+            last_observed_at_unix_ms: snapshot.last_observed_at_unix_ms,
+            recent_error_count: snapshot.recent_errors.len(),
+        }
+    }
+}
+
+impl ControlApiRecentAdminActionPayload {
+    fn from_event(event: GenerationChangeEvent) -> Self {
+        Self {
+            kind: event.kind,
+            operation: event.entry.operation,
+            generation: event.entry.generation,
+            status: event.entry.status,
+            config_version: event.entry.config_version,
+            requested_by: event.entry.requested_by,
+            trigger_source: event.entry.trigger_source,
+            requested_at_ms: event.entry.requested_at_ms,
+            completed_at_ms: event.entry.completed_at_ms,
+            event_emitted_at_ms: event.emitted_at_ms,
+            summary: event.entry.summary,
         }
     }
 }

--- a/crates/edge/src/quic_listener/control_api/service.rs
+++ b/crates/edge/src/quic_listener/control_api/service.rs
@@ -259,11 +259,13 @@ impl QUICListener {
             peer,
             tls_stream.get_ref().1.peer_certificates(),
             runtime_state.security.identity_source.as_ref(),
+            runtime_state.primary_listener_label.clone(),
         );
         let io = TokioIo::new(tls_stream);
         let service = service_fn(move |mut req: Request<Incoming>| {
             let state = state.clone();
-            let request_context = request_context.clone();
+            let request_context =
+                Self::augment_control_api_request_context(request_context.clone(), &req);
             async move {
                 req.extensions_mut().insert(request_context);
                 Ok::<_, hyper::Error>(Self::handle_control_api_request(req, &state).await)

--- a/crates/edge/src/quic_listener/control_api/tests.rs
+++ b/crates/edge/src/quic_listener/control_api/tests.rs
@@ -2493,6 +2493,86 @@ async fn control_api_runtime_history_renders_recorded_generation_changes() {
 }
 
 #[tokio::test]
+async fn control_api_runtime_history_observability_view_stays_stable_without_admin_actions() {
+    let dir = tempdir().expect("tempdir");
+    let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
+    let config_path = dir.path().join("runtime.yaml");
+    let mut config = test_config(cert, key);
+    config.observability.control_api.enabled = true;
+    write_config_file(&config_path, &config);
+
+    let bundle = runtime_bundle_from_config(config_path.to_string_lossy().as_ref(), &config);
+    let (state, _) = runtime_bundle_control_api_state(bundle);
+
+    let payload = json_body(QUICListener::render_control_api_runtime_history(&state)).await;
+
+    assert_eq!(
+        payload["observability"],
+        serde_json::json!({
+            "contract_version": "v1",
+            "audit_schema_version": "v1",
+            "current_generation": 0,
+            "documentation": {
+                "observability_contract": "docs/architecture/observability-contract.md",
+                "control_plane_operations": "docs/operations/control-plane.md",
+                "metrics_and_alerts_operations": "docs/operations/metrics-and-alerts.md",
+                "distributed_quota_operations": "docs/operations/distributed-quota.md"
+            },
+            "dashboard_packages": [
+                {
+                    "dashboard_id": "edge_traffic",
+                    "definition_path": "deploy/observability/grafana/edge-traffic.json",
+                    "focus": "edge traffic, status mix, and latency"
+                },
+                {
+                    "dashboard_id": "admission_overload",
+                    "definition_path": "deploy/observability/grafana/admission-overload.json",
+                    "focus": "admission, overload, quota, and auth outcomes"
+                },
+                {
+                    "dashboard_id": "backend_health",
+                    "definition_path": "deploy/observability/grafana/backend-health.json",
+                    "focus": "backend health, dns refresh, and client rotations"
+                },
+                {
+                    "dashboard_id": "retries_hedges",
+                    "definition_path": "deploy/observability/grafana/retries-hedges.json",
+                    "focus": "retry amplification and hedge effectiveness"
+                },
+                {
+                    "dashboard_id": "tls_certificates",
+                    "definition_path": "deploy/observability/grafana/tls-certificates.json",
+                    "focus": "tls handshake failures and certificate expiry"
+                },
+                {
+                    "dashboard_id": "control_plane",
+                    "definition_path": "deploy/observability/grafana/control-plane.json",
+                    "focus": "runtime activity, watchdog state, and control-plane health"
+                }
+            ],
+            "backend_health_summary": {
+                "availability": "healthy",
+                "placed_total": 1,
+                "healthy": 1,
+                "unhealthy": 0,
+                "unknown": 0,
+                "active_membership": 1,
+                "suppressed_membership": 0,
+                "removed_membership": 0
+            },
+            "quota_backend_health_summary": {
+                "enabled": false,
+                "active_backend": "in_memory",
+                "availability": "disabled",
+                "degraded": false,
+                "recent_error_count": 0
+            },
+            "recent_admin_actions": []
+        })
+    );
+}
+
+#[tokio::test]
 async fn control_api_runtime_history_generation_filters_to_requested_generation() {
     let dir = tempdir().expect("tempdir");
     let (cert, key) = write_test_cert_for_name(dir.path(), "server", "api.example.com");
@@ -2723,65 +2803,70 @@ async fn control_api_runtime_snapshot_exposes_quota_policy_and_backend_status() 
     assert_eq!(policies[0]["burst"]["window_secs"], 1);
     assert_eq!(policies[0]["sustained"]["requests"], 500);
     assert_eq!(policies[0]["sustained"]["window_secs"], 60);
-    assert_eq!(payload["observability"]["contract_version"], "v1");
-    assert_eq!(payload["observability"]["audit_schema_version"], "v1");
-    assert_eq!(payload["observability"]["current_generation"], 0);
     assert_eq!(
-        payload["observability"]["documentation"]["observability_contract"],
-        "docs/architecture/observability-contract.md"
-    );
-    assert_eq!(
-        payload["observability"]["documentation"]["control_plane_operations"],
-        "docs/operations/control-plane.md"
-    );
-    assert_eq!(
-        payload["observability"]["backend_health_summary"]["availability"],
-        "healthy"
-    );
-    assert_eq!(
-        payload["observability"]["backend_health_summary"]["placed_total"],
-        1
-    );
-    assert_eq!(
-        payload["observability"]["backend_health_summary"]["healthy"],
-        1
-    );
-    assert_eq!(
-        payload["observability"]["backend_health_summary"]["active_membership"],
-        1
-    );
-    assert_eq!(
-        payload["observability"]["quota_backend_health_summary"]["enabled"],
-        true
-    );
-    assert_eq!(
-        payload["observability"]["quota_backend_health_summary"]["active_backend"],
-        "redis"
-    );
-    assert_eq!(
-        payload["observability"]["quota_backend_health_summary"]["availability"],
-        "degraded"
-    );
-    assert_eq!(
-        payload["observability"]["quota_backend_health_summary"]["recent_error_count"],
-        1
-    );
-    assert_eq!(
-        payload["observability"]["recent_admin_actions"]
-            .as_array()
-            .map(Vec::len),
-        Some(0)
-    );
-    assert!(
-        payload["observability"]["dashboard_packages"]
-            .as_array()
-            .expect("dashboard package refs")
-            .iter()
-            .any(|entry| {
-                entry["dashboard_id"] == "control_plane"
-                    && entry["definition_path"] == "deploy/observability/grafana/control-plane.json"
-            }),
-        "runtime snapshot should link observability packages by stable definition path"
+        payload["observability"],
+        serde_json::json!({
+            "contract_version": "v1",
+            "audit_schema_version": "v1",
+            "current_generation": 0,
+            "documentation": {
+                "observability_contract": "docs/architecture/observability-contract.md",
+                "control_plane_operations": "docs/operations/control-plane.md",
+                "metrics_and_alerts_operations": "docs/operations/metrics-and-alerts.md",
+                "distributed_quota_operations": "docs/operations/distributed-quota.md"
+            },
+            "dashboard_packages": [
+                {
+                    "dashboard_id": "edge_traffic",
+                    "definition_path": "deploy/observability/grafana/edge-traffic.json",
+                    "focus": "edge traffic, status mix, and latency"
+                },
+                {
+                    "dashboard_id": "admission_overload",
+                    "definition_path": "deploy/observability/grafana/admission-overload.json",
+                    "focus": "admission, overload, quota, and auth outcomes"
+                },
+                {
+                    "dashboard_id": "backend_health",
+                    "definition_path": "deploy/observability/grafana/backend-health.json",
+                    "focus": "backend health, dns refresh, and client rotations"
+                },
+                {
+                    "dashboard_id": "retries_hedges",
+                    "definition_path": "deploy/observability/grafana/retries-hedges.json",
+                    "focus": "retry amplification and hedge effectiveness"
+                },
+                {
+                    "dashboard_id": "tls_certificates",
+                    "definition_path": "deploy/observability/grafana/tls-certificates.json",
+                    "focus": "tls handshake failures and certificate expiry"
+                },
+                {
+                    "dashboard_id": "control_plane",
+                    "definition_path": "deploy/observability/grafana/control-plane.json",
+                    "focus": "runtime activity, watchdog state, and control-plane health"
+                }
+            ],
+            "backend_health_summary": {
+                "availability": "healthy",
+                "placed_total": 1,
+                "healthy": 1,
+                "unhealthy": 0,
+                "unknown": 0,
+                "active_membership": 1,
+                "suppressed_membership": 0,
+                "removed_membership": 0
+            },
+            "quota_backend_health_summary": {
+                "enabled": true,
+                "active_backend": "redis",
+                "availability": "degraded",
+                "degraded": true,
+                "health_reason": "error",
+                "recent_error_count": 1
+            },
+            "recent_admin_actions": []
+        })
     );
 }
 

--- a/crates/edge/src/quic_listener/control_api/tests.rs
+++ b/crates/edge/src/quic_listener/control_api/tests.rs
@@ -264,6 +264,10 @@ fn attach_control_api_request_context<B>(
         .insert(super::admin_identity::ControlApiRequestContext {
             peer_addr: peer_addr.parse().expect("peer socket addr"),
             mtls_identity,
+            listener: None,
+            request_id: None,
+            trace_id: None,
+            span_id: None,
         });
 }
 
@@ -1487,6 +1491,7 @@ fn control_api_builds_mtls_identity_from_subject_role_mapping() {
         "127.0.0.1:9443".parse().expect("peer addr"),
         Some(std::slice::from_ref(&cert_der)),
         Some(&identity_source),
+        Some("edge-primary".to_string()),
     );
     let identity =
         QUICListener::build_admin_identity(Some(request_context), None, Some(&identity_source))
@@ -1504,6 +1509,41 @@ fn control_api_builds_mtls_identity_from_subject_role_mapping() {
     assert_eq!(
         identity.peer_addr.expect("peer addr").ip().to_string(),
         "127.0.0.1"
+    );
+}
+
+#[test]
+fn control_api_request_context_captures_operator_correlation_headers() {
+    let request_context = super::admin_identity::ControlApiRequestContext {
+        peer_addr: "127.0.0.1:9443".parse().expect("peer socket addr"),
+        mtls_identity: None,
+        listener: Some("edge-primary".to_string()),
+        request_id: None,
+        trace_id: None,
+        span_id: None,
+    };
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/admin/runtime")
+        .header(header::HeaderName::from_static("x-request-id"), "req-42")
+        .header(
+            header::HeaderName::from_static("traceparent"),
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+        )
+        .body(())
+        .expect("control api request");
+
+    let request_context = QUICListener::augment_control_api_request_context(request_context, &req);
+
+    assert_eq!(request_context.listener.as_deref(), Some("edge-primary"));
+    assert_eq!(request_context.request_id.as_deref(), Some("req-42"));
+    assert_eq!(
+        request_context.trace_id.as_deref(),
+        Some("4bf92f3577b34da6a3ce929d0e0e4736")
+    );
+    assert_eq!(
+        request_context.span_id.as_deref(),
+        Some("00f067aa0ba902b7")
     );
 }
 

--- a/crates/edge/src/quic_listener/control_api/tests.rs
+++ b/crates/edge/src/quic_listener/control_api/tests.rs
@@ -1541,10 +1541,7 @@ fn control_api_request_context_captures_operator_correlation_headers() {
         request_context.trace_id.as_deref(),
         Some("4bf92f3577b34da6a3ce929d0e0e4736")
     );
-    assert_eq!(
-        request_context.span_id.as_deref(),
-        Some("00f067aa0ba902b7")
-    );
+    assert_eq!(request_context.span_id.as_deref(), Some("00f067aa0ba902b7"));
 }
 
 #[tokio::test]
@@ -2438,6 +2435,9 @@ async fn control_api_runtime_history_renders_recorded_generation_changes() {
 
     let payload = json_body(QUICListener::render_control_api_runtime_history(&state)).await;
     assert_eq!(payload["active_generation"], 1);
+    assert_eq!(payload["observability"]["contract_version"], "v1");
+    assert_eq!(payload["observability"]["audit_schema_version"], "v1");
+    assert_eq!(payload["observability"]["current_generation"], 1);
     assert_eq!(
         payload["retained_generations"].as_array().map(Vec::len),
         Some(3)
@@ -2472,6 +2472,24 @@ async fn control_api_runtime_history_renders_recorded_generation_changes() {
     assert_eq!(payload["retained_generations"][2]["has_bundle"], true);
     assert_eq!(payload["entries"].as_array().map(Vec::len), Some(1));
     assert_eq!(payload["entries"][0]["operation"], "activate");
+    assert_eq!(
+        payload["observability"]["recent_admin_actions"]
+            .as_array()
+            .map(Vec::len),
+        Some(1)
+    );
+    assert_eq!(
+        payload["observability"]["recent_admin_actions"][0]["kind"],
+        "activation_succeeded"
+    );
+    assert_eq!(
+        payload["observability"]["recent_admin_actions"][0]["operation"],
+        "activate"
+    );
+    assert_eq!(
+        payload["observability"]["recent_admin_actions"][0]["requested_by"],
+        "test"
+    );
 }
 
 #[tokio::test]
@@ -2705,6 +2723,66 @@ async fn control_api_runtime_snapshot_exposes_quota_policy_and_backend_status() 
     assert_eq!(policies[0]["burst"]["window_secs"], 1);
     assert_eq!(policies[0]["sustained"]["requests"], 500);
     assert_eq!(policies[0]["sustained"]["window_secs"], 60);
+    assert_eq!(payload["observability"]["contract_version"], "v1");
+    assert_eq!(payload["observability"]["audit_schema_version"], "v1");
+    assert_eq!(payload["observability"]["current_generation"], 0);
+    assert_eq!(
+        payload["observability"]["documentation"]["observability_contract"],
+        "docs/architecture/observability-contract.md"
+    );
+    assert_eq!(
+        payload["observability"]["documentation"]["control_plane_operations"],
+        "docs/operations/control-plane.md"
+    );
+    assert_eq!(
+        payload["observability"]["backend_health_summary"]["availability"],
+        "healthy"
+    );
+    assert_eq!(
+        payload["observability"]["backend_health_summary"]["placed_total"],
+        1
+    );
+    assert_eq!(
+        payload["observability"]["backend_health_summary"]["healthy"],
+        1
+    );
+    assert_eq!(
+        payload["observability"]["backend_health_summary"]["active_membership"],
+        1
+    );
+    assert_eq!(
+        payload["observability"]["quota_backend_health_summary"]["enabled"],
+        true
+    );
+    assert_eq!(
+        payload["observability"]["quota_backend_health_summary"]["active_backend"],
+        "redis"
+    );
+    assert_eq!(
+        payload["observability"]["quota_backend_health_summary"]["availability"],
+        "degraded"
+    );
+    assert_eq!(
+        payload["observability"]["quota_backend_health_summary"]["recent_error_count"],
+        1
+    );
+    assert_eq!(
+        payload["observability"]["recent_admin_actions"]
+            .as_array()
+            .map(Vec::len),
+        Some(0)
+    );
+    assert!(
+        payload["observability"]["dashboard_packages"]
+            .as_array()
+            .expect("dashboard package refs")
+            .iter()
+            .any(|entry| {
+                entry["dashboard_id"] == "control_plane"
+                    && entry["definition_path"] == "deploy/observability/grafana/control-plane.json"
+            }),
+        "runtime snapshot should link observability packages by stable definition path"
+    );
 }
 
 #[tokio::test]

--- a/crates/edge/tests/regression/main.rs
+++ b/crates/edge/tests/regression/main.rs
@@ -11,3 +11,4 @@
 
 mod hash;
 mod metrics;
+mod observability_bundle;

--- a/crates/edge/tests/regression/observability_bundle.rs
+++ b/crates/edge/tests/regression/observability_bundle.rs
@@ -1,0 +1,167 @@
+//! Regression contract for packaged observability artifacts.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use serde_json::Value as JsonValue;
+use serde_yaml::Value as YamlValue;
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("workspace root")
+}
+
+fn observability_root() -> PathBuf {
+    repo_root().join("deploy/observability")
+}
+
+fn grafana_dashboard_paths() -> Vec<PathBuf> {
+    let mut paths = fs::read_dir(observability_root().join("grafana"))
+        .expect("grafana directory")
+        .map(|entry| entry.expect("dashboard dir entry").path())
+        .filter(|path| path.extension().and_then(|value| value.to_str()) == Some("json"))
+        .collect::<Vec<_>>();
+    paths.sort();
+    paths
+}
+
+fn flatten_panels<'a>(panels: &'a [JsonValue], output: &mut Vec<&'a JsonValue>) {
+    for panel in panels {
+        output.push(panel);
+        if let Some(children) = panel.get("panels").and_then(JsonValue::as_array) {
+            flatten_panels(children, output);
+        }
+    }
+}
+
+#[test]
+fn grafana_dashboards_parse_and_expose_required_contract_fields() {
+    let dashboards = grafana_dashboard_paths();
+    assert_eq!(
+        dashboards.len(),
+        6,
+        "expected the packaged observability bundle to ship six Grafana dashboards"
+    );
+
+    for dashboard in dashboards {
+        let source = fs::read_to_string(&dashboard).expect("read dashboard");
+        let value: JsonValue =
+            serde_json::from_str(&source).unwrap_or_else(|err| panic!("{dashboard:?}: {err}"));
+
+        assert!(
+            value.get("uid").and_then(JsonValue::as_str).is_some(),
+            "{dashboard:?} must declare a stable uid"
+        );
+        assert!(
+            value.get("title").and_then(JsonValue::as_str).is_some(),
+            "{dashboard:?} must declare a human title"
+        );
+        assert!(
+            value.get("schemaVersion").and_then(JsonValue::as_u64).is_some(),
+            "{dashboard:?} must declare a Grafana schemaVersion"
+        );
+        assert!(
+            value.get("version").and_then(JsonValue::as_u64).is_some(),
+            "{dashboard:?} must declare an artifact version"
+        );
+
+        let panels = value["panels"]
+            .as_array()
+            .unwrap_or_else(|| panic!("{dashboard:?} must contain a top-level panels array"));
+        assert!(
+            !panels.is_empty(),
+            "{dashboard:?} must contain at least one panel"
+        );
+        assert!(
+            value["annotations"]["list"].as_array().is_some(),
+            "{dashboard:?} must declare annotation configuration"
+        );
+        let templating = value["templating"]["list"]
+            .as_array()
+            .unwrap_or_else(|| panic!("{dashboard:?} must declare dashboard variables"));
+        assert!(
+            templating.iter().any(|entry| {
+                entry["name"].as_str() == Some("datasource")
+                    && entry["type"].as_str() == Some("datasource")
+            }),
+            "{dashboard:?} must include a datasource variable"
+        );
+
+        let mut flattened = Vec::new();
+        flatten_panels(panels, &mut flattened);
+        for panel in flattened {
+            assert!(
+                panel.get("id").and_then(JsonValue::as_u64).is_some(),
+                "{dashboard:?} contains a panel without an id"
+            );
+            assert!(
+                panel.get("type").and_then(JsonValue::as_str).is_some(),
+                "{dashboard:?} contains a panel without a type"
+            );
+            if let Some(targets) = panel.get("targets").and_then(JsonValue::as_array) {
+                for target in targets {
+                    assert!(
+                        target.get("refId").and_then(JsonValue::as_str).is_some(),
+                        "{dashboard:?} contains a query target without a refId"
+                    );
+                    if let Some(expr) = target.get("expr").and_then(JsonValue::as_str) {
+                        assert!(
+                            !expr.trim().is_empty(),
+                            "{dashboard:?} contains an empty PromQL expression"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn prometheus_rule_files_parse_and_expose_required_contract_fields() {
+    for relative in [
+        "prometheus/recording-rules.yaml",
+        "prometheus/alerts.yaml",
+    ] {
+        let path = observability_root().join(relative);
+        let source = fs::read_to_string(&path).expect("read Prometheus rules file");
+        let value: YamlValue =
+            serde_yaml::from_str(&source).unwrap_or_else(|err| panic!("{path:?}: {err}"));
+
+        let groups = value["groups"]
+            .as_sequence()
+            .unwrap_or_else(|| panic!("{path:?} must contain a groups sequence"));
+        assert!(
+            !groups.is_empty(),
+            "{path:?} must contain at least one rule group"
+        );
+
+        for group in groups {
+            assert!(
+                group["name"].as_str().is_some(),
+                "{path:?} contains a rule group without a name"
+            );
+            let rules = group["rules"]
+                .as_sequence()
+                .unwrap_or_else(|| panic!("{path:?} contains a group without rules"));
+            assert!(
+                !rules.is_empty(),
+                "{path:?} contains an empty rule group"
+            );
+
+            for rule in rules {
+                assert!(
+                    rule["expr"].as_str().is_some(),
+                    "{path:?} contains a rule without an expr"
+                );
+                assert!(
+                    rule["record"].as_str().is_some() || rule["alert"].as_str().is_some(),
+                    "{path:?} contains a rule without a record or alert name"
+                );
+            }
+        }
+    }
+}

--- a/crates/edge/tests/regression/observability_bundle.rs
+++ b/crates/edge/tests/regression/observability_bundle.rs
@@ -61,7 +61,10 @@ fn grafana_dashboards_parse_and_expose_required_contract_fields() {
             "{dashboard:?} must declare a human title"
         );
         assert!(
-            value.get("schemaVersion").and_then(JsonValue::as_u64).is_some(),
+            value
+                .get("schemaVersion")
+                .and_then(JsonValue::as_u64)
+                .is_some(),
             "{dashboard:?} must declare a Grafana schemaVersion"
         );
         assert!(
@@ -122,10 +125,7 @@ fn grafana_dashboards_parse_and_expose_required_contract_fields() {
 
 #[test]
 fn prometheus_rule_files_parse_and_expose_required_contract_fields() {
-    for relative in [
-        "prometheus/recording-rules.yaml",
-        "prometheus/alerts.yaml",
-    ] {
+    for relative in ["prometheus/recording-rules.yaml", "prometheus/alerts.yaml"] {
         let path = observability_root().join(relative);
         let source = fs::read_to_string(&path).expect("read Prometheus rules file");
         let value: YamlValue =
@@ -147,10 +147,7 @@ fn prometheus_rule_files_parse_and_expose_required_contract_fields() {
             let rules = group["rules"]
                 .as_sequence()
                 .unwrap_or_else(|| panic!("{path:?} contains a group without rules"));
-            assert!(
-                !rules.is_empty(),
-                "{path:?} contains an empty rule group"
-            );
+            assert!(!rules.is_empty(), "{path:?} contains an empty rule group");
 
             for rule in rules {
                 assert!(

--- a/deploy/observability/grafana/admission-overload.json
+++ b/deploy/observability/grafana/admission-overload.json
@@ -42,6 +42,36 @@
         "textFormat": "Successful runtime rollback observed from control-plane metrics. Use runtime history and admin audit events to identify the exact generation transition.",
         "titleFormat": "Runtime rollback",
         "type": "tags"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "enable": true,
+        "expr": "changes(spooky_brownout_active[1m]) > 0",
+        "hide": false,
+        "iconColor": "rgba(255, 99, 71, 1)",
+        "name": "Brownout State Changes",
+        "step": "60s",
+        "textFormat": "Brownout state changed. Correlate with overload shed reason, inflight pressure, and adaptive admission behavior.",
+        "titleFormat": "Brownout state change",
+        "type": "tags"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "enable": true,
+        "expr": "sum(increase(spooky_quota_backend_health_total{reason!=\"available\"}[1m])) > 0",
+        "hide": false,
+        "iconColor": "rgba(255, 191, 0, 1)",
+        "name": "Quota Backend Degraded",
+        "step": "60s",
+        "textFormat": "Quota backend degraded activity observed. Correlate with backend mode, policy outcomes, and recent admin actions.",
+        "titleFormat": "Quota backend degraded",
+        "type": "tags"
       }
     ]
   },
@@ -582,7 +612,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (backend_mode, reason) (spooky:quota_backend_health_events_by_mode_reason:rate5m)",
+          "expr": "sum by (backend_mode, reason) (spooky:quota_backend_health_events_by_mode_reason:rate5m{backend_mode=~\"${quota_backend_mode:regex}\"})",
           "legendFormat": "{{backend_mode}} :: {{reason}}",
           "refId": "A"
         }
@@ -646,7 +676,7 @@
       },
       "targets": [
         {
-          "expr": "topk(12, sum by (policy, reason) (spooky:quota_denials_by_policy_reason_backend_mode:rate5m))",
+          "expr": "topk(12, sum by (policy, reason) (spooky:quota_denials_by_policy_reason_backend_mode:rate5m{policy=~\"${quota_policy:regex}\",backend_mode=~\"${quota_backend_mode:regex}\"}))",
           "legendFormat": "{{policy}} :: {{reason}}",
           "refId": "A"
         }
@@ -806,6 +836,211 @@
       ],
       "title": "Auth Contract Detail",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 48
+      },
+      "id": 15,
+      "panels": [],
+      "title": "Operator Drilldown",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Contract rejections are auth denials, scoped rate limits, and quota denials. This excludes overload and backend-saturation decisions.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 2
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 49
+      },
+      "id": 16,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "100 * sum(spooky:contract_reject_ratio:rate5m) or vector(0)",
+          "legendFormat": "contract reject ratio",
+          "refId": "A"
+        }
+      ],
+      "title": "Contract Reject Ratio",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Explicit contract failure composition. Use this before looking at overload charts so contract semantics are not mistaken for capacity failures.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 6,
+        "y": 49
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:auth_denials:rate5m)",
+          "legendFormat": "auth denied",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(spooky:request_rate_limited:rate5m)",
+          "legendFormat": "scoped rate limited",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(spooky:quota_denials:rate5m)",
+          "legendFormat": "quota denied",
+          "refId": "C"
+        }
+      ],
+      "title": "Contract Reject Composition",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Quota outcomes by configured policy. Use this to isolate the policy driving operator-visible quota behavior before diving into deny reasons.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 15,
+        "y": 49
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (policy, decision) (spooky:quota_outcomes_by_policy_decision:rate5m{policy=~\"${quota_policy:regex}\"})",
+          "legendFormat": "{{policy}} :: {{decision}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Quota Outcomes by Policy",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",
@@ -835,6 +1070,70 @@
         "refresh": 1,
         "regex": "",
         "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(spooky_quota_policy_outcomes_total, policy)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Quota Policy",
+        "multi": true,
+        "name": "quota_policy",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(spooky_quota_policy_outcomes_total, policy)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(spooky_quota_backend_health_total, backend_mode)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Quota Backend Mode",
+        "multi": true,
+        "name": "quota_backend_mode",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(spooky_quota_backend_health_total, backend_mode)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
       }
     ]
   },
@@ -846,6 +1145,6 @@
   "timezone": "",
   "title": "Spooky Admission, Overload, Quota, and Auth",
   "uid": "spooky-admission-overload",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/deploy/observability/grafana/admission-overload.json
+++ b/deploy/observability/grafana/admission-overload.json
@@ -1,0 +1,851 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "enable": true,
+        "expr": "sum(increase(spooky_runtime_activation_total{result=\"success\"}[1m])) > 0",
+        "hide": false,
+        "iconColor": "rgba(0, 191, 255, 1)",
+        "name": "Runtime Activations",
+        "step": "60s",
+        "textFormat": "Successful runtime activation observed from control-plane metrics. Correlate admission behavior with active generation, alerts, and admin audit history.",
+        "titleFormat": "Runtime activation",
+        "type": "tags"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "enable": true,
+        "expr": "sum(increase(spooky_runtime_rollback_total{result=\"success\"}[1m])) > 0",
+        "hide": false,
+        "iconColor": "rgba(255, 140, 0, 1)",
+        "name": "Runtime Rollbacks",
+        "step": "60s",
+        "textFormat": "Successful runtime rollback observed from control-plane metrics. Use runtime history and admin audit events to identify the exact generation transition.",
+        "titleFormat": "Runtime rollback",
+        "type": "tags"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Overload and Admission",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Brownout is an overload-control state, not a quota or auth decision.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "Inactive"
+                },
+                "1": {
+                  "text": "Active"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:brownout_active)",
+          "legendFormat": "brownout",
+          "refId": "A"
+        }
+      ],
+      "title": "Brownout State",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Total overload shed rate from the packaged overload recording rule.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 3,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.1
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:overload_shed:rate5m)",
+          "legendFormat": "shed",
+          "refId": "A"
+        }
+      ],
+      "title": "Overload Shed Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Open-circuit rejections are part of overload protection, not auth or quota contract failure.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 3,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:circuit_breaker_rejected:rate5m)",
+          "legendFormat": "circuit rejects",
+          "refId": "A"
+        }
+      ],
+      "title": "Circuit Open Reject Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Scoped request rate limits are shown separately from quota and overload.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 3,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:request_rate_limited:rate5m)",
+          "legendFormat": "scoped limits",
+          "refId": "A"
+        }
+      ],
+      "title": "Scoped Rate Limit Reject Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Canonical overload causes from the packaged recording rule. These are overload decisions only, not quota or auth outcomes.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 18,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "mappings": [],
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (reason) (spooky:overload_shed_by_reason:rate5m)",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Overload Shed by Reason",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Adaptive admission behavior is shown separately from quota and auth: shed decisions plus successful micro-wait admissions by scope.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:overload_shed_by_reason:rate5m{reason=\"adaptive_admission\"})",
+          "legendFormat": "adaptive admission shed",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (scope) (spooky:inflight_wait_admit_by_scope:rate5m)",
+          "legendFormat": "micro-wait {{scope}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Adaptive Admission Behavior",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "id": 8,
+      "panels": [],
+      "title": "Quota Contract",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Quota contract decisions are intentionally separate from overload. Allow, deny, failed-open, and failed-closed are shown without merging into overload buckets.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (decision) (spooky:quota_outcomes_by_decision:rate5m{decision=~\"allowed|denied|failed_open|failed_closed\"})",
+          "legendFormat": "{{decision}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Quota Decisions",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Quota backend health is operational support for the contract and is kept visually separate from overload admission state.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "mappings": [],
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (backend_mode, reason) (spooky:quota_backend_health_events_by_mode_reason:rate5m)",
+          "legendFormat": "{{backend_mode}} :: {{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Quota Backend Health",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Top quota denials by policy and reason. This panel intentionally excludes overload and auth outcomes.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 3,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 11,
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": false,
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "expr": "topk(12, sum by (policy, reason) (spooky:quota_denials_by_policy_reason_backend_mode:rate5m))",
+          "legendFormat": "{{policy}} :: {{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Top Quota Denials by Policy and Reason",
+      "type": "bargauge"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 37
+      },
+      "id": 12,
+      "panels": [],
+      "title": "Auth Contract",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Auth contract outcomes are shown separately from overload and quota. Denied means contract rejection; unavailable means auth dependency failure or timeout.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 38
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:auth_denials:rate5m)",
+          "legendFormat": "auth denied",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(spooky:external_auth_unavailable:rate5m)",
+          "legendFormat": "auth unavailable",
+          "refId": "B"
+        }
+      ],
+      "title": "Auth Denied vs Unavailable",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Detail panel showing where auth contract failures come from: external denials, JWT denials, external timeouts, and external errors.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 38
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:external_auth_denials:rate5m)",
+          "legendFormat": "external auth denied",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(spooky:jwt_auth_denials:rate5m)",
+          "legendFormat": "jwt denied",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(spooky:external_auth_timeout:rate5m)",
+          "legendFormat": "external auth timeout",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(spooky:external_auth_error:rate5m)",
+          "legendFormat": "external auth error",
+          "refId": "D"
+        }
+      ],
+      "title": "Auth Contract Detail",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "spooky",
+    "observability",
+    "admission",
+    "overload",
+    "quota",
+    "auth"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Spooky Admission, Overload, Quota, and Auth",
+  "uid": "spooky-admission-overload",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/observability/grafana/backend-health.json
+++ b/deploy/observability/grafana/backend-health.json
@@ -563,7 +563,7 @@
       },
       "targets": [
         {
-          "expr": "topk(12, sum by (upstream, backend) (spooky:backend_errors_by_upstream_backend:rate5m))",
+          "expr": "topk(12, sum by (upstream, backend) (spooky:backend_errors_by_upstream_backend:rate5m{upstream=~\"${upstream:regex}\",backend=~\"${backend:regex}\"}))",
           "legendFormat": "{{upstream}} / {{backend}}",
           "refId": "A"
         }
@@ -832,12 +832,217 @@
       },
       "targets": [
         {
-          "expr": "topk(12, max by (backend) (time() - spooky_backend_dns_last_refresh_success_seconds))",
+          "expr": "topk(12, max by (backend) ((time() - spooky_backend_dns_last_refresh_success_seconds{backend=~\"${backend:regex}\"})))",
           "legendFormat": "{{backend}}",
           "refId": "A"
         }
       ],
       "title": "Last Successful DNS Refresh Age by Backend",
+      "type": "bargauge"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 47
+      },
+      "id": 15,
+      "panels": [],
+      "title": "Operator Drilldown",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Combined backend timeout and backend error pressure. This is the request-path failure rate, not active health probing.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 48
+      },
+      "id": 16,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:backend_failure_pressure:rate5m) or vector(0)",
+          "legendFormat": "backend failure pressure",
+          "refId": "A"
+        }
+      ],
+      "title": "Backend Failure Pressure",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Observed upstream socket connect attempts by backend. This helps distinguish traffic concentration from passive failure concentration.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 6,
+        "y": 48
+      },
+      "id": 17,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "targets": [
+        {
+          "expr": "topk(12, sum by (backend) (spooky:backend_connect_attempts_by_backend:rate5m{backend=~\"${backend:regex}\"}))",
+          "legendFormat": "{{backend}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Connect Attempts by Backend",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Current resolved address count retained per backend. This is the fastest packaged view into DNS shrinkage, empty answers, or unexpectedly single-homed backends.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "green",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 15,
+        "y": 48
+      },
+      "id": 18,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "targets": [
+        {
+          "expr": "topk(12, max by (backend) (spooky_backend_dns_resolved_addresses{backend=~\"${backend:regex}\"}))",
+          "legendFormat": "{{backend}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Resolved Address Count by Backend",
       "type": "bargauge"
     }
   ],
@@ -868,6 +1073,70 @@
         "refresh": 1,
         "regex": "",
         "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(spooky_upstream_requests_total, upstream)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Upstream",
+        "multi": true,
+        "name": "upstream",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(spooky_upstream_requests_total, upstream)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "/^(?!unrouted$).*/",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(spooky_backend_requests_total, backend)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Backend",
+        "multi": true,
+        "name": "backend",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(spooky_backend_requests_total, backend)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "/^(?!__none__$).*/",
+        "sort": 1,
+        "type": "query"
       }
     ]
   },
@@ -879,6 +1148,6 @@
   "timezone": "",
   "title": "Spooky Backend Health and DNS Lifecycle",
   "uid": "spooky-backend-health",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/deploy/observability/grafana/backend-health.json
+++ b/deploy/observability/grafana/backend-health.json
@@ -1,0 +1,884 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "enable": true,
+        "expr": "sum(increase(spooky_runtime_activation_total{result=\"success\"}[1m])) > 0",
+        "hide": false,
+        "iconColor": "rgba(0, 191, 255, 1)",
+        "name": "Runtime Activations",
+        "step": "60s",
+        "textFormat": "Successful runtime activation observed from control-plane metrics. Correlate backend behavior with generation changes and admin audit history.",
+        "titleFormat": "Runtime activation",
+        "type": "tags"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "enable": true,
+        "expr": "sum(increase(spooky_runtime_rollback_total{result=\"success\"}[1m])) > 0",
+        "hide": false,
+        "iconColor": "rgba(255, 140, 0, 1)",
+        "name": "Runtime Rollbacks",
+        "step": "60s",
+        "textFormat": "Successful runtime rollback observed from control-plane metrics. Use runtime history and admin audit events to identify the exact generation transition.",
+        "titleFormat": "Runtime rollback",
+        "type": "tags"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Backend Health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "5-minute active health-check failure ratio. This is the active probe view, separate from passive request failures.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "100 * sum(spooky:health_check_failure_ratio:rate5m)",
+          "legendFormat": "health check failure ratio",
+          "refId": "A"
+        }
+      ],
+      "title": "Health Check Failure Ratio",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "5-minute total backend timeout rate across the fleet.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.1
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:backend_timeouts:rate5m)",
+          "legendFormat": "timeouts",
+          "refId": "A"
+        }
+      ],
+      "title": "Backend Timeout Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "5-minute total backend error rate across the fleet.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.1
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:backend_errors:rate5m)",
+          "legendFormat": "errors",
+          "refId": "A"
+        }
+      ],
+      "title": "Backend Error Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "5-minute DNS refresh failure ratio across backend resolvers.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "100 * sum(spooky:backend_dns_refresh_failure_ratio:rate5m)",
+          "legendFormat": "dns refresh failure ratio",
+          "refId": "A"
+        }
+      ],
+      "title": "DNS Refresh Failure Ratio",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Active health-check probe outcomes. These are the canonical active backend health signals.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:health_checks_success:rate5m)",
+          "legendFormat": "success",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(spooky:health_checks_failure:rate5m)",
+          "legendFormat": "failure",
+          "refId": "B"
+        }
+      ],
+      "title": "Active Health Check Outcomes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Passive backend failure observations by canonical reason. This complements active checks instead of replacing them.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (reason) (spooky:health_failures_by_reason:rate5m)",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Passive Health Failures by Reason",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Request-path backend timeout and error pressure. These are request failures, not probe failures.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:backend_timeouts:rate5m)",
+          "legendFormat": "timeouts",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(spooky:backend_errors:rate5m)",
+          "legendFormat": "errors",
+          "refId": "B"
+        }
+      ],
+      "title": "Backend Timeout and Error Pressure",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Top upstream/backend pairs currently contributing backend-error outcomes.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 9,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "targets": [
+        {
+          "expr": "topk(12, sum by (upstream, backend) (spooky:backend_errors_by_upstream_backend:rate5m))",
+          "legendFormat": "{{upstream}} / {{backend}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Top Backend Errors by Upstream and Backend",
+      "type": "bargauge"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 10,
+      "panels": [],
+      "title": "DNS Refresh and Rotation",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "DNS refresh outcomes and address-set changes. Address-set changes are the topology churn signal that can trigger client rotation.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:backend_dns_refresh_successes:rate5m)",
+          "legendFormat": "refresh success",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(spooky:backend_dns_refresh_failures:rate5m)",
+          "legendFormat": "refresh failure",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(spooky:backend_dns_address_set_changes:rate5m)",
+          "legendFormat": "address-set changes",
+          "refId": "C"
+        }
+      ],
+      "title": "DNS Refresh Outcomes and Address-Set Changes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Rotation events triggered by DNS topology changes, plus rotation failures that may leave stale pooled state behind.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:backend_client_rotation_events:rate5m)",
+          "legendFormat": "rotation events",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(spooky:backend_client_rotation_failures:rate5m)",
+          "legendFormat": "rotation failures",
+          "refId": "B"
+        }
+      ],
+      "title": "Client Rotations and Failures",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Per-backend resolved address-set size retained after the last successful refresh.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 37
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "topk(12, max by (backend) (spooky_backend_dns_resolved_addresses))",
+          "legendFormat": "{{backend}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Resolved Addresses by Backend",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Age since the last successful DNS refresh. Higher values indicate stale resolver state.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 300
+              },
+              {
+                "color": "red",
+                "value": 900
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 37
+      },
+      "id": 14,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "targets": [
+        {
+          "expr": "topk(12, max by (backend) (time() - spooky_backend_dns_last_refresh_success_seconds))",
+          "legendFormat": "{{backend}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Last Successful DNS Refresh Age by Backend",
+      "type": "bargauge"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "spooky",
+    "observability",
+    "backend",
+    "health",
+    "dns",
+    "resilience"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Spooky Backend Health and DNS Lifecycle",
+  "uid": "spooky-backend-health",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/observability/grafana/control-plane.json
+++ b/deploy/observability/grafana/control-plane.json
@@ -1,0 +1,774 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "enable": true,
+        "expr": "sum(increase(spooky_runtime_activation_total{result=\"success\"}[1m])) > 0",
+        "hide": false,
+        "iconColor": "rgba(0, 191, 255, 1)",
+        "name": "Runtime Activations",
+        "step": "60s",
+        "textFormat": "Successful runtime activation observed from control-plane metrics. Correlate these points with admin audit events and generation changes.",
+        "titleFormat": "Runtime activation",
+        "type": "tags"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "enable": true,
+        "expr": "sum(increase(spooky_runtime_rollback_total{result=\"success\"}[1m])) > 0",
+        "hide": false,
+        "iconColor": "rgba(255, 140, 0, 1)",
+        "name": "Runtime Rollbacks",
+        "step": "60s",
+        "textFormat": "Successful runtime rollback observed from control-plane metrics. Use runtime history and admin audit events to identify the exact generation transition.",
+        "titleFormat": "Runtime rollback",
+        "type": "tags"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Runtime State",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Current active runtime generation identifier.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "max(spooky_runtime_active_generation)",
+          "legendFormat": "active generation",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Runtime Generation",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Current visible runtime history depth.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "max(spooky_runtime_history_depth)",
+          "legendFormat": "history depth",
+          "refId": "A"
+        }
+      ],
+      "title": "Runtime History Depth",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "5-minute aggregate control-plane activity rate from packaged admin-plane counters. These metric events should correlate with emitted audit records, but the audit stream remains the source of truth.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:control_plane_activity_events:rate5m)",
+          "legendFormat": "activity events",
+          "refId": "A"
+        }
+      ],
+      "title": "Audit-Correlated Control-Plane Activity Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "5-minute control-plane error event rate from limiter drops, degraded watchdog windows, and runtime panics.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              },
+              {
+                "color": "red",
+                "value": 0.1
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:control_plane_error_events:rate5m)",
+          "legendFormat": "error events",
+          "refId": "A"
+        }
+      ],
+      "title": "Control-Plane Error Event Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Staged validation and preview activity plus activation and rollback outcomes. This is the operator workflow panel.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:runtime_validation_attempts:rate5m)",
+          "legendFormat": "validation attempts",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(spooky:runtime_preview_attempts:rate5m)",
+          "legendFormat": "preview attempts",
+          "refId": "B"
+        },
+        {
+          "expr": "sum by (result) (spooky:runtime_activation_outcomes_by_result_reason:rate5m)",
+          "legendFormat": "activate {{result}}",
+          "refId": "C"
+        },
+        {
+          "expr": "sum by (result) (spooky:runtime_rollback_outcomes_by_result_reason:rate5m)",
+          "legendFormat": "rollback {{result}}",
+          "refId": "D"
+        }
+      ],
+      "title": "Validation, Preview, Activation, and Rollback Activity",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Runtime activation and rollback outcomes by result and canonical reason. Use this panel when operation volume is low but failures are distinct.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (result, reason) (spooky:runtime_activation_outcomes_by_result_reason:rate5m)",
+          "legendFormat": "activate {{result}} / {{reason}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (result, reason) (spooky:runtime_rollback_outcomes_by_result_reason:rate5m)",
+          "legendFormat": "rollback {{result}} / {{reason}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Runtime Outcomes by Result and Reason",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "id": 8,
+      "panels": [],
+      "title": "Rejections and Health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Control-plane runtime rejections by canonical operator reason.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (reason) (spooky:runtime_rejections_by_reason:rate5m)",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Runtime Rejections by Reason",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Watchdog state and runtime health counters. These are the operator safety-net signals.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:watchdog_degraded_windows:rate5m)",
+          "legendFormat": "degraded windows",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(spooky:watchdog_restart_requests:rate5m)",
+          "legendFormat": "restart requests",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(spooky:watchdog_restart_hooks:rate5m)",
+          "legendFormat": "restart hooks",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(spooky:runtime_panics:rate5m)",
+          "legendFormat": "runtime panics",
+          "refId": "D"
+        }
+      ],
+      "title": "Watchdog State and Runtime Health",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Metric-side control-plane activity series that should correlate with emitted admin audit records. The audit log remains the authoritative event stream.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:runtime_validation_attempts:rate5m)",
+          "legendFormat": "validate",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(spooky:runtime_preview_attempts:rate5m)",
+          "legendFormat": "preview",
+          "refId": "B"
+        },
+        {
+          "expr": "sum without (result, reason) (spooky:runtime_activation_outcomes_by_result_reason:rate5m)",
+          "legendFormat": "activate outcomes",
+          "refId": "C"
+        },
+        {
+          "expr": "sum without (result, reason) (spooky:runtime_rollback_outcomes_by_result_reason:rate5m)",
+          "legendFormat": "rollback outcomes",
+          "refId": "D"
+        },
+        {
+          "expr": "sum(spooky:watchdog_restart_requests:rate5m)",
+          "legendFormat": "restart requests",
+          "refId": "E"
+        }
+      ],
+      "title": "Audit-Correlated Activity Rates",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Control API admission pressure and failure signals.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:control_api_connection_limit_drops:rate5m)",
+          "legendFormat": "connection limit drops",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(spooky:control_plane_error_events:rate5m)",
+          "legendFormat": "error events",
+          "refId": "B"
+        }
+      ],
+      "title": "Control API Pressure and Error Events",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "spooky",
+    "observability",
+    "control-plane",
+    "admin-plane",
+    "runtime"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Spooky Control-Plane Activity",
+  "uid": "spooky-control-plane",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/observability/grafana/control-plane.json
+++ b/deploy/observability/grafana/control-plane.json
@@ -42,6 +42,21 @@
         "textFormat": "Successful runtime rollback observed from control-plane metrics. Use runtime history and admin audit events to identify the exact generation transition.",
         "titleFormat": "Runtime rollback",
         "type": "tags"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "enable": true,
+        "expr": "sum(increase(spooky_watchdog_degraded_windows[1m])) > 0",
+        "hide": false,
+        "iconColor": "rgba(255, 0, 0, 1)",
+        "name": "Watchdog Degraded",
+        "step": "60s",
+        "textFormat": "Watchdog degraded window observed. Correlate with runtime panics, connection-limit drops, and recent admin operations.",
+        "titleFormat": "Watchdog degraded",
+        "type": "tags"
       }
     ]
   },
@@ -730,6 +745,147 @@
       ],
       "title": "Control API Pressure and Error Events",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 37
+      },
+      "id": 13,
+      "panels": [],
+      "title": "Operator Drilldown",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Activation plus rollback activity rate. This is the packaged control-plane change pressure view for rollout-heavy periods.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.02
+              },
+              {
+                "color": "red",
+                "value": 0.2
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 38
+      },
+      "id": 14,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:runtime_change_events:rate5m) or vector(0)",
+          "legendFormat": "runtime change events",
+          "refId": "A"
+        }
+      ],
+      "title": "Runtime Change Event Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Failure-side runtime outcomes only. This tells operators whether deploy churn is benign or whether the control plane is actively struggling to apply changes.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 18,
+        "x": 6,
+        "y": 38
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (result, reason) (spooky:runtime_activation_outcomes_by_result_reason:rate5m{result!=\"success\"})",
+          "legendFormat": "activate {{result}} / {{reason}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (result, reason) (spooky:runtime_rollback_outcomes_by_result_reason:rate5m{result!=\"success\"})",
+          "legendFormat": "rollback {{result}} / {{reason}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Runtime Failure Outcomes",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",
@@ -769,6 +925,6 @@
   "timezone": "",
   "title": "Spooky Control-Plane Activity",
   "uid": "spooky-control-plane",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/deploy/observability/grafana/edge-traffic.json
+++ b/deploy/observability/grafana/edge-traffic.json
@@ -1,0 +1,912 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "enable": true,
+        "expr": "sum(increase(spooky_runtime_activation_total{result=\"success\"}[1m])) > 0",
+        "hide": false,
+        "iconColor": "rgba(0, 191, 255, 1)",
+        "name": "Runtime Activations",
+        "step": "60s",
+        "textFormat": "Successful runtime activation observed from control-plane metrics. Correlate with active generation, alerting, and admin audit history.",
+        "titleFormat": "Runtime activation",
+        "type": "tags"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "enable": true,
+        "expr": "sum(increase(spooky_runtime_rollback_total{result=\"success\"}[1m])) > 0",
+        "hide": false,
+        "iconColor": "rgba(255, 140, 0, 1)",
+        "name": "Runtime Rollbacks",
+        "step": "60s",
+        "textFormat": "Successful runtime rollback observed from control-plane metrics. Use runtime history and admin audit events to identify the exact generation transition.",
+        "titleFormat": "Runtime rollback",
+        "type": "tags"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Cluster-wide 5-minute request rate derived from the packaged edge-traffic recording rule.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:requests:rate5m)",
+          "legendFormat": "request rate",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Success rate from the packaged 30-minute availability denominator and numerator contract.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 99
+              },
+              {
+                "color": "green",
+                "value": 99.9
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "100 * (1 - (sum(spooky:slo_request_server_errors:rate30m) / clamp_min(sum(spooky:slo_requests:rate30m), 0.000001)))",
+          "legendFormat": "success rate",
+          "refId": "A"
+        }
+      ],
+      "title": "Success Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Cluster-wide successful-request p50 latency using the raw histogram, aggregated across instances.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 100
+              },
+              {
+                "color": "red",
+                "value": 250
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(spooky_upstream_request_latency_ms_bucket{outcome=\"success\"}[30m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        }
+      ],
+      "title": "P50 Latency",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Cluster-wide successful-request p95 latency using the raw histogram, aggregated across instances.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 250
+              },
+              {
+                "color": "red",
+                "value": 750
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(spooky_upstream_request_latency_ms_bucket{outcome=\"success\"}[30m])))",
+          "legendFormat": "p95",
+          "refId": "A"
+        }
+      ],
+      "title": "P95 Latency",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Cluster-wide successful-request p99 latency using the raw histogram, aggregated across instances.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 500
+              },
+              {
+                "color": "red",
+                "value": 1000
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(spooky_upstream_request_latency_ms_bucket{outcome=\"success\"}[30m])))",
+          "legendFormat": "p99",
+          "refId": "A"
+        }
+      ],
+      "title": "P99 Latency",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Highest active runtime generation currently reported by the edge fleet.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "max(spooky_runtime_active_generation)",
+          "legendFormat": "active generation",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Runtime Generation",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Cluster-wide 5-minute request volume broken out by upstream using the packaged recording rule.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (upstream) (spooky:requests_by_upstream:rate5m)",
+          "legendFormat": "{{upstream}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Traffic Volume by Upstream",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Cluster-wide success rate and server-error rate derived from the packaged 30-minute SLO contract.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 6,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "100 * (1 - (sum(spooky:slo_request_server_errors:rate30m) / clamp_min(sum(spooky:slo_requests:rate30m), 0.000001)))",
+          "legendFormat": "success rate",
+          "refId": "A"
+        },
+        {
+          "expr": "100 * (sum(spooky:slo_request_server_errors:rate30m) / clamp_min(sum(spooky:slo_requests:rate30m), 0.000001))",
+          "legendFormat": "server error rate",
+          "refId": "B"
+        }
+      ],
+      "title": "Success and Server Error Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Cluster-wide request-rate mix by HTTP status class from the packaged status-class recording rule.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "mappings": [],
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (status_class) (spooky:requests_by_status_class:rate5m)",
+          "legendFormat": "{{status_class}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Status Class Mix",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Cluster-wide request outcome mix aggregated from the packaged upstream-outcome recording rule.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "mappings": [],
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (outcome) (spooky:requests_by_upstream_outcome:rate5m)",
+          "legendFormat": "{{outcome}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Upstream Outcome Mix",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Cluster-wide p50, p95, and p99 successful-request latency. Raw histogram aggregation is used here because percentile math must happen on bucket series, not on already-aggregated percentile gauges.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(spooky_upstream_request_latency_ms_bucket{outcome=\"success\"}[$__rate_interval])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(spooky_upstream_request_latency_ms_bucket{outcome=\"success\"}[$__rate_interval])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(spooky_upstream_request_latency_ms_bucket{outcome=\"success\"}[$__rate_interval])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Latency Percentiles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Top upstreams by 5-minute server-error ratio, aggregated across instances from packaged recording rules.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
+      "id": 12,
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": false,
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "expr": "topk(10, 100 * sum by (upstream) (spooky:request_server_errors_by_upstream:rate5m) / clamp_min(sum by (upstream) (spooky:requests_by_upstream:rate5m), 0.000001))",
+          "legendFormat": "{{upstream}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Top Failing Upstreams",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Top upstream/backend pairs by 5-minute backend-error rate, aggregated across instances from the packaged recording rule.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 3,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.25
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 33
+      },
+      "id": 13,
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": false,
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "expr": "topk(10, sum by (upstream, backend) (spooky:backend_errors_by_upstream_backend:rate5m))",
+          "legendFormat": "{{upstream}} :: {{backend}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Top Failing Backends",
+      "type": "bargauge"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "spooky",
+    "observability",
+    "edge",
+    "traffic",
+    "latency"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Spooky Edge Traffic and Latency",
+  "uid": "spooky-edge-traffic",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/observability/grafana/edge-traffic.json
+++ b/deploy/observability/grafana/edge-traffic.json
@@ -100,7 +100,7 @@
       },
       "targets": [
         {
-          "expr": "sum(spooky:requests:rate5m)",
+          "expr": "sum(spooky:requests_by_upstream:rate5m{upstream=~\"${upstream:regex}\"})",
           "legendFormat": "request rate",
           "refId": "A"
         }
@@ -165,7 +165,7 @@
       },
       "targets": [
         {
-          "expr": "100 * (1 - (sum(spooky:slo_request_server_errors:rate30m) / clamp_min(sum(spooky:slo_requests:rate30m), 0.000001)))",
+          "expr": "100 * (1 - (sum(rate(spooky_upstream_requests_total{status_class=\"5xx\",upstream=~\"${upstream:regex}\"}[30m])) / clamp_min(sum(rate(spooky_upstream_requests_total{upstream=~\"${upstream:regex}\"}[30m])), 0.000001)))",
           "legendFormat": "success rate",
           "refId": "A"
         }
@@ -230,7 +230,7 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.50, sum by (le) (rate(spooky_upstream_request_latency_ms_bucket{outcome=\"success\"}[30m])))",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(spooky_upstream_request_latency_ms_bucket{outcome=\"success\",upstream=~\"${upstream:regex}\"}[30m])))",
           "legendFormat": "p50",
           "refId": "A"
         }
@@ -295,7 +295,7 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(spooky_upstream_request_latency_ms_bucket{outcome=\"success\"}[30m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(spooky_upstream_request_latency_ms_bucket{outcome=\"success\",upstream=~\"${upstream:regex}\"}[30m])))",
           "legendFormat": "p95",
           "refId": "A"
         }
@@ -360,7 +360,7 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(spooky_upstream_request_latency_ms_bucket{outcome=\"success\"}[30m])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(spooky_upstream_request_latency_ms_bucket{outcome=\"success\",upstream=~\"${upstream:regex}\"}[30m])))",
           "legendFormat": "p99",
           "refId": "A"
         }
@@ -477,7 +477,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (upstream) (spooky:requests_by_upstream:rate5m)",
+          "expr": "sum by (upstream) (spooky:requests_by_upstream:rate5m{upstream=~\"${upstream:regex}\"})",
           "legendFormat": "{{upstream}}",
           "refId": "A"
         }
@@ -538,12 +538,12 @@
       },
       "targets": [
         {
-          "expr": "100 * (1 - (sum(spooky:slo_request_server_errors:rate30m) / clamp_min(sum(spooky:slo_requests:rate30m), 0.000001)))",
+          "expr": "100 * (1 - (sum(rate(spooky_upstream_requests_total{status_class=\"5xx\",upstream=~\"${upstream:regex}\"}[30m])) / clamp_min(sum(rate(spooky_upstream_requests_total{upstream=~\"${upstream:regex}\"}[30m])), 0.000001)))",
           "legendFormat": "success rate",
           "refId": "A"
         },
         {
-          "expr": "100 * (sum(spooky:slo_request_server_errors:rate30m) / clamp_min(sum(spooky:slo_requests:rate30m), 0.000001))",
+          "expr": "100 * (sum(rate(spooky_upstream_requests_total{status_class=\"5xx\",upstream=~\"${upstream:regex}\"}[30m])) / clamp_min(sum(rate(spooky_upstream_requests_total{upstream=~\"${upstream:regex}\"}[30m])), 0.000001))",
           "legendFormat": "server error rate",
           "refId": "B"
         }
@@ -603,7 +603,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (status_class) (spooky:requests_by_status_class:rate5m)",
+          "expr": "sum by (status_class) (rate(spooky_upstream_requests_total{upstream=~\"${upstream:regex}\"}[5m]))",
           "legendFormat": "{{status_class}}",
           "refId": "A"
         }
@@ -663,7 +663,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (outcome) (spooky:requests_by_upstream_outcome:rate5m)",
+          "expr": "sum by (outcome) (rate(spooky_upstream_requests_total{upstream=~\"${upstream:regex}\"}[5m]))",
           "legendFormat": "{{outcome}}",
           "refId": "A"
         }
@@ -723,17 +723,17 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.50, sum by (le) (rate(spooky_upstream_request_latency_ms_bucket{outcome=\"success\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(spooky_upstream_request_latency_ms_bucket{outcome=\"success\",upstream=~\"${upstream:regex}\"}[$__rate_interval])))",
           "legendFormat": "p50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(spooky_upstream_request_latency_ms_bucket{outcome=\"success\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(spooky_upstream_request_latency_ms_bucket{outcome=\"success\",upstream=~\"${upstream:regex}\"}[$__rate_interval])))",
           "legendFormat": "p95",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(spooky_upstream_request_latency_ms_bucket{outcome=\"success\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(spooky_upstream_request_latency_ms_bucket{outcome=\"success\",upstream=~\"${upstream:regex}\"}[$__rate_interval])))",
           "legendFormat": "p99",
           "refId": "C"
         }
@@ -861,12 +861,152 @@
       },
       "targets": [
         {
-          "expr": "topk(10, sum by (upstream, backend) (spooky:backend_errors_by_upstream_backend:rate5m))",
+          "expr": "topk(10, sum by (upstream, backend) (spooky:backend_errors_by_upstream_backend:rate5m{upstream=~\"${upstream:regex}\"}))",
           "legendFormat": "{{upstream}} :: {{backend}}",
           "refId": "A"
         }
       ],
       "title": "Top Failing Backends",
+      "type": "bargauge"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 43
+      },
+      "id": 14,
+      "panels": [],
+      "title": "Operator Drilldown",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Contract rejections are auth denials, scoped rate limits, and quota denials. This is intentionally separate from overload and server-side backend failure.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 2
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 44
+      },
+      "id": 15,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "100 * sum(spooky:contract_reject_ratio:rate5m) or vector(0)",
+          "legendFormat": "contract reject ratio",
+          "refId": "A"
+        }
+      ],
+      "title": "Contract Reject Ratio",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Success gap by upstream highlights where user-visible success is trailing even when aggregate fleet metrics still look acceptable.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 2
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 18,
+        "x": 6,
+        "y": 44
+      },
+      "id": 16,
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": false,
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "expr": "topk(10, (1 - spooky:requests_by_upstream_success_ratio:rate5m{upstream=~\"${upstream:regex}\"}) * 100)",
+          "legendFormat": "{{upstream}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Top Upstream Success Gaps",
       "type": "bargauge"
     }
   ],
@@ -896,6 +1036,38 @@
         "refresh": 1,
         "regex": "",
         "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(spooky_upstream_requests_total, upstream)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Upstream",
+        "multi": true,
+        "name": "upstream",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(spooky_upstream_requests_total, upstream)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "/^(?!unrouted$).*/",
+        "sort": 1,
+        "type": "query"
       }
     ]
   },
@@ -907,6 +1079,6 @@
   "timezone": "",
   "title": "Spooky Edge Traffic and Latency",
   "uid": "spooky-edge-traffic",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/deploy/observability/grafana/retries-hedges.json
+++ b/deploy/observability/grafana/retries-hedges.json
@@ -1,0 +1,829 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "enable": true,
+        "expr": "sum(increase(spooky_runtime_activation_total{result=\"success\"}[1m])) > 0",
+        "hide": false,
+        "iconColor": "rgba(0, 191, 255, 1)",
+        "name": "Runtime Activations",
+        "step": "60s",
+        "textFormat": "Successful runtime activation observed from control-plane metrics. Correlate retry and hedge behavior with generation changes and admin audit history.",
+        "titleFormat": "Runtime activation",
+        "type": "tags"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "enable": true,
+        "expr": "sum(increase(spooky_runtime_rollback_total{result=\"success\"}[1m])) > 0",
+        "hide": false,
+        "iconColor": "rgba(255, 140, 0, 1)",
+        "name": "Runtime Rollbacks",
+        "step": "60s",
+        "textFormat": "Successful runtime rollback observed from control-plane metrics. Use runtime history and admin audit events to identify the exact generation transition.",
+        "titleFormat": "Runtime rollback",
+        "type": "tags"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Retries",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "5-minute retry attempt rate across the fleet.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:retry_attempts:rate5m)",
+          "legendFormat": "retry attempts",
+          "refId": "A"
+        }
+      ],
+      "title": "Retry Attempt Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "5-minute retry ratio relative to request volume.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "100 * sum(spooky:retry_attempt_ratio:rate5m)",
+          "legendFormat": "retry ratio",
+          "refId": "A"
+        }
+      ],
+      "title": "Retry Ratio",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "5-minute hedge trigger rate across the fleet.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:hedge_triggered:rate5m)",
+          "legendFormat": "hedge triggers",
+          "refId": "A"
+        }
+      ],
+      "title": "Hedge Trigger Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "5-minute hedge waste ratio. High waste indicates extra work without winning the race.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 25
+              },
+              {
+                "color": "red",
+                "value": 50
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "100 * sum(spooky:hedge_waste_ratio:rate5m)",
+          "legendFormat": "hedge waste ratio",
+          "refId": "A"
+        }
+      ],
+      "title": "Hedge Waste Ratio",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Retry attempts broken out by the canonical retry trigger reasons.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (reason) (spooky:retry_attempts_by_reason:rate5m)",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Retry Reasons",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Retry denials broken out by policy reason. These are blocked retries, not executed retries.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (reason) (spooky:retry_denied_by_reason:rate5m)",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Retry Denials by Reason",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Retry pressure shown alongside backend timeouts. This helps explain whether timeouts are driving retry amplification.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:retry_attempts:rate5m)",
+          "legendFormat": "retry attempts",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(spooky:backend_timeouts:rate5m)",
+          "legendFormat": "backend timeouts",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(spooky:backend_errors:rate5m)",
+          "legendFormat": "backend errors",
+          "refId": "C"
+        }
+      ],
+      "title": "Retry Pressure vs Backend Failure Pressure",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 9,
+      "panels": [],
+      "title": "Hedges",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Hedge trigger, win, waste, and primary-still-won outcomes. This is the operator view of hedge effectiveness.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:hedge_triggered:rate5m)",
+          "legendFormat": "triggered",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(spooky:hedge_won:rate5m)",
+          "legendFormat": "won",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(spooky:hedge_wasted:rate5m)",
+          "legendFormat": "wasted",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(spooky:hedge_primary_won_after_trigger:rate5m)",
+          "legendFormat": "primary won after trigger",
+          "refId": "D"
+        }
+      ],
+      "title": "Hedge Trigger, Win, Waste, and Primary-Won Patterns",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Derived hedge quality ratios. Win and waste should be read together rather than in isolation.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "100 * sum(spooky:hedge_win_ratio:rate5m)",
+          "legendFormat": "win ratio",
+          "refId": "A"
+        },
+        {
+          "expr": "100 * sum(spooky:hedge_waste_ratio:rate5m)",
+          "legendFormat": "waste ratio",
+          "refId": "B"
+        },
+        {
+          "expr": "100 * (sum(spooky:hedge_primary_won_after_trigger:rate5m) / clamp_min(sum(spooky:hedge_triggered:rate5m), 0.000001))",
+          "legendFormat": "primary won after trigger ratio",
+          "refId": "C"
+        }
+      ],
+      "title": "Hedge Effectiveness Ratios",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Average milliseconds the primary remained late after a hedge trigger. This helps tune hedge delays and reveals unnecessary duplicate work.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 150
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 37
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:hedge_primary_late_avg_ms:5m)",
+          "legendFormat": "avg late ms",
+          "refId": "A"
+        }
+      ],
+      "title": "Average Primary Late Time After Hedge Trigger",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Late-primary sample rate. This indicates how much data is feeding the hedge lateness average.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 37
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:hedge_primary_late_samples:rate5m)",
+          "legendFormat": "late samples",
+          "refId": "A"
+        }
+      ],
+      "title": "Primary Late Sample Rate",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "spooky",
+    "observability",
+    "retries",
+    "hedges",
+    "resilience"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Spooky Retries and Hedges",
+  "uid": "spooky-retries-hedges",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/observability/grafana/retries-hedges.json
+++ b/deploy/observability/grafana/retries-hedges.json
@@ -785,6 +785,157 @@
       ],
       "title": "Primary Late Sample Rate",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 47
+      },
+      "id": 14,
+      "panels": [],
+      "title": "Operator Drilldown",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Retry denials are policy guardrails, not successful retries. A rising ratio means protection is engaging before retries can amplify backend distress.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 48
+      },
+      "id": 15,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "100 * sum(spooky:retry_denial_ratio:rate5m) or vector(0)",
+          "legendFormat": "retry denial ratio",
+          "refId": "A"
+        }
+      ],
+      "title": "Retry Denial Ratio",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Operator guardrail mix: retry attempts, retry denials, hedge triggers, and hedge waste. Read these together to understand whether resilience logic is helping or just adding work.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 18,
+        "x": 6,
+        "y": 48
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:retry_attempts:rate5m)",
+          "legendFormat": "retry attempts",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(spooky:retry_denials:rate5m)",
+          "legendFormat": "retry denials",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(spooky:hedge_triggered:rate5m)",
+          "legendFormat": "hedge triggered",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(spooky:hedge_wasted:rate5m)",
+          "legendFormat": "hedge wasted",
+          "refId": "D"
+        }
+      ],
+      "title": "Retry and Hedge Guardrail Mix",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",
@@ -824,6 +975,6 @@
   "timezone": "",
   "title": "Spooky Retries and Hedges",
   "uid": "spooky-retries-hedges",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/deploy/observability/grafana/tls-certificates.json
+++ b/deploy/observability/grafana/tls-certificates.json
@@ -1,0 +1,676 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "enable": true,
+        "expr": "sum(increase(spooky_runtime_activation_total{result=\"success\"}[1m])) > 0",
+        "hide": false,
+        "iconColor": "rgba(0, 191, 255, 1)",
+        "name": "Runtime Activations",
+        "step": "60s",
+        "textFormat": "Successful runtime activation observed from control-plane metrics. Correlate TLS changes with active generation, rollout timing, and admin audit history.",
+        "titleFormat": "Runtime activation",
+        "type": "tags"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "enable": true,
+        "expr": "sum(increase(spooky_runtime_rollback_total{result=\"success\"}[1m])) > 0",
+        "hide": false,
+        "iconColor": "rgba(255, 140, 0, 1)",
+        "name": "Runtime Rollbacks",
+        "step": "60s",
+        "textFormat": "Successful runtime rollback observed from control-plane metrics. Use runtime history and admin audit events to identify the exact generation transition.",
+        "titleFormat": "Runtime rollback",
+        "type": "tags"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Handshake and Expiry",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "5-minute downstream TLS handshake failure ratio.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "100 * sum(spooky:tls_handshake_failure_ratio:rate5m)",
+          "legendFormat": "failure ratio",
+          "refId": "A"
+        }
+      ],
+      "title": "Handshake Failure Ratio",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "5-minute downstream TLS handshake failure rate.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:tls_handshake_failures:rate5m)",
+          "legendFormat": "handshake failures",
+          "refId": "A"
+        }
+      ],
+      "title": "Handshake Failure Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Minimum downstream certificate days remaining across listeners and server names.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 14
+              },
+              {
+                "color": "green",
+                "value": 30
+              }
+            ]
+          },
+          "unit": "d"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "min(spooky:tls_certificate_days_remaining_by_listener_server_name:min)",
+          "legendFormat": "minimum days remaining",
+          "refId": "A"
+        }
+      ],
+      "title": "Minimum Certificate Days Remaining",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "5-minute upstream TLS failure rate across backend connections.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(spooky:upstream_tls_failures_by_backend:rate5m)",
+          "legendFormat": "upstream tls failures",
+          "refId": "A"
+        }
+      ],
+      "title": "Upstream TLS Failure Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Canonical downstream handshake failure causes by listener and reason.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (listener, reason) (spooky:tls_handshake_failures_by_listener_reason:rate5m)",
+          "legendFormat": "{{listener}} / {{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Downstream Handshake Failures by Listener and Reason",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Upstream TLS failures by backend, request phase, and reason. Use this to separate handshake problems from request-path TLS failures.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "topk(12, sum by (backend, phase, reason) (spooky:upstream_tls_failures_by_backend_phase_reason:rate5m))",
+          "legendFormat": "{{backend}} / {{phase}} / {{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Top Upstream TLS Failures by Backend, Phase, and Reason",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Lowest certificate lifetime by listener and server name. This is the operator expiry queue.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 14
+              },
+              {
+                "color": "green",
+                "value": 30
+              }
+            ]
+          },
+          "unit": "d"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 8,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "targets": [
+        {
+          "expr": "bottomk(12, spooky:tls_certificate_days_remaining_by_listener_server_name:min)",
+          "legendFormat": "{{listener}} / {{server_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Lowest Certificate Days Remaining",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Certificate selection outcomes by listener. Unexpected selections or fallback paths should stand out here.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (listener, selection) (spooky:tls_certificate_selection_by_listener_selection:rate5m)",
+          "legendFormat": "{{listener}} / {{selection}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Certificate Selection Outcomes by Listener",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 10,
+      "panels": [],
+      "title": "Protocol Mix",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Negotiated downstream ALPN protocols by listener. Sudden shifts can indicate client or certificate/path issues.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (listener, protocol) (spooky:tls_alpn_by_listener_protocol:rate5m)",
+          "legendFormat": "{{listener}} / {{protocol}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Negotiated ALPN by Listener",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "spooky",
+    "observability",
+    "tls",
+    "certificates",
+    "admin-plane"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Spooky TLS Certificates and Handshakes",
+  "uid": "spooky-tls-certificates",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/observability/grafana/tls-certificates.json
+++ b/deploy/observability/grafana/tls-certificates.json
@@ -120,7 +120,7 @@
       },
       "targets": [
         {
-          "expr": "100 * sum(spooky:tls_handshake_failure_ratio:rate5m)",
+          "expr": "(100 * sum(spooky:tls_handshake_failure_ratio:rate5m)) or vector(0)",
           "legendFormat": "failure ratio",
           "refId": "A"
         }
@@ -184,7 +184,7 @@
       },
       "targets": [
         {
-          "expr": "sum(spooky:tls_handshake_failures:rate5m)",
+          "expr": "sum(spooky:tls_handshake_failures:rate5m) or vector(0)",
           "legendFormat": "handshake failures",
           "refId": "A"
         }

--- a/deploy/observability/grafana/tls-certificates.json
+++ b/deploy/observability/grafana/tls-certificates.json
@@ -248,7 +248,7 @@
       },
       "targets": [
         {
-          "expr": "min(spooky:tls_certificate_days_remaining_by_listener_server_name:min)",
+          "expr": "min(spooky:tls_certificate_days_remaining_by_listener_server_name:min{listener=~\"${listener:regex}\",server_name=~\"${server_name:regex}\"})",
           "legendFormat": "minimum days remaining",
           "refId": "A"
         }
@@ -312,7 +312,7 @@
       },
       "targets": [
         {
-          "expr": "sum(spooky:upstream_tls_failures_by_backend:rate5m)",
+          "expr": "sum(spooky:upstream_tls_failures_by_backend:rate5m{backend=~\"${backend:regex}\"})",
           "legendFormat": "upstream tls failures",
           "refId": "A"
         }
@@ -371,7 +371,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (listener, reason) (spooky:tls_handshake_failures_by_listener_reason:rate5m)",
+          "expr": "sum by (listener, reason) (spooky:tls_handshake_failures_by_listener_reason:rate5m{listener=~\"${listener:regex}\"})",
           "legendFormat": "{{listener}} / {{reason}}",
           "refId": "A"
         }
@@ -430,7 +430,7 @@
       },
       "targets": [
         {
-          "expr": "topk(12, sum by (backend, phase, reason) (spooky:upstream_tls_failures_by_backend_phase_reason:rate5m))",
+          "expr": "topk(12, sum by (backend, phase, reason) (spooky:upstream_tls_failures_by_backend_phase_reason:rate5m{backend=~\"${backend:regex}\"}))",
           "legendFormat": "{{backend}} / {{phase}} / {{reason}}",
           "refId": "A"
         }
@@ -494,7 +494,7 @@
       },
       "targets": [
         {
-          "expr": "bottomk(12, spooky:tls_certificate_days_remaining_by_listener_server_name:min)",
+          "expr": "bottomk(12, spooky:tls_certificate_days_remaining_by_listener_server_name:min{listener=~\"${listener:regex}\",server_name=~\"${server_name:regex}\"})",
           "legendFormat": "{{listener}} / {{server_name}}",
           "refId": "A"
         }
@@ -553,7 +553,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (listener, selection) (spooky:tls_certificate_selection_by_listener_selection:rate5m)",
+          "expr": "sum by (listener, selection) (spooky:tls_certificate_selection_by_listener_selection:rate5m{listener=~\"${listener:regex}\"})",
           "legendFormat": "{{listener}} / {{selection}}",
           "refId": "A"
         }
@@ -625,13 +625,154 @@
       },
       "targets": [
         {
-          "expr": "sum by (listener, protocol) (spooky:tls_alpn_by_listener_protocol:rate5m)",
+          "expr": "sum by (listener, protocol) (spooky:tls_alpn_by_listener_protocol:rate5m{listener=~\"${listener:regex}\"})",
           "legendFormat": "{{listener}} / {{protocol}}",
           "refId": "A"
         }
       ],
       "title": "Negotiated ALPN by Listener",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 37
+      },
+      "id": 12,
+      "panels": [],
+      "title": "Operator Drilldown",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Downstream TLS success rate across the fleet. Read this beside failure reason distribution and certificate selection outcomes.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 95
+              },
+              {
+                "color": "green",
+                "value": 99
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 38
+      },
+      "id": 13,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "(100 * (1 - sum(spooky:tls_handshake_failure_ratio:rate5m))) or vector(0)",
+          "legendFormat": "handshake success rate",
+          "refId": "A"
+        }
+      ],
+      "title": "Handshake Success Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Certificate expiry queue filtered by listener and server name. This is the immediate operator view for rollover prioritization.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 14
+              },
+              {
+                "color": "green",
+                "value": 30
+              }
+            ]
+          },
+          "unit": "d"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 18,
+        "x": 6,
+        "y": 38
+      },
+      "id": 14,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "targets": [
+        {
+          "expr": "bottomk(12, spooky:tls_certificate_days_remaining_by_listener_server_name:min{listener=~\"${listener:regex}\",server_name=~\"${server_name:regex}\"})",
+          "legendFormat": "{{listener}} / {{server_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Filtered Certificate Expiry Queue",
+      "type": "bargauge"
     }
   ],
   "refresh": "30s",
@@ -660,6 +801,102 @@
         "refresh": 1,
         "regex": "",
         "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(spooky_downstream_tls_handshake_failure_total, listener)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Listener",
+        "multi": true,
+        "name": "listener",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(spooky_downstream_tls_handshake_failure_total, listener)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(spooky_upstream_tls_failure_total, backend)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Backend",
+        "multi": true,
+        "name": "backend",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(spooky_upstream_tls_failure_total, backend)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(spooky_downstream_tls_certificate_days_remaining, server_name)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Server Name",
+        "multi": true,
+        "name": "server_name",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(spooky_downstream_tls_certificate_days_remaining, server_name)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
       }
     ]
   },
@@ -671,6 +908,6 @@
   "timezone": "",
   "title": "Spooky TLS Certificates and Handshakes",
   "uid": "spooky-tls-certificates",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/deploy/observability/prometheus/alerts.yaml
+++ b/deploy/observability/prometheus/alerts.yaml
@@ -1,0 +1,240 @@
+groups:
+  - name: spooky-page-alerts
+    interval: 30s
+    rules:
+      - alert: SpookyAvailabilityBurnRatePage
+        expr: >-
+          spooky:requests:rate5m > 1
+          and spooky:slo_requests:rate30m > 0.2
+          and spooky:request_server_error_ratio:rate5m > 0.0144
+          and spooky:slo_request_server_error_ratio:rate30m > 0.006
+        for: 5m
+        labels:
+          severity: page
+          service: spooky
+          domain: edge-traffic
+          slo: availability
+          windows: 5m_30m
+        annotations:
+          summary: Spooky availability error budget is burning at page-level speed
+          description: >-
+            The recorded 5-minute and 30-minute request server-error ratios are
+            simultaneously above the packaged page thresholds. This alert assumes
+            a 99.9% availability objective and is intended to catch fast and
+            sustained edge failure growth without relying on raw PromQL at alert
+            time.
+          runbook: docs/operations/runbook.md#scenario-rising-503-rate
+
+      - alert: SpookyP99LatencyBurnPage
+        expr: >-
+          spooky:requests:rate5m > 1
+          and spooky:slo_requests:rate30m > 0.2
+          and spooky:request_latency_ms:p99_5m > 1500
+          and spooky:slo_request_latency_ms:p99_30m > 1000
+        for: 10m
+        labels:
+          severity: page
+          service: spooky
+          domain: edge-traffic
+          slo: p99-latency
+          windows: 5m_30m
+        annotations:
+          summary: Spooky p99 latency is burning through the packaged latency budget
+          description: >-
+            The recorded p99 latency is elevated in both the fast 5-minute and
+            sustained 30-minute windows. The packaged defaults assume a 1s p99
+            objective and page only when the short window materially exceeds it
+            while the long window stays above it.
+          runbook: docs/operations/runbook.md#scenario-backend-timeout-surge
+
+      - alert: SpookyBackendTimeoutSurgePage
+        expr: >-
+          spooky:requests:rate5m > 1
+          and spooky:slo_requests:rate30m > 0.2
+          and spooky:backend_timeout_ratio:rate5m > 0.05
+          and spooky:slo_backend_timeout_ratio:30m > 0.02
+        for: 10m
+        labels:
+          severity: page
+          service: spooky
+          domain: backends
+          slo: backend-timeout
+        annotations:
+          summary: Backend timeout ratio is at page level
+          description: >-
+            Backend timeouts are elevated in both the short and sustained windows
+            relative to total request rate. This usually indicates upstream fleet
+            regression, network path problems, or concurrency pressure that is
+            now user-visible.
+          runbook: docs/operations/runbook.md#scenario-backend-timeout-surge
+
+      - alert: SpookyTlsCertificateExpiryCritical
+        expr: >-
+          spooky:tls_certificate_days_remaining_by_listener_server_name:min < 7
+        for: 30m
+        labels:
+          severity: page
+          service: spooky
+          domain: tls
+        annotations:
+          summary: TLS certificate expiry is in the critical window
+          description: >-
+            A downstream listener certificate has fewer than 7 days remaining
+            before expiration. Inspect the affected listener and server_name
+            labels on the firing series and rotate certificate material before
+            client handshakes start failing.
+          runbook: docs/operations/runbook.md#scenario-cert-rotation
+
+      - alert: SpookyWatchdogDegraded
+        expr: >-
+          spooky:watchdog_degraded_windows:rate5m > 0
+        for: 10m
+        labels:
+          severity: page
+          service: spooky
+          domain: control-plane
+        annotations:
+          summary: Watchdog degraded windows are being recorded
+          description: >-
+            The packaged watchdog degradation recording rule is non-zero for a
+            sustained period. The process is still up, but control-plane safety
+            mechanisms are reporting unhealthy evaluation windows.
+          runbook: docs/operations/runbook.md#scenario-control-api-or-metrics-endpoint-unavailable
+
+      - alert: SpookyRuntimePanicObserved
+        expr: >-
+          spooky:runtime_panics:rate5m > 0
+        for: 2m
+        labels:
+          severity: page
+          service: spooky
+          domain: control-plane
+        annotations:
+          summary: Runtime panics have been observed in Spooky
+          description: >-
+            The packaged runtime panic recording rule is non-zero. This indicates
+            one or more runtime tasks panicked recently and requires immediate
+            investigation even if traffic is still partially flowing.
+          runbook: docs/operations/runbook.md#after-any-incident
+
+      - alert: SpookyControlPlaneUnavailable
+        expr: >-
+          absent(spooky:control_plane_error_events:rate5m)
+        for: 10m
+        labels:
+          severity: page
+          service: spooky
+          domain: control-plane
+        annotations:
+          summary: Spooky control-plane observability series are unavailable
+          description: >-
+            The control-plane recording-rule series are absent. In practice this
+            usually means the Spooky process is down, the metrics endpoint is not
+            being scraped, or the recording rules were not loaded correctly.
+          runbook: docs/operations/runbook.md#scenario-control-api-or-metrics-endpoint-unavailable
+
+  - name: spooky-ticket-alerts
+    interval: 30s
+    rules:
+      - alert: SpookyRetryGrowth
+        expr: >-
+          spooky:requests:rate5m > 1
+          and spooky:retry_attempt_ratio:rate5m > 0.05
+        for: 15m
+        labels:
+          severity: ticket
+          service: spooky
+          domain: resilience
+        annotations:
+          summary: Retry volume is rising
+          description: >-
+            The packaged retry-attempt ratio is above 5% of request rate for a
+            sustained period. This is usually an early sign of backend timeout,
+            transport, or pool instability before hard failure rates fully spike.
+          runbook: docs/operations/runbook.md#scenario-backend-timeout-surge
+
+      - alert: SpookyHedgeGrowth
+        expr: >-
+          spooky:requests:rate5m > 1
+          and spooky:hedge_trigger_ratio:rate5m > 0.02
+        for: 15m
+        labels:
+          severity: ticket
+          service: spooky
+          domain: resilience
+        annotations:
+          summary: Hedge activity is rising
+          description: >-
+            Hedge triggers are above 2% of request volume for a sustained period.
+            That usually means tail latency is deteriorating enough that the
+            hedge policy is engaging routinely rather than exceptionally.
+          runbook: docs/operations/runbook.md#scenario-backend-timeout-surge
+
+      - alert: SpookyBackendDnsRefreshFailures
+        expr: >-
+          spooky:backend_dns_refresh_failures:rate5m > 0
+          and spooky:backend_dns_refresh_failure_ratio:rate5m > 0.10
+        for: 15m
+        labels:
+          severity: ticket
+          service: spooky
+          domain: backends
+        annotations:
+          summary: Backend DNS refresh failures are rising
+          description: >-
+            The packaged DNS refresh recording rules show ongoing failures and a
+            failure ratio above 10%. Address-set refresh is no longer reliably
+            converging and stale backend endpoints may be retained.
+          runbook: docs/operations/runbook.md#scenario-backend-timeout-surge
+
+      - alert: SpookyBrownoutActiveTooLong
+        expr: >-
+          spooky:brownout_active > 0
+        for: 15m
+        labels:
+          severity: ticket
+          service: spooky
+          domain: admission
+        annotations:
+          summary: Brownout mode has remained active too long
+          description: >-
+            Brownout is continuously active beyond the packaged tolerance window.
+            The edge is protecting itself, but capacity or load shape should be
+            reviewed before this turns into a user-visible availability issue.
+          runbook: docs/operations/runbook.md#scenario-brownout-or-overload-triggering
+
+      - alert: SpookyQuotaBackendDegraded
+        expr: >-
+          sum by (backend_mode, reason)
+          (spooky:quota_backend_health_events_by_mode_reason:rate5m{reason!="available"}) > 0
+        for: 10m
+        labels:
+          severity: ticket
+          service: spooky
+          domain: quota
+        annotations:
+          summary: Distributed quota backend is degraded
+          description: >-
+            Quota backend health events are being recorded in a non-available
+            state. Inspect the backend_mode and reason labels to determine
+            whether Redis timeouts, backend unavailability, or another quota
+            evaluation fault is degrading enforcement.
+          runbook: docs/operations/distributed-quota.md
+
+      - alert: SpookyTlsHandshakeFailuresRising
+        expr: >-
+          spooky:tls_handshake_failure_ratio:rate5m > 0.02
+          and spooky:slo_tls_handshake_failure_ratio:30m > 0.005
+        for: 15m
+        labels:
+          severity: ticket
+          service: spooky
+          domain: tls
+          windows: 5m_30m
+        annotations:
+          summary: TLS handshake failures are rising
+          description: >-
+            The recorded handshake failure ratio is elevated in both the short
+            and sustained windows. This usually points to certificate, client
+            authentication, ALPN, or protocol compatibility issues.
+          runbook: docs/operations/runbook.md#scenario-handshake-failures-or-client-connection-failures

--- a/deploy/observability/prometheus/recording-rules.yaml
+++ b/deploy/observability/prometheus/recording-rules.yaml
@@ -116,6 +116,38 @@ groups:
           sum without (status_class, outcome)
           (rate(spooky_backend_requests_total{outcome="backend_error"}[5m]))
 
+      - record: spooky:retry_attempts:rate5m
+        expr: >-
+          sum without (reason)
+          (rate(spooky_retry_attempts_total[5m]))
+
+      - record: spooky:retry_attempts_by_reason:rate5m
+        expr: >-
+          rate(spooky_retry_attempts_total[5m])
+
+      - record: spooky:retry_attempt_ratio:rate5m
+        expr: >-
+          spooky:retry_attempts:rate5m
+          / clamp_min(spooky:requests:rate5m, 0.000001)
+
+      - record: spooky:hedge_triggered:rate5m
+        expr: >-
+          rate(spooky_hedge_triggered_total[5m])
+
+      - record: spooky:hedge_wasted:rate5m
+        expr: >-
+          rate(spooky_hedge_wasted_total[5m])
+
+      - record: spooky:hedge_trigger_ratio:rate5m
+        expr: >-
+          spooky:hedge_triggered:rate5m
+          / clamp_min(spooky:requests:rate5m, 0.000001)
+
+      - record: spooky:hedge_waste_ratio:rate5m
+        expr: >-
+          spooky:hedge_wasted:rate5m
+          / clamp_min(spooky:hedge_triggered:rate5m, 0.000001)
+
       - record: spooky:external_auth_denials:rate5m
         expr: >-
           rate(spooky_external_auth_denied[5m])
@@ -158,6 +190,11 @@ groups:
         expr: >-
           rate(spooky_quota_backend_health_total[5m])
 
+      - record: spooky:quota_backend_degraded_events:rate5m
+        expr: >-
+          sum without (backend_mode, reason)
+          (rate(spooky_quota_backend_health_total{reason!="available"}[5m]))
+
       - record: spooky:tls_handshake_failures:rate5m
         expr: >-
           sum without (listener, reason)
@@ -198,6 +235,32 @@ groups:
       - record: spooky:watchdog_restart_requests:rate5m
         expr: >-
           rate(spooky_watchdog_restart_requests[5m])
+
+      - record: spooky:backend_dns_refresh_failures:rate5m
+        expr: >-
+          rate(spooky_backend_dns_refresh_failure_total[5m])
+
+      - record: spooky:backend_dns_refresh_successes:rate5m
+        expr: >-
+          rate(spooky_backend_dns_refresh_success_total[5m])
+
+      - record: spooky:backend_dns_refresh_failure_ratio:rate5m
+        expr: >-
+          spooky:backend_dns_refresh_failures:rate5m
+          / clamp_min(
+            spooky:backend_dns_refresh_failures:rate5m
+            + spooky:backend_dns_refresh_successes:rate5m,
+            0.000001
+          )
+
+      - record: spooky:brownout_active
+        expr: >-
+          max(spooky_brownout_active)
+
+      - record: spooky:tls_certificate_days_remaining_by_listener_server_name:min
+        expr: >-
+          min by (listener, server_name)
+          (spooky_downstream_tls_certificate_days_remaining)
 
   - name: spooky-slo-inputs
     interval: 30s

--- a/deploy/observability/prometheus/recording-rules.yaml
+++ b/deploy/observability/prometheus/recording-rules.yaml
@@ -20,6 +20,11 @@ groups:
           sum without (status_class)
           (rate(spooky_upstream_requests_total[5m]))
 
+      - record: spooky:requests_by_status_class:rate5m
+        expr: >-
+          sum without (upstream, outcome)
+          (rate(spooky_upstream_requests_total[5m]))
+
       - record: spooky:request_server_errors:rate5m
         expr: >-
           sum without (upstream, status_class, outcome)

--- a/deploy/observability/prometheus/recording-rules.yaml
+++ b/deploy/observability/prometheus/recording-rules.yaml
@@ -132,7 +132,13 @@ groups:
       - record: spooky:backend_errors_by_upstream_backend:rate5m
         expr: >-
           sum without (status_class, outcome)
-          (rate(spooky_backend_requests_total{outcome="backend_error"}[5m]))
+          (
+            rate(
+              spooky_backend_requests_total{
+                outcome=~"failure|timeout|backend_error"
+              }[5m]
+            )
+          )
 
       - record: spooky:health_checks_total:rate5m
         expr: >-

--- a/deploy/observability/prometheus/recording-rules.yaml
+++ b/deploy/observability/prometheus/recording-rules.yaml
@@ -102,6 +102,10 @@ groups:
         expr: >-
           rate(spooky_overload_shed_by_reason_total[5m])
 
+      - record: spooky:inflight_wait_admit_by_scope:rate5m
+        expr: >-
+          rate(spooky_inflight_wait_admit_total[5m])
+
       - record: spooky:overload_shed_ratio:rate5m
         expr: >-
           spooky:overload_shed:rate5m
@@ -153,9 +157,22 @@ groups:
           spooky:hedge_wasted:rate5m
           / clamp_min(spooky:hedge_triggered:rate5m, 0.000001)
 
+      - record: spooky:external_auth_timeout:rate5m
+        expr: >-
+          rate(spooky_external_auth_timeout[5m])
+
+      - record: spooky:external_auth_error:rate5m
+        expr: >-
+          rate(spooky_external_auth_error[5m])
+
       - record: spooky:external_auth_denials:rate5m
         expr: >-
           rate(spooky_external_auth_denied[5m])
+
+      - record: spooky:external_auth_unavailable:rate5m
+        expr: >-
+          spooky:external_auth_timeout:rate5m
+          + spooky:external_auth_error:rate5m
 
       - record: spooky:jwt_auth_denials:rate5m
         expr: >-
@@ -180,6 +197,16 @@ groups:
         expr: >-
           sum without (policy, reason, selector_dimensions, backend_mode, decision)
           (rate(spooky_quota_policy_outcomes_total{decision="denied"}[5m]))
+
+      - record: spooky:quota_outcomes_by_decision:rate5m
+        expr: >-
+          sum without (policy, reason, selector_dimensions, backend_mode)
+          (rate(spooky_quota_policy_outcomes_total[5m]))
+
+      - record: spooky:quota_outcomes_by_policy_decision:rate5m
+        expr: >-
+          sum without (reason, selector_dimensions, backend_mode)
+          (rate(spooky_quota_policy_outcomes_total[5m]))
 
       - record: spooky:quota_denials_by_policy_reason_backend_mode:rate5m
         expr: >-
@@ -240,6 +267,14 @@ groups:
       - record: spooky:watchdog_restart_requests:rate5m
         expr: >-
           rate(spooky_watchdog_restart_requests[5m])
+
+      - record: spooky:circuit_breaker_rejected:rate5m
+        expr: >-
+          rate(spooky_circuit_breaker_rejected_total[5m])
+
+      - record: spooky:request_rate_limited:rate5m
+        expr: >-
+          rate(spooky_request_rate_limited[5m])
 
       - record: spooky:backend_dns_refresh_failures:rate5m
         expr: >-

--- a/deploy/observability/prometheus/recording-rules.yaml
+++ b/deploy/observability/prometheus/recording-rules.yaml
@@ -292,6 +292,23 @@ groups:
         expr: >-
           rate(spooky_downstream_tls_handshake_failure_total[5m])
 
+      - record: spooky:tls_certificate_selection_by_listener_selection:rate5m
+        expr: >-
+          rate(spooky_downstream_tls_certificate_selection_total[5m])
+
+      - record: spooky:tls_alpn_by_listener_protocol:rate5m
+        expr: >-
+          rate(spooky_downstream_tls_alpn_total[5m])
+
+      - record: spooky:upstream_tls_failures_by_backend_phase_reason:rate5m
+        expr: >-
+          rate(spooky_upstream_tls_failure_total[5m])
+
+      - record: spooky:upstream_tls_failures_by_backend:rate5m
+        expr: >-
+          sum by (backend)
+          (rate(spooky_upstream_tls_failure_total[5m]))
+
       - record: spooky:tls_handshake_attempts:rate5m
         expr: >-
           rate(spooky_downstream_tls_handshake_success_total[5m])
@@ -306,23 +323,60 @@ groups:
         expr: >-
           rate(spooky_control_api_connection_limit_drops[5m])
 
+      - record: spooky:runtime_validation_attempts:rate5m
+        expr: >-
+          rate(spooky_runtime_validation_attempts_total[5m])
+
+      - record: spooky:runtime_preview_attempts:rate5m
+        expr: >-
+          rate(spooky_runtime_preview_attempts_total[5m])
+
+      - record: spooky:runtime_activation_outcomes_by_result_reason:rate5m
+        expr: >-
+          rate(spooky_runtime_activation_total[5m])
+
+      - record: spooky:runtime_rollback_outcomes_by_result_reason:rate5m
+        expr: >-
+          rate(spooky_runtime_rollback_total[5m])
+
+      - record: spooky:runtime_rejections_by_reason:rate5m
+        expr: >-
+          rate(spooky_runtime_rejections_total[5m])
+
       - record: spooky:watchdog_degraded_windows:rate5m
         expr: >-
           rate(spooky_watchdog_degraded_windows[5m])
 
+      - record: spooky:watchdog_restart_hooks:rate5m
+        expr: >-
+          rate(spooky_watchdog_restart_hooks[5m])
+
+      - record: spooky:watchdog_restart_requests:rate5m
+        expr: >-
+          rate(spooky_watchdog_restart_requests[5m])
+
       - record: spooky:runtime_panics:rate5m
         expr: >-
           rate(spooky_runtime_panics[5m])
+
+      - record: spooky:control_plane_activity_events:rate5m
+        expr: >-
+          spooky:runtime_validation_attempts:rate5m
+          + spooky:runtime_preview_attempts:rate5m
+          + sum without (result, reason)
+            (spooky:runtime_activation_outcomes_by_result_reason:rate5m)
+          + sum without (result, reason)
+            (spooky:runtime_rollback_outcomes_by_result_reason:rate5m)
+          + sum without (reason)
+            (spooky:runtime_rejections_by_reason:rate5m)
+          + spooky:watchdog_restart_requests:rate5m
+          + spooky:watchdog_restart_hooks:rate5m
 
       - record: spooky:control_plane_error_events:rate5m
         expr: >-
           spooky:control_api_connection_limit_drops:rate5m
           + spooky:watchdog_degraded_windows:rate5m
           + spooky:runtime_panics:rate5m
-
-      - record: spooky:watchdog_restart_requests:rate5m
-        expr: >-
-          rate(spooky_watchdog_restart_requests[5m])
 
       - record: spooky:circuit_breaker_rejected:rate5m
         expr: >-

--- a/deploy/observability/prometheus/recording-rules.yaml
+++ b/deploy/observability/prometheus/recording-rules.yaml
@@ -115,15 +115,45 @@ groups:
         expr: >-
           rate(spooky_backend_timeouts[5m])
 
+      - record: spooky:backend_errors:rate5m
+        expr: >-
+          rate(spooky_backend_errors[5m])
+
       - record: spooky:backend_timeout_ratio:rate5m
         expr: >-
           spooky:backend_timeouts:rate5m
+          / clamp_min(spooky:requests:rate5m, 0.000001)
+
+      - record: spooky:backend_error_ratio:rate5m
+        expr: >-
+          spooky:backend_errors:rate5m
           / clamp_min(spooky:requests:rate5m, 0.000001)
 
       - record: spooky:backend_errors_by_upstream_backend:rate5m
         expr: >-
           sum without (status_class, outcome)
           (rate(spooky_backend_requests_total{outcome="backend_error"}[5m]))
+
+      - record: spooky:health_checks_total:rate5m
+        expr: >-
+          rate(spooky_health_checks_total[5m])
+
+      - record: spooky:health_checks_success:rate5m
+        expr: >-
+          rate(spooky_health_checks_success[5m])
+
+      - record: spooky:health_checks_failure:rate5m
+        expr: >-
+          rate(spooky_health_checks_failure[5m])
+
+      - record: spooky:health_check_failure_ratio:rate5m
+        expr: >-
+          spooky:health_checks_failure:rate5m
+          / clamp_min(spooky:health_checks_total:rate5m, 0.000001)
+
+      - record: spooky:health_failures_by_reason:rate5m
+        expr: >-
+          rate(spooky_health_failures_total[5m])
 
       - record: spooky:retry_attempts:rate5m
         expr: >-
@@ -134,6 +164,10 @@ groups:
         expr: >-
           rate(spooky_retry_attempts_total[5m])
 
+      - record: spooky:retry_denied_by_reason:rate5m
+        expr: >-
+          rate(spooky_retry_denied_total[5m])
+
       - record: spooky:retry_attempt_ratio:rate5m
         expr: >-
           spooky:retry_attempts:rate5m
@@ -143,14 +177,36 @@ groups:
         expr: >-
           rate(spooky_hedge_triggered_total[5m])
 
+      - record: spooky:hedge_won:rate5m
+        expr: >-
+          rate(spooky_hedge_won_total[5m])
+
       - record: spooky:hedge_wasted:rate5m
         expr: >-
           rate(spooky_hedge_wasted_total[5m])
+
+      - record: spooky:hedge_primary_won_after_trigger:rate5m
+        expr: >-
+          rate(spooky_hedge_primary_won_after_trigger_total[5m])
+
+      - record: spooky:hedge_primary_late_samples:rate5m
+        expr: >-
+          rate(spooky_hedge_primary_late_samples_total[5m])
+
+      - record: spooky:hedge_primary_late_avg_ms:5m
+        expr: >-
+          rate(spooky_hedge_primary_late_ms_total[5m])
+          / clamp_min(spooky:hedge_primary_late_samples:rate5m, 0.000001)
 
       - record: spooky:hedge_trigger_ratio:rate5m
         expr: >-
           spooky:hedge_triggered:rate5m
           / clamp_min(spooky:requests:rate5m, 0.000001)
+
+      - record: spooky:hedge_win_ratio:rate5m
+        expr: >-
+          spooky:hedge_won:rate5m
+          / clamp_min(spooky:hedge_triggered:rate5m, 0.000001)
 
       - record: spooky:hedge_waste_ratio:rate5m
         expr: >-
@@ -283,6 +339,27 @@ groups:
       - record: spooky:backend_dns_refresh_successes:rate5m
         expr: >-
           rate(spooky_backend_dns_refresh_success_total[5m])
+
+      - record: spooky:backend_dns_address_set_changes:rate5m
+        expr: >-
+          rate(spooky_backend_dns_address_set_changes_total[5m])
+
+      - record: spooky:backend_client_rotation_events:rate5m
+        expr: >-
+          rate(spooky_backend_client_rotations_total[5m])
+
+      - record: spooky:backend_client_rotation_failures:rate5m
+        expr: >-
+          rate(spooky_backend_client_rotation_failures_total[5m])
+
+      - record: spooky:backend_client_rotations_by_backend:rate5m
+        expr: >-
+          rate(spooky_backend_client_rotations[5m])
+
+      - record: spooky:backend_connect_attempts_by_backend:rate5m
+        expr: >-
+          sum by (backend)
+          (rate(spooky_backend_connect_attempt_total[5m]))
 
       - record: spooky:backend_dns_refresh_failure_ratio:rate5m
         expr: >-

--- a/deploy/observability/prometheus/recording-rules.yaml
+++ b/deploy/observability/prometheus/recording-rules.yaml
@@ -1,0 +1,288 @@
+groups:
+  - name: spooky-golden-signals
+    interval: 30s
+    rules:
+      # Preserve external scrape labels while collapsing only the noisy
+      # request-outcome dimensions. These rules are intended to be the stable
+      # dashboard layer for traffic, latency, and operator failure signals.
+      - record: spooky:requests:rate5m
+        expr: >-
+          sum without (upstream, status_class, outcome)
+          (rate(spooky_upstream_requests_total[5m]))
+
+      - record: spooky:requests_by_upstream:rate5m
+        expr: >-
+          sum without (status_class, outcome)
+          (rate(spooky_upstream_requests_total[5m]))
+
+      - record: spooky:requests_by_upstream_outcome:rate5m
+        expr: >-
+          sum without (status_class)
+          (rate(spooky_upstream_requests_total[5m]))
+
+      - record: spooky:request_server_errors:rate5m
+        expr: >-
+          sum without (upstream, status_class, outcome)
+          (rate(spooky_upstream_requests_total{status_class="5xx"}[5m]))
+
+      - record: spooky:request_server_errors_by_upstream:rate5m
+        expr: >-
+          sum without (status_class, outcome)
+          (rate(spooky_upstream_requests_total{status_class="5xx"}[5m]))
+
+      - record: spooky:request_server_error_ratio:rate5m
+        expr: >-
+          spooky:request_server_errors:rate5m
+          / clamp_min(spooky:requests:rate5m, 0.000001)
+
+      - record: spooky:request_server_error_ratio_by_upstream:rate5m
+        expr: >-
+          spooky:request_server_errors_by_upstream:rate5m
+          / clamp_min(spooky:requests_by_upstream:rate5m, 0.000001)
+
+      - record: spooky:request_latency_ms:p50_5m
+        expr: >-
+          histogram_quantile(
+            0.50,
+            sum without (upstream, outcome)
+            (rate(spooky_upstream_request_latency_ms_bucket{outcome="success"}[5m]))
+          )
+
+      - record: spooky:request_latency_ms:p95_5m
+        expr: >-
+          histogram_quantile(
+            0.95,
+            sum without (upstream, outcome)
+            (rate(spooky_upstream_request_latency_ms_bucket{outcome="success"}[5m]))
+          )
+
+      - record: spooky:request_latency_ms:p99_5m
+        expr: >-
+          histogram_quantile(
+            0.99,
+            sum without (upstream, outcome)
+            (rate(spooky_upstream_request_latency_ms_bucket{outcome="success"}[5m]))
+          )
+
+      - record: spooky:request_latency_ms_by_upstream:p50_5m
+        expr: >-
+          histogram_quantile(
+            0.50,
+            sum without (outcome)
+            (rate(spooky_upstream_request_latency_ms_bucket{outcome="success"}[5m]))
+          )
+
+      - record: spooky:request_latency_ms_by_upstream:p95_5m
+        expr: >-
+          histogram_quantile(
+            0.95,
+            sum without (outcome)
+            (rate(spooky_upstream_request_latency_ms_bucket{outcome="success"}[5m]))
+          )
+
+      - record: spooky:request_latency_ms_by_upstream:p99_5m
+        expr: >-
+          histogram_quantile(
+            0.99,
+            sum without (outcome)
+            (rate(spooky_upstream_request_latency_ms_bucket{outcome="success"}[5m]))
+          )
+
+      - record: spooky:overload_shed:rate5m
+        expr: >-
+          sum without (reason)
+          (rate(spooky_overload_shed_by_reason_total[5m]))
+
+      - record: spooky:overload_shed_by_reason:rate5m
+        expr: >-
+          rate(spooky_overload_shed_by_reason_total[5m])
+
+      - record: spooky:overload_shed_ratio:rate5m
+        expr: >-
+          spooky:overload_shed:rate5m
+          / clamp_min(spooky:requests:rate5m, 0.000001)
+
+      - record: spooky:backend_timeouts:rate5m
+        expr: >-
+          rate(spooky_backend_timeouts[5m])
+
+      - record: spooky:backend_timeout_ratio:rate5m
+        expr: >-
+          spooky:backend_timeouts:rate5m
+          / clamp_min(spooky:requests:rate5m, 0.000001)
+
+      - record: spooky:backend_errors_by_upstream_backend:rate5m
+        expr: >-
+          sum without (status_class, outcome)
+          (rate(spooky_backend_requests_total{outcome="backend_error"}[5m]))
+
+      - record: spooky:external_auth_denials:rate5m
+        expr: >-
+          rate(spooky_external_auth_denied[5m])
+
+      - record: spooky:jwt_auth_denials:rate5m
+        expr: >-
+          sum without (reason)
+          (rate(spooky_jwt_validation_failures_total[5m]))
+
+      - record: spooky:jwt_auth_denials_by_reason:rate5m
+        expr: >-
+          rate(spooky_jwt_validation_failures_total[5m])
+
+      - record: spooky:auth_denials:rate5m
+        expr: >-
+          spooky:external_auth_denials:rate5m
+          + spooky:jwt_auth_denials:rate5m
+
+      - record: spooky:auth_denial_ratio:rate5m
+        expr: >-
+          spooky:auth_denials:rate5m
+          / clamp_min(spooky:requests:rate5m, 0.000001)
+
+      - record: spooky:quota_denials:rate5m
+        expr: >-
+          sum without (policy, reason, selector_dimensions, backend_mode, decision)
+          (rate(spooky_quota_policy_outcomes_total{decision="denied"}[5m]))
+
+      - record: spooky:quota_denials_by_policy_reason_backend_mode:rate5m
+        expr: >-
+          sum without (selector_dimensions, decision)
+          (rate(spooky_quota_policy_outcomes_total{decision="denied"}[5m]))
+
+      - record: spooky:quota_denial_ratio:rate5m
+        expr: >-
+          spooky:quota_denials:rate5m
+          / clamp_min(spooky:requests:rate5m, 0.000001)
+
+      - record: spooky:quota_backend_health_events_by_mode_reason:rate5m
+        expr: >-
+          rate(spooky_quota_backend_health_total[5m])
+
+      - record: spooky:tls_handshake_failures:rate5m
+        expr: >-
+          sum without (listener, reason)
+          (rate(spooky_downstream_tls_handshake_failure_total[5m]))
+
+      - record: spooky:tls_handshake_failures_by_listener_reason:rate5m
+        expr: >-
+          rate(spooky_downstream_tls_handshake_failure_total[5m])
+
+      - record: spooky:tls_handshake_attempts:rate5m
+        expr: >-
+          rate(spooky_downstream_tls_handshake_success_total[5m])
+          + spooky:tls_handshake_failures:rate5m
+
+      - record: spooky:tls_handshake_failure_ratio:rate5m
+        expr: >-
+          spooky:tls_handshake_failures:rate5m
+          / clamp_min(spooky:tls_handshake_attempts:rate5m, 0.000001)
+
+      - record: spooky:control_api_connection_limit_drops:rate5m
+        expr: >-
+          rate(spooky_control_api_connection_limit_drops[5m])
+
+      - record: spooky:watchdog_degraded_windows:rate5m
+        expr: >-
+          rate(spooky_watchdog_degraded_windows[5m])
+
+      - record: spooky:runtime_panics:rate5m
+        expr: >-
+          rate(spooky_runtime_panics[5m])
+
+      - record: spooky:control_plane_error_events:rate5m
+        expr: >-
+          spooky:control_api_connection_limit_drops:rate5m
+          + spooky:watchdog_degraded_windows:rate5m
+          + spooky:runtime_panics:rate5m
+
+      - record: spooky:watchdog_restart_requests:rate5m
+        expr: >-
+          rate(spooky_watchdog_restart_requests[5m])
+
+  - name: spooky-slo-inputs
+    interval: 30s
+    rules:
+      - record: spooky:slo_requests:rate30m
+        expr: >-
+          sum without (upstream, status_class, outcome)
+          (rate(spooky_upstream_requests_total[30m]))
+
+      - record: spooky:slo_request_server_errors:rate30m
+        expr: >-
+          sum without (upstream, status_class, outcome)
+          (rate(spooky_upstream_requests_total{status_class="5xx"}[30m]))
+
+      - record: spooky:slo_request_server_error_ratio:rate30m
+        expr: >-
+          spooky:slo_request_server_errors:rate30m
+          / clamp_min(spooky:slo_requests:rate30m, 0.000001)
+
+      - record: spooky:slo_availability_ratio:30m
+        expr: >-
+          1 - spooky:slo_request_server_error_ratio:rate30m
+
+      - record: spooky:slo_request_latency_ms:p50_30m
+        expr: >-
+          histogram_quantile(
+            0.50,
+            sum without (upstream, outcome)
+            (rate(spooky_upstream_request_latency_ms_bucket{outcome="success"}[30m]))
+          )
+
+      - record: spooky:slo_request_latency_ms:p95_30m
+        expr: >-
+          histogram_quantile(
+            0.95,
+            sum without (upstream, outcome)
+            (rate(spooky_upstream_request_latency_ms_bucket{outcome="success"}[30m]))
+          )
+
+      - record: spooky:slo_request_latency_ms:p99_30m
+        expr: >-
+          histogram_quantile(
+            0.99,
+            sum without (upstream, outcome)
+            (rate(spooky_upstream_request_latency_ms_bucket{outcome="success"}[30m]))
+          )
+
+      - record: spooky:slo_overload_shed_ratio:30m
+        expr: >-
+          sum without (reason)
+          (rate(spooky_overload_shed_by_reason_total[30m]))
+          / clamp_min(spooky:slo_requests:rate30m, 0.000001)
+
+      - record: spooky:slo_backend_timeout_ratio:30m
+        expr: >-
+          rate(spooky_backend_timeouts[30m])
+          / clamp_min(spooky:slo_requests:rate30m, 0.000001)
+
+      - record: spooky:slo_auth_denial_ratio:30m
+        expr: >-
+          (
+            rate(spooky_external_auth_denied[30m])
+            + sum without (reason) (rate(spooky_jwt_validation_failures_total[30m]))
+          )
+          / clamp_min(spooky:slo_requests:rate30m, 0.000001)
+
+      - record: spooky:slo_quota_denial_ratio:30m
+        expr: >-
+          sum without (policy, reason, selector_dimensions, backend_mode, decision)
+          (rate(spooky_quota_policy_outcomes_total{decision="denied"}[30m]))
+          / clamp_min(spooky:slo_requests:rate30m, 0.000001)
+
+      - record: spooky:slo_tls_handshake_failure_ratio:30m
+        expr: >-
+          sum without (listener, reason)
+          (rate(spooky_downstream_tls_handshake_failure_total[30m]))
+          / clamp_min(
+            rate(spooky_downstream_tls_handshake_success_total[30m])
+            + sum without (listener, reason)
+              (rate(spooky_downstream_tls_handshake_failure_total[30m])),
+            0.000001
+          )
+
+      - record: spooky:slo_control_plane_error_events:rate30m
+        expr: >-
+          rate(spooky_control_api_connection_limit_drops[30m])
+          + rate(spooky_watchdog_degraded_windows[30m])
+          + rate(spooky_runtime_panics[30m])

--- a/deploy/observability/prometheus/recording-rules.yaml
+++ b/deploy/observability/prometheus/recording-rules.yaml
@@ -45,6 +45,14 @@ groups:
           spooky:request_server_errors_by_upstream:rate5m
           / clamp_min(spooky:requests_by_upstream:rate5m, 0.000001)
 
+      - record: spooky:requests_by_upstream_success_ratio:rate5m
+        expr: >-
+          (
+            spooky:requests_by_upstream:rate5m
+            - spooky:request_server_errors_by_upstream:rate5m
+          )
+          / clamp_min(spooky:requests_by_upstream:rate5m, 0.000001)
+
       - record: spooky:request_latency_ms:p50_5m
         expr: >-
           histogram_quantile(
@@ -129,6 +137,11 @@ groups:
           spooky:backend_errors:rate5m
           / clamp_min(spooky:requests:rate5m, 0.000001)
 
+      - record: spooky:backend_failure_pressure:rate5m
+        expr: >-
+          spooky:backend_timeouts:rate5m
+          + spooky:backend_errors:rate5m
+
       - record: spooky:backend_errors_by_upstream_backend:rate5m
         expr: >-
           sum without (status_class, outcome)
@@ -174,9 +187,19 @@ groups:
         expr: >-
           rate(spooky_retry_denied_total[5m])
 
+      - record: spooky:retry_denials:rate5m
+        expr: >-
+          sum without (reason)
+          (rate(spooky_retry_denied_total[5m]))
+
       - record: spooky:retry_attempt_ratio:rate5m
         expr: >-
           spooky:retry_attempts:rate5m
+          / clamp_min(spooky:requests:rate5m, 0.000001)
+
+      - record: spooky:retry_denial_ratio:rate5m
+        expr: >-
+          spooky:retry_denials:rate5m
           / clamp_min(spooky:requests:rate5m, 0.000001)
 
       - record: spooky:hedge_triggered:rate5m
@@ -255,6 +278,13 @@ groups:
           spooky:auth_denials:rate5m
           / clamp_min(spooky:requests:rate5m, 0.000001)
 
+      - record: spooky:contract_rejects:rate5m
+        expr: >-
+          spooky:auth_denials:rate5m
+          + rate(spooky_request_rate_limited[5m])
+          + sum without (policy, reason, selector_dimensions, backend_mode, decision)
+            (rate(spooky_quota_policy_outcomes_total{decision="denied"}[5m]))
+
       - record: spooky:quota_denials:rate5m
         expr: >-
           sum without (policy, reason, selector_dimensions, backend_mode, decision)
@@ -280,6 +310,11 @@ groups:
           spooky:quota_denials:rate5m
           / clamp_min(spooky:requests:rate5m, 0.000001)
 
+      - record: spooky:contract_reject_ratio:rate5m
+        expr: >-
+          spooky:contract_rejects:rate5m
+          / clamp_min(spooky:requests:rate5m, 0.000001)
+
       - record: spooky:quota_backend_health_events_by_mode_reason:rate5m
         expr: >-
           rate(spooky_quota_backend_health_total[5m])
@@ -293,6 +328,10 @@ groups:
         expr: >-
           sum without (listener, reason)
           (rate(spooky_downstream_tls_handshake_failure_total[5m]))
+
+      - record: spooky:tls_handshake_successes:rate5m
+        expr: >-
+          rate(spooky_downstream_tls_handshake_success_total[5m])
 
       - record: spooky:tls_handshake_failures_by_listener_reason:rate5m
         expr: >-
@@ -344,6 +383,13 @@ groups:
       - record: spooky:runtime_rollback_outcomes_by_result_reason:rate5m
         expr: >-
           rate(spooky_runtime_rollback_total[5m])
+
+      - record: spooky:runtime_change_events:rate5m
+        expr: >-
+          sum without (result, reason)
+          (spooky:runtime_activation_outcomes_by_result_reason:rate5m)
+          + sum without (result, reason)
+          (spooky:runtime_rollback_outcomes_by_result_reason:rate5m)
 
       - record: spooky:runtime_rejections_by_reason:rate5m
         expr: >-

--- a/deploy/observability/slo/README.md
+++ b/deploy/observability/slo/README.md
@@ -1,0 +1,301 @@
+# Spooky SLO Package
+
+This directory defines the operator SLO contract for Spooky before any Grafana
+dashboard packaging.
+
+The goal is to make the SLO math explicit, stable, and reviewable:
+
+- what population each SLO measures
+- which requests count against the objective
+- which operational events are intentionally excluded
+- which packaged recording rules should be used for dashboards and reports
+
+Use the PromQL definitions in [definitions.promql](definitions.promql) for
+operator views. Those queries are built on the packaged recording rules in
+[`../prometheus/recording-rules.yaml`](../prometheus/recording-rules.yaml), not
+directly on raw scrape-time PromQL.
+
+## Contract Rules
+
+- Use packaged `spooky:slo_*` recording rules for SLO reporting.
+- Do not redefine the numerator or denominator ad hoc in dashboards.
+- Keep overload, quota, auth, and backend-failure concepts separate.
+- Treat denominator changes as SLO contract changes, not dashboard tweaks.
+
+## SLO Inventory
+
+The first packaged operator SLOs are:
+
+- availability
+- p50 latency
+- p95 latency
+- p99 latency
+- overload shed rate
+- backend timeout rate
+- auth failure rate
+
+Quota denial rate is also defined as an operator view because it must remain
+explicitly separate from overload and availability, even though it is not part
+of the primary availability SLO.
+
+## Shared Request Population
+
+The default denominator for traffic-rate SLOs is:
+
+- `sum without (upstream, status_class, outcome) (rate(spooky_upstream_requests_total[window]))`
+
+Meaning:
+
+- every completed request observed by Spooky counts in the population
+- status class and terminal outcome stay available in the raw metric, but the
+  packaged SLO denominator intentionally collapses them
+- 4xx responses remain in the denominator but do not count as availability
+  failures unless another SLO explicitly says they do
+
+This denominator is exposed through:
+
+- `spooky:slo_requests:rate30m`
+
+## Availability SLO
+
+### Objective
+
+The packaged page-alert thresholds assume a 99.9% availability objective unless
+your operators override them.
+
+### Denominator
+
+- all completed requests in `spooky_upstream_requests_total`
+
+### Failure numerator
+
+- `sum without (upstream, status_class, outcome) (rate(spooky_upstream_requests_total{status_class="5xx"}[window]))`
+
+### What counts as an availability failure
+
+- upstream responses that land in HTTP `5xx`
+- overload-generated `503` responses
+- backend timeout paths that surface as `5xx`
+- backend transport, protocol, bridge, or TLS failures that surface as `5xx`
+
+### What does not count as an availability failure
+
+- client `4xx`
+- auth denials
+- quota denials
+- scoped rate-limit denials
+
+### Why
+
+Availability here is the coarse user-visible server-failure contract. Auth and
+quota failures are tracked separately because they are policy-contract outcomes,
+not edge availability failures.
+
+### Packaged reporting series
+
+- `spooky:slo_request_server_error_ratio:rate30m`
+- `spooky:slo_availability_ratio:30m`
+
+## Latency SLOs
+
+### Objective population
+
+Latency SLOs measure only successful requests.
+
+### Denominator population
+
+- `spooky_upstream_request_latency_ms_bucket{outcome="success"}`
+
+### What is included
+
+- requests whose terminal outcome is `success`
+
+### What is excluded
+
+- timeouts
+- overload shed responses
+- rate-limited responses
+- auth denials
+- quota denials
+- backend-error terminal outcomes
+
+### Why
+
+A latency percentile should describe the latency delivered for successful
+service, not mix successful and rejected work into one percentile.
+
+### Packaged reporting series
+
+- `spooky:slo_request_latency_ms:p50_30m`
+- `spooky:slo_request_latency_ms:p95_30m`
+- `spooky:slo_request_latency_ms:p99_30m`
+
+## Overload Shed Rate SLO
+
+### Denominator
+
+- all completed requests in `spooky_upstream_requests_total`
+
+### Numerator
+
+- `sum without (reason) (rate(spooky_overload_shed_by_reason_total[window]))`
+
+### What counts as overload
+
+Only canonical overload-control decisions, including reasons such as:
+
+- `brownout`
+- `adaptive_admission`
+- `route_cap`
+- `route_global_cap`
+- `global_inflight`
+- `upstream_inflight`
+- `backend_inflight`
+- `circuit_open`
+- `request_buffer_cap`
+- `response_prebuffer_cap`
+- `connection_cap`
+
+### What does not count as overload
+
+- quota denials
+- scoped request rate-limit denials
+- auth denials
+
+### Why
+
+Overload is a capacity-protection signal. Quota and auth are policy-contract
+signals and must stay separate in operator reporting.
+
+### Packaged reporting series
+
+- `spooky:slo_overload_shed_ratio:30m`
+
+## Backend Timeout Rate SLO
+
+### Denominator
+
+- all completed requests in `spooky_upstream_requests_total`
+
+### Numerator
+
+- `rate(spooky_backend_timeouts[window])`
+
+### What counts
+
+- backend timeout events emitted by the forwarding path
+
+### What does not count
+
+- generic backend errors that were not timeout-classified
+- overload shed
+- quota denials
+- auth denials
+
+### Why
+
+Timeouts are a leading reliability signal distinct from broader backend-error
+buckets.
+
+### Packaged reporting series
+
+- `spooky:slo_backend_timeout_ratio:30m`
+
+## Auth Failure Rate SLO
+
+### Denominator
+
+- all completed requests in `spooky_upstream_requests_total`
+
+### Numerator
+
+- `rate(spooky_external_auth_denied[window])`
+- `sum without (reason) (rate(spooky_jwt_validation_failures_total[window]))`
+
+These are added together in the packaged recording rule.
+
+### What counts as an auth failure
+
+- explicit external-auth denials
+- local JWT validation failures
+
+### What does not count as an auth failure
+
+- generic `spooky_policy_denied`
+- quota denials
+- overload shed
+- external-auth transport errors or timeouts when the request was failed open
+
+### Why
+
+`spooky_policy_denied` is intentionally excluded because it mixes non-auth path
+or method policy with auth-adjacent behavior. The auth SLO is scoped only to
+explicit authentication and authorization contract failures that already have
+their own stable metric families.
+
+### Packaged reporting series
+
+- `spooky:slo_auth_denial_ratio:30m`
+
+## Quota Denial Operator View
+
+Quota is not folded into overload or availability reporting.
+
+### Denominator
+
+- all completed requests in `spooky_upstream_requests_total`
+
+### Numerator
+
+- `sum without (policy, reason, selector_dimensions, backend_mode, decision) (rate(spooky_quota_policy_outcomes_total{decision="denied"}[window]))`
+
+### What counts as a quota denial
+
+- `decision="denied"` in `spooky_quota_policy_outcomes_total`
+
+### What does not count as a quota denial
+
+- `decision="failed_open"`
+- `decision="failed_closed"`
+- overload shed
+- scoped request rate-limited events
+
+### Why
+
+Quota enforcement is a contract outcome. Backend degradation in the quota store
+is tracked separately through quota backend health and should not be mislabeled
+as ordinary overload.
+
+### Packaged reporting series
+
+- `spooky:slo_quota_denial_ratio:30m`
+
+## Backend Failure Interpretation Boundaries
+
+`backend timeout` and `backend failure` are not interchangeable.
+
+For this package:
+
+- backend timeout SLO uses `spooky_backend_timeouts`
+- broader backend-error behavior uses
+  `spooky:backend_errors_by_upstream_backend:rate5m`
+- upstream `5xx` availability failures may include backend error classes, but
+  the SLO package still keeps timeout and availability views separate
+
+If you need a broader backend-failure SLO later, define it explicitly rather
+than silently widening the timeout numerator.
+
+## Reporting Windows
+
+The packaged SLO reporting window is currently:
+
+- `30m` for operator reporting and alert support
+
+The faster `5m` recording rules remain available for burn-rate and incident
+views, but they are not the canonical reporting window for these SLO ratios.
+
+## Related Files
+
+- [definitions.promql](definitions.promql)
+- [../prometheus/recording-rules.yaml](../prometheus/recording-rules.yaml)
+- [../prometheus/alerts.yaml](../prometheus/alerts.yaml)

--- a/deploy/observability/slo/definitions.promql
+++ b/deploy/observability/slo/definitions.promql
@@ -1,0 +1,86 @@
+# Spooky SLO operator queries
+#
+# Use these packaged definitions for dashboards and operator reports. They are
+# built on the `spooky:slo_*` recording rules and other bounded recording-rule
+# series, not on raw scrape-time PromQL.
+
+# Availability
+spooky:slo_availability_ratio:30m
+
+# Availability failure ratio
+spooky:slo_request_server_error_ratio:rate30m
+
+# Availability error-budget burn relative to a 99.9% objective
+spooky:slo_request_server_error_ratio:rate30m / 0.001
+
+# p50 latency in milliseconds
+spooky:slo_request_latency_ms:p50_30m
+
+# p95 latency in milliseconds
+spooky:slo_request_latency_ms:p95_30m
+
+# p99 latency in milliseconds
+spooky:slo_request_latency_ms:p99_30m
+
+# Overload shed ratio
+spooky:slo_overload_shed_ratio:30m
+
+# Backend timeout ratio
+spooky:slo_backend_timeout_ratio:30m
+
+# Auth failure ratio
+spooky:slo_auth_denial_ratio:30m
+
+# Quota denial ratio
+spooky:slo_quota_denial_ratio:30m
+
+# TLS handshake failure ratio
+spooky:slo_tls_handshake_failure_ratio:30m
+
+# Control-plane error-event rate
+spooky:slo_control_plane_error_events:rate30m
+
+# Current request rate for SLO population context
+spooky:slo_requests:rate30m
+
+# Short-window companion queries for burn-rate panels
+spooky:request_server_error_ratio:rate5m
+spooky:request_latency_ms:p99_5m
+spooky:backend_timeout_ratio:rate5m
+spooky:auth_denial_ratio:rate5m
+spooky:quota_denial_ratio:rate5m
+spooky:overload_shed_ratio:rate5m
+
+# Breakdown views for operators
+
+# By-upstream server-error ratio
+spooky:request_server_error_ratio_by_upstream:rate5m
+
+# By-upstream request rate
+spooky:requests_by_upstream:rate5m
+
+# By-upstream outcome mix
+spooky:requests_by_upstream_outcome:rate5m
+
+# By-upstream latency
+spooky:request_latency_ms_by_upstream:p50_5m
+spooky:request_latency_ms_by_upstream:p95_5m
+spooky:request_latency_ms_by_upstream:p99_5m
+
+# By-upstream and backend backend-error view
+spooky:backend_errors_by_upstream_backend:rate5m
+
+# Overload reason breakdown
+spooky:overload_shed_by_reason:rate5m
+
+# JWT auth denials by reason
+spooky:jwt_auth_denials_by_reason:rate5m
+
+# Quota denials by policy, reason, and backend mode
+spooky:quota_denials_by_policy_reason_backend_mode:rate5m
+
+# Quota backend health by backend mode and reason
+spooky:quota_backend_health_events_by_mode_reason:rate5m
+
+# TLS handshake failures by listener and reason
+spooky:tls_handshake_failures_by_listener_reason:rate5m

--- a/docs/architecture/observability-contract.md
+++ b/docs/architecture/observability-contract.md
@@ -232,12 +232,39 @@ The runtime snapshot should describe the current active generation and shared op
 Important snapshot areas include:
 
 - active generation id and config path
+- observability package metadata and contract versions
 - worker expectations
 - watchdog state
 - adaptive admission state
 - backend lifecycle inventory
 - coarse metrics summary
 - listener TLS inventory
+
+### Observability package metadata
+
+The runtime snapshot is also the packaged entry point into observability for operators.
+
+The snapshot should expose:
+
+- the current active generation
+- the active observability contract version
+- the control-plane audit schema version
+- a backend health summary
+- a quota backend health summary
+- recent tracked admin/runtime actions when runtime history is available
+- stable references to shipped dashboard definition files
+- stable references to operator documentation files
+
+These references should point to repository-managed assets such as:
+
+- `deploy/observability/grafana/*.json`
+- `docs/architecture/observability-contract.md`
+- `docs/operations/control-plane.md`
+- `docs/operations/metrics-and-alerts.md`
+- `docs/operations/distributed-quota.md`
+
+This is intentionally not a UI URL contract. The control plane should expose stable
+package references that other operator tooling can map into local workflows.
 
 ### Backend snapshot meanings
 

--- a/docs/architecture/observability-contract.md
+++ b/docs/architecture/observability-contract.md
@@ -1,14 +1,16 @@
 # Observability Contract
 
-This document defines the stable observability contract for Spooky after the refactor work that centralized reason vocabularies, outcome recording, backend lifecycle snapshots, and control-plane runtime views.
+This document defines the stable observability contract for Spooky after the refactor work that centralized reason vocabularies, outcome recording, backend lifecycle snapshots, control-plane runtime views, and admin audit events.
 
 ## Purpose
 
-Spooky has three operator-facing observability surfaces:
+Spooky has five operator-facing observability surfaces:
 
 - Prometheus metrics
 - structured operational logs
+- OTLP traces
 - control API runtime snapshots
+- structured control-plane audit events
 
 These surfaces should describe the same events using the same vocabulary.
 
@@ -18,19 +20,47 @@ The source of truth for that vocabulary is:
 
 This file defines the canonical enums, stable slugs, and field names that all emitters should use.
 
+## Source Of Truth
+
+The source of truth is not a dashboard JSON file, alert rule, or one emitter implementation.
+
+The source of truth is the canonical vocabulary in:
+
+- `crates/edge/src/observability/mod.rs`
+
+Operator-packaged assets must be derived from that module's stable public meaning.
+
+The main source-of-truth enums and helper types are:
+
+- `RequestOutcomeReason`
+- `BackendHealthReason`
+- `RetryDecisionReason`
+- `HedgeDecisionReason`
+- `AdmissionDecisionReason`
+- `AdmissionOverloadCause`
+- `QuotaPolicyDecision`
+- `QuotaPolicyReason`
+- `QuotaBackendHealthReason`
+- `OperationalEventContext`
+- `MetricReasonLabels`
+
+If one of those enums changes, that is an observability contract change. Dashboard queries, alert rules, runbooks, and control-plane JSON examples must be reviewed together.
+
 ## Contract Rule
 
 One operational concept should have:
 
 - one canonical enum value
 - one canonical slug string
-- one consistent meaning across metrics, logs, and control API payloads
+- one consistent meaning across metrics, logs, traces, control API payloads, and audit events
 
 The contract exists to prevent drift such as:
 
 - one reason name in metrics
 - a different prose string in logs
 - a third serialized form in control-plane JSON
+- a fourth ad hoc field in audit events
+- a fifth trace attribute that cannot be joined back to the operator vocabulary
 
 ## Canonical Reason Families
 
@@ -53,9 +83,57 @@ That means the slug should be treated as the stable value for:
 
 - metric label values
 - structured log `reason=` values
+- trace span attributes describing the same reason
 - control API serialized fields
+- audit event `reason` values
 
 Changing a slug is an observability contract change, not a cosmetic refactor.
+
+## Operator Correlation Contract
+
+Operators need a stable path from an alert to a dashboard panel to an event log or audit record to a runtime snapshot.
+
+The default correlation field set is:
+
+- `request_id`
+- `trace_id`
+- `span_id`
+- `event_id`
+- `generation`
+- `listener`
+- `route`
+- `upstream`
+- `backend`
+- `reason`
+- `failure_class`
+- `policy`
+- `component`
+
+### Correlation field meanings
+
+- `request_id` identifies a request-path event when request-scoped logging or tracing exists
+- `trace_id` identifies the distributed trace carrying the request or control-plane action
+- `span_id` identifies the local operation within that trace
+- `event_id` identifies a discrete audit or operator-significant event
+- `generation` identifies the active or candidate runtime generation involved in a control-plane action
+- `listener` identifies the ingress or admin listener involved in the event
+- `route` is a route identity when route-specific visibility exists
+- `upstream` is the canonical traffic attribution field for request-path metrics and logs
+- `backend` is the selected backend identity
+- `reason` is the canonical reason slug from `crates/edge/src/observability/mod.rs`
+- `failure_class` is a coarse refinement axis where `reason` alone is not sufficient
+- `policy` identifies the named policy that produced a decision when policy attribution exists
+- `component` identifies the subsystem such as `admission`, `quota`, `tls`, `runtime`, or `control_api`
+
+### Surface expectations
+
+- metrics should use low-cardinality correlation dimensions only
+- logs should emit the canonical field names when the values are known
+- traces should carry the same canonical names as span attributes where request or control-plane tracing exists
+- control API snapshots should expose current state using the same identities and reason slugs
+- audit events should serialize the same actor, target, generation, and reason meaning used elsewhere
+
+Absence is better than fabricated values. If a field is not known, omit it rather than inventing placeholders.
 
 ## Structured Log Field Contract
 
@@ -81,6 +159,27 @@ These fields are rendered in stable `key=value` form and unset fields are omitte
 
 Do not invent new ad hoc field keys for the same concept if the canonical field already exists.
 
+## Trace Attribute Contract
+
+Tracing is a diagnostic surface, not a separate vocabulary.
+
+Where traces are emitted, span and event attributes should reuse the canonical names:
+
+- `request_id`
+- `trace_id`
+- `span_id`
+- `generation`
+- `listener`
+- `route`
+- `upstream`
+- `backend`
+- `reason`
+- `failure_class`
+- `policy`
+- `component`
+
+Trace attributes may include additional diagnostic detail, but canonical operator fields must keep the same names and meanings as logs, metrics, control API, and audit events.
+
 ## Metric Label Contract
 
 Reasoned metric emitters should use the canonical label model:
@@ -105,6 +204,24 @@ This is what allows dashboards to compare:
 - admission denials
 
 without each emitter choosing different label semantics.
+
+## Audit Event Contract
+
+The control-plane audit stream is part of the operator observability bundle, not a side channel.
+
+Audit events should use the same identities and reason vocabulary as other surfaces, with fields oriented around:
+
+- actor
+- action
+- target
+- generation
+- result
+- reason
+- event_id
+- peer address
+- authentication mechanism
+
+Audit events may include control-plane-specific context, but they should not redefine canonical reason values or resource identities already established elsewhere.
 
 ## Control API Snapshot Contract
 
@@ -151,6 +268,50 @@ That means runtime snapshot rendering should depend on:
 
 It should not reconstruct state by reaching into multiple unrelated listener internals.
 
+## Canonical Dimensions Versus Diagnostic Dimensions
+
+The operator bundle must distinguish between dimensions that are safe for dashboards and alerts and dimensions that belong only in logs, traces, or targeted investigation.
+
+### Canonical operator dimensions
+
+These are acceptable for stable metrics, dashboards, alerts, and control-plane summaries:
+
+- `upstream`
+- `backend`
+- `listener`
+- `protocol`
+- `status_class`
+- `outcome`
+- `reason`
+- `failure_class`
+- `policy`
+- `component`
+- `generation` when bounded to active or recent generations
+
+### High-cardinality diagnostic dimensions
+
+These should not be introduced as default metric labels or dashboard variables:
+
+- raw request path
+- user id
+- tenant id
+- token id
+- client ip
+- header values
+- query strings
+- certificate fingerprints for every request
+- arbitrary trace baggage
+- per-request nonce or session identifiers
+
+These belong in:
+
+- structured logs
+- trace attributes
+- audit events where operationally justified
+- control-plane detail views
+
+The rule is simple: if a dimension can grow with end-user traffic, it is diagnostic by default, not metric-facing by default.
+
 ## Metrics vs Logs vs Control API
 
 These surfaces serve different operational jobs.
@@ -171,6 +332,14 @@ Logs are for:
 - request-path and lifecycle debugging
 - understanding the exact reason a single action happened
 
+### Traces
+
+Traces are for:
+
+- cross-component timing analysis
+- causal sequencing within a single request or control-plane action
+- joining request-path latency with retry, hedge, auth, and backend sub-operations
+
 ### Control API snapshots
 
 Control API snapshots are for:
@@ -179,6 +348,15 @@ Control API snapshots are for:
 - rollout verification
 - backend and watchdog status inspection
 - runtime-generation confirmation
+
+### Audit events
+
+Audit events are for:
+
+- operator accountability
+- change history
+- security-relevant admin actions
+- correlating runtime changes with traffic or control-plane symptoms
 
 They should complement each other, not contradict each other.
 
@@ -201,6 +379,27 @@ Avoid introducing unbounded labels such as:
 - per-request trace tokens
 
 If a dimension is needed for debugging but not for alerting, prefer logs or control-plane snapshots over high-cardinality metrics.
+
+## Dashboard And Alert Compatibility Promise
+
+Shipped dashboards and alert rules are versioned operator assets that depend on this contract.
+
+Compatibility promises:
+
+- canonical metric names and canonical reason label values are treated as stable operator API
+- dashboard panels should depend on canonical metrics or recording rules built from canonical metrics
+- alert rules should depend on canonical metrics or recording rules, not prose log parsing
+- control-plane examples and runbooks should use the same reason slugs and field names as the code contract
+- additive fields are allowed when they do not change existing meanings
+- renaming a canonical slug, field key, or low-cardinality label is a breaking observability change
+
+When a breaking observability change is unavoidable:
+
+- update `crates/edge/src/observability/mod.rs`
+- update this contract document in the same change
+- update shipped dashboards and alerts in the same change
+- document migration notes for operators
+- avoid silent drift where old dashboards continue to query non-existent or semantically changed series
 
 ## Backend Lifecycle Observability
 

--- a/docs/operations/control-plane.md
+++ b/docs/operations/control-plane.md
@@ -209,6 +209,26 @@ This ensures:
 - restart and reload actions act on the same authoritative runtime handle
 - backend lifecycle state is rendered from one canonical inventory
 
+### Observability package entry point
+
+`GET /admin/runtime` and the runtime history reads are also the operator entry point into the
+packaged observability bundle.
+
+The runtime/control-plane views now expose:
+
+- current active generation
+- observability contract version
+- audit schema version
+- backend health summary
+- quota backend health summary
+- recent tracked admin/runtime actions when history exists
+- dashboard definition references
+- documentation references
+
+These references are repository asset paths, not UI URLs. Operators and automation should treat
+them as stable package identifiers that can be mapped into Grafana imports, runbooks, or internal
+control-plane tooling without assuming one frontend.
+
 ## Authentication and Access Model
 
 ### Control API

--- a/docs/operations/observability-bundle.md
+++ b/docs/operations/observability-bundle.md
@@ -1,0 +1,560 @@
+# Observability Operator Bundle
+
+This page documents the shipped operator observability bundle for Spooky.
+
+It is the packaging guide for the artifacts under:
+
+- `deploy/observability/grafana/`
+- `deploy/observability/prometheus/recording-rules.yaml`
+- `deploy/observability/prometheus/alerts.yaml`
+- `deploy/observability/slo/`
+
+Use this page when you need to answer:
+
+- which dashboard to open first
+- what each alert severity means
+- how to interpret the packaged SLOs
+- how to correlate one incident across metrics, logs, traces, control API, and audit
+- how to roll out or version the observability package safely
+
+The canonical observability vocabulary still lives in
+[`docs/architecture/observability-contract.md`](../architecture/observability-contract.md)
+and `crates/edge/src/observability/mod.rs`. This page describes the shipped
+operator experience built on top of that contract.
+
+## Shipped Package
+
+The current package is made of four layers:
+
+1. recording rules
+2. alert rules
+3. SLO definitions
+4. Grafana dashboards
+
+The operator-facing contract version and audit schema version are surfaced in
+the control API runtime views. At this point the packaged values are:
+
+- observability contract version: `v1`
+- audit schema version: `v1`
+
+## Package Inventory
+
+### Prometheus recording rules
+
+File:
+
+- `deploy/observability/prometheus/recording-rules.yaml`
+
+Purpose:
+
+- turn raw scrape-time series into stable operator queries
+- keep dashboards and alerts off ad hoc raw PromQL
+- provide bounded-cardinality rollups for traffic, admission, backend, TLS, quota, and control-plane views
+
+### Prometheus alert rules
+
+File:
+
+- `deploy/observability/prometheus/alerts.yaml`
+
+Purpose:
+
+- define page-level and ticket-level production alerts
+- consume recording rules instead of duplicating raw query logic
+- map every alert to a concrete runbook or operations document
+
+### SLO package
+
+Files:
+
+- `deploy/observability/slo/README.md`
+- `deploy/observability/slo/definitions.promql`
+
+Purpose:
+
+- lock the numerator and denominator contracts for operator reporting
+- keep overload, quota, auth, and backend timeout concepts separate
+- provide the canonical 30-minute reporting layer used by dashboards and burn-rate alerts
+
+### Grafana dashboards
+
+Files:
+
+- `deploy/observability/grafana/edge-traffic.json`
+- `deploy/observability/grafana/admission-overload.json`
+- `deploy/observability/grafana/backend-health.json`
+- `deploy/observability/grafana/retries-hedges.json`
+- `deploy/observability/grafana/tls-certificates.json`
+- `deploy/observability/grafana/control-plane.json`
+
+Purpose:
+
+- provide a packaged operator workflow instead of leaving teams to assemble dashboards ad hoc
+- make the distinction between traffic failure, overload, quota, auth, backend health, TLS, and control-plane state obvious
+
+## Dashboard Guide
+
+### `edge-traffic.json`
+
+Dashboard:
+
+- title: `Spooky Edge Traffic and Latency`
+- uid: `spooky-edge-traffic`
+
+Open this first for:
+
+- request volume shifts
+- success-rate regression
+- p50, p95, or p99 latency growth
+- failing upstream or backend concentration
+- active runtime generation drift across the fleet
+
+Primary panels:
+
+- `Request Rate`
+- `Success Rate`
+- `P50 Latency`
+- `P95 Latency`
+- `P99 Latency`
+- `Traffic Volume by Upstream`
+- `Status Class Mix`
+- `Upstream Outcome Mix`
+- `Top Failing Upstreams`
+- `Top Failing Backends`
+
+Operator intent:
+
+- this is the entry dashboard for customer-visible traffic symptoms
+- use it to decide whether the problem is broad, upstream-localized, or backend-localized before opening specialized dashboards
+
+### `admission-overload.json`
+
+Dashboard:
+
+- title: `Spooky Admission, Overload, Quota, and Auth`
+- uid: `spooky-admission-overload`
+
+Open this when:
+
+- 429 or policy denials rise
+- 503s might be overload-related
+- brownout or adaptive admission is suspected
+- quota backend degradation is reported
+- auth denials or auth dependency failures increase
+
+Primary panels:
+
+- `Brownout State`
+- `Overload Shed Rate`
+- `Circuit Open Reject Rate`
+- `Scoped Rate Limit Reject Rate`
+- `Overload Shed by Reason`
+- `Adaptive Admission Behavior`
+- `Quota Decisions`
+- `Quota Backend Health`
+- `Top Quota Denials by Policy and Reason`
+- `Auth Denied vs Unavailable`
+- `Auth Contract Detail`
+
+Operator intent:
+
+- preserve the runtime boundary between overload control and policy-contract failure
+- do not interpret quota denial as overload
+- do not interpret auth unavailability as quota exhaustion
+
+### `backend-health.json`
+
+Dashboard:
+
+- title: `Spooky Backend Health and DNS Lifecycle`
+- uid: `spooky-backend-health`
+
+Open this when:
+
+- backend timeouts are rising
+- backend errors are concentrated on a subset of upstream/backend pairs
+- active probe failures and request-path failures disagree
+- DNS refresh or topology churn may be driving instability
+
+Primary panels:
+
+- `Health Check Failure Ratio`
+- `Backend Timeout Rate`
+- `Backend Error Rate`
+- `DNS Refresh Failure Ratio`
+- `Active Health Check Outcomes`
+- `Passive Health Failures by Reason`
+- `Backend Timeout and Error Pressure`
+- `Top Backend Errors by Upstream and Backend`
+- `DNS Refresh Outcomes and Address-Set Changes`
+- `Client Rotations and Failures`
+- `Resolved Addresses by Backend`
+- `Last Successful DNS Refresh Age by Backend`
+
+Operator intent:
+
+- separate active health probes from passive request-path failures
+- show when DNS churn or stale resolver state is the real cause of backend instability
+
+### `retries-hedges.json`
+
+Dashboard:
+
+- title: `Spooky Retries and Hedges`
+- uid: `spooky-retries-hedges`
+
+Open this when:
+
+- retries increase faster than raw request failure
+- hedge activity appears to be masking latency regression
+- duplicate work might be amplifying backend pressure
+
+Primary panels:
+
+- `Retry Attempt Rate`
+- `Retry Ratio`
+- `Retry Reasons`
+- `Retry Denials by Reason`
+- `Retry Pressure vs Backend Failure Pressure`
+- `Hedge Trigger Rate`
+- `Hedge Waste Ratio`
+- `Hedge Trigger, Win, Waste, and Primary-Won Patterns`
+- `Hedge Effectiveness Ratios`
+- `Average Primary Late Time After Hedge Trigger`
+- `Primary Late Sample Rate`
+
+Operator intent:
+
+- distinguish resilience behavior that is helping from resilience behavior that is amplifying failure
+- read retry growth and hedge waste together with backend timeout pressure
+
+### `tls-certificates.json`
+
+Dashboard:
+
+- title: `Spooky TLS Certificates and Handshakes`
+- uid: `spooky-tls-certificates`
+
+Open this when:
+
+- handshake failures rise
+- a certificate rotation is in progress
+- ALPN negotiation or SNI selection looks wrong
+- upstream TLS failures might be request-path specific
+
+Primary panels:
+
+- `Handshake Failure Ratio`
+- `Handshake Failure Rate`
+- `Minimum Certificate Days Remaining`
+- `Upstream TLS Failure Rate`
+- `Downstream Handshake Failures by Listener and Reason`
+- `Top Upstream TLS Failures by Backend, Phase, and Reason`
+- `Lowest Certificate Days Remaining`
+- `Certificate Selection Outcomes by Listener`
+- `Negotiated ALPN by Listener`
+
+Operator intent:
+
+- separate downstream handshake problems from upstream TLS request-path failures
+- make certificate expiry and unexpected selection behavior visible before client impact broadens
+
+### `control-plane.json`
+
+Dashboard:
+
+- title: `Spooky Control-Plane Activity`
+- uid: `spooky-control-plane`
+
+Open this when:
+
+- reload, activation, rollback, or restart workflows fail
+- watchdog or runtime panic signals appear
+- audit-correlated control-plane activity needs validation
+- runtime generation state might be drifting across the fleet
+
+Primary panels:
+
+- `Runtime State`
+- `Active Runtime Generation`
+- `Runtime History Depth`
+- `Audit-Correlated Control-Plane Activity Rate`
+- `Control-Plane Error Event Rate`
+- `Validation, Preview, Activation, and Rollback Activity`
+- `Runtime Outcomes by Result and Reason`
+- `Runtime Rejections by Reason`
+- `Watchdog State and Runtime Health`
+- `Control API Pressure and Error Events`
+
+Operator intent:
+
+- this is the admin-plane dashboard, not a traffic dashboard
+- use it to correlate runtime operations with emitted audit events and to verify whether the control plane is healthy enough to support incident response
+
+## Alert Severity And Runbook Mapping
+
+The alert package has two severities:
+
+- `page`: operator action is expected immediately because user impact or control-plane safety is already at risk
+- `ticket`: the issue is meaningful and should be investigated, but it is not yet assumed to require immediate paging
+
+### Page alerts
+
+| Alert | Meaning | First dashboard | Runbook |
+| --- | --- | --- | --- |
+| `SpookyAvailabilityBurnRatePage` | 5xx availability budget is burning in fast and sustained windows | `edge-traffic.json` | `docs/operations/runbook.md#scenario-rising-503-rate` |
+| `SpookyP99LatencyBurnPage` | p99 latency is materially above the packaged objective in fast and sustained windows | `edge-traffic.json` | `docs/operations/runbook.md#scenario-backend-timeout-surge` |
+| `SpookyBackendTimeoutSurgePage` | backend timeout ratio is high enough to threaten user-visible reliability | `backend-health.json` | `docs/operations/runbook.md#scenario-backend-timeout-surge` |
+| `SpookyTlsCertificateExpiryCritical` | at least one downstream certificate has fewer than 7 days remaining | `tls-certificates.json` | `docs/operations/runbook.md#scenario-cert-rotation` |
+| `SpookyWatchdogDegraded` | watchdog degraded windows are being recorded continuously | `control-plane.json` | `docs/operations/runbook.md#scenario-control-api-or-metrics-endpoint-unavailable` |
+| `SpookyRuntimePanicObserved` | runtime panic counters are non-zero in the recent window | `control-plane.json` | `docs/operations/runbook.md#after-any-incident` |
+| `SpookyControlPlaneUnavailable` | packaged control-plane recording-rule series are absent | `control-plane.json` | `docs/operations/runbook.md#scenario-control-api-or-metrics-endpoint-unavailable` |
+
+### Ticket alerts
+
+| Alert | Meaning | First dashboard | Runbook |
+| --- | --- | --- | --- |
+| `SpookyRetryGrowth` | retry ratio is rising and may be amplifying backend trouble | `retries-hedges.json` | `docs/operations/runbook.md#scenario-backend-timeout-surge` |
+| `SpookyHedgeGrowth` | hedge activity is becoming routine rather than exceptional | `retries-hedges.json` | `docs/operations/runbook.md#scenario-backend-timeout-surge` |
+| `SpookyBackendDnsRefreshFailures` | DNS refresh failures and ratio indicate stale or unstable backend resolution | `backend-health.json` | `docs/operations/runbook.md#scenario-backend-timeout-surge` |
+| `SpookyBrownoutActiveTooLong` | brownout is staying active beyond the tolerated window | `admission-overload.json` | `docs/operations/runbook.md#scenario-brownout-or-overload-triggering` |
+| `SpookyQuotaBackendDegraded` | the distributed quota backend is timing out, unavailable, or otherwise degraded | `admission-overload.json` | `docs/operations/distributed-quota.md` |
+| `SpookyTlsHandshakeFailuresRising` | downstream handshake failures are rising above normal background levels | `tls-certificates.json` | `docs/operations/runbook.md#scenario-handshake-failures-or-client-connection-failures` |
+
+## SLO Interpretation
+
+The SLO package is defined in `deploy/observability/slo/`. Use the packaged
+`spooky:slo_*` series for reporting rather than rebuilding numerator and
+denominator logic in Grafana.
+
+### Availability
+
+Primary series:
+
+- `spooky:slo_availability_ratio:30m`
+- `spooky:slo_request_server_error_ratio:rate30m`
+
+Interpretation:
+
+- this is the coarse user-visible server-failure contract
+- upstream `5xx`, overload-generated `503`, and backend failures that surface as `5xx` count here
+- auth denials, quota denials, and scoped rate limits do not count here
+
+### Latency
+
+Primary series:
+
+- `spooky:slo_request_latency_ms:p50_30m`
+- `spooky:slo_request_latency_ms:p95_30m`
+- `spooky:slo_request_latency_ms:p99_30m`
+
+Interpretation:
+
+- these percentiles describe successful service only
+- rejected work, timeout outcomes, and quota or auth denials are intentionally excluded
+- use the edge traffic dashboard for cluster-wide latency, then move to backend or retry dashboards if tails deteriorate
+
+### Overload shed rate
+
+Primary series:
+
+- `spooky:slo_overload_shed_ratio:30m`
+
+Interpretation:
+
+- only canonical overload-control decisions count
+- quota denials, auth denials, and scoped rate limits are excluded
+- this is a capacity-protection signal, not a general policy-denial signal
+
+### Backend timeout rate
+
+Primary series:
+
+- `spooky:slo_backend_timeout_ratio:30m`
+
+Interpretation:
+
+- this is narrower than overall backend failure
+- it should be read with `backend-health.json` and `retries-hedges.json`
+- do not silently widen it into a generic backend error SLO
+
+### Auth failure rate
+
+Primary series:
+
+- `spooky:slo_auth_denial_ratio:30m`
+
+Interpretation:
+
+- this covers explicit auth contract failures such as external auth denial and local JWT validation failure
+- it does not fold in generic policy rejection or fail-open dependency errors
+
+### Quota denial operator view
+
+Primary series:
+
+- `spooky:slo_quota_denial_ratio:30m`
+
+Interpretation:
+
+- quota is a contract-enforcement view, not overload
+- quota backend degradation should be interpreted alongside quota backend health, not mislabeled as ordinary traffic failure
+
+## Correlation Workflow
+
+The observability bundle is designed so an operator can start from any one
+surface and move to the others without translating vocabulary.
+
+The stable correlation fields are:
+
+- `request_id`
+- `trace_id`
+- `span_id`
+- `event_id`
+- `generation`
+- `listener`
+- `route`
+- `upstream`
+- `backend`
+- `reason`
+- `failure_class`
+- `policy`
+- `component`
+
+The source of truth for reason and decision vocabulary is:
+
+- `crates/edge/src/observability/mod.rs`
+
+### Alert to dashboard
+
+1. Read the firing series labels.
+2. Keep the canonical low-cardinality labels intact:
+   `upstream`, `backend`, `listener`, `reason`, `decision`, `policy`, `backend_mode`.
+3. Open the dashboard named in the alert mapping above.
+4. Validate whether the issue is traffic, admission, backend, TLS, or control-plane scoped.
+
+### Dashboard to control API
+
+Use the control API when you need current runtime state rather than trend.
+
+Look for:
+
+- current runtime generation
+- backend lifecycle and membership state
+- quota backend availability and recent errors
+- active observability contract version
+- recent admin actions
+- audit schema version
+
+The main runtime entry points are documented in
+[Control Plane](control-plane.md).
+
+### Dashboard to logs and traces
+
+Use logs and traces when the packaged metrics explain the class of failure but
+not the specific request path.
+
+Look for the same canonical names:
+
+- logs: `request_id`, `upstream`, `backend`, `reason`, `failure_class`
+- traces: `trace_id`, `span_id`, `generation`, `listener`, `upstream`, `backend`, `reason`
+
+Do not correlate by prose strings when a canonical slug is available.
+
+### Control API to audit
+
+Use the audit stream when the incident involves:
+
+- reload or activation attempts
+- rollback decisions
+- control-plane auth failures
+- certificate reload attempts
+- actor attribution
+
+Audit is the source of truth for control-plane action history. Metrics and
+dashboards show rate and trend; audit shows who did what, against which target,
+with which generation and result.
+
+## Incident Workflows
+
+### Rising 5xx or latency page
+
+1. Open `edge-traffic.json`.
+2. Check whether `Top Failing Upstreams` or `Top Failing Backends` is concentrated.
+3. If timeout-heavy, move to `backend-health.json`.
+4. If retry or hedge growth is visible, move to `retries-hedges.json`.
+5. If 503s are overload-generated rather than upstream-generated, move to `admission-overload.json`.
+
+### Quota backend degraded
+
+1. Open `admission-overload.json`.
+2. Read `Quota Decisions`, `Quota Backend Health`, and `Top Quota Denials by Policy and Reason`.
+3. Confirm current backend mode and degraded state in the control API runtime snapshot.
+4. Use [Distributed Quota](distributed-quota.md) for fail-open, fail-closed, and fallback interpretation.
+
+### TLS or certificate incident
+
+1. Open `tls-certificates.json`.
+2. Separate downstream handshake failures from upstream TLS failures.
+3. Check the certificate days-remaining panels before assuming the issue is trust or routing.
+4. If the issue followed a certificate or listener change, use the runbook certificate-rotation path.
+
+### Control-plane incident
+
+1. Open `control-plane.json`.
+2. Check runtime generation, recent activity rate, runtime outcomes, watchdog state, and control API pressure.
+3. Read runtime snapshot and runtime history from the control API.
+4. Use audit records for actor attribution and operation sequence.
+
+## Rollout And Versioning
+
+### Prometheus rollout order
+
+1. Load `deploy/observability/prometheus/recording-rules.yaml`.
+2. Confirm the `spooky:*` recording-rule series are present.
+3. Load `deploy/observability/prometheus/alerts.yaml`.
+4. Validate that every alert evaluates against recording rules rather than missing raw series.
+5. Only then import or refresh dashboards.
+
+Do not roll out alert rules before the recording rules they consume.
+
+### Grafana import rules
+
+- import the dashboard JSON files from `deploy/observability/grafana/`
+- preserve the packaged `uid` values so links, references, and operator runbooks stay stable
+- treat the repo JSON as the source of truth rather than hand-editing panels in production
+- if you customize a dashboard locally, either keep it clearly separate or upstream the change into the repo package
+
+Current packaged dashboard JSON files all ship with explicit `version` fields.
+Treat a dashboard `version` bump in the repo as an intentional artifact change
+that should be reviewed together with alert, SLO, or recording-rule changes.
+
+### Control API compatibility checks
+
+After rollout, confirm the control API runtime snapshot exposes:
+
+- `observability.contract_version`
+- `observability.audit_schema_version`
+- `observability.dashboard_packages`
+- `observability.documentation`
+
+This is the runtime proof that the node is serving the expected operator bundle
+contract.
+
+### Safe production update pattern
+
+1. update recording rules
+2. wait for the new recording series to appear
+3. update alerts
+4. import dashboard JSON changes
+5. verify runtime snapshot metadata
+6. verify one page alert, one ticket alert, and one dashboard query in staging or canary before fleet-wide rollout
+
+## Related Pages
+
+- [Observability Contract](../architecture/observability-contract.md)
+- [Metrics and Alerts](metrics-and-alerts.md)
+- [Control Plane](control-plane.md)
+- [Distributed Quota](distributed-quota.md)
+- [Runbook](runbook.md)
+- [Spooky SLO Package](../../deploy/observability/slo/README.md)

--- a/docs/operations/overview.md
+++ b/docs/operations/overview.md
@@ -9,6 +9,7 @@ This section is for deployment, rollout, validation, and production operation of
 - [Validation](../deployment/validation.md) covers pre-production and post-change validation patterns.
 - [Migration](../deployment/migration.md) covers moving traffic from an existing proxy stack.
 - [Distributed Quota](distributed-quota.md) covers policy examples, Redis backend rollout, degraded-mode behavior, and operator interpretation.
+- [Observability Operator Bundle](observability-bundle.md) covers the shipped dashboards, alerts, SLO package, and cross-surface incident workflow.
 - [Runbook](runbook.md) is the incident and maintenance quick-reference.
 - [Sizing And Capacity](sizing-and-capacity.md) covers the main host and concurrency inputs that shape safe operation.
 - [Host Tuning](host-tuning.md) groups host-level guidance.

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -4,7 +4,9 @@ WORKDIR /workspace
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
+        clang \
         cmake \
+        libclang-dev \
         ninja-build \
         pkg-config \
         perl \

--- a/packaging/docker/Dockerfile.dev
+++ b/packaging/docker/Dockerfile.dev
@@ -4,7 +4,9 @@ WORKDIR /workspace
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
+        clang \
         cmake \
+        libclang-dev \
         ninja-build \
         pkg-config \
         perl \

--- a/spooky/src/app.rs
+++ b/spooky/src/app.rs
@@ -62,12 +62,10 @@ pub(crate) fn main_entry() {
         &config_yaml.log.file.path,
         config_yaml.log.format == spooky_config::config::LogFormat::Json,
     );
-    spooky_utils::telemetry::init::init_tracing(
-        config_yaml.observability.tracing.enabled,
-        &config_yaml.observability.tracing.service_name,
-        config_yaml.observability.tracing.otlp_endpoint.as_deref(),
-        config_yaml.observability.tracing.sample_ratio,
-    );
+    // NOTE: tracing is initialized inside the Tokio runtime (see `run`), not
+    // here. The OTLP tonic exporter spawns a background task while building its
+    // channel, which panics with "there is no reactor running" when constructed
+    // before the runtime exists.
     runtime_guard::install_panic_hook();
 
     let uid = unsafe { libc::getuid() };
@@ -125,6 +123,7 @@ pub(crate) fn main_entry() {
     runtime.block_on(run(
         runtime_config,
         config_yaml.log.clone(),
+        config_yaml.observability.tracing.clone(),
         uid,
         config_path,
     ));
@@ -133,9 +132,19 @@ pub(crate) fn main_entry() {
 async fn run(
     runtime_config: RuntimeConfig,
     log_config: spooky_config::config::Log,
+    tracing_config: spooky_config::config::Tracing,
     uid: libc::uid_t,
     config_path: String,
 ) {
+    // Must happen inside the runtime: the OTLP tonic exporter spawns a task on
+    // the current reactor while building its channel.
+    spooky_utils::telemetry::init::init_tracing(
+        tracing_config.enabled,
+        &tracing_config.service_name,
+        tracing_config.otlp_endpoint.as_deref(),
+        tracing_config.sample_ratio,
+    );
+
     let runtime_bundle =
         match QUICListener::build_runtime_bundle(config_path, log_config, &runtime_config) {
             Ok(bundle) => bundle,

--- a/spooky/src/bin/h3_client.rs
+++ b/spooky/src/bin/h3_client.rs
@@ -22,8 +22,16 @@ struct Cli {
     #[arg(long, default_value = "/")]
     path: String,
 
+    #[arg(long, default_value = "GET")]
+    method: String,
+
     #[arg(long, default_value = "localhost")]
     host: String,
+
+    /// Additional request headers as `name=value`. Repeat to add more headers.
+    /// Pseudo-headers such as `:protocol=websocket` are supported.
+    #[arg(long = "header")]
+    headers: Vec<String>,
 
     #[arg(long)]
     insecure: bool,
@@ -73,6 +81,18 @@ fn emit_request_result(ok: bool, latency_ns: u128, report_latency: bool) {
 
 fn should_retry_request(attempts_started: usize, max_request_retries: usize) -> bool {
     attempts_started <= max_request_retries
+}
+
+fn parse_header_arg(header: &str) -> Result<(Vec<u8>, Vec<u8>), String> {
+    let (name, value) = header
+        .split_once('=')
+        .ok_or_else(|| format!("invalid --header '{header}': expected name=value"))?;
+    let name = name.trim();
+    let value = value.trim();
+    if name.is_empty() {
+        return Err(format!("invalid --header '{header}': header name is empty"));
+    }
+    Ok((name.as_bytes().to_vec(), value.as_bytes().to_vec()))
 }
 
 fn open_connection(
@@ -169,6 +189,11 @@ fn run_client(cli: &Cli) -> Result<(), Box<dyn std::error::Error>> {
     let mut last_error: Option<String> = None;
     let mut inflight: HashMap<u64, InflightRequest> = HashMap::new();
     let per_request_timeout = Duration::from_millis(cli.request_timeout_ms);
+    let extra_headers = cli
+        .headers
+        .iter()
+        .map(|header| parse_header_arg(header))
+        .collect::<Result<Vec<_>, _>>()?;
 
     // Kick off handshake packet(s).
     let _ = flush_egress(&mut conn, &socket, &mut out);
@@ -224,13 +249,18 @@ fn run_client(cli: &Cli) -> Result<(), Box<dyn std::error::Error>> {
                 let first_start_ref = request_started[request_id].get_or_insert_with(Instant::now);
                 let first_start = *first_start_ref;
 
-                let req = vec![
-                    quiche::h3::Header::new(b":method", b"GET"),
+                let mut req = vec![
+                    quiche::h3::Header::new(b":method", cli.method.as_bytes()),
                     quiche::h3::Header::new(b":scheme", b"https"),
                     quiche::h3::Header::new(b":authority", cli.host.as_bytes()),
                     quiche::h3::Header::new(b":path", cli.path.as_bytes()),
                     quiche::h3::Header::new(b"user-agent", b"spooky-h3-client"),
                 ];
+                req.extend(
+                    extra_headers
+                        .iter()
+                        .map(|(name, value)| quiche::h3::Header::new(name, value)),
+                );
 
                 match h3.send_request(&mut conn, &req, true) {
                     Ok(stream_id) => {
@@ -439,6 +469,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     if cli.request_timeout_ms == 0 {
         return Err("--request-timeout-ms must be >= 1".into());
+    }
+
+    if cli.method.trim().is_empty() {
+        return Err("--method must not be empty".into());
     }
 
     run_client(&cli)


### PR DESCRIPTION
## Summary
This PR packages the observability operator bundle for Spooky and rounds it out with the committed operator-facing artifacts, runtime surfaces, and supporting traffic tooling.

It adds:
- Grafana dashboards for edge traffic and latency, admission and overload, backend health, retries and hedges, DNS lifecycle, TLS certificates and handshakes, and control-plane activity
- Prometheus recording rules for golden signals, contract and quota outcomes, latency, backend pressure, and operator summary views
- SLO definitions and operator documentation for dashboards, alerts, incident workflows, and rollout guidance
- Control API observability metadata and dashboard linkage so runtime introspection exposes the active observability contract
- Tests covering dashboard and alert artifacts, canonical reason slugs, audit serialization, and control-plane observability views
- Operator drilldowns and summary-rule refinements across the dashboard package
- `h3_client` support for configurable HTTP methods and headers so observability traffic generation can exercise more QUIC-only runtime paths

## Why
This turns the existing raw metrics, logs, tracing, and runtime views into a production-grade operator package with a stable contract, packaged dashboards, derived rules, and clearer control-plane discoverability.

## Testing
- Added observability bundle contract and artifact coverage in the test suite
- Committed changes include validation for dashboard, alert, and control-plane observability surfaces